### PR TITLE
Add more options for VexRiscv generation.

### DIFF
--- a/pythondata_cpu_vexriscv/verilog/src/main/scala/vexriscv/GenCoreDefault.scala
+++ b/pythondata_cpu_vexriscv/verilog/src/main/scala/vexriscv/GenCoreDefault.scala
@@ -362,9 +362,9 @@ class PerfCsrPlugin( val csrCount : Int ) extends Plugin[VexRiscv]{
       for (idx <- 0 until csrCount) {
 
           val cycleCounter = Reg(UInt(32 bits))
-          val enable =       Reg(UInt(32 bits))   // only the LSB is used
+          val enable       = Reg(Bool()) init(False)
 
-          when ( enable(0) ) {
+          when ( enable ) {
             cycleCounter := cycleCounter + 1
           }
 


### PR DESCRIPTION
No changes to default behavior or to generation
of existing variants.

I tested by regenerating all VexRiscv variant Verilogs,
to ensure that I did not accidentally introduce any behavior
changes.  There were no changes other than the embedded hashes.

Signed-off-by: Tim Callahan <tcal@google.com>