### PR TITLE
Update VexRiscv to `b6118e6cc2a3`, sbt to 1.9.7, SpinalHDL to 1.9.4; make PMP plugin selection configurable

### DIFF
--- a/pythondata_cpu_vexriscv/verilog/VexRiscv.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv.v
@@ -1,38 +1,38 @@
-// Generator : SpinalHDL v1.7.1    git head : 0444bb76ab1d6e19f0ec46bc03c4769776deb7d5
+// Generator : SpinalHDL v1.9.4    git head : 270018552577f3bb8e5339ee2583c9c22d324215
 // Component : VexRiscv
-// Git hash  : 581fcb065adf7ea8b626f939ff51679d4c95872f
+// Git hash  : 63430af99f84cc1d11d58b556debe1cc3f238c67
 
 `timescale 1ns/1ps
 
 module VexRiscv (
-  input      [31:0]   externalResetVector,
-  input               timerInterrupt,
-  input               softwareInterrupt,
-  input      [31:0]   externalInterruptArray,
-  output reg          iBusWishbone_CYC,
-  output reg          iBusWishbone_STB,
-  input               iBusWishbone_ACK,
-  output              iBusWishbone_WE,
-  output     [29:0]   iBusWishbone_ADR,
-  input      [31:0]   iBusWishbone_DAT_MISO,
-  output     [31:0]   iBusWishbone_DAT_MOSI,
-  output     [3:0]    iBusWishbone_SEL,
-  input               iBusWishbone_ERR,
-  output     [2:0]    iBusWishbone_CTI,
-  output     [1:0]    iBusWishbone_BTE,
-  output              dBusWishbone_CYC,
-  output              dBusWishbone_STB,
-  input               dBusWishbone_ACK,
-  output              dBusWishbone_WE,
-  output     [29:0]   dBusWishbone_ADR,
-  input      [31:0]   dBusWishbone_DAT_MISO,
-  output     [31:0]   dBusWishbone_DAT_MOSI,
-  output     [3:0]    dBusWishbone_SEL,
-  input               dBusWishbone_ERR,
-  output     [2:0]    dBusWishbone_CTI,
-  output     [1:0]    dBusWishbone_BTE,
-  input               clk,
-  input               reset
+  input  wire [31:0]   externalResetVector,
+  input  wire          timerInterrupt,
+  input  wire          softwareInterrupt,
+  input  wire [31:0]   externalInterruptArray,
+  output reg           iBusWishbone_CYC,
+  output reg           iBusWishbone_STB,
+  input  wire          iBusWishbone_ACK,
+  output wire          iBusWishbone_WE,
+  output wire [29:0]   iBusWishbone_ADR,
+  input  wire [31:0]   iBusWishbone_DAT_MISO,
+  output wire [31:0]   iBusWishbone_DAT_MOSI,
+  output wire [3:0]    iBusWishbone_SEL,
+  input  wire          iBusWishbone_ERR,
+  output wire [2:0]    iBusWishbone_CTI,
+  output wire [1:0]    iBusWishbone_BTE,
+  output wire          dBusWishbone_CYC,
+  output wire          dBusWishbone_STB,
+  input  wire          dBusWishbone_ACK,
+  output wire          dBusWishbone_WE,
+  output wire [29:0]   dBusWishbone_ADR,
+  input  wire [31:0]   dBusWishbone_DAT_MISO,
+  output wire [31:0]   dBusWishbone_DAT_MOSI,
+  output wire [3:0]    dBusWishbone_SEL,
+  input  wire          dBusWishbone_ERR,
+  output wire [2:0]    dBusWishbone_CTI,
+  output wire [1:0]    dBusWishbone_BTE,
+  input  wire          clk,
+  input  wire          reset
 );
   localparam ShiftCtrlEnum_DISABLE_1 = 2'd0;
   localparam ShiftCtrlEnum_SLL_1 = 2'd1;
@@ -90,7 +90,6 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_flush_valid;
   wire                dataCache_1_io_cpu_flush_payload_singleLine;
   wire       [6:0]    dataCache_1_io_cpu_flush_payload_lineId;
-  wire                dataCache_1_io_mem_cmd_ready;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
@@ -118,6 +117,7 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_writeBack_exclusiveOk;
   wire                dataCache_1_io_cpu_flush_ready;
   wire                dataCache_1_io_cpu_redo;
+  wire                dataCache_1_io_cpu_writesPending;
   wire                dataCache_1_io_mem_cmd_valid;
   wire                dataCache_1_io_mem_cmd_payload_wr;
   wire                dataCache_1_io_mem_cmd_payload_uncached;
@@ -129,12 +129,11 @@ module VexRiscv (
   wire       [51:0]   _zz_memory_MUL_LOW;
   wire       [51:0]   _zz_memory_MUL_LOW_1;
   wire       [51:0]   _zz_memory_MUL_LOW_2;
-  wire       [51:0]   _zz_memory_MUL_LOW_3;
-  wire       [32:0]   _zz_memory_MUL_LOW_4;
-  wire       [51:0]   _zz_memory_MUL_LOW_5;
-  wire       [49:0]   _zz_memory_MUL_LOW_6;
-  wire       [51:0]   _zz_memory_MUL_LOW_7;
-  wire       [49:0]   _zz_memory_MUL_LOW_8;
+  wire       [32:0]   _zz_memory_MUL_LOW_3;
+  wire       [51:0]   _zz_memory_MUL_LOW_4;
+  wire       [49:0]   _zz_memory_MUL_LOW_5;
+  wire       [51:0]   _zz_memory_MUL_LOW_6;
+  wire       [49:0]   _zz_memory_MUL_LOW_7;
   wire       [31:0]   _zz_execute_SHIFT_RIGHT;
   wire       [32:0]   _zz_execute_SHIFT_RIGHT_1;
   wire       [32:0]   _zz_execute_SHIFT_RIGHT_2;
@@ -143,19 +142,19 @@ module VexRiscv (
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_2;
   wire                _zz_decode_LEGAL_INSTRUCTION_3;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_4;
-  wire       [13:0]   _zz_decode_LEGAL_INSTRUCTION_5;
+  wire       [12:0]   _zz_decode_LEGAL_INSTRUCTION_5;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_6;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_7;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_8;
   wire                _zz_decode_LEGAL_INSTRUCTION_9;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_10;
-  wire       [7:0]    _zz_decode_LEGAL_INSTRUCTION_11;
+  wire       [6:0]    _zz_decode_LEGAL_INSTRUCTION_11;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_12;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_13;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_14;
   wire                _zz_decode_LEGAL_INSTRUCTION_15;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_16;
-  wire       [1:0]    _zz_decode_LEGAL_INSTRUCTION_17;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_17;
   wire       [3:0]    _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1;
   reg        [31:0]   _zz_IBusCachedPlugin_jump_pcLoad_payload_5;
   wire       [1:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_6;
@@ -196,123 +195,120 @@ module VexRiscv (
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_13;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_14;
   wire                _zz__zz_decode_IS_RS2_SIGNED_15;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_16;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_17;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_16;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_17;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_18;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_19;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_20;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_21;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_22;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_23;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_20;
+  wire       [20:0]   _zz__zz_decode_IS_RS2_SIGNED_21;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_22;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_23;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_24;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_25;
-  wire       [20:0]   _zz__zz_decode_IS_RS2_SIGNED_26;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_27;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_28;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_29;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_30;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_31;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_32;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_33;
-  wire       [17:0]   _zz__zz_decode_IS_RS2_SIGNED_34;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_35;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_25;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_26;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_27;
+  wire       [17:0]   _zz__zz_decode_IS_RS2_SIGNED_28;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_29;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_30;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_31;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_32;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_33;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_34;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_35;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_36;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_37;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_37;
   wire                _zz__zz_decode_IS_RS2_SIGNED_38;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_39;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_39;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_40;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_41;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_42;
-  wire       [14:0]   _zz__zz_decode_IS_RS2_SIGNED_43;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_44;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_41;
+  wire       [13:0]   _zz__zz_decode_IS_RS2_SIGNED_42;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_43;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_44;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_45;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_46;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_47;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_46;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_47;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_48;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_49;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_50;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_49;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_50;
   wire                _zz__zz_decode_IS_RS2_SIGNED_51;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_52;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_53;
-  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_54;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_55;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_56;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_57;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_52;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_53;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_54;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_55;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_56;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_57;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_58;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_59;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_60;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_61;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_59;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_60;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_61;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_62;
-  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_63;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_63;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_64;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_65;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_66;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_65;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_66;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_67;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_68;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_69;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_70;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_71;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_69;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_70;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_71;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_72;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_73;
-  wire       [10:0]   _zz__zz_decode_IS_RS2_SIGNED_74;
-  wire       [5:0]    _zz__zz_decode_IS_RS2_SIGNED_75;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_76;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_77;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_73;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_74;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_75;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_76;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_77;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_78;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_79;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_80;
-  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_81;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_82;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_83;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_84;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_85;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_86;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_87;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_88;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_80;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_81;
+  wire       [9:0]    _zz__zz_decode_IS_RS2_SIGNED_82;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_83;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_84;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_85;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_86;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_87;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_88;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_89;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_90;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_90;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_91;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_92;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_93;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_94;
-  wire       [7:0]    _zz__zz_decode_IS_RS2_SIGNED_95;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_96;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_97;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_98;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_99;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_100;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_101;
-  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_102;
+  wire       [6:0]    _zz__zz_decode_IS_RS2_SIGNED_95;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_96;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_97;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_98;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_99;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_100;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_101;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_102;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_103;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_104;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_105;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_104;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_105;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_106;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_107;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_107;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_108;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_109;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_110;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_109;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_110;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_111;
-  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_112;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_113;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_114;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_112;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_113;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_114;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_115;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_116;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_117;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_116;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_117;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_118;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_119;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_119;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_120;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_121;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_122;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_121;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_122;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_123;
-  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_124;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_125;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_126;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_127;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_128;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_129;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_130;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_131;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_132;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_124;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_125;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_126;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_127;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_128;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_129;
   wire                _zz_RegFilePlugin_regFile_port;
   wire                _zz_decode_RegFilePlugin_rs1Data;
   wire                _zz_RegFilePlugin_regFile_port_1;
@@ -320,14 +316,12 @@ module VexRiscv (
   wire       [0:0]    _zz__zz_execute_REGFILE_WRITE_DATA;
   wire       [2:0]    _zz__zz_execute_SRC1;
   wire       [4:0]    _zz__zz_execute_SRC1_1;
-  wire       [11:0]   _zz__zz_execute_SRC2_3;
+  wire       [11:0]   _zz__zz_execute_SRC2_2;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_1;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_2;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_3;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_4;
-  wire       [31:0]   _zz_execute_SrcPlugin_addSub_5;
-  wire       [31:0]   _zz_execute_SrcPlugin_addSub_6;
   wire       [19:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_2;
   wire       [11:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_4;
   wire       [31:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_6;
@@ -476,7 +470,7 @@ module VexRiscv (
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_execute_SRC2;
+  wire       [31:0]   _zz_execute_to_memory_PC;
   wire       [1:0]    execute_SRC2_CTRL;
   wire       [1:0]    _zz_execute_SRC2_CTRL;
   wire       [1:0]    execute_SRC1_CTRL;
@@ -655,8 +649,9 @@ module VexRiscv (
   wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
   wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
   wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
-  wire                CsrPlugin_csrMapping_allowCsrSignal;
+  reg                 CsrPlugin_csrMapping_allowCsrSignal;
   wire                CsrPlugin_csrMapping_hazardFree;
+  wire                CsrPlugin_csrMapping_doForceFailCsr;
   wire                CsrPlugin_inWfi /* verilator public */ ;
   wire                CsrPlugin_thirdPartyWake;
   reg                 CsrPlugin_jumpInterface_valid;
@@ -675,6 +670,7 @@ module VexRiscv (
   wire                CsrPlugin_allowInterrupts;
   wire                CsrPlugin_allowException;
   wire                CsrPlugin_allowEbreakException;
+  wire                CsrPlugin_xretAwayFromMachine;
   wire                IBusCachedPlugin_externalFlush;
   wire                IBusCachedPlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
@@ -694,14 +690,13 @@ module VexRiscv (
   reg                 IBusCachedPlugin_fetchPc_pcRegPropagate;
   reg                 IBusCachedPlugin_fetchPc_booted;
   reg                 IBusCachedPlugin_fetchPc_inc;
-  wire                when_Fetcher_l134;
-  wire                IBusCachedPlugin_fetchPc_output_fire_1;
-  wire                when_Fetcher_l134_1;
+  wire                when_Fetcher_l133;
+  wire                when_Fetcher_l133_1;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pc;
   wire                IBusCachedPlugin_fetchPc_redo_valid;
   wire       [31:0]   IBusCachedPlugin_fetchPc_redo_payload;
   reg                 IBusCachedPlugin_fetchPc_flushed;
-  wire                when_Fetcher_l161;
+  wire                when_Fetcher_l160;
   reg                 IBusCachedPlugin_iBusRsp_redoFetch;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_ready;
@@ -729,8 +724,8 @@ module VexRiscv (
   wire                _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready;
   wire                IBusCachedPlugin_iBusRsp_flush;
   wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
-  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
-  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid;
+  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1;
   wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
@@ -743,18 +738,18 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_output_payload_rsp_error;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   wire                IBusCachedPlugin_iBusRsp_output_payload_isRvc;
-  wire                when_Fetcher_l243;
-  wire                when_Fetcher_l323;
+  wire                when_Fetcher_l242;
+  wire                when_Fetcher_l322;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
-  wire                when_Fetcher_l332;
+  wire                when_Fetcher_l331;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
-  wire                when_Fetcher_l332_1;
+  wire                when_Fetcher_l331_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
-  wire                when_Fetcher_l332_2;
+  wire                when_Fetcher_l331_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
-  wire                when_Fetcher_l332_3;
+  wire                when_Fetcher_l331_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                when_Fetcher_l332_4;
+  wire                when_Fetcher_l331_4;
   wire                _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   reg        [18:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1;
   wire                _zz_2;
@@ -780,69 +775,70 @@ module VexRiscv (
   wire                IBusCachedPlugin_rsp_iBusRspOutputHalt;
   wire                IBusCachedPlugin_rsp_issueDetected;
   reg                 IBusCachedPlugin_rsp_redoFetch;
-  wire                when_IBusCachedPlugin_l239;
-  wire                when_IBusCachedPlugin_l244;
+  wire                when_IBusCachedPlugin_l245;
   wire                when_IBusCachedPlugin_l250;
   wire                when_IBusCachedPlugin_l256;
-  wire                when_IBusCachedPlugin_l267;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_valid;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_ready;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_address;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_data;
-  wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_size;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_last;
-  reg                 dataCache_1_io_mem_cmd_rValid;
-  reg                 dataCache_1_io_mem_cmd_rData_wr;
-  reg                 dataCache_1_io_mem_cmd_rData_uncached;
-  reg        [31:0]   dataCache_1_io_mem_cmd_rData_address;
-  reg        [31:0]   dataCache_1_io_mem_cmd_rData_data;
-  reg        [3:0]    dataCache_1_io_mem_cmd_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_rData_size;
-  reg                 dataCache_1_io_mem_cmd_rData_last;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
-  wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data;
-  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
-  wire                when_Stream_l368;
+  wire                when_IBusCachedPlugin_l262;
+  wire                when_IBusCachedPlugin_l273;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_valid;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+  wire       [3:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+  wire       [2:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_size;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rValidN;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rData_wr;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rData_uncached;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_rData_address;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_rData_data;
+  reg        [3:0]    toplevel_dataCache_1_io_mem_cmd_rData_mask;
+  reg        [2:0]    toplevel_dataCache_1_io_mem_cmd_rData_size;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rData_last;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
+  wire       [3:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
+  wire       [2:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_address;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_data;
+  reg        [3:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
+  reg        [2:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_size;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  wire                when_Stream_l369;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
-  wire                when_DBusCachedPlugin_l308;
+  wire                when_DBusCachedPlugin_l352;
   wire       [1:0]    execute_DBusCachedPlugin_size;
   reg        [31:0]   _zz_execute_MEMORY_STORE_DATA_RF;
-  wire                dataCache_1_io_cpu_flush_isStall;
-  wire                when_DBusCachedPlugin_l350;
-  wire                when_DBusCachedPlugin_l366;
-  wire                when_DBusCachedPlugin_l393;
-  wire                when_DBusCachedPlugin_l446;
-  wire                when_DBusCachedPlugin_l466;
+  wire                toplevel_dataCache_1_io_cpu_flush_isStall;
+  wire                when_DBusCachedPlugin_l394;
+  wire                when_DBusCachedPlugin_l410;
+  wire                when_DBusCachedPlugin_l472;
+  wire                when_DBusCachedPlugin_l533;
+  wire                when_DBusCachedPlugin_l553;
+  wire       [31:0]   writeBack_DBusCachedPlugin_rspData;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_0;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_1;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_2;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
   wire       [31:0]   writeBack_DBusCachedPlugin_rspRf;
-  wire       [1:0]    switch_Misc_l210;
+  wire       [1:0]    switch_Misc_l232;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_1;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated_2;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
-  wire                when_DBusCachedPlugin_l492;
+  wire                when_DBusCachedPlugin_l580;
   wire       [31:0]   _zz_decode_IS_RS2_SIGNED;
   wire                _zz_decode_IS_RS2_SIGNED_1;
   wire                _zz_decode_IS_RS2_SIGNED_2;
@@ -864,15 +860,15 @@ module VexRiscv (
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
   reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
   reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_7;
+  reg                 _zz_10;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
   reg        [31:0]   _zz_execute_REGFILE_WRITE_DATA;
   reg        [31:0]   _zz_execute_SRC1;
-  wire                _zz_execute_SRC2_1;
-  reg        [19:0]   _zz_execute_SRC2_2;
-  wire                _zz_execute_SRC2_3;
-  reg        [19:0]   _zz_execute_SRC2_4;
-  reg        [31:0]   _zz_execute_SRC2_5;
+  wire                _zz_execute_SRC2;
+  reg        [19:0]   _zz_execute_SRC2_1;
+  wire                _zz_execute_SRC2_2;
+  reg        [19:0]   _zz_execute_SRC2_3;
+  reg        [31:0]   _zz_execute_SRC2_4;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   wire       [4:0]    execute_FullBarrelShifterPlugin_amplitude;
@@ -909,7 +905,7 @@ module VexRiscv (
   wire                when_HazardSimplePlugin_l108;
   wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    switch_Misc_l210_1;
+  wire       [2:0]    switch_Misc_l232_1;
   reg                 _zz_execute_BRANCH_COND_RESULT;
   reg                 _zz_execute_BRANCH_COND_RESULT_1;
   wire                _zz_execute_BranchPlugin_missAlignedTarget;
@@ -948,9 +944,9 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_mtval;
   reg        [63:0]   CsrPlugin_mcycle;
   reg        [63:0]   CsrPlugin_minstret;
-  wire                _zz_when_CsrPlugin_l965;
-  wire                _zz_when_CsrPlugin_l965_1;
-  wire                _zz_when_CsrPlugin_l965_2;
+  wire                _zz_when_CsrPlugin_l1302;
+  wire                _zz_when_CsrPlugin_l1302_1;
+  wire                _zz_when_CsrPlugin_l1302_2;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -965,56 +961,59 @@ module VexRiscv (
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
   wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code;
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
-  wire                when_CsrPlugin_l922;
-  wire                when_CsrPlugin_l922_1;
-  wire                when_CsrPlugin_l922_2;
-  wire                when_CsrPlugin_l922_3;
-  wire                when_CsrPlugin_l935;
+  wire                when_CsrPlugin_l1259;
+  wire                when_CsrPlugin_l1259_1;
+  wire                when_CsrPlugin_l1259_2;
+  wire                when_CsrPlugin_l1259_3;
+  wire                when_CsrPlugin_l1272;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
-  wire                when_CsrPlugin_l959;
-  wire                when_CsrPlugin_l965;
-  wire                when_CsrPlugin_l965_1;
-  wire                when_CsrPlugin_l965_2;
+  wire                when_CsrPlugin_l1296;
+  wire                when_CsrPlugin_l1302;
+  wire                when_CsrPlugin_l1302_1;
+  wire                when_CsrPlugin_l1302_2;
   wire                CsrPlugin_exception;
   wire                CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
-  wire                when_CsrPlugin_l993;
-  wire                when_CsrPlugin_l993_1;
-  wire                when_CsrPlugin_l993_2;
-  wire                when_CsrPlugin_l998;
+  wire                when_CsrPlugin_l1335;
+  wire                when_CsrPlugin_l1335_1;
+  wire                when_CsrPlugin_l1335_2;
+  wire                when_CsrPlugin_l1340;
   reg                 CsrPlugin_pipelineLiberator_done;
-  wire                when_CsrPlugin_l1004;
+  wire                when_CsrPlugin_l1346;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
+  wire                CsrPlugin_trapCauseEbreakDebug;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
-  wire                when_CsrPlugin_l1032;
-  wire                when_CsrPlugin_l1077;
-  wire       [1:0]    switch_CsrPlugin_l1081;
+  wire                CsrPlugin_trapEnterDebug;
+  wire                when_CsrPlugin_l1390;
+  wire                when_CsrPlugin_l1398;
+  wire                when_CsrPlugin_l1456;
+  wire       [1:0]    switch_CsrPlugin_l1460;
   reg                 execute_CsrPlugin_wfiWake;
-  wire                when_CsrPlugin_l1129;
+  wire                when_CsrPlugin_l1527;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire                when_CsrPlugin_l1149;
-  wire                when_CsrPlugin_l1150;
-  wire                when_CsrPlugin_l1157;
+  wire                when_CsrPlugin_l1547;
+  wire                when_CsrPlugin_l1548;
+  wire                when_CsrPlugin_l1555;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   wire       [31:0]   execute_CsrPlugin_readToWriteData;
-  wire                switch_Misc_l210_2;
+  wire                switch_Misc_l232_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
-  wire                when_CsrPlugin_l1189;
-  wire                when_CsrPlugin_l1193;
+  wire                when_CsrPlugin_l1587;
+  wire                when_CsrPlugin_l1591;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg                 execute_MulPlugin_aSigned;
   reg                 execute_MulPlugin_bSigned;
@@ -1061,7 +1060,7 @@ module VexRiscv (
   reg        [32:0]   _zz_memory_DivPlugin_rs1_1;
   reg        [31:0]   externalInterruptArray_regNext;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit;
-  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
+  wire       [31:0]   _zz_externalInterrupt;
   wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
   wire                when_Pipeline_l124_1;
@@ -1192,28 +1191,29 @@ module VexRiscv (
   wire                when_Pipeline_l154_1;
   wire                when_Pipeline_l151_2;
   wire                when_Pipeline_l154_2;
-  wire                when_CsrPlugin_l1277;
+  wire                when_CsrPlugin_l1669;
   reg                 execute_CsrPlugin_csr_3264;
-  wire                when_CsrPlugin_l1277_1;
+  wire                when_CsrPlugin_l1669_1;
   reg                 execute_CsrPlugin_csr_768;
-  wire                when_CsrPlugin_l1277_2;
+  wire                when_CsrPlugin_l1669_2;
   reg                 execute_CsrPlugin_csr_836;
-  wire                when_CsrPlugin_l1277_3;
+  wire                when_CsrPlugin_l1669_3;
   reg                 execute_CsrPlugin_csr_772;
-  wire                when_CsrPlugin_l1277_4;
+  wire                when_CsrPlugin_l1669_4;
   reg                 execute_CsrPlugin_csr_773;
-  wire                when_CsrPlugin_l1277_5;
+  wire                when_CsrPlugin_l1669_5;
   reg                 execute_CsrPlugin_csr_833;
-  wire                when_CsrPlugin_l1277_6;
+  wire                when_CsrPlugin_l1669_6;
   reg                 execute_CsrPlugin_csr_834;
-  wire                when_CsrPlugin_l1277_7;
+  wire                when_CsrPlugin_l1669_7;
   reg                 execute_CsrPlugin_csr_835;
-  wire                when_CsrPlugin_l1277_8;
+  wire                when_CsrPlugin_l1669_8;
   reg                 execute_CsrPlugin_csr_3008;
-  wire                when_CsrPlugin_l1277_9;
+  wire                when_CsrPlugin_l1669_9;
   reg                 execute_CsrPlugin_csr_4032;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
+  wire       [1:0]    switch_CsrPlugin_l1031;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
-  wire       [1:0]    switch_CsrPlugin_l723;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_5;
@@ -1221,19 +1221,22 @@ module VexRiscv (
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_8;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_10;
-  wire                when_CsrPlugin_l1310;
-  wire                when_CsrPlugin_l1315;
+  wire                when_CsrPlugin_l1702;
+  wire       [11:0]   _zz_when_CsrPlugin_l1709;
+  wire                when_CsrPlugin_l1709;
+  reg                 when_CsrPlugin_l1719;
+  wire                when_CsrPlugin_l1717;
+  wire                when_CsrPlugin_l1725;
   reg        [2:0]    _zz_iBusWishbone_ADR;
   wire                when_InstructionCache_l239;
   reg                 _zz_iBus_rsp_valid;
   reg        [31:0]   iBusWishbone_DAT_MISO_regNext;
-  reg        [2:0]    _zz_dBus_cmd_ready;
+  reg        [2:0]    _zz_dBusWishbone_ADR;
+  wire                _zz_dBusWishbone_CYC;
+  wire                _zz_dBus_cmd_ready;
   wire                _zz_dBus_cmd_ready_1;
   wire                _zz_dBus_cmd_ready_2;
-  wire                _zz_dBus_cmd_ready_3;
-  wire                _zz_dBus_cmd_ready_4;
-  wire                _zz_dBus_cmd_ready_5;
+  wire                _zz_dBusWishbone_ADR_1;
   reg                 _zz_dBus_rsp_valid;
   reg        [31:0]   dBusWishbone_DAT_MISO_regNext;
   `ifndef SYNTHESIS
@@ -1320,15 +1323,14 @@ module VexRiscv (
   (* no_rw_check , ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
   assign _zz_when = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
-  assign _zz_memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW_1) + $signed(_zz_memory_MUL_LOW_5));
-  assign _zz_memory_MUL_LOW_1 = ($signed(_zz_memory_MUL_LOW_2) + $signed(_zz_memory_MUL_LOW_3));
-  assign _zz_memory_MUL_LOW_2 = 52'h0;
-  assign _zz_memory_MUL_LOW_4 = {1'b0,memory_MUL_LL};
-  assign _zz_memory_MUL_LOW_3 = {{19{_zz_memory_MUL_LOW_4[32]}}, _zz_memory_MUL_LOW_4};
-  assign _zz_memory_MUL_LOW_6 = ({16'd0,memory_MUL_LH} <<< 16);
-  assign _zz_memory_MUL_LOW_5 = {{2{_zz_memory_MUL_LOW_6[49]}}, _zz_memory_MUL_LOW_6};
-  assign _zz_memory_MUL_LOW_8 = ({16'd0,memory_MUL_HL} <<< 16);
-  assign _zz_memory_MUL_LOW_7 = {{2{_zz_memory_MUL_LOW_8[49]}}, _zz_memory_MUL_LOW_8};
+  assign _zz_memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW_1) + $signed(_zz_memory_MUL_LOW_4));
+  assign _zz_memory_MUL_LOW_1 = ($signed(52'h0000000000000) + $signed(_zz_memory_MUL_LOW_2));
+  assign _zz_memory_MUL_LOW_3 = {1'b0,memory_MUL_LL};
+  assign _zz_memory_MUL_LOW_2 = {{19{_zz_memory_MUL_LOW_3[32]}}, _zz_memory_MUL_LOW_3};
+  assign _zz_memory_MUL_LOW_5 = ({16'd0,memory_MUL_LH} <<< 5'd16);
+  assign _zz_memory_MUL_LOW_4 = {{2{_zz_memory_MUL_LOW_5[49]}}, _zz_memory_MUL_LOW_5};
+  assign _zz_memory_MUL_LOW_7 = ({16'd0,memory_MUL_HL} <<< 5'd16);
+  assign _zz_memory_MUL_LOW_6 = {{2{_zz_memory_MUL_LOW_7[49]}}, _zz_memory_MUL_LOW_7};
   assign _zz_execute_SHIFT_RIGHT_1 = ($signed(_zz_execute_SHIFT_RIGHT_2) >>> execute_FullBarrelShifterPlugin_amplitude);
   assign _zz_execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT_1[31 : 0];
   assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == ShiftCtrlEnum_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
@@ -1344,20 +1346,18 @@ module VexRiscv (
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
   assign _zz_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId_1;
-  assign _zz_io_cpu_flush_payload_lineId_1 = (execute_RS1 >>> 5);
+  assign _zz_io_cpu_flush_payload_lineId_1 = (execute_RS1 >>> 3'd5);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code_1 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
   assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
   assign _zz__zz_execute_SRC1 = 3'b100;
   assign _zz__zz_execute_SRC1_1 = execute_INSTRUCTION[19 : 15];
-  assign _zz__zz_execute_SRC2_3 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz__zz_execute_SRC2_2 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
   assign _zz_execute_SrcPlugin_addSub = ($signed(_zz_execute_SrcPlugin_addSub_1) + $signed(_zz_execute_SrcPlugin_addSub_4));
   assign _zz_execute_SrcPlugin_addSub_1 = ($signed(_zz_execute_SrcPlugin_addSub_2) + $signed(_zz_execute_SrcPlugin_addSub_3));
   assign _zz_execute_SrcPlugin_addSub_2 = execute_SRC1;
   assign _zz_execute_SrcPlugin_addSub_3 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? _zz_execute_SrcPlugin_addSub_5 : _zz_execute_SrcPlugin_addSub_6);
-  assign _zz_execute_SrcPlugin_addSub_5 = 32'h00000001;
-  assign _zz_execute_SrcPlugin_addSub_6 = 32'h0;
+  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? 32'h00000001 : 32'h00000000);
   assign _zz__zz_execute_BranchPlugin_missAlignedTarget_2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
   assign _zz__zz_execute_BranchPlugin_missAlignedTarget_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
   assign _zz__zz_execute_BranchPlugin_missAlignedTarget_6 = {_zz_execute_BranchPlugin_missAlignedTarget_1,execute_INSTRUCTION[31 : 20]};
@@ -1369,7 +1369,7 @@ module VexRiscv (
   assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code & (~ _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1));
   assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code - 2'b01);
   assign _zz_writeBack_MulPlugin_result = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
-  assign _zz_writeBack_MulPlugin_result_1 = ({32'd0,writeBack_MUL_HH} <<< 32);
+  assign _zz_writeBack_MulPlugin_result_1 = ({32'd0,writeBack_MUL_HH} <<< 6'd32);
   assign _zz__zz_decode_RS2_2 = writeBack_MUL_LOW[31 : 0];
   assign _zz__zz_decode_RS2_2_1 = writeBack_MulPlugin_result[63 : 32];
   assign _zz_memory_DivPlugin_div_counter_valueNext_1 = memory_DivPlugin_div_counter_willIncrement;
@@ -1387,30 +1387,30 @@ module VexRiscv (
   assign _zz_memory_DivPlugin_rs1_2 = {32'd0, _zz_memory_DivPlugin_rs1_3};
   assign _zz_memory_DivPlugin_rs2_2 = _zz_memory_DivPlugin_rs2;
   assign _zz_memory_DivPlugin_rs2_1 = {31'd0, _zz_memory_DivPlugin_rs2_2};
-  assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 5);
+  assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 3'd5);
   assign _zz_decode_RegFilePlugin_rs1Data = 1'b1;
   assign _zz_decode_RegFilePlugin_rs2Data = 1'b1;
   assign _zz_IBusCachedPlugin_jump_pcLoad_payload_6 = {_zz_IBusCachedPlugin_jump_pcLoad_payload_4,_zz_IBusCachedPlugin_jump_pcLoad_payload_3};
   assign _zz_writeBack_DBusCachedPlugin_rspShifted_1 = dataCache_1_io_cpu_writeBack_address[1 : 0];
   assign _zz_writeBack_DBusCachedPlugin_rspShifted_3 = dataCache_1_io_cpu_writeBack_address[1 : 1];
-  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000107f;
-  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00002073;
-  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000207f;
+  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000407f);
+  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00004063;
+  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000107f) == 32'h00000013);
   assign _zz_decode_LEGAL_INSTRUCTION_5 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_6) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_7 == _zz_decode_LEGAL_INSTRUCTION_8),{_zz_decode_LEGAL_INSTRUCTION_9,{_zz_decode_LEGAL_INSTRUCTION_10,_zz_decode_LEGAL_INSTRUCTION_11}}}}}};
   assign _zz_decode_LEGAL_INSTRUCTION_6 = 32'h0000505f;
   assign _zz_decode_LEGAL_INSTRUCTION_7 = (decode_INSTRUCTION & 32'h0000707b);
   assign _zz_decode_LEGAL_INSTRUCTION_8 = 32'h00000063;
   assign _zz_decode_LEGAL_INSTRUCTION_9 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
   assign _zz_decode_LEGAL_INSTRUCTION_10 = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
-  assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h00001013),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,{_zz_decode_LEGAL_INSTRUCTION_16,_zz_decode_LEGAL_INSTRUCTION_17}}}}}};
-  assign _zz_decode_LEGAL_INSTRUCTION_12 = 32'hfc00307f;
+  assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & 32'hbe00705f) == 32'h00005013),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h00001013),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,{_zz_decode_LEGAL_INSTRUCTION_16,_zz_decode_LEGAL_INSTRUCTION_17}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_12 = 32'hfe00305f;
   assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'hbe00707f);
-  assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h00005033;
-  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
-  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
-  assign _zz_decode_LEGAL_INSTRUCTION_17 = {((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073),((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073)};
+  assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h00000033;
+  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
+  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073);
+  assign _zz_decode_LEGAL_INSTRUCTION_17 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073);
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_4 = decode_INSTRUCTION[31];
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_5 = decode_INSTRUCTION[31];
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_6 = decode_INSTRUCTION[7];
@@ -1420,133 +1420,130 @@ module VexRiscv (
   assign _zz__zz_decode_IS_RS2_SIGNED_3 = ((decode_INSTRUCTION & 32'h10003050) == 32'h00000050);
   assign _zz__zz_decode_IS_RS2_SIGNED_4 = (|((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_5) == 32'h10000050));
   assign _zz__zz_decode_IS_RS2_SIGNED_6 = (|{_zz__zz_decode_IS_RS2_SIGNED_7,_zz__zz_decode_IS_RS2_SIGNED_8});
-  assign _zz__zz_decode_IS_RS2_SIGNED_9 = {(|{_zz__zz_decode_IS_RS2_SIGNED_10,_zz__zz_decode_IS_RS2_SIGNED_11}),{(|_zz__zz_decode_IS_RS2_SIGNED_13),{_zz__zz_decode_IS_RS2_SIGNED_15,{_zz__zz_decode_IS_RS2_SIGNED_18,_zz__zz_decode_IS_RS2_SIGNED_26}}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_9 = {(|{_zz__zz_decode_IS_RS2_SIGNED_10,_zz__zz_decode_IS_RS2_SIGNED_11}),{(|_zz__zz_decode_IS_RS2_SIGNED_13),{_zz__zz_decode_IS_RS2_SIGNED_15,{_zz__zz_decode_IS_RS2_SIGNED_18,_zz__zz_decode_IS_RS2_SIGNED_21}}}};
   assign _zz__zz_decode_IS_RS2_SIGNED_5 = 32'h10403050;
   assign _zz__zz_decode_IS_RS2_SIGNED_7 = ((decode_INSTRUCTION & 32'h00001050) == 32'h00001050);
   assign _zz__zz_decode_IS_RS2_SIGNED_8 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002050);
   assign _zz__zz_decode_IS_RS2_SIGNED_10 = _zz_decode_IS_RS2_SIGNED_4;
   assign _zz__zz_decode_IS_RS2_SIGNED_11 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_12) == 32'h00000004);
   assign _zz__zz_decode_IS_RS2_SIGNED_13 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_14) == 32'h00000040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_15 = (|{_zz__zz_decode_IS_RS2_SIGNED_16,_zz__zz_decode_IS_RS2_SIGNED_17});
-  assign _zz__zz_decode_IS_RS2_SIGNED_18 = (|{_zz__zz_decode_IS_RS2_SIGNED_19,_zz__zz_decode_IS_RS2_SIGNED_21});
-  assign _zz__zz_decode_IS_RS2_SIGNED_26 = {(|_zz__zz_decode_IS_RS2_SIGNED_27),{_zz__zz_decode_IS_RS2_SIGNED_29,{_zz__zz_decode_IS_RS2_SIGNED_32,_zz__zz_decode_IS_RS2_SIGNED_34}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_15 = (|(_zz__zz_decode_IS_RS2_SIGNED_16 == _zz__zz_decode_IS_RS2_SIGNED_17));
+  assign _zz__zz_decode_IS_RS2_SIGNED_18 = (|{_zz__zz_decode_IS_RS2_SIGNED_19,_zz__zz_decode_IS_RS2_SIGNED_20});
+  assign _zz__zz_decode_IS_RS2_SIGNED_21 = {(|_zz__zz_decode_IS_RS2_SIGNED_22),{_zz__zz_decode_IS_RS2_SIGNED_23,{_zz__zz_decode_IS_RS2_SIGNED_25,_zz__zz_decode_IS_RS2_SIGNED_28}}};
   assign _zz__zz_decode_IS_RS2_SIGNED_12 = 32'h0000001c;
   assign _zz__zz_decode_IS_RS2_SIGNED_14 = 32'h00000058;
-  assign _zz__zz_decode_IS_RS2_SIGNED_16 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00005010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_17 = ((decode_INSTRUCTION & 32'h02007064) == 32'h00005020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_19 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_20) == 32'h40001010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_21 = {(_zz__zz_decode_IS_RS2_SIGNED_22 == _zz__zz_decode_IS_RS2_SIGNED_23),(_zz__zz_decode_IS_RS2_SIGNED_24 == _zz__zz_decode_IS_RS2_SIGNED_25)};
-  assign _zz__zz_decode_IS_RS2_SIGNED_27 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_28) == 32'h00000024);
-  assign _zz__zz_decode_IS_RS2_SIGNED_29 = (|(_zz__zz_decode_IS_RS2_SIGNED_30 == _zz__zz_decode_IS_RS2_SIGNED_31));
-  assign _zz__zz_decode_IS_RS2_SIGNED_32 = (|_zz__zz_decode_IS_RS2_SIGNED_33);
-  assign _zz__zz_decode_IS_RS2_SIGNED_34 = {(|_zz__zz_decode_IS_RS2_SIGNED_35),{_zz__zz_decode_IS_RS2_SIGNED_38,{_zz__zz_decode_IS_RS2_SIGNED_40,_zz__zz_decode_IS_RS2_SIGNED_43}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_20 = 32'h40003054;
-  assign _zz__zz_decode_IS_RS2_SIGNED_22 = (decode_INSTRUCTION & 32'h00007034);
-  assign _zz__zz_decode_IS_RS2_SIGNED_23 = 32'h00001010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_24 = (decode_INSTRUCTION & 32'h02007054);
-  assign _zz__zz_decode_IS_RS2_SIGNED_25 = 32'h00001010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_28 = 32'h00000064;
-  assign _zz__zz_decode_IS_RS2_SIGNED_30 = (decode_INSTRUCTION & 32'h00001000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_31 = 32'h00001000;
-  assign _zz__zz_decode_IS_RS2_SIGNED_33 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_35 = {((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_36) == 32'h00002000),((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_37) == 32'h00001000)};
-  assign _zz__zz_decode_IS_RS2_SIGNED_38 = (|((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_39) == 32'h00004008));
-  assign _zz__zz_decode_IS_RS2_SIGNED_40 = (|{_zz__zz_decode_IS_RS2_SIGNED_41,_zz__zz_decode_IS_RS2_SIGNED_42});
-  assign _zz__zz_decode_IS_RS2_SIGNED_43 = {(|{_zz__zz_decode_IS_RS2_SIGNED_44,_zz__zz_decode_IS_RS2_SIGNED_46}),{(|_zz__zz_decode_IS_RS2_SIGNED_49),{_zz__zz_decode_IS_RS2_SIGNED_51,{_zz__zz_decode_IS_RS2_SIGNED_61,_zz__zz_decode_IS_RS2_SIGNED_74}}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_36 = 32'h00002010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_37 = 32'h00005000;
-  assign _zz__zz_decode_IS_RS2_SIGNED_39 = 32'h00004048;
-  assign _zz__zz_decode_IS_RS2_SIGNED_41 = ((decode_INSTRUCTION & 32'h00000034) == 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_42 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_44 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_45) == 32'h00000040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_46 = {_zz_decode_IS_RS2_SIGNED_2,(_zz__zz_decode_IS_RS2_SIGNED_47 == _zz__zz_decode_IS_RS2_SIGNED_48)};
-  assign _zz__zz_decode_IS_RS2_SIGNED_49 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_50) == 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_51 = (|{_zz__zz_decode_IS_RS2_SIGNED_52,{_zz__zz_decode_IS_RS2_SIGNED_53,_zz__zz_decode_IS_RS2_SIGNED_54}});
-  assign _zz__zz_decode_IS_RS2_SIGNED_61 = (|{_zz__zz_decode_IS_RS2_SIGNED_62,_zz__zz_decode_IS_RS2_SIGNED_63});
-  assign _zz__zz_decode_IS_RS2_SIGNED_74 = {(|_zz__zz_decode_IS_RS2_SIGNED_75),{_zz__zz_decode_IS_RS2_SIGNED_87,{_zz__zz_decode_IS_RS2_SIGNED_90,_zz__zz_decode_IS_RS2_SIGNED_95}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_45 = 32'h00000050;
-  assign _zz__zz_decode_IS_RS2_SIGNED_47 = (decode_INSTRUCTION & 32'h00403040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_48 = 32'h00000040;
-  assign _zz__zz_decode_IS_RS2_SIGNED_50 = 32'h00000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_52 = ((decode_INSTRUCTION & 32'h00000040) == 32'h00000040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_53 = _zz_decode_IS_RS2_SIGNED_3;
-  assign _zz__zz_decode_IS_RS2_SIGNED_54 = {(_zz__zz_decode_IS_RS2_SIGNED_55 == _zz__zz_decode_IS_RS2_SIGNED_56),{_zz__zz_decode_IS_RS2_SIGNED_57,_zz__zz_decode_IS_RS2_SIGNED_59}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_62 = _zz_decode_IS_RS2_SIGNED_3;
-  assign _zz__zz_decode_IS_RS2_SIGNED_63 = {(_zz__zz_decode_IS_RS2_SIGNED_64 == _zz__zz_decode_IS_RS2_SIGNED_65),{_zz__zz_decode_IS_RS2_SIGNED_66,{_zz__zz_decode_IS_RS2_SIGNED_68,_zz__zz_decode_IS_RS2_SIGNED_71}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_75 = {_zz_decode_IS_RS2_SIGNED_4,{_zz__zz_decode_IS_RS2_SIGNED_76,{_zz__zz_decode_IS_RS2_SIGNED_78,_zz__zz_decode_IS_RS2_SIGNED_81}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_87 = (|{_zz_decode_IS_RS2_SIGNED_3,_zz__zz_decode_IS_RS2_SIGNED_88});
-  assign _zz__zz_decode_IS_RS2_SIGNED_90 = (|{_zz__zz_decode_IS_RS2_SIGNED_91,_zz__zz_decode_IS_RS2_SIGNED_92});
-  assign _zz__zz_decode_IS_RS2_SIGNED_95 = {(|_zz__zz_decode_IS_RS2_SIGNED_96),{_zz__zz_decode_IS_RS2_SIGNED_99,{_zz__zz_decode_IS_RS2_SIGNED_101,_zz__zz_decode_IS_RS2_SIGNED_112}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_55 = (decode_INSTRUCTION & 32'h00004020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_56 = 32'h00004020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_57 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_58) == 32'h00000010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_59 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_60) == 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_64 = (decode_INSTRUCTION & 32'h00002030);
-  assign _zz__zz_decode_IS_RS2_SIGNED_65 = 32'h00002010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_66 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_67) == 32'h00000010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_68 = (_zz__zz_decode_IS_RS2_SIGNED_69 == _zz__zz_decode_IS_RS2_SIGNED_70);
-  assign _zz__zz_decode_IS_RS2_SIGNED_71 = (_zz__zz_decode_IS_RS2_SIGNED_72 == _zz__zz_decode_IS_RS2_SIGNED_73);
-  assign _zz__zz_decode_IS_RS2_SIGNED_76 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_77) == 32'h00001010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_78 = (_zz__zz_decode_IS_RS2_SIGNED_79 == _zz__zz_decode_IS_RS2_SIGNED_80);
-  assign _zz__zz_decode_IS_RS2_SIGNED_81 = {_zz__zz_decode_IS_RS2_SIGNED_82,{_zz__zz_decode_IS_RS2_SIGNED_83,_zz__zz_decode_IS_RS2_SIGNED_85}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_88 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_89) == 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_91 = _zz_decode_IS_RS2_SIGNED_3;
+  assign _zz__zz_decode_IS_RS2_SIGNED_16 = (decode_INSTRUCTION & 32'h02007054);
+  assign _zz__zz_decode_IS_RS2_SIGNED_17 = 32'h00005010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_19 = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_20 = ((decode_INSTRUCTION & 32'h02007054) == 32'h00001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_22 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
+  assign _zz__zz_decode_IS_RS2_SIGNED_23 = (|((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_24) == 32'h00001000));
+  assign _zz__zz_decode_IS_RS2_SIGNED_25 = (|(_zz__zz_decode_IS_RS2_SIGNED_26 == _zz__zz_decode_IS_RS2_SIGNED_27));
+  assign _zz__zz_decode_IS_RS2_SIGNED_28 = {(|{_zz__zz_decode_IS_RS2_SIGNED_29,_zz__zz_decode_IS_RS2_SIGNED_30}),{(|_zz__zz_decode_IS_RS2_SIGNED_31),{_zz__zz_decode_IS_RS2_SIGNED_32,{_zz__zz_decode_IS_RS2_SIGNED_37,_zz__zz_decode_IS_RS2_SIGNED_42}}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_24 = 32'h00001000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_26 = (decode_INSTRUCTION & 32'h00003000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_27 = 32'h00002000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_29 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_30 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00001000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_31 = ((decode_INSTRUCTION & 32'h00004048) == 32'h00004008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_32 = (|{(_zz__zz_decode_IS_RS2_SIGNED_33 == _zz__zz_decode_IS_RS2_SIGNED_34),(_zz__zz_decode_IS_RS2_SIGNED_35 == _zz__zz_decode_IS_RS2_SIGNED_36)});
+  assign _zz__zz_decode_IS_RS2_SIGNED_37 = (|{_zz__zz_decode_IS_RS2_SIGNED_38,{_zz__zz_decode_IS_RS2_SIGNED_39,_zz__zz_decode_IS_RS2_SIGNED_40}});
+  assign _zz__zz_decode_IS_RS2_SIGNED_42 = {(|_zz__zz_decode_IS_RS2_SIGNED_43),{(|_zz__zz_decode_IS_RS2_SIGNED_44),{_zz__zz_decode_IS_RS2_SIGNED_55,{_zz__zz_decode_IS_RS2_SIGNED_68,_zz__zz_decode_IS_RS2_SIGNED_82}}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_33 = (decode_INSTRUCTION & 32'h00000034);
+  assign _zz__zz_decode_IS_RS2_SIGNED_34 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_35 = (decode_INSTRUCTION & 32'h00000064);
+  assign _zz__zz_decode_IS_RS2_SIGNED_36 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_38 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_39 = _zz_decode_IS_RS2_SIGNED_2;
+  assign _zz__zz_decode_IS_RS2_SIGNED_40 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_41) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_43 = ((decode_INSTRUCTION & 32'h00000020) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_44 = {(_zz__zz_decode_IS_RS2_SIGNED_45 == _zz__zz_decode_IS_RS2_SIGNED_46),{_zz_decode_IS_RS2_SIGNED_3,{_zz__zz_decode_IS_RS2_SIGNED_47,_zz__zz_decode_IS_RS2_SIGNED_50}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_55 = (|{_zz_decode_IS_RS2_SIGNED_3,{_zz__zz_decode_IS_RS2_SIGNED_56,_zz__zz_decode_IS_RS2_SIGNED_59}});
+  assign _zz__zz_decode_IS_RS2_SIGNED_68 = (|{_zz__zz_decode_IS_RS2_SIGNED_69,_zz__zz_decode_IS_RS2_SIGNED_70});
+  assign _zz__zz_decode_IS_RS2_SIGNED_82 = {(|_zz__zz_decode_IS_RS2_SIGNED_83),{_zz__zz_decode_IS_RS2_SIGNED_86,{_zz__zz_decode_IS_RS2_SIGNED_91,_zz__zz_decode_IS_RS2_SIGNED_95}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_41 = 32'h00403040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_45 = (decode_INSTRUCTION & 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_46 = 32'h00000040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_47 = (_zz__zz_decode_IS_RS2_SIGNED_48 == _zz__zz_decode_IS_RS2_SIGNED_49);
+  assign _zz__zz_decode_IS_RS2_SIGNED_50 = {_zz__zz_decode_IS_RS2_SIGNED_51,_zz__zz_decode_IS_RS2_SIGNED_53};
+  assign _zz__zz_decode_IS_RS2_SIGNED_56 = (_zz__zz_decode_IS_RS2_SIGNED_57 == _zz__zz_decode_IS_RS2_SIGNED_58);
+  assign _zz__zz_decode_IS_RS2_SIGNED_59 = {_zz__zz_decode_IS_RS2_SIGNED_60,{_zz__zz_decode_IS_RS2_SIGNED_62,_zz__zz_decode_IS_RS2_SIGNED_65}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_69 = _zz_decode_IS_RS2_SIGNED_4;
+  assign _zz__zz_decode_IS_RS2_SIGNED_70 = {_zz__zz_decode_IS_RS2_SIGNED_71,{_zz__zz_decode_IS_RS2_SIGNED_73,_zz__zz_decode_IS_RS2_SIGNED_76}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_83 = {_zz_decode_IS_RS2_SIGNED_3,_zz__zz_decode_IS_RS2_SIGNED_84};
+  assign _zz__zz_decode_IS_RS2_SIGNED_86 = (|{_zz__zz_decode_IS_RS2_SIGNED_87,_zz__zz_decode_IS_RS2_SIGNED_88});
+  assign _zz__zz_decode_IS_RS2_SIGNED_91 = (|_zz__zz_decode_IS_RS2_SIGNED_92);
+  assign _zz__zz_decode_IS_RS2_SIGNED_95 = {_zz__zz_decode_IS_RS2_SIGNED_96,{_zz__zz_decode_IS_RS2_SIGNED_98,_zz__zz_decode_IS_RS2_SIGNED_109}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_48 = (decode_INSTRUCTION & 32'h00004020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_49 = 32'h00004020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_51 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_52) == 32'h00000010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_53 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_54) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_57 = (decode_INSTRUCTION & 32'h00002030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_58 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_60 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_61) == 32'h00000010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_62 = (_zz__zz_decode_IS_RS2_SIGNED_63 == _zz__zz_decode_IS_RS2_SIGNED_64);
+  assign _zz__zz_decode_IS_RS2_SIGNED_65 = (_zz__zz_decode_IS_RS2_SIGNED_66 == _zz__zz_decode_IS_RS2_SIGNED_67);
+  assign _zz__zz_decode_IS_RS2_SIGNED_71 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_72) == 32'h00001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_73 = (_zz__zz_decode_IS_RS2_SIGNED_74 == _zz__zz_decode_IS_RS2_SIGNED_75);
+  assign _zz__zz_decode_IS_RS2_SIGNED_76 = {_zz__zz_decode_IS_RS2_SIGNED_77,{_zz__zz_decode_IS_RS2_SIGNED_78,_zz__zz_decode_IS_RS2_SIGNED_80}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_84 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_85) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_87 = _zz_decode_IS_RS2_SIGNED_3;
+  assign _zz__zz_decode_IS_RS2_SIGNED_88 = (_zz__zz_decode_IS_RS2_SIGNED_89 == _zz__zz_decode_IS_RS2_SIGNED_90);
   assign _zz__zz_decode_IS_RS2_SIGNED_92 = (_zz__zz_decode_IS_RS2_SIGNED_93 == _zz__zz_decode_IS_RS2_SIGNED_94);
-  assign _zz__zz_decode_IS_RS2_SIGNED_96 = (_zz__zz_decode_IS_RS2_SIGNED_97 == _zz__zz_decode_IS_RS2_SIGNED_98);
-  assign _zz__zz_decode_IS_RS2_SIGNED_99 = (|_zz__zz_decode_IS_RS2_SIGNED_100);
-  assign _zz__zz_decode_IS_RS2_SIGNED_101 = (|_zz__zz_decode_IS_RS2_SIGNED_102);
-  assign _zz__zz_decode_IS_RS2_SIGNED_112 = {_zz__zz_decode_IS_RS2_SIGNED_113,{_zz__zz_decode_IS_RS2_SIGNED_116,_zz__zz_decode_IS_RS2_SIGNED_124}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_58 = 32'h00000030;
-  assign _zz__zz_decode_IS_RS2_SIGNED_60 = 32'h02000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_67 = 32'h00001030;
-  assign _zz__zz_decode_IS_RS2_SIGNED_69 = (decode_INSTRUCTION & 32'h02002060);
-  assign _zz__zz_decode_IS_RS2_SIGNED_70 = 32'h00002020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_72 = (decode_INSTRUCTION & 32'h02003020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_73 = 32'h00000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_77 = 32'h00001010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_79 = (decode_INSTRUCTION & 32'h00002010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_80 = 32'h00002010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_82 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_83 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_84) == 32'h00000004);
-  assign _zz__zz_decode_IS_RS2_SIGNED_85 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_86) == 32'h0);
-  assign _zz__zz_decode_IS_RS2_SIGNED_89 = 32'h00000070;
-  assign _zz__zz_decode_IS_RS2_SIGNED_93 = (decode_INSTRUCTION & 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_94 = 32'h0;
-  assign _zz__zz_decode_IS_RS2_SIGNED_97 = (decode_INSTRUCTION & 32'h00004014);
-  assign _zz__zz_decode_IS_RS2_SIGNED_98 = 32'h00004010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_100 = ((decode_INSTRUCTION & 32'h00006014) == 32'h00002010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_102 = {(_zz__zz_decode_IS_RS2_SIGNED_103 == _zz__zz_decode_IS_RS2_SIGNED_104),{_zz_decode_IS_RS2_SIGNED_2,{_zz__zz_decode_IS_RS2_SIGNED_105,_zz__zz_decode_IS_RS2_SIGNED_107}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_113 = (|(_zz__zz_decode_IS_RS2_SIGNED_114 == _zz__zz_decode_IS_RS2_SIGNED_115));
-  assign _zz__zz_decode_IS_RS2_SIGNED_116 = (|{_zz__zz_decode_IS_RS2_SIGNED_117,_zz__zz_decode_IS_RS2_SIGNED_119});
-  assign _zz__zz_decode_IS_RS2_SIGNED_124 = {(|_zz__zz_decode_IS_RS2_SIGNED_125),{_zz__zz_decode_IS_RS2_SIGNED_128,_zz__zz_decode_IS_RS2_SIGNED_130}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_84 = 32'h0000000c;
-  assign _zz__zz_decode_IS_RS2_SIGNED_86 = 32'h00000028;
-  assign _zz__zz_decode_IS_RS2_SIGNED_103 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz__zz_decode_IS_RS2_SIGNED_104 = 32'h0;
-  assign _zz__zz_decode_IS_RS2_SIGNED_105 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_106) == 32'h00002000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_107 = {(_zz__zz_decode_IS_RS2_SIGNED_108 == _zz__zz_decode_IS_RS2_SIGNED_109),(_zz__zz_decode_IS_RS2_SIGNED_110 == _zz__zz_decode_IS_RS2_SIGNED_111)};
-  assign _zz__zz_decode_IS_RS2_SIGNED_114 = (decode_INSTRUCTION & 32'h00000058);
-  assign _zz__zz_decode_IS_RS2_SIGNED_115 = 32'h0;
-  assign _zz__zz_decode_IS_RS2_SIGNED_117 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_118) == 32'h00000040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_119 = {(_zz__zz_decode_IS_RS2_SIGNED_120 == _zz__zz_decode_IS_RS2_SIGNED_121),(_zz__zz_decode_IS_RS2_SIGNED_122 == _zz__zz_decode_IS_RS2_SIGNED_123)};
-  assign _zz__zz_decode_IS_RS2_SIGNED_125 = {(_zz__zz_decode_IS_RS2_SIGNED_126 == _zz__zz_decode_IS_RS2_SIGNED_127),_zz_decode_IS_RS2_SIGNED_1};
-  assign _zz__zz_decode_IS_RS2_SIGNED_128 = (|{_zz__zz_decode_IS_RS2_SIGNED_129,_zz_decode_IS_RS2_SIGNED_1});
-  assign _zz__zz_decode_IS_RS2_SIGNED_130 = (|(_zz__zz_decode_IS_RS2_SIGNED_131 == _zz__zz_decode_IS_RS2_SIGNED_132));
-  assign _zz__zz_decode_IS_RS2_SIGNED_106 = 32'h00006004;
-  assign _zz__zz_decode_IS_RS2_SIGNED_108 = (decode_INSTRUCTION & 32'h00005004);
-  assign _zz__zz_decode_IS_RS2_SIGNED_109 = 32'h00001000;
-  assign _zz__zz_decode_IS_RS2_SIGNED_110 = (decode_INSTRUCTION & 32'h00004050);
-  assign _zz__zz_decode_IS_RS2_SIGNED_111 = 32'h00004000;
-  assign _zz__zz_decode_IS_RS2_SIGNED_118 = 32'h00000044;
-  assign _zz__zz_decode_IS_RS2_SIGNED_120 = (decode_INSTRUCTION & 32'h00002014);
-  assign _zz__zz_decode_IS_RS2_SIGNED_121 = 32'h00002010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_122 = (decode_INSTRUCTION & 32'h40000034);
-  assign _zz__zz_decode_IS_RS2_SIGNED_123 = 32'h40000030;
-  assign _zz__zz_decode_IS_RS2_SIGNED_126 = (decode_INSTRUCTION & 32'h00000014);
-  assign _zz__zz_decode_IS_RS2_SIGNED_127 = 32'h00000004;
-  assign _zz__zz_decode_IS_RS2_SIGNED_129 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000004);
-  assign _zz__zz_decode_IS_RS2_SIGNED_131 = (decode_INSTRUCTION & 32'h00005048);
-  assign _zz__zz_decode_IS_RS2_SIGNED_132 = 32'h00001008;
+  assign _zz__zz_decode_IS_RS2_SIGNED_96 = (|_zz__zz_decode_IS_RS2_SIGNED_97);
+  assign _zz__zz_decode_IS_RS2_SIGNED_98 = (|_zz__zz_decode_IS_RS2_SIGNED_99);
+  assign _zz__zz_decode_IS_RS2_SIGNED_109 = {_zz__zz_decode_IS_RS2_SIGNED_110,{_zz__zz_decode_IS_RS2_SIGNED_113,_zz__zz_decode_IS_RS2_SIGNED_121}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_52 = 32'h00000030;
+  assign _zz__zz_decode_IS_RS2_SIGNED_54 = 32'h02000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_61 = 32'h00001030;
+  assign _zz__zz_decode_IS_RS2_SIGNED_63 = (decode_INSTRUCTION & 32'h02002060);
+  assign _zz__zz_decode_IS_RS2_SIGNED_64 = 32'h00002020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_66 = (decode_INSTRUCTION & 32'h02003020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_67 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_72 = 32'h00001010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_74 = (decode_INSTRUCTION & 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_75 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_77 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_78 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_79) == 32'h00000004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_80 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_81) == 32'h00000000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_85 = 32'h00000070;
+  assign _zz__zz_decode_IS_RS2_SIGNED_89 = (decode_INSTRUCTION & 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_90 = 32'h00000000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_93 = (decode_INSTRUCTION & 32'h00004014);
+  assign _zz__zz_decode_IS_RS2_SIGNED_94 = 32'h00004010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_97 = ((decode_INSTRUCTION & 32'h00006014) == 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_99 = {(_zz__zz_decode_IS_RS2_SIGNED_100 == _zz__zz_decode_IS_RS2_SIGNED_101),{_zz_decode_IS_RS2_SIGNED_2,{_zz__zz_decode_IS_RS2_SIGNED_102,_zz__zz_decode_IS_RS2_SIGNED_104}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_110 = (|(_zz__zz_decode_IS_RS2_SIGNED_111 == _zz__zz_decode_IS_RS2_SIGNED_112));
+  assign _zz__zz_decode_IS_RS2_SIGNED_113 = (|{_zz__zz_decode_IS_RS2_SIGNED_114,_zz__zz_decode_IS_RS2_SIGNED_116});
+  assign _zz__zz_decode_IS_RS2_SIGNED_121 = {(|_zz__zz_decode_IS_RS2_SIGNED_122),{_zz__zz_decode_IS_RS2_SIGNED_125,_zz__zz_decode_IS_RS2_SIGNED_127}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_79 = 32'h0000000c;
+  assign _zz__zz_decode_IS_RS2_SIGNED_81 = 32'h00000028;
+  assign _zz__zz_decode_IS_RS2_SIGNED_100 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz__zz_decode_IS_RS2_SIGNED_101 = 32'h00000000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_102 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_103) == 32'h00002000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_104 = {(_zz__zz_decode_IS_RS2_SIGNED_105 == _zz__zz_decode_IS_RS2_SIGNED_106),(_zz__zz_decode_IS_RS2_SIGNED_107 == _zz__zz_decode_IS_RS2_SIGNED_108)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_111 = (decode_INSTRUCTION & 32'h00000058);
+  assign _zz__zz_decode_IS_RS2_SIGNED_112 = 32'h00000000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_114 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_115) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_116 = {(_zz__zz_decode_IS_RS2_SIGNED_117 == _zz__zz_decode_IS_RS2_SIGNED_118),(_zz__zz_decode_IS_RS2_SIGNED_119 == _zz__zz_decode_IS_RS2_SIGNED_120)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_122 = {(_zz__zz_decode_IS_RS2_SIGNED_123 == _zz__zz_decode_IS_RS2_SIGNED_124),_zz_decode_IS_RS2_SIGNED_1};
+  assign _zz__zz_decode_IS_RS2_SIGNED_125 = (|{_zz__zz_decode_IS_RS2_SIGNED_126,_zz_decode_IS_RS2_SIGNED_1});
+  assign _zz__zz_decode_IS_RS2_SIGNED_127 = (|(_zz__zz_decode_IS_RS2_SIGNED_128 == _zz__zz_decode_IS_RS2_SIGNED_129));
+  assign _zz__zz_decode_IS_RS2_SIGNED_103 = 32'h00006004;
+  assign _zz__zz_decode_IS_RS2_SIGNED_105 = (decode_INSTRUCTION & 32'h00005004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_106 = 32'h00001000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_107 = (decode_INSTRUCTION & 32'h00004050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_108 = 32'h00004000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_115 = 32'h00000044;
+  assign _zz__zz_decode_IS_RS2_SIGNED_117 = (decode_INSTRUCTION & 32'h00002014);
+  assign _zz__zz_decode_IS_RS2_SIGNED_118 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_119 = (decode_INSTRUCTION & 32'h40000034);
+  assign _zz__zz_decode_IS_RS2_SIGNED_120 = 32'h40000030;
+  assign _zz__zz_decode_IS_RS2_SIGNED_123 = (decode_INSTRUCTION & 32'h00000014);
+  assign _zz__zz_decode_IS_RS2_SIGNED_124 = 32'h00000004;
+  assign _zz__zz_decode_IS_RS2_SIGNED_126 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_128 = (decode_INSTRUCTION & 32'h00005048);
+  assign _zz__zz_decode_IS_RS2_SIGNED_129 = 32'h00001008;
   assign _zz_execute_BranchPlugin_branch_src2_6 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_7 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_8 = execute_INSTRUCTION[7];
@@ -1659,8 +1656,9 @@ module VexRiscv (
     .io_cpu_flush_ready                     (dataCache_1_io_cpu_flush_ready                   ), //o
     .io_cpu_flush_payload_singleLine        (dataCache_1_io_cpu_flush_payload_singleLine      ), //i
     .io_cpu_flush_payload_lineId            (dataCache_1_io_cpu_flush_payload_lineId[6:0]     ), //i
+    .io_cpu_writesPending                   (dataCache_1_io_cpu_writesPending                 ), //o
     .io_mem_cmd_valid                       (dataCache_1_io_mem_cmd_valid                     ), //o
-    .io_mem_cmd_ready                       (dataCache_1_io_mem_cmd_ready                     ), //i
+    .io_mem_cmd_ready                       (toplevel_dataCache_1_io_mem_cmd_rValidN          ), //i
     .io_mem_cmd_payload_wr                  (dataCache_1_io_mem_cmd_payload_wr                ), //o
     .io_mem_cmd_payload_uncached            (dataCache_1_io_mem_cmd_payload_uncached          ), //o
     .io_mem_cmd_payload_address             (dataCache_1_io_mem_cmd_payload_address[31:0]     ), //o
@@ -2368,7 +2366,7 @@ module VexRiscv (
   end
   `endif
 
-  assign memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW) + $signed(_zz_memory_MUL_LOW_7));
+  assign memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW) + $signed(_zz_memory_MUL_LOW_6));
   assign memory_MUL_HH = execute_to_memory_MUL_HH;
   assign execute_MUL_HH = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bHigh));
   assign execute_MUL_HL = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bSLow));
@@ -2381,7 +2379,7 @@ module VexRiscv (
   assign memory_MEMORY_STORE_DATA_RF = execute_to_memory_MEMORY_STORE_DATA_RF;
   assign execute_MEMORY_STORE_DATA_RF = _zz_execute_MEMORY_STORE_DATA_RF;
   assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
-  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
+  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h00)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h00))));
   assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
   assign decode_IS_RS2_SIGNED = _zz_decode_IS_RS2_SIGNED[31];
@@ -2446,7 +2444,7 @@ module VexRiscv (
   assign decode_RS1_USE = _zz_decode_IS_RS2_SIGNED[5];
   always @(*) begin
     _zz_decode_RS2 = execute_REGFILE_WRITE_DATA;
-    if(when_CsrPlugin_l1189) begin
+    if(when_CsrPlugin_l1587) begin
       _zz_decode_RS2 = CsrPlugin_csrMapping_readDataSignal;
     end
   end
@@ -2542,7 +2540,7 @@ module VexRiscv (
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_execute_SRC2 = execute_PC;
+  assign _zz_execute_to_memory_PC = execute_PC;
   assign execute_SRC2_CTRL = _zz_execute_SRC2_CTRL;
   assign execute_SRC1_CTRL = _zz_execute_SRC1_CTRL;
   assign decode_SRC_USE_SUB_LESS = _zz_decode_IS_RS2_SIGNED[3];
@@ -2550,7 +2548,7 @@ module VexRiscv (
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
   assign execute_ALU_CTRL = _zz_execute_ALU_CTRL;
-  assign execute_SRC2 = _zz_execute_SRC2_5;
+  assign execute_SRC2 = _zz_execute_SRC2_4;
   assign execute_SRC1 = _zz_execute_SRC1;
   assign execute_ALU_BITWISE_CTRL = _zz_execute_ALU_BITWISE_CTRL;
   assign _zz_lastStageRegFileWrite_payload_address = writeBack_INSTRUCTION;
@@ -2570,10 +2568,10 @@ module VexRiscv (
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00001073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
+  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000107f) == 32'h00001073),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00002073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
   always @(*) begin
     _zz_decode_RS2_2 = writeBack_REGFILE_WRITE_DATA;
-    if(when_DBusCachedPlugin_l492) begin
+    if(when_DBusCachedPlugin_l580) begin
       _zz_decode_RS2_2 = writeBack_DBusCachedPlugin_rspFormated;
     end
     if(when_MulPlugin_l147) begin
@@ -2606,28 +2604,28 @@ module VexRiscv (
   assign decode_FLUSH_ALL = _zz_decode_IS_RS2_SIGNED[0];
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_4 = IBusCachedPlugin_rsp_issueDetected_3;
-    if(when_IBusCachedPlugin_l256) begin
+    if(when_IBusCachedPlugin_l262) begin
       IBusCachedPlugin_rsp_issueDetected_4 = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_3 = IBusCachedPlugin_rsp_issueDetected_2;
-    if(when_IBusCachedPlugin_l250) begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_rsp_issueDetected_3 = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
-    if(when_IBusCachedPlugin_l244) begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
-    if(when_IBusCachedPlugin_l239) begin
+    if(when_IBusCachedPlugin_l245) begin
       IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
@@ -2653,7 +2651,7 @@ module VexRiscv (
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
   always @(*) begin
     decode_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l308) begin
+    if(when_DBusCachedPlugin_l352) begin
       decode_arbitration_haltItself = 1'b1;
     end
   end
@@ -2666,7 +2664,7 @@ module VexRiscv (
     if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(when_CsrPlugin_l1129) begin
+    if(when_CsrPlugin_l1527) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
@@ -2694,10 +2692,10 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l350) begin
+    if(when_DBusCachedPlugin_l394) begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(when_CsrPlugin_l1193) begin
+    if(when_CsrPlugin_l1591) begin
       if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
@@ -2706,7 +2704,7 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if(when_DBusCachedPlugin_l366) begin
+    if(when_DBusCachedPlugin_l410) begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
@@ -2762,7 +2760,7 @@ module VexRiscv (
 
   always @(*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l466) begin
+    if(when_DBusCachedPlugin_l553) begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
@@ -2793,10 +2791,10 @@ module VexRiscv (
     if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -2807,13 +2805,13 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @(*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(when_CsrPlugin_l935) begin
+    if(when_CsrPlugin_l1272) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
@@ -2821,33 +2819,43 @@ module VexRiscv (
   assign IBusCachedPlugin_forceNoDecodeCond = 1'b0;
   always @(*) begin
     IBusCachedPlugin_incomingInstruction = 1'b0;
-    if(when_Fetcher_l243) begin
+    if(when_Fetcher_l242) begin
       IBusCachedPlugin_incomingInstruction = 1'b1;
     end
   end
 
   assign BranchPlugin_inDebugNoFetchFlag = 1'b0;
-  assign CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+  always @(*) begin
+    CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+    if(when_CsrPlugin_l1702) begin
+      CsrPlugin_csrMapping_allowCsrSignal = 1'b1;
+    end
+    if(when_CsrPlugin_l1709) begin
+      CsrPlugin_csrMapping_allowCsrSignal = 1'b1;
+    end
+  end
+
+  assign CsrPlugin_csrMapping_doForceFailCsr = 1'b0;
   assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
   assign CsrPlugin_inWfi = 1'b0;
   assign CsrPlugin_thirdPartyWake = 1'b0;
   always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(when_CsrPlugin_l1077) begin
-      case(switch_CsrPlugin_l1081)
+    if(when_CsrPlugin_l1456) begin
+      case(switch_CsrPlugin_l1460)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -2861,6 +2869,7 @@ module VexRiscv (
   assign CsrPlugin_allowInterrupts = 1'b1;
   assign CsrPlugin_allowException = 1'b1;
   assign CsrPlugin_allowEbreakException = 1'b1;
+  assign CsrPlugin_xretAwayFromMachine = 1'b0;
   assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
   assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusCachedPlugin_redoBranch_valid,IBusCachedPlugin_predictionJumpInterface_valid}}} != 4'b0000);
   assign _zz_IBusCachedPlugin_jump_pcLoad_payload = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
@@ -2888,9 +2897,8 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l134 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
-  assign IBusCachedPlugin_fetchPc_output_fire_1 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
-  assign when_Fetcher_l134_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
+  assign when_Fetcher_l133 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l133_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
   always @(*) begin
     IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_IBusCachedPlugin_fetchPc_pc);
     if(IBusCachedPlugin_fetchPc_redo_valid) begin
@@ -2913,7 +2921,7 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l161 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
+  assign when_Fetcher_l160 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
   assign IBusCachedPlugin_fetchPc_output_valid = ((! IBusCachedPlugin_fetcherHalt) && IBusCachedPlugin_fetchPc_booted);
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
   always @(*) begin
@@ -2950,7 +2958,7 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_1_output_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b0;
-    if(when_IBusCachedPlugin_l267) begin
+    if(when_IBusCachedPlugin_l273) begin
       IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b1;
     end
   end
@@ -2963,9 +2971,9 @@ module VexRiscv (
   assign IBusCachedPlugin_fetchPc_redo_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_iBusRsp_flush = ((decode_arbitration_removeIt || (decode_arbitration_flushNext && (! decode_arbitration_isStuck))) || IBusCachedPlugin_iBusRsp_redoFetch);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
-  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1 = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
   assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid)) || IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready);
   assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
@@ -2975,18 +2983,18 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
   always @(*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
-    if(when_Fetcher_l323) begin
+    if(when_Fetcher_l322) begin
       IBusCachedPlugin_iBusRsp_readyForError = 1'b0;
     end
   end
 
-  assign when_Fetcher_l243 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
-  assign when_Fetcher_l323 = (! IBusCachedPlugin_pcValids_0);
-  assign when_Fetcher_l332 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
-  assign when_Fetcher_l332_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
-  assign when_Fetcher_l332_2 = (! execute_arbitration_isStuck);
-  assign when_Fetcher_l332_3 = (! memory_arbitration_isStuck);
-  assign when_Fetcher_l332_4 = (! writeBack_arbitration_isStuck);
+  assign when_Fetcher_l242 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
+  assign when_Fetcher_l322 = (! IBusCachedPlugin_pcValids_0);
+  assign when_Fetcher_l331 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l331_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
+  assign when_Fetcher_l331_2 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l331_3 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l331_4 = (! writeBack_arbitration_isStuck);
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
@@ -3141,87 +3149,86 @@ module VexRiscv (
   assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
   always @(*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(when_IBusCachedPlugin_l239) begin
+    if(when_IBusCachedPlugin_l245) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(when_IBusCachedPlugin_l250) begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_cache_io_cpu_fill_valid = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
-    if(when_IBusCachedPlugin_l250) begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_cache_io_cpu_fill_valid = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_valid = 1'b0;
-    if(when_IBusCachedPlugin_l244) begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
-    if(when_IBusCachedPlugin_l256) begin
+    if(when_IBusCachedPlugin_l262) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_payload_code = 4'bxxxx;
-    if(when_IBusCachedPlugin_l244) begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b1100;
     end
-    if(when_IBusCachedPlugin_l256) begin
+    if(when_IBusCachedPlugin_l262) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b0001;
     end
   end
 
   assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_2_input_payload[31 : 2],2'b00};
-  assign when_IBusCachedPlugin_l239 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign when_IBusCachedPlugin_l244 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
-  assign when_IBusCachedPlugin_l250 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
-  assign when_IBusCachedPlugin_l256 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
-  assign when_IBusCachedPlugin_l267 = (IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt);
+  assign when_IBusCachedPlugin_l245 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign when_IBusCachedPlugin_l250 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign when_IBusCachedPlugin_l256 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
+  assign when_IBusCachedPlugin_l262 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
+  assign when_IBusCachedPlugin_l273 = (IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt);
   assign IBusCachedPlugin_iBusRsp_output_valid = IBusCachedPlugin_iBusRsp_stages_2_output_valid;
   assign IBusCachedPlugin_iBusRsp_stages_2_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
   assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_decode_data;
   assign IBusCachedPlugin_iBusRsp_output_payload_pc = IBusCachedPlugin_iBusRsp_stages_2_output_payload;
   assign IBusCachedPlugin_cache_io_flush = (decode_arbitration_isValid && decode_FLUSH_ALL);
-  assign dataCache_1_io_mem_cmd_ready = (! dataCache_1_io_mem_cmd_rValid);
-  assign dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || dataCache_1_io_mem_cmd_rValid);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_wr : dataCache_1_io_mem_cmd_payload_wr);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_uncached : dataCache_1_io_mem_cmd_payload_uncached);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_address = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_address : dataCache_1_io_mem_cmd_payload_address);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_data = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_data : dataCache_1_io_mem_cmd_payload_data);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_mask : dataCache_1_io_mem_cmd_payload_mask);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_size = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_size : dataCache_1_io_mem_cmd_payload_size);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_last : dataCache_1_io_mem_cmd_payload_last);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || (! toplevel_dataCache_1_io_mem_cmd_rValidN));
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_wr : toplevel_dataCache_1_io_mem_cmd_rData_wr);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_uncached : toplevel_dataCache_1_io_mem_cmd_rData_uncached);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_address = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_address : toplevel_dataCache_1_io_mem_cmd_rData_address);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_data = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_data : toplevel_dataCache_1_io_mem_cmd_rData_data);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_mask : toplevel_dataCache_1_io_mem_cmd_rData_mask);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_size = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_size : toplevel_dataCache_1_io_mem_cmd_rData_size);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_last = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_last : toplevel_dataCache_1_io_mem_cmd_rData_last);
   always @(*) begin
-    dataCache_1_io_mem_cmd_s2mPipe_ready = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
-    if(when_Stream_l368) begin
-      dataCache_1_io_mem_cmd_s2mPipe_ready = 1'b1;
+    toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
+    if(when_Stream_l369) begin
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l368 = (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_rValid;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_rData_address;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_rData_data;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size = dataCache_1_io_mem_cmd_s2mPipe_rData_size;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_rData_last;
-  assign dBus_cmd_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
-  assign dBus_cmd_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
-  assign dBus_cmd_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
-  assign dBus_cmd_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
-  assign dBus_cmd_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
-  assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  assign dBus_cmd_payload_size = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
-  assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  assign when_DBusCachedPlugin_l308 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
+  assign when_Stream_l369 = (! toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_address;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_data;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_size;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  assign dBus_cmd_valid = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
+  assign dBus_cmd_payload_wr = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
+  assign dBus_cmd_payload_uncached = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
+  assign dBus_cmd_payload_address = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
+  assign dBus_cmd_payload_data = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
+  assign dBus_cmd_payload_mask = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
+  assign dBus_cmd_payload_size = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
+  assign dBus_cmd_payload_last = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  assign when_DBusCachedPlugin_l352 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
   assign dataCache_1_io_cpu_execute_isValid = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
   assign dataCache_1_io_cpu_execute_address = execute_SRC_ADD;
@@ -3240,11 +3247,11 @@ module VexRiscv (
   end
 
   assign dataCache_1_io_cpu_flush_valid = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
-  assign dataCache_1_io_cpu_flush_payload_singleLine = (execute_INSTRUCTION[19 : 15] != 5'h0);
+  assign dataCache_1_io_cpu_flush_payload_singleLine = (execute_INSTRUCTION[19 : 15] != 5'h00);
   assign dataCache_1_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId[6:0];
-  assign dataCache_1_io_cpu_flush_isStall = (dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready));
-  assign when_DBusCachedPlugin_l350 = (dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
-  assign when_DBusCachedPlugin_l366 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
+  assign toplevel_dataCache_1_io_cpu_flush_isStall = (dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready));
+  assign when_DBusCachedPlugin_l394 = (toplevel_dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
+  assign when_DBusCachedPlugin_l410 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
   assign dataCache_1_io_cpu_memory_isValid = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
   assign dataCache_1_io_cpu_memory_address = memory_REGFILE_WRITE_DATA;
   assign DBusCachedPlugin_mmuBus_cmd_0_isValid = dataCache_1_io_cpu_memory_isValid;
@@ -3254,12 +3261,12 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
   always @(*) begin
     dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if(when_DBusCachedPlugin_l393) begin
+    if(when_DBusCachedPlugin_l472) begin
       dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = 1'b1;
     end
   end
 
-  assign when_DBusCachedPlugin_l393 = (1'b0 && (! dataCache_1_io_cpu_memory_isWrite));
+  assign when_DBusCachedPlugin_l472 = (1'b0 && (! dataCache_1_io_cpu_memory_isWrite));
   always @(*) begin
     dataCache_1_io_cpu_writeBack_isValid = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
     if(writeBack_arbitration_haltByOther) begin
@@ -3272,7 +3279,7 @@ module VexRiscv (
   assign dataCache_1_io_cpu_writeBack_storeData[31 : 0] = writeBack_MEMORY_STORE_DATA_RF;
   always @(*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(when_DBusCachedPlugin_l446) begin
+    if(when_DBusCachedPlugin_l533) begin
       if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
@@ -3282,7 +3289,7 @@ module VexRiscv (
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(when_DBusCachedPlugin_l446) begin
+    if(when_DBusCachedPlugin_l533) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
@@ -3301,7 +3308,7 @@ module VexRiscv (
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
-    if(when_DBusCachedPlugin_l446) begin
+    if(when_DBusCachedPlugin_l533) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code};
       end
@@ -3314,12 +3321,13 @@ module VexRiscv (
     end
   end
 
-  assign when_DBusCachedPlugin_l446 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign when_DBusCachedPlugin_l466 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
-  assign writeBack_DBusCachedPlugin_rspSplits_0 = dataCache_1_io_cpu_writeBack_data[7 : 0];
-  assign writeBack_DBusCachedPlugin_rspSplits_1 = dataCache_1_io_cpu_writeBack_data[15 : 8];
-  assign writeBack_DBusCachedPlugin_rspSplits_2 = dataCache_1_io_cpu_writeBack_data[23 : 16];
-  assign writeBack_DBusCachedPlugin_rspSplits_3 = dataCache_1_io_cpu_writeBack_data[31 : 24];
+  assign when_DBusCachedPlugin_l533 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l553 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
+  assign writeBack_DBusCachedPlugin_rspData = dataCache_1_io_cpu_writeBack_data;
+  assign writeBack_DBusCachedPlugin_rspSplits_0 = writeBack_DBusCachedPlugin_rspData[7 : 0];
+  assign writeBack_DBusCachedPlugin_rspSplits_1 = writeBack_DBusCachedPlugin_rspData[15 : 8];
+  assign writeBack_DBusCachedPlugin_rspSplits_2 = writeBack_DBusCachedPlugin_rspData[23 : 16];
+  assign writeBack_DBusCachedPlugin_rspSplits_3 = writeBack_DBusCachedPlugin_rspData[31 : 24];
   always @(*) begin
     writeBack_DBusCachedPlugin_rspShifted[7 : 0] = _zz_writeBack_DBusCachedPlugin_rspShifted;
     writeBack_DBusCachedPlugin_rspShifted[15 : 8] = _zz_writeBack_DBusCachedPlugin_rspShifted_2;
@@ -3328,7 +3336,7 @@ module VexRiscv (
   end
 
   assign writeBack_DBusCachedPlugin_rspRf = writeBack_DBusCachedPlugin_rspShifted[31 : 0];
-  assign switch_Misc_l210 = writeBack_INSTRUCTION[13 : 12];
+  assign switch_Misc_l232 = writeBack_INSTRUCTION[13 : 12];
   assign _zz_writeBack_DBusCachedPlugin_rspFormated = (writeBack_DBusCachedPlugin_rspRf[7] && (! writeBack_INSTRUCTION[14]));
   always @(*) begin
     _zz_writeBack_DBusCachedPlugin_rspFormated_1[31] = _zz_writeBack_DBusCachedPlugin_rspFormated;
@@ -3380,7 +3388,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    case(switch_Misc_l210)
+    case(switch_Misc_l232)
       2'b00 : begin
         writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_1;
       end
@@ -3393,7 +3401,7 @@ module VexRiscv (
     endcase
   end
 
-  assign when_DBusCachedPlugin_l492 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l580 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
   assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
@@ -3413,10 +3421,10 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign DBusCachedPlugin_mmuBus_busy = 1'b0;
   assign _zz_decode_IS_RS2_SIGNED_1 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_decode_IS_RS2_SIGNED_2 = ((decode_INSTRUCTION & 32'h00000018) == 32'h0);
+  assign _zz_decode_IS_RS2_SIGNED_2 = ((decode_INSTRUCTION & 32'h00000018) == 32'h00000000);
   assign _zz_decode_IS_RS2_SIGNED_3 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
   assign _zz_decode_IS_RS2_SIGNED_4 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_decode_IS_RS2_SIGNED_5 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
+  assign _zz_decode_IS_RS2_SIGNED_5 = ((decode_INSTRUCTION & 32'h00001000) == 32'h00000000);
   assign _zz_decode_IS_RS2_SIGNED = {(|_zz_decode_IS_RS2_SIGNED_5),{(|_zz_decode_IS_RS2_SIGNED_5),{(|(_zz__zz_decode_IS_RS2_SIGNED == _zz__zz_decode_IS_RS2_SIGNED_1)),{(|_zz__zz_decode_IS_RS2_SIGNED_2),{(|_zz__zz_decode_IS_RS2_SIGNED_3),{_zz__zz_decode_IS_RS2_SIGNED_4,{_zz__zz_decode_IS_RS2_SIGNED_6,_zz__zz_decode_IS_RS2_SIGNED_9}}}}}}};
   assign _zz_decode_SRC1_CTRL_2 = _zz_decode_IS_RS2_SIGNED[2 : 1];
   assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
@@ -3435,29 +3443,29 @@ module VexRiscv (
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
-  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h0);
+  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h00);
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
   assign decode_RegFilePlugin_rs1Data = _zz_RegFilePlugin_regFile_port0;
   assign decode_RegFilePlugin_rs2Data = _zz_RegFilePlugin_regFile_port1;
   always @(*) begin
     lastStageRegFileWrite_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
-    if(_zz_7) begin
+    if(_zz_10) begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
   always @(*) begin
     lastStageRegFileWrite_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
-    if(_zz_7) begin
-      lastStageRegFileWrite_payload_address = 5'h0;
+    if(_zz_10) begin
+      lastStageRegFileWrite_payload_address = 5'h00;
     end
   end
 
   always @(*) begin
     lastStageRegFileWrite_payload_data = _zz_decode_RS2_2;
-    if(_zz_7) begin
-      lastStageRegFileWrite_payload_data = 32'h0;
+    if(_zz_10) begin
+      lastStageRegFileWrite_payload_data = 32'h00000000;
     end
   end
 
@@ -3498,7 +3506,7 @@ module VexRiscv (
         _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
       Src1CtrlEnum_IMU : begin
-        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h000};
       end
       default : begin
         _zz_execute_SRC1 = {27'd0, _zz__zz_execute_SRC1_1};
@@ -3506,67 +3514,67 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_execute_SRC2_1 = execute_INSTRUCTION[31];
+  assign _zz_execute_SRC2 = execute_INSTRUCTION[31];
   always @(*) begin
-    _zz_execute_SRC2_2[19] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[18] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[17] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[16] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[15] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[14] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[13] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[12] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[11] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[10] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[9] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[8] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[7] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[6] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[5] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[4] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[3] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[2] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[1] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[0] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_1[19] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[18] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[17] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[16] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[15] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[14] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[13] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[12] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[11] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[10] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[9] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[8] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[7] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[6] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[5] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[4] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[3] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[2] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[1] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[0] = _zz_execute_SRC2;
   end
 
-  assign _zz_execute_SRC2_3 = _zz__zz_execute_SRC2_3[11];
+  assign _zz_execute_SRC2_2 = _zz__zz_execute_SRC2_2[11];
   always @(*) begin
-    _zz_execute_SRC2_4[19] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[18] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[17] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[16] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[15] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[14] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[13] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[12] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[11] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[10] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[9] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[8] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[7] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[6] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[5] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[4] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[3] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[2] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[1] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[0] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_3[19] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[18] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[17] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[16] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[15] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[14] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[13] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[12] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[11] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[10] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[9] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[8] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[7] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[6] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[5] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[4] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[3] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[2] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[1] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[0] = _zz_execute_SRC2_2;
   end
 
   always @(*) begin
     case(execute_SRC2_CTRL)
       Src2CtrlEnum_RS : begin
-        _zz_execute_SRC2_5 = execute_RS2;
+        _zz_execute_SRC2_4 = execute_RS2;
       end
       Src2CtrlEnum_IMI : begin
-        _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
+        _zz_execute_SRC2_4 = {_zz_execute_SRC2_1,execute_INSTRUCTION[31 : 20]};
       end
       Src2CtrlEnum_IMS : begin
-        _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_execute_SRC2_4 = {_zz_execute_SRC2_3,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_execute_SRC2_5 = _zz_execute_SRC2;
+        _zz_execute_SRC2_4 = _zz_execute_to_memory_PC;
       end
     endcase
   end
@@ -3732,16 +3740,19 @@ module VexRiscv (
   assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
   assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign switch_Misc_l210_1 = execute_INSTRUCTION[14 : 12];
+  assign switch_Misc_l232_1 = execute_INSTRUCTION[14 : 12];
   always @(*) begin
-    casez(switch_Misc_l210_1)
+    case(switch_Misc_l232_1)
       3'b000 : begin
         _zz_execute_BRANCH_COND_RESULT = execute_BranchPlugin_eq;
       end
       3'b001 : begin
         _zz_execute_BRANCH_COND_RESULT = (! execute_BranchPlugin_eq);
       end
-      3'b1?1 : begin
+      3'b101 : begin
+        _zz_execute_BRANCH_COND_RESULT = (! execute_SRC_LESS);
+      end
+      3'b111 : begin
         _zz_execute_BRANCH_COND_RESULT = (! execute_SRC_LESS);
       end
       default : begin
@@ -3947,9 +3958,9 @@ module VexRiscv (
 
   assign CsrPlugin_misa_base = 2'b01;
   assign CsrPlugin_misa_extensions = 26'h0000042;
-  assign _zz_when_CsrPlugin_l965 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_when_CsrPlugin_l965_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_when_CsrPlugin_l965_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign _zz_when_CsrPlugin_l1302 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l1302_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l1302_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
   assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
@@ -3994,29 +4005,29 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l922 = (! decode_arbitration_isStuck);
-  assign when_CsrPlugin_l922_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l922_2 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l922_3 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l935 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
+  assign when_CsrPlugin_l1259 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l1272 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-  assign when_CsrPlugin_l959 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign when_CsrPlugin_l965 = ((_zz_when_CsrPlugin_l965 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l965_1 = ((_zz_when_CsrPlugin_l965_1 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l965_2 = ((_zz_when_CsrPlugin_l965_2 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1296 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l1302 = ((_zz_when_CsrPlugin_l1302 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1302_1 = ((_zz_when_CsrPlugin_l1302_1 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1302_2 = ((_zz_when_CsrPlugin_l1302_2 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_lastStageWasWfi = 1'b0;
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  assign when_CsrPlugin_l993 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l993_1 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l993_2 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l998 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  assign when_CsrPlugin_l1335 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1335_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l1335_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l1340 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
   always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(when_CsrPlugin_l1004) begin
+    if(when_CsrPlugin_l1346) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException) begin
@@ -4024,7 +4035,7 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l1004 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
+  assign when_CsrPlugin_l1346 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
   always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
@@ -4040,6 +4051,7 @@ module VexRiscv (
     end
   end
 
+  assign CsrPlugin_trapCauseEbreakDebug = 1'b0;
   always @(*) begin
     CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
@@ -4062,11 +4074,13 @@ module VexRiscv (
     endcase
   end
 
-  assign when_CsrPlugin_l1032 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign when_CsrPlugin_l1077 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
-  assign switch_CsrPlugin_l1081 = writeBack_INSTRUCTION[29 : 28];
+  assign CsrPlugin_trapEnterDebug = 1'b0;
+  assign when_CsrPlugin_l1390 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1398 = (! CsrPlugin_trapEnterDebug);
+  assign when_CsrPlugin_l1456 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign switch_CsrPlugin_l1460 = writeBack_INSTRUCTION[29 : 28];
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign when_CsrPlugin_l1129 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
+  assign when_CsrPlugin_l1527 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
   assign execute_CsrPlugin_blockedBySideEffects = ((|{writeBack_arbitration_isValid,memory_arbitration_isValid}) || 1'b0);
   always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
@@ -4113,18 +4127,18 @@ module VexRiscv (
     if(CsrPlugin_csrMapping_allowCsrSignal) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(when_CsrPlugin_l1315) begin
+    if(when_CsrPlugin_l1725) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if(when_CsrPlugin_l1149) begin
-      if(when_CsrPlugin_l1150) begin
+    if(when_CsrPlugin_l1547) begin
+      if(when_CsrPlugin_l1548) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
@@ -4132,14 +4146,14 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(when_CsrPlugin_l1157) begin
+    if(when_CsrPlugin_l1555) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(when_CsrPlugin_l1157) begin
+    if(when_CsrPlugin_l1555) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -4152,19 +4166,19 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  assign when_CsrPlugin_l1149 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
-  assign when_CsrPlugin_l1150 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
-  assign when_CsrPlugin_l1157 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
+  assign when_CsrPlugin_l1547 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign when_CsrPlugin_l1548 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1555 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
   always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -4173,9 +4187,9 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
   assign execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
-  assign switch_Misc_l210_2 = execute_INSTRUCTION[13];
+  assign switch_Misc_l232_2 = execute_INSTRUCTION[13];
   always @(*) begin
-    case(switch_Misc_l210_2)
+    case(switch_Misc_l232_2)
       1'b0 : begin
         _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
@@ -4186,8 +4200,8 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
-  assign when_CsrPlugin_l1189 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign when_CsrPlugin_l1193 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
+  assign when_CsrPlugin_l1587 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1591 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
@@ -4250,12 +4264,12 @@ module VexRiscv (
   assign memory_DivPlugin_div_counter_willOverflow = (memory_DivPlugin_div_counter_willOverflowIfInc && memory_DivPlugin_div_counter_willIncrement);
   always @(*) begin
     if(memory_DivPlugin_div_counter_willOverflow) begin
-      memory_DivPlugin_div_counter_valueNext = 6'h0;
+      memory_DivPlugin_div_counter_valueNext = 6'h00;
     end else begin
       memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_memory_DivPlugin_div_counter_valueNext);
     end
     if(memory_DivPlugin_div_counter_willClear) begin
-      memory_DivPlugin_div_counter_valueNext = 6'h0;
+      memory_DivPlugin_div_counter_valueNext = 6'h00;
     end
   end
 
@@ -4279,8 +4293,8 @@ module VexRiscv (
     _zz_memory_DivPlugin_rs1_1[31 : 0] = execute_RS1;
   end
 
-  assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
-  assign externalInterrupt = (|_zz_CsrPlugin_csrMapping_readDataInit_1);
+  assign _zz_externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
+  assign externalInterrupt = (|_zz_externalInterrupt);
   assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
@@ -4396,91 +4410,101 @@ module VexRiscv (
   assign when_Pipeline_l154_1 = ((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt));
   assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
   assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
-  assign when_CsrPlugin_l1277 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_2 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_3 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_4 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_5 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_6 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_7 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_8 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_9 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_8 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_9 = (! execute_arbitration_isStuck);
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_1 = 32'h00000000;
     if(execute_CsrPlugin_csr_3264) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_2[12 : 0] = 13'h1000;
-      _zz_CsrPlugin_csrMapping_readDataInit_2[25 : 20] = 6'h20;
+      _zz_CsrPlugin_csrMapping_readDataInit_1[12 : 0] = 13'h1000;
+      _zz_CsrPlugin_csrMapping_readDataInit_1[25 : 20] = 6'h20;
     end
   end
 
-  assign switch_CsrPlugin_l723 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
+  assign switch_CsrPlugin_l1031 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h00000000;
     if(execute_CsrPlugin_csr_768) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_3[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_3[3 : 3] = CsrPlugin_mstatus_MIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_3[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[12 : 11] = CsrPlugin_mstatus_MPP;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h00000000;
     if(execute_CsrPlugin_csr_836) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_4[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_4[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_4[3 : 3] = CsrPlugin_mip_MSIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[3 : 3] = CsrPlugin_mip_MSIP;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h00000000;
     if(execute_CsrPlugin_csr_772) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_5[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_5[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_5[3 : 3] = CsrPlugin_mie_MSIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[3 : 3] = CsrPlugin_mie_MSIE;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h00000000;
     if(execute_CsrPlugin_csr_833) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_6[31 : 0] = CsrPlugin_mepc;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[31 : 0] = CsrPlugin_mepc;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h00000000;
     if(execute_CsrPlugin_csr_834) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_7[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_CsrPlugin_csrMapping_readDataInit_7[3 : 0] = CsrPlugin_mcause_exceptionCode;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h00000000;
     if(execute_CsrPlugin_csr_835) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_8[31 : 0] = CsrPlugin_mtval;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[31 : 0] = CsrPlugin_mtval;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h00000000;
     if(execute_CsrPlugin_csr_3008) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_9[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
+      _zz_CsrPlugin_csrMapping_readDataInit_8[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_10 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h00000000;
     if(execute_CsrPlugin_csr_4032) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_10[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_1;
+      _zz_CsrPlugin_csrMapping_readDataInit_9[31 : 0] = _zz_externalInterrupt;
     end
   end
 
-  assign CsrPlugin_csrMapping_readDataInit = ((((_zz_CsrPlugin_csrMapping_readDataInit_2 | _zz_CsrPlugin_csrMapping_readDataInit_3) | (_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5)) | ((_zz_CsrPlugin_csrMapping_readDataInit_6 | _zz_CsrPlugin_csrMapping_readDataInit_7) | (_zz_CsrPlugin_csrMapping_readDataInit_8 | _zz_CsrPlugin_csrMapping_readDataInit_9))) | _zz_CsrPlugin_csrMapping_readDataInit_10);
-  assign when_CsrPlugin_l1310 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign when_CsrPlugin_l1315 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign CsrPlugin_csrMapping_readDataInit = ((((_zz_CsrPlugin_csrMapping_readDataInit_1 | _zz_CsrPlugin_csrMapping_readDataInit_2) | (_zz_CsrPlugin_csrMapping_readDataInit_3 | _zz_CsrPlugin_csrMapping_readDataInit_4)) | ((_zz_CsrPlugin_csrMapping_readDataInit_5 | _zz_CsrPlugin_csrMapping_readDataInit_6) | (_zz_CsrPlugin_csrMapping_readDataInit_7 | _zz_CsrPlugin_csrMapping_readDataInit_8))) | _zz_CsrPlugin_csrMapping_readDataInit_9);
+  assign when_CsrPlugin_l1702 = ((execute_arbitration_isValid && execute_IS_CSR) && (({execute_CsrPlugin_csrAddress[11 : 2],2'b00} == 12'h3a0) || ({execute_CsrPlugin_csrAddress[11 : 4],4'b0000} == 12'h3b0)));
+  assign _zz_when_CsrPlugin_l1709 = (execute_CsrPlugin_csrAddress & 12'hf60);
+  assign when_CsrPlugin_l1709 = (((execute_arbitration_isValid && execute_IS_CSR) && (5'h03 <= execute_CsrPlugin_csrAddress[4 : 0])) && (((_zz_when_CsrPlugin_l1709 == 12'hb00) || (((_zz_when_CsrPlugin_l1709 == 12'hc00) && (! execute_CsrPlugin_writeInstruction)) && (CsrPlugin_privilege == 2'b11))) || ((execute_CsrPlugin_csrAddress & 12'hfe0) == 12'h320)));
+  always @(*) begin
+    when_CsrPlugin_l1719 = CsrPlugin_csrMapping_doForceFailCsr;
+    if(when_CsrPlugin_l1717) begin
+      when_CsrPlugin_l1719 = 1'b1;
+    end
+  end
+
+  assign when_CsrPlugin_l1717 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1725 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
   assign iBusWishbone_ADR = {_zz_iBusWishbone_ADR_1,_zz_iBusWishbone_ADR};
   assign iBusWishbone_CTI = ((_zz_iBusWishbone_ADR == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
@@ -4506,20 +4530,20 @@ module VexRiscv (
   assign iBus_rsp_valid = _zz_iBus_rsp_valid;
   assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
   assign iBus_rsp_payload_error = 1'b0;
-  assign _zz_dBus_cmd_ready_5 = (dBus_cmd_payload_size == 3'b101);
-  assign _zz_dBus_cmd_ready_1 = dBus_cmd_valid;
-  assign _zz_dBus_cmd_ready_3 = dBus_cmd_payload_wr;
-  assign _zz_dBus_cmd_ready_4 = ((! _zz_dBus_cmd_ready_5) || (_zz_dBus_cmd_ready == 3'b111));
-  assign dBus_cmd_ready = (_zz_dBus_cmd_ready_2 && (_zz_dBus_cmd_ready_3 || _zz_dBus_cmd_ready_4));
-  assign dBusWishbone_ADR = ((_zz_dBus_cmd_ready_5 ? {{dBus_cmd_payload_address[31 : 5],_zz_dBus_cmd_ready},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
-  assign dBusWishbone_CTI = (_zz_dBus_cmd_ready_5 ? (_zz_dBus_cmd_ready_4 ? 3'b111 : 3'b010) : 3'b000);
+  assign _zz_dBusWishbone_ADR_1 = (dBus_cmd_payload_size == 3'b101);
+  assign _zz_dBusWishbone_CYC = dBus_cmd_valid;
+  assign _zz_dBus_cmd_ready_1 = dBus_cmd_payload_wr;
+  assign _zz_dBus_cmd_ready_2 = ((! _zz_dBusWishbone_ADR_1) || (_zz_dBusWishbone_ADR == 3'b111));
+  assign dBus_cmd_ready = (_zz_dBus_cmd_ready && (_zz_dBus_cmd_ready_1 || _zz_dBus_cmd_ready_2));
+  assign dBusWishbone_ADR = ((_zz_dBusWishbone_ADR_1 ? {{dBus_cmd_payload_address[31 : 5],_zz_dBusWishbone_ADR},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2'd2);
+  assign dBusWishbone_CTI = (_zz_dBusWishbone_ADR_1 ? (_zz_dBus_cmd_ready_2 ? 3'b111 : 3'b010) : 3'b000);
   assign dBusWishbone_BTE = 2'b00;
-  assign dBusWishbone_SEL = (_zz_dBus_cmd_ready_3 ? dBus_cmd_payload_mask : 4'b1111);
-  assign dBusWishbone_WE = _zz_dBus_cmd_ready_3;
+  assign dBusWishbone_SEL = (_zz_dBus_cmd_ready_1 ? dBus_cmd_payload_mask : 4'b1111);
+  assign dBusWishbone_WE = _zz_dBus_cmd_ready_1;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_payload_data;
-  assign _zz_dBus_cmd_ready_2 = (_zz_dBus_cmd_ready_1 && dBusWishbone_ACK);
-  assign dBusWishbone_CYC = _zz_dBus_cmd_ready_1;
-  assign dBusWishbone_STB = _zz_dBus_cmd_ready_1;
+  assign _zz_dBus_cmd_ready = (_zz_dBusWishbone_CYC && dBusWishbone_ACK);
+  assign dBusWishbone_CYC = _zz_dBusWishbone_CYC;
+  assign dBusWishbone_STB = _zz_dBusWishbone_CYC;
   assign dBus_rsp_valid = _zz_dBus_rsp_valid;
   assign dBus_rsp_payload_data = dBusWishbone_DAT_MISO_regNext;
   assign dBus_rsp_payload_error = 1'b0;
@@ -4529,18 +4553,18 @@ module VexRiscv (
       IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
-      _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+      _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= 1'b0;
       _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= 32'h0;
-      dataCache_1_io_mem_cmd_rValid <= 1'b0;
-      dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= 32'h0;
-      _zz_7 <= 1'b1;
+      IBusCachedPlugin_rspCounter <= 32'h00000000;
+      toplevel_dataCache_1_io_mem_cmd_rValidN <= 1'b1;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
+      DBusCachedPlugin_rspCounter <= 32'h00000000;
+      _zz_10 <= 1'b1;
       HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
       CsrPlugin_mstatus_MIE <= 1'b0;
       CsrPlugin_mstatus_MPIE <= 1'b0;
@@ -4548,8 +4572,8 @@ module VexRiscv (
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
-      CsrPlugin_mcycle <= 64'h0;
-      CsrPlugin_minstret <= 64'h0;
+      CsrPlugin_mcycle <= 64'h0000000000000000;
+      CsrPlugin_minstret <= 64'h0000000000000000;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= 1'b0;
@@ -4560,14 +4584,14 @@ module VexRiscv (
       CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
-      memory_DivPlugin_div_counter_value <= 6'h0;
-      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h0;
+      memory_DivPlugin_div_counter_value <= 6'h00;
+      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h00000000;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
       _zz_iBusWishbone_ADR <= 3'b000;
       _zz_iBus_rsp_valid <= 1'b0;
-      _zz_dBus_cmd_ready <= 3'b000;
+      _zz_dBusWishbone_ADR <= 3'b000;
       _zz_dBus_rsp_valid <= 1'b0;
     end else begin
       if(IBusCachedPlugin_fetchPc_correction) begin
@@ -4577,23 +4601,23 @@ module VexRiscv (
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusCachedPlugin_fetchPc_booted <= 1'b1;
-      if(when_Fetcher_l134) begin
+      if(when_Fetcher_l133) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_output_fire_1) begin
+      if(IBusCachedPlugin_fetchPc_output_fire) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b1;
       end
-      if(when_Fetcher_l134_1) begin
+      if(when_Fetcher_l133_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(when_Fetcher_l161) begin
+      if(when_Fetcher_l160) begin
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
       if(IBusCachedPlugin_iBusRsp_flush) begin
-        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= 1'b0;
       end
       if(_zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready) begin
-        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
       if(IBusCachedPlugin_iBusRsp_flush) begin
         _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
@@ -4604,13 +4628,13 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if(when_Fetcher_l332) begin
+      if(when_Fetcher_l331) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(when_Fetcher_l332_1) begin
+      if(when_Fetcher_l331_1) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= IBusCachedPlugin_injector_nextPcCalc_valids_0;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -4619,7 +4643,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(when_Fetcher_l332_2) begin
+      if(when_Fetcher_l331_2) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= IBusCachedPlugin_injector_nextPcCalc_valids_1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -4628,7 +4652,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(when_Fetcher_l332_3) begin
+      if(when_Fetcher_l331_3) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -4637,7 +4661,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if(when_Fetcher_l332_4) begin
+      if(when_Fetcher_l331_4) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= IBusCachedPlugin_injector_nextPcCalc_valids_3;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -4647,67 +4671,67 @@ module VexRiscv (
         IBusCachedPlugin_rspCounter <= (IBusCachedPlugin_rspCounter + 32'h00000001);
       end
       if(dataCache_1_io_mem_cmd_valid) begin
-        dataCache_1_io_mem_cmd_rValid <= 1'b1;
+        toplevel_dataCache_1_io_mem_cmd_rValidN <= 1'b0;
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
-        dataCache_1_io_mem_cmd_rValid <= 1'b0;
+      if(toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+        toplevel_dataCache_1_io_mem_cmd_rValidN <= 1'b1;
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
-        dataCache_1_io_mem_cmd_s2mPipe_rValid <= dataCache_1_io_mem_cmd_s2mPipe_valid;
+      if(toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+        toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_valid;
       end
       if(dBus_rsp_valid) begin
         DBusCachedPlugin_rspCounter <= (DBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      _zz_7 <= 1'b0;
+      _zz_10 <= 1'b0;
       HazardSimplePlugin_writeBackBuffer_valid <= HazardSimplePlugin_writeBackWrites_valid;
       CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
       if(writeBack_arbitration_isFiring) begin
         CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
       end
-      if(when_CsrPlugin_l922) begin
+      if(when_CsrPlugin_l1259) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if(when_CsrPlugin_l922_1) begin
+      if(when_CsrPlugin_l1259_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if(when_CsrPlugin_l922_2) begin
+      if(when_CsrPlugin_l1259_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if(when_CsrPlugin_l922_3) begin
+      if(when_CsrPlugin_l1259_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(when_CsrPlugin_l959) begin
-        if(when_CsrPlugin_l965) begin
+      if(when_CsrPlugin_l1296) begin
+        if(when_CsrPlugin_l1302) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_1) begin
+        if(when_CsrPlugin_l1302_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_2) begin
+        if(when_CsrPlugin_l1302_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
       if(CsrPlugin_pipelineLiberator_active) begin
-        if(when_CsrPlugin_l993) begin
+        if(when_CsrPlugin_l1335) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if(when_CsrPlugin_l993_1) begin
+        if(when_CsrPlugin_l1335_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if(when_CsrPlugin_l993_2) begin
+        if(when_CsrPlugin_l1335_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(when_CsrPlugin_l998) begin
+      if(when_CsrPlugin_l1340) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
@@ -4716,19 +4740,21 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(when_CsrPlugin_l1032) begin
-        case(CsrPlugin_targetPrivilege)
-          2'b11 : begin
-            CsrPlugin_mstatus_MIE <= 1'b0;
-            CsrPlugin_mstatus_MPIE <= CsrPlugin_mstatus_MIE;
-            CsrPlugin_mstatus_MPP <= CsrPlugin_privilege;
-          end
-          default : begin
-          end
-        endcase
+      if(when_CsrPlugin_l1390) begin
+        if(when_CsrPlugin_l1398) begin
+          case(CsrPlugin_targetPrivilege)
+            2'b11 : begin
+              CsrPlugin_mstatus_MIE <= 1'b0;
+              CsrPlugin_mstatus_MPIE <= CsrPlugin_mstatus_MIE;
+              CsrPlugin_mstatus_MPP <= CsrPlugin_privilege;
+            end
+            default : begin
+            end
+          endcase
+        end
       end
-      if(when_CsrPlugin_l1077) begin
-        case(switch_CsrPlugin_l1081)
+      if(when_CsrPlugin_l1456) begin
+        case(switch_CsrPlugin_l1460)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -4738,7 +4764,7 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l965_2,{_zz_when_CsrPlugin_l965_1,_zz_when_CsrPlugin_l965}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l1302_2,{_zz_when_CsrPlugin_l1302_1,_zz_when_CsrPlugin_l1302}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
       if(when_Pipeline_l151) begin
         execute_arbitration_isValid <= 1'b0;
@@ -4762,7 +4788,7 @@ module VexRiscv (
         if(execute_CsrPlugin_writeEnable) begin
           CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
           CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
-          case(switch_CsrPlugin_l723)
+          case(switch_CsrPlugin_l1031)
             2'b11 : begin
               CsrPlugin_mstatus_MPP <= 2'b11;
             end
@@ -4789,13 +4815,13 @@ module VexRiscv (
         end
       end
       _zz_iBus_rsp_valid <= (iBusWishbone_CYC && iBusWishbone_ACK);
-      if((_zz_dBus_cmd_ready_1 && _zz_dBus_cmd_ready_2)) begin
-        _zz_dBus_cmd_ready <= (_zz_dBus_cmd_ready + 3'b001);
-        if(_zz_dBus_cmd_ready_4) begin
-          _zz_dBus_cmd_ready <= 3'b000;
+      if((_zz_dBusWishbone_CYC && _zz_dBus_cmd_ready)) begin
+        _zz_dBusWishbone_ADR <= (_zz_dBusWishbone_ADR + 3'b001);
+        if(_zz_dBus_cmd_ready_2) begin
+          _zz_dBusWishbone_ADR <= 3'b000;
         end
       end
-      _zz_dBus_rsp_valid <= ((_zz_dBus_cmd_ready_1 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
+      _zz_dBus_rsp_valid <= ((_zz_dBusWishbone_CYC && (! dBusWishbone_WE)) && dBusWishbone_ACK);
     end
   end
 
@@ -4809,23 +4835,23 @@ module VexRiscv (
     if(IBusCachedPlugin_iBusRsp_stages_2_input_ready) begin
       IBusCachedPlugin_s2_tightlyCoupledHit <= IBusCachedPlugin_s1_tightlyCoupledHit;
     end
-    if(dataCache_1_io_mem_cmd_ready) begin
-      dataCache_1_io_mem_cmd_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
-      dataCache_1_io_mem_cmd_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
-      dataCache_1_io_mem_cmd_rData_address <= dataCache_1_io_mem_cmd_payload_address;
-      dataCache_1_io_mem_cmd_rData_data <= dataCache_1_io_mem_cmd_payload_data;
-      dataCache_1_io_mem_cmd_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
-      dataCache_1_io_mem_cmd_rData_size <= dataCache_1_io_mem_cmd_payload_size;
-      dataCache_1_io_mem_cmd_rData_last <= dataCache_1_io_mem_cmd_payload_last;
+    if(toplevel_dataCache_1_io_mem_cmd_rValidN) begin
+      toplevel_dataCache_1_io_mem_cmd_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
+      toplevel_dataCache_1_io_mem_cmd_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
+      toplevel_dataCache_1_io_mem_cmd_rData_address <= dataCache_1_io_mem_cmd_payload_address;
+      toplevel_dataCache_1_io_mem_cmd_rData_data <= dataCache_1_io_mem_cmd_payload_data;
+      toplevel_dataCache_1_io_mem_cmd_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
+      toplevel_dataCache_1_io_mem_cmd_rData_size <= dataCache_1_io_mem_cmd_payload_size;
+      toplevel_dataCache_1_io_mem_cmd_rData_last <= dataCache_1_io_mem_cmd_payload_last;
     end
-    if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
-      dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_address <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_data <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_size <= dataCache_1_io_mem_cmd_s2mPipe_payload_size;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_last <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+    if(toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_address <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_data <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_size <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_size;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_last <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_last;
     end
     HazardSimplePlugin_writeBackBuffer_payload_address <= HazardSimplePlugin_writeBackWrites_payload_address;
     HazardSimplePlugin_writeBackBuffer_payload_data <= HazardSimplePlugin_writeBackWrites_payload_data;
@@ -4848,33 +4874,35 @@ module VexRiscv (
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(when_CsrPlugin_l959) begin
-      if(when_CsrPlugin_l965) begin
+    if(when_CsrPlugin_l1296) begin
+      if(when_CsrPlugin_l1302) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l965_1) begin
+      if(when_CsrPlugin_l1302_1) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l965_2) begin
+      if(when_CsrPlugin_l1302_2) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(when_CsrPlugin_l1032) begin
-      case(CsrPlugin_targetPrivilege)
-        2'b11 : begin
-          CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
-          CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
-          CsrPlugin_mepc <= writeBack_PC;
-          if(CsrPlugin_hadException) begin
-            CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
+    if(when_CsrPlugin_l1390) begin
+      if(when_CsrPlugin_l1398) begin
+        case(CsrPlugin_targetPrivilege)
+          2'b11 : begin
+            CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
+            CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
+            CsrPlugin_mepc <= writeBack_PC;
+            if(CsrPlugin_hadException) begin
+              CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
+            end
           end
-        end
-        default : begin
-        end
-      endcase
+          default : begin
+          end
+        endcase
+      end
     end
     if(when_MulDivIterativePlugin_l126) begin
       memory_DivPlugin_div_done <= 1'b1;
@@ -4892,17 +4920,17 @@ module VexRiscv (
       end
     end
     if(when_MulDivIterativePlugin_l162) begin
-      memory_DivPlugin_accumulator <= 65'h0;
+      memory_DivPlugin_accumulator <= 65'h00000000000000000;
       memory_DivPlugin_rs1 <= ((_zz_memory_DivPlugin_rs1 ? (~ _zz_memory_DivPlugin_rs1_1) : _zz_memory_DivPlugin_rs1_1) + _zz_memory_DivPlugin_rs1_2);
       memory_DivPlugin_rs2 <= ((_zz_memory_DivPlugin_rs2 ? (~ execute_RS2) : execute_RS2) + _zz_memory_DivPlugin_rs2_1);
-      memory_DivPlugin_div_needRevert <= ((_zz_memory_DivPlugin_rs1 ^ (_zz_memory_DivPlugin_rs2 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
+      memory_DivPlugin_div_needRevert <= ((_zz_memory_DivPlugin_rs1 ^ (_zz_memory_DivPlugin_rs2 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h00000000) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
     end
     externalInterruptArray_regNext <= externalInterruptArray;
     if(when_Pipeline_l124) begin
       decode_to_execute_PC <= decode_PC;
     end
     if(when_Pipeline_l124_1) begin
-      execute_to_memory_PC <= _zz_execute_SRC2;
+      execute_to_memory_PC <= _zz_execute_to_memory_PC;
     end
     if(when_Pipeline_l124_2) begin
       memory_to_writeBack_PC <= memory_PC;
@@ -5084,34 +5112,34 @@ module VexRiscv (
     if(when_Pipeline_l124_61) begin
       memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
     end
-    if(when_CsrPlugin_l1277) begin
+    if(when_CsrPlugin_l1669) begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
     end
-    if(when_CsrPlugin_l1277_1) begin
+    if(when_CsrPlugin_l1669_1) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if(when_CsrPlugin_l1277_2) begin
+    if(when_CsrPlugin_l1669_2) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if(when_CsrPlugin_l1277_3) begin
+    if(when_CsrPlugin_l1669_3) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if(when_CsrPlugin_l1277_4) begin
+    if(when_CsrPlugin_l1669_4) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if(when_CsrPlugin_l1277_5) begin
+    if(when_CsrPlugin_l1669_5) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if(when_CsrPlugin_l1277_6) begin
+    if(when_CsrPlugin_l1669_6) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if(when_CsrPlugin_l1277_7) begin
+    if(when_CsrPlugin_l1669_7) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if(when_CsrPlugin_l1277_8) begin
+    if(when_CsrPlugin_l1669_8) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if(when_CsrPlugin_l1277_9) begin
+    if(when_CsrPlugin_l1669_9) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
     if(execute_CsrPlugin_csr_836) begin
@@ -5122,7 +5150,6 @@ module VexRiscv (
     if(execute_CsrPlugin_csr_773) begin
       if(execute_CsrPlugin_writeEnable) begin
         CsrPlugin_mtvec_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 2];
-        CsrPlugin_mtvec_mode <= CsrPlugin_csrMapping_writeDataSignal[1 : 0];
       end
     end
     if(execute_CsrPlugin_csr_833) begin
@@ -5138,76 +5165,75 @@ module VexRiscv (
 endmodule
 
 module DataCache (
-  input               io_cpu_execute_isValid,
-  input      [31:0]   io_cpu_execute_address,
-  output reg          io_cpu_execute_haltIt,
-  input               io_cpu_execute_args_wr,
-  input      [1:0]    io_cpu_execute_args_size,
-  input               io_cpu_execute_args_totalyConsistent,
-  output              io_cpu_execute_refilling,
-  input               io_cpu_memory_isValid,
-  input               io_cpu_memory_isStuck,
-  output              io_cpu_memory_isWrite,
-  input      [31:0]   io_cpu_memory_address,
-  input      [31:0]   io_cpu_memory_mmuRsp_physicalAddress,
-  input               io_cpu_memory_mmuRsp_isIoAccess,
-  input               io_cpu_memory_mmuRsp_isPaging,
-  input               io_cpu_memory_mmuRsp_allowRead,
-  input               io_cpu_memory_mmuRsp_allowWrite,
-  input               io_cpu_memory_mmuRsp_allowExecute,
-  input               io_cpu_memory_mmuRsp_exception,
-  input               io_cpu_memory_mmuRsp_refilling,
-  input               io_cpu_memory_mmuRsp_bypassTranslation,
-  input               io_cpu_writeBack_isValid,
-  input               io_cpu_writeBack_isStuck,
-  input               io_cpu_writeBack_isFiring,
-  input               io_cpu_writeBack_isUser,
-  output reg          io_cpu_writeBack_haltIt,
-  output              io_cpu_writeBack_isWrite,
-  input      [31:0]   io_cpu_writeBack_storeData,
-  output reg [31:0]   io_cpu_writeBack_data,
-  input      [31:0]   io_cpu_writeBack_address,
-  output              io_cpu_writeBack_mmuException,
-  output              io_cpu_writeBack_unalignedAccess,
-  output reg          io_cpu_writeBack_accessError,
-  output              io_cpu_writeBack_keepMemRspData,
-  input               io_cpu_writeBack_fence_SW,
-  input               io_cpu_writeBack_fence_SR,
-  input               io_cpu_writeBack_fence_SO,
-  input               io_cpu_writeBack_fence_SI,
-  input               io_cpu_writeBack_fence_PW,
-  input               io_cpu_writeBack_fence_PR,
-  input               io_cpu_writeBack_fence_PO,
-  input               io_cpu_writeBack_fence_PI,
-  input      [3:0]    io_cpu_writeBack_fence_FM,
-  output              io_cpu_writeBack_exclusiveOk,
-  output reg          io_cpu_redo,
-  input               io_cpu_flush_valid,
-  output              io_cpu_flush_ready,
-  input               io_cpu_flush_payload_singleLine,
-  input      [6:0]    io_cpu_flush_payload_lineId,
-  output reg          io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output reg          io_mem_cmd_payload_wr,
-  output              io_mem_cmd_payload_uncached,
-  output reg [31:0]   io_mem_cmd_payload_address,
-  output     [31:0]   io_mem_cmd_payload_data,
-  output     [3:0]    io_mem_cmd_payload_mask,
-  output reg [2:0]    io_mem_cmd_payload_size,
-  output              io_mem_cmd_payload_last,
-  input               io_mem_rsp_valid,
-  input               io_mem_rsp_payload_last,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input               clk,
-  input               reset
+  input  wire          io_cpu_execute_isValid,
+  input  wire [31:0]   io_cpu_execute_address,
+  output reg           io_cpu_execute_haltIt,
+  input  wire          io_cpu_execute_args_wr,
+  input  wire [1:0]    io_cpu_execute_args_size,
+  input  wire          io_cpu_execute_args_totalyConsistent,
+  output wire          io_cpu_execute_refilling,
+  input  wire          io_cpu_memory_isValid,
+  input  wire          io_cpu_memory_isStuck,
+  output wire          io_cpu_memory_isWrite,
+  input  wire [31:0]   io_cpu_memory_address,
+  input  wire [31:0]   io_cpu_memory_mmuRsp_physicalAddress,
+  input  wire          io_cpu_memory_mmuRsp_isIoAccess,
+  input  wire          io_cpu_memory_mmuRsp_isPaging,
+  input  wire          io_cpu_memory_mmuRsp_allowRead,
+  input  wire          io_cpu_memory_mmuRsp_allowWrite,
+  input  wire          io_cpu_memory_mmuRsp_allowExecute,
+  input  wire          io_cpu_memory_mmuRsp_exception,
+  input  wire          io_cpu_memory_mmuRsp_refilling,
+  input  wire          io_cpu_memory_mmuRsp_bypassTranslation,
+  input  wire          io_cpu_writeBack_isValid,
+  input  wire          io_cpu_writeBack_isStuck,
+  input  wire          io_cpu_writeBack_isFiring,
+  input  wire          io_cpu_writeBack_isUser,
+  output reg           io_cpu_writeBack_haltIt,
+  output wire          io_cpu_writeBack_isWrite,
+  input  wire [31:0]   io_cpu_writeBack_storeData,
+  output reg  [31:0]   io_cpu_writeBack_data,
+  input  wire [31:0]   io_cpu_writeBack_address,
+  output wire          io_cpu_writeBack_mmuException,
+  output wire          io_cpu_writeBack_unalignedAccess,
+  output reg           io_cpu_writeBack_accessError,
+  output wire          io_cpu_writeBack_keepMemRspData,
+  input  wire          io_cpu_writeBack_fence_SW,
+  input  wire          io_cpu_writeBack_fence_SR,
+  input  wire          io_cpu_writeBack_fence_SO,
+  input  wire          io_cpu_writeBack_fence_SI,
+  input  wire          io_cpu_writeBack_fence_PW,
+  input  wire          io_cpu_writeBack_fence_PR,
+  input  wire          io_cpu_writeBack_fence_PO,
+  input  wire          io_cpu_writeBack_fence_PI,
+  input  wire [3:0]    io_cpu_writeBack_fence_FM,
+  output wire          io_cpu_writeBack_exclusiveOk,
+  output reg           io_cpu_redo,
+  input  wire          io_cpu_flush_valid,
+  output wire          io_cpu_flush_ready,
+  input  wire          io_cpu_flush_payload_singleLine,
+  input  wire [6:0]    io_cpu_flush_payload_lineId,
+  output wire          io_cpu_writesPending,
+  output reg           io_mem_cmd_valid,
+  input  wire          io_mem_cmd_ready,
+  output reg           io_mem_cmd_payload_wr,
+  output wire          io_mem_cmd_payload_uncached,
+  output reg  [31:0]   io_mem_cmd_payload_address,
+  output wire [31:0]   io_mem_cmd_payload_data,
+  output wire [3:0]    io_mem_cmd_payload_mask,
+  output reg  [2:0]    io_mem_cmd_payload_size,
+  output wire          io_mem_cmd_payload_last,
+  input  wire          io_mem_rsp_valid,
+  input  wire          io_mem_rsp_payload_last,
+  input  wire [31:0]   io_mem_rsp_payload_data,
+  input  wire          io_mem_rsp_payload_error,
+  input  wire          clk,
+  input  wire          reset
 );
 
   reg        [21:0]   _zz_ways_0_tags_port0;
   reg        [31:0]   _zz_ways_0_data_port0;
   wire       [21:0]   _zz_ways_0_tags_port;
-  wire       [9:0]    _zz_stage0_dataColisions;
-  wire       [9:0]    _zz__zz_stageA_dataColisions;
   wire       [0:0]    _zz_when;
   wire       [2:0]    _zz_loader_counter_valueNext;
   wire       [0:0]    _zz_loader_counter_valueNext_1;
@@ -5244,40 +5270,40 @@ module DataCache (
   wire                _zz_ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRsp;
-  wire                when_DataCache_l642;
   wire                when_DataCache_l645;
-  wire                when_DataCache_l664;
+  wire                when_DataCache_l648;
+  wire                when_DataCache_l667;
   wire                rspSync;
   wire                rspLast;
   reg                 memCmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_DataCache_l686;
+  wire                when_DataCache_l689;
   reg        [3:0]    _zz_stage0_mask;
   wire       [3:0]    stage0_mask;
   wire       [0:0]    stage0_dataColisions;
   wire       [0:0]    stage0_wayInvalidate;
   wire                stage0_isAmo;
-  wire                when_DataCache_l771;
+  wire                when_DataCache_l776;
   reg                 stageA_request_wr;
   reg        [1:0]    stageA_request_size;
   reg                 stageA_request_totalyConsistent;
-  wire                when_DataCache_l771_1;
+  wire                when_DataCache_l776_1;
   reg        [3:0]    stageA_mask;
   wire                stageA_isAmo;
   wire                stageA_isLrsc;
   wire       [0:0]    stageA_wayHits;
-  wire                when_DataCache_l771_2;
+  wire                when_DataCache_l776_2;
   reg        [0:0]    stageA_wayInvalidate;
-  wire                when_DataCache_l771_3;
+  wire                when_DataCache_l776_3;
   reg        [0:0]    stage0_dataColisions_regNextWhen;
   wire       [0:0]    _zz_stageA_dataColisions;
   wire       [0:0]    stageA_dataColisions;
-  wire                when_DataCache_l822;
+  wire                when_DataCache_l827;
   reg                 stageB_request_wr;
   reg        [1:0]    stageB_request_size;
   reg                 stageB_request_totalyConsistent;
   reg                 stageB_mmuRspFreeze;
-  wire                when_DataCache_l824;
+  wire                when_DataCache_l829;
   reg        [31:0]   stageB_mmuRsp_physicalAddress;
   reg                 stageB_mmuRsp_isIoAccess;
   reg                 stageB_mmuRsp_isPaging;
@@ -5287,52 +5313,54 @@ module DataCache (
   reg                 stageB_mmuRsp_exception;
   reg                 stageB_mmuRsp_refilling;
   reg                 stageB_mmuRsp_bypassTranslation;
-  wire                when_DataCache_l821;
+  wire                when_DataCache_l826;
   reg                 stageB_tagsReadRsp_0_valid;
   reg                 stageB_tagsReadRsp_0_error;
   reg        [19:0]   stageB_tagsReadRsp_0_address;
-  wire                when_DataCache_l821_1;
+  wire                when_DataCache_l826_1;
   reg        [31:0]   stageB_dataReadRsp_0;
-  wire                when_DataCache_l820;
+  wire                when_DataCache_l825;
   reg        [0:0]    stageB_wayInvalidate;
   wire                stageB_consistancyHazard;
-  wire                when_DataCache_l820_1;
+  wire                when_DataCache_l825_1;
   reg        [0:0]    stageB_dataColisions;
-  wire                when_DataCache_l820_2;
+  wire                when_DataCache_l825_2;
   reg                 stageB_unaligned;
-  wire                when_DataCache_l820_3;
+  wire                when_DataCache_l825_3;
   reg        [0:0]    stageB_waysHitsBeforeInvalidate;
   wire       [0:0]    stageB_waysHits;
   wire                stageB_waysHit;
   wire       [31:0]   stageB_dataMux;
-  wire                when_DataCache_l820_4;
+  wire                when_DataCache_l825_4;
   reg        [3:0]    stageB_mask;
   reg                 stageB_loaderValid;
   wire       [31:0]   stageB_ioMemRspMuxed;
   reg                 stageB_flusher_waitDone;
   wire                stageB_flusher_hold;
   reg        [7:0]    stageB_flusher_counter;
-  wire                when_DataCache_l850;
-  wire                when_DataCache_l856;
+  wire                when_DataCache_l855;
+  wire                when_DataCache_l861;
+  wire                when_DataCache_l863;
   reg                 stageB_flusher_start;
+  wire                when_DataCache_l877;
   wire                stageB_isAmo;
   wire                stageB_isAmoCached;
   wire                stageB_isExternalLsrc;
   wire                stageB_isExternalAmo;
   wire       [31:0]   stageB_requestDataBypass;
   reg                 stageB_cpuWriteToCache;
-  wire                when_DataCache_l926;
+  wire                when_DataCache_l931;
   wire                stageB_badPermissions;
   wire                stageB_loadStoreFault;
   wire                stageB_bypassCache;
-  wire                when_DataCache_l995;
-  wire                when_DataCache_l1004;
+  wire                when_DataCache_l1000;
   wire                when_DataCache_l1009;
-  wire                when_DataCache_l1020;
-  wire                when_DataCache_l1032;
-  wire                when_DataCache_l991;
-  wire                when_DataCache_l1066;
-  wire                when_DataCache_l1075;
+  wire                when_DataCache_l1014;
+  wire                when_DataCache_l1025;
+  wire                when_DataCache_l1037;
+  wire                when_DataCache_l996;
+  wire                when_DataCache_l1072;
+  wire                when_DataCache_l1081;
   reg                 loader_valid;
   reg                 loader_counter_willIncrement;
   wire                loader_counter_willClear;
@@ -5344,12 +5372,12 @@ module DataCache (
   reg                 loader_error;
   wire                loader_kill;
   reg                 loader_killReg;
-  wire                when_DataCache_l1090;
+  wire                when_DataCache_l1097;
   wire                loader_done;
-  wire                when_DataCache_l1118;
-  reg                 loader_valid_regNext;
-  wire                when_DataCache_l1122;
   wire                when_DataCache_l1125;
+  reg                 loader_valid_regNext;
+  wire                when_DataCache_l1129;
+  wire                when_DataCache_l1132;
   (* no_rw_check , ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
   (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
   (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
@@ -5360,8 +5388,6 @@ module DataCache (
   reg [7:0] _zz_ways_0_datasymbol_read_2;
   reg [7:0] _zz_ways_0_datasymbol_read_3;
 
-  assign _zz_stage0_dataColisions = (io_cpu_execute_address[11 : 2] >>> 0);
-  assign _zz__zz_stageA_dataColisions = (io_cpu_memory_address[11 : 2] >>> 0);
   assign _zz_when = 1'b1;
   assign _zz_loader_counter_valueNext_1 = loader_counter_willIncrement;
   assign _zz_loader_counter_valueNext = {2'd0, _zz_loader_counter_valueNext_1};
@@ -5408,14 +5434,14 @@ module DataCache (
 
   always @(*) begin
     _zz_1 = 1'b0;
-    if(when_DataCache_l645) begin
+    if(when_DataCache_l648) begin
       _zz_1 = 1'b1;
     end
   end
 
   always @(*) begin
     _zz_2 = 1'b0;
-    if(when_DataCache_l642) begin
+    if(when_DataCache_l645) begin
       _zz_2 = 1'b1;
     end
   end
@@ -5429,43 +5455,45 @@ module DataCache (
   assign _zz_ways_0_dataReadRspMem = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
   assign ways_0_dataReadRspMem = _zz_ways_0_data_port0;
   assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
-  assign when_DataCache_l642 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
-  assign when_DataCache_l645 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
+  assign when_DataCache_l645 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
+  assign when_DataCache_l648 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
   always @(*) begin
     tagsReadCmd_valid = 1'b0;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       tagsReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     tagsReadCmd_payload = 7'bxxxxxxx;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
     end
   end
 
   always @(*) begin
     dataReadCmd_valid = 1'b0;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       dataReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     dataReadCmd_payload = 10'bxxxxxxxxxx;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       dataReadCmd_payload = io_cpu_execute_address[11 : 2];
     end
   end
 
   always @(*) begin
     tagsWriteCmd_valid = 1'b0;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_valid = 1'b1;
     end
-    if(when_DataCache_l1066) begin
-      tagsWriteCmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        tagsWriteCmd_valid = 1'b0;
+      end
     end
     if(loader_done) begin
       tagsWriteCmd_valid = 1'b1;
@@ -5474,7 +5502,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_way = 1'bx;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_payload_way = 1'b1;
     end
     if(loader_done) begin
@@ -5484,7 +5512,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_address = 7'bxxxxxxx;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_payload_address = stageB_flusher_counter[6:0];
     end
     if(loader_done) begin
@@ -5494,7 +5522,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_data_valid = 1'bx;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_payload_data_valid = 1'b0;
     end
     if(loader_done) begin
@@ -5519,14 +5547,16 @@ module DataCache (
   always @(*) begin
     dataWriteCmd_valid = 1'b0;
     if(stageB_cpuWriteToCache) begin
-      if(when_DataCache_l926) begin
+      if(when_DataCache_l931) begin
         dataWriteCmd_valid = 1'b1;
       end
     end
-    if(when_DataCache_l1066) begin
-      dataWriteCmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        dataWriteCmd_valid = 1'b0;
+      end
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_valid = 1'b1;
     end
   end
@@ -5536,7 +5566,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_way = stageB_waysHits;
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_way = loader_waysAllocator;
     end
   end
@@ -5546,7 +5576,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
     end
   end
@@ -5556,7 +5586,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_data = io_mem_rsp_payload_data;
     end
   end
@@ -5569,15 +5599,15 @@ module DataCache (
         dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
       end
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_mask = 4'b1111;
     end
   end
 
-  assign when_DataCache_l664 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  assign when_DataCache_l667 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
   always @(*) begin
     io_cpu_execute_haltIt = 1'b0;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       io_cpu_execute_haltIt = 1'b1;
     end
   end
@@ -5585,7 +5615,7 @@ module DataCache (
   assign rspSync = 1'b1;
   assign rspLast = 1'b1;
   assign io_mem_cmd_fire = (io_mem_cmd_valid && io_mem_cmd_ready);
-  assign when_DataCache_l686 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l689 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     _zz_stage0_mask = 4'bxxxx;
     case(io_cpu_execute_args_size)
@@ -5604,45 +5634,45 @@ module DataCache (
   end
 
   assign stage0_mask = (_zz_stage0_mask <<< io_cpu_execute_address[1 : 0]);
-  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_stage0_dataColisions)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_execute_address[11 : 2])) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stage0_wayInvalidate = 1'b0;
   assign stage0_isAmo = 1'b0;
-  assign when_DataCache_l771 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l771_1 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l776 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l776_1 = (! io_cpu_memory_isStuck);
   assign io_cpu_memory_isWrite = stageA_request_wr;
   assign stageA_isAmo = 1'b0;
   assign stageA_isLrsc = 1'b0;
   assign stageA_wayHits = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign when_DataCache_l771_2 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l771_3 = (! io_cpu_memory_isStuck);
-  assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz__zz_stageA_dataColisions)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign when_DataCache_l776_2 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l776_3 = (! io_cpu_memory_isStuck);
+  assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_memory_address[11 : 2])) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_stageA_dataColisions);
-  assign when_DataCache_l822 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l827 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_mmuRspFreeze = 1'b0;
-    if(when_DataCache_l1125) begin
+    if(when_DataCache_l1132) begin
       stageB_mmuRspFreeze = 1'b1;
     end
   end
 
-  assign when_DataCache_l824 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
-  assign when_DataCache_l821 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l821_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l820 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l829 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
+  assign when_DataCache_l826 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l826_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825 = (! io_cpu_writeBack_isStuck);
   assign stageB_consistancyHazard = 1'b0;
-  assign when_DataCache_l820_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l820_2 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l820_3 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_2 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_3 = (! io_cpu_writeBack_isStuck);
   assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
   assign stageB_waysHit = (|stageB_waysHits);
   assign stageB_dataMux = stageB_dataReadRsp_0;
-  assign when_DataCache_l820_4 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_4 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_loaderValid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
             if(io_mem_cmd_ready) begin
               stageB_loaderValid = 1'b1;
             end
@@ -5650,8 +5680,10 @@ module DataCache (
         end
       end
     end
-    if(when_DataCache_l1066) begin
-      stageB_loaderValid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        stageB_loaderValid = 1'b0;
+      end
     end
   end
 
@@ -5660,28 +5692,32 @@ module DataCache (
     io_cpu_writeBack_haltIt = 1'b1;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l991) begin
-          if(when_DataCache_l995) begin
+        if(when_DataCache_l996) begin
+          if(when_DataCache_l1000) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
         end else begin
-          if(when_DataCache_l1004) begin
-            if(when_DataCache_l1009) begin
+          if(when_DataCache_l1009) begin
+            if(when_DataCache_l1014) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1066) begin
-      io_cpu_writeBack_haltIt = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        io_cpu_writeBack_haltIt = 1'b0;
+      end
     end
   end
 
   assign stageB_flusher_hold = 1'b0;
-  assign when_DataCache_l850 = (! stageB_flusher_counter[7]);
-  assign when_DataCache_l856 = (! stageB_flusher_hold);
+  assign when_DataCache_l855 = (! stageB_flusher_counter[7]);
+  assign when_DataCache_l861 = (! stageB_flusher_hold);
+  assign when_DataCache_l863 = (io_cpu_flush_valid && io_cpu_flush_payload_singleLine);
   assign io_cpu_flush_ready = (stageB_flusher_waitDone && stageB_flusher_counter[7]);
+  assign when_DataCache_l877 = (io_cpu_flush_valid && io_cpu_flush_payload_singleLine);
   assign stageB_isAmo = 1'b0;
   assign stageB_isAmoCached = 1'b0;
   assign stageB_isExternalLsrc = 1'b0;
@@ -5691,8 +5727,8 @@ module DataCache (
     stageB_cpuWriteToCache = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(when_DataCache_l1009) begin
             stageB_cpuWriteToCache = 1'b1;
           end
         end
@@ -5700,26 +5736,28 @@ module DataCache (
     end
   end
 
-  assign when_DataCache_l926 = (stageB_request_wr && stageB_waysHit);
+  assign when_DataCache_l931 = (stageB_request_wr && stageB_waysHit);
   assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_isAmo)));
   assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
   always @(*) begin
     io_cpu_redo = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(when_DataCache_l1004) begin
-            if(when_DataCache_l1020) begin
+        if(!when_DataCache_l996) begin
+          if(when_DataCache_l1009) begin
+            if(when_DataCache_l1025) begin
               io_cpu_redo = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1075) begin
-      io_cpu_redo = 1'b1;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1081) begin
+        io_cpu_redo = 1'b1;
+      end
     end
-    if(when_DataCache_l1122) begin
+    if(when_DataCache_l1129) begin
       io_cpu_redo = 1'b1;
     end
   end
@@ -5740,23 +5778,25 @@ module DataCache (
     io_mem_cmd_valid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l991) begin
+        if(when_DataCache_l996) begin
           io_mem_cmd_valid = (! memCmdSent);
         end else begin
-          if(when_DataCache_l1004) begin
+          if(when_DataCache_l1009) begin
             if(stageB_request_wr) begin
               io_mem_cmd_valid = 1'b1;
             end
           end else begin
-            if(when_DataCache_l1032) begin
+            if(when_DataCache_l1037) begin
               io_mem_cmd_valid = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1066) begin
-      io_mem_cmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        io_mem_cmd_valid = 1'b0;
+      end
     end
   end
 
@@ -5764,9 +5804,9 @@ module DataCache (
     io_mem_cmd_payload_address = stageB_mmuRsp_physicalAddress;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
-            io_mem_cmd_payload_address[4 : 0] = 5'h0;
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
+            io_mem_cmd_payload_address[4 : 0] = 5'h00;
           end
         end
       end
@@ -5778,8 +5818,8 @@ module DataCache (
     io_mem_cmd_payload_wr = stageB_request_wr;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
             io_mem_cmd_payload_wr = 1'b0;
           end
         end
@@ -5794,8 +5834,8 @@ module DataCache (
     io_mem_cmd_payload_size = {1'd0, stageB_request_size};
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
             io_mem_cmd_payload_size = 3'b101;
           end
         end
@@ -5805,12 +5845,12 @@ module DataCache (
 
   assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
   assign io_cpu_writeBack_keepMemRspData = 1'b0;
-  assign when_DataCache_l995 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
-  assign when_DataCache_l1004 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
-  assign when_DataCache_l1009 = ((! stageB_request_wr) || io_mem_cmd_ready);
-  assign when_DataCache_l1020 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
-  assign when_DataCache_l1032 = (! memCmdSent);
-  assign when_DataCache_l991 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  assign when_DataCache_l1000 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
+  assign when_DataCache_l1009 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
+  assign when_DataCache_l1014 = ((! stageB_request_wr) || io_mem_cmd_ready);
+  assign when_DataCache_l1025 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
+  assign when_DataCache_l1037 = (! memCmdSent);
+  assign when_DataCache_l996 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
   always @(*) begin
     if(stageB_bypassCache) begin
       io_cpu_writeBack_data = stageB_ioMemRspMuxed;
@@ -5819,11 +5859,11 @@ module DataCache (
     end
   end
 
-  assign when_DataCache_l1066 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign when_DataCache_l1075 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
+  assign when_DataCache_l1072 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign when_DataCache_l1081 = (stageB_mmuRsp_refilling || stageB_consistancyHazard);
   always @(*) begin
     loader_counter_willIncrement = 1'b0;
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       loader_counter_willIncrement = 1'b1;
     end
   end
@@ -5839,12 +5879,12 @@ module DataCache (
   end
 
   assign loader_kill = 1'b0;
-  assign when_DataCache_l1090 = ((loader_valid && io_mem_rsp_valid) && rspLast);
+  assign when_DataCache_l1097 = ((loader_valid && io_mem_rsp_valid) && rspLast);
   assign loader_done = loader_counter_willOverflow;
-  assign when_DataCache_l1118 = (! loader_valid);
-  assign when_DataCache_l1122 = (loader_valid && (! loader_valid_regNext));
+  assign when_DataCache_l1125 = (! loader_valid);
+  assign when_DataCache_l1129 = (loader_valid && (! loader_valid_regNext));
   assign io_cpu_execute_refilling = loader_valid;
-  assign when_DataCache_l1125 = (stageB_loaderValid || loader_valid);
+  assign when_DataCache_l1132 = (stageB_loaderValid || loader_valid);
   always @(posedge clk) begin
     tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
     tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
@@ -5852,26 +5892,26 @@ module DataCache (
     tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
     tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
     tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if(when_DataCache_l771) begin
+    if(when_DataCache_l776) begin
       stageA_request_wr <= io_cpu_execute_args_wr;
       stageA_request_size <= io_cpu_execute_args_size;
       stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
     end
-    if(when_DataCache_l771_1) begin
+    if(when_DataCache_l776_1) begin
       stageA_mask <= stage0_mask;
     end
-    if(when_DataCache_l771_2) begin
+    if(when_DataCache_l776_2) begin
       stageA_wayInvalidate <= stage0_wayInvalidate;
     end
-    if(when_DataCache_l771_3) begin
+    if(when_DataCache_l776_3) begin
       stage0_dataColisions_regNextWhen <= stage0_dataColisions;
     end
-    if(when_DataCache_l822) begin
+    if(when_DataCache_l827) begin
       stageB_request_wr <= stageA_request_wr;
       stageB_request_size <= stageA_request_size;
       stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
     end
-    if(when_DataCache_l824) begin
+    if(when_DataCache_l829) begin
       stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
       stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
       stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
@@ -5882,27 +5922,27 @@ module DataCache (
       stageB_mmuRsp_refilling <= io_cpu_memory_mmuRsp_refilling;
       stageB_mmuRsp_bypassTranslation <= io_cpu_memory_mmuRsp_bypassTranslation;
     end
-    if(when_DataCache_l821) begin
+    if(when_DataCache_l826) begin
       stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
       stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
       stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
     end
-    if(when_DataCache_l821_1) begin
+    if(when_DataCache_l826_1) begin
       stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
     end
-    if(when_DataCache_l820) begin
+    if(when_DataCache_l825) begin
       stageB_wayInvalidate <= stageA_wayInvalidate;
     end
-    if(when_DataCache_l820_1) begin
+    if(when_DataCache_l825_1) begin
       stageB_dataColisions <= stageA_dataColisions;
     end
-    if(when_DataCache_l820_2) begin
+    if(when_DataCache_l825_2) begin
       stageB_unaligned <= ({((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)),((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0))} != 2'b00);
     end
-    if(when_DataCache_l820_3) begin
+    if(when_DataCache_l825_3) begin
       stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
     end
-    if(when_DataCache_l820_4) begin
+    if(when_DataCache_l825_4) begin
       stageB_mask <= stageA_mask;
     end
     loader_valid_regNext <= loader_valid;
@@ -5912,7 +5952,7 @@ module DataCache (
     if(reset) begin
       memCmdSent <= 1'b0;
       stageB_flusher_waitDone <= 1'b0;
-      stageB_flusher_counter <= 8'h0;
+      stageB_flusher_counter <= 8'h00;
       stageB_flusher_start <= 1'b1;
       loader_valid <= 1'b0;
       loader_counter_value <= 3'b000;
@@ -5923,16 +5963,16 @@ module DataCache (
       if(io_mem_cmd_fire) begin
         memCmdSent <= 1'b1;
       end
-      if(when_DataCache_l686) begin
+      if(when_DataCache_l689) begin
         memCmdSent <= 1'b0;
       end
       if(io_cpu_flush_ready) begin
         stageB_flusher_waitDone <= 1'b0;
       end
-      if(when_DataCache_l850) begin
-        if(when_DataCache_l856) begin
+      if(when_DataCache_l855) begin
+        if(when_DataCache_l861) begin
           stageB_flusher_counter <= (stageB_flusher_counter + 8'h01);
-          if(io_cpu_flush_payload_singleLine) begin
+          if(when_DataCache_l863) begin
             stageB_flusher_counter[7] <= 1'b1;
           end
         end
@@ -5940,17 +5980,17 @@ module DataCache (
       stageB_flusher_start <= (((((((! stageB_flusher_waitDone) && (! stageB_flusher_start)) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
       if(stageB_flusher_start) begin
         stageB_flusher_waitDone <= 1'b1;
-        stageB_flusher_counter <= 8'h0;
-        if(io_cpu_flush_payload_singleLine) begin
+        stageB_flusher_counter <= 8'h00;
+        if(when_DataCache_l877) begin
           stageB_flusher_counter <= {1'b0,io_cpu_flush_payload_lineId};
         end
       end
       `ifndef SYNTHESIS
         `ifdef FORMAL
-          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))); // DataCache.scala:L1077
+          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))); // DataCache.scala:L1084
         `else
           if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-            $display("ERROR writeBack stuck by another plugin is not allowed"); // DataCache.scala:L1077
+            $display("ERROR writeBack stuck by another plugin is not allowed"); // DataCache.scala:L1084
           end
         `endif
       `endif
@@ -5961,7 +6001,7 @@ module DataCache (
       if(loader_kill) begin
         loader_killReg <= 1'b1;
       end
-      if(when_DataCache_l1090) begin
+      if(when_DataCache_l1097) begin
         loader_error <= (loader_error || io_mem_rsp_payload_error);
       end
       if(loader_done) begin
@@ -5969,7 +6009,7 @@ module DataCache (
         loader_error <= 1'b0;
         loader_killReg <= 1'b0;
       end
-      if(when_DataCache_l1118) begin
+      if(when_DataCache_l1125) begin
         loader_waysAllocator <= _zz_loader_waysAllocator[0:0];
       end
     end
@@ -5979,46 +6019,46 @@ module DataCache (
 endmodule
 
 module InstructionCache (
-  input               io_flush,
-  input               io_cpu_prefetch_isValid,
-  output reg          io_cpu_prefetch_haltIt,
-  input      [31:0]   io_cpu_prefetch_pc,
-  input               io_cpu_fetch_isValid,
-  input               io_cpu_fetch_isStuck,
-  input               io_cpu_fetch_isRemoved,
-  input      [31:0]   io_cpu_fetch_pc,
-  output     [31:0]   io_cpu_fetch_data,
-  input      [31:0]   io_cpu_fetch_mmuRsp_physicalAddress,
-  input               io_cpu_fetch_mmuRsp_isIoAccess,
-  input               io_cpu_fetch_mmuRsp_isPaging,
-  input               io_cpu_fetch_mmuRsp_allowRead,
-  input               io_cpu_fetch_mmuRsp_allowWrite,
-  input               io_cpu_fetch_mmuRsp_allowExecute,
-  input               io_cpu_fetch_mmuRsp_exception,
-  input               io_cpu_fetch_mmuRsp_refilling,
-  input               io_cpu_fetch_mmuRsp_bypassTranslation,
-  output     [31:0]   io_cpu_fetch_physicalAddress,
-  input               io_cpu_decode_isValid,
-  input               io_cpu_decode_isStuck,
-  input      [31:0]   io_cpu_decode_pc,
-  output     [31:0]   io_cpu_decode_physicalAddress,
-  output     [31:0]   io_cpu_decode_data,
-  output              io_cpu_decode_cacheMiss,
-  output              io_cpu_decode_error,
-  output              io_cpu_decode_mmuRefilling,
-  output              io_cpu_decode_mmuException,
-  input               io_cpu_decode_isUser,
-  input               io_cpu_fill_valid,
-  input      [31:0]   io_cpu_fill_payload,
-  output              io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output     [31:0]   io_mem_cmd_payload_address,
-  output     [2:0]    io_mem_cmd_payload_size,
-  input               io_mem_rsp_valid,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input               clk,
-  input               reset
+  input  wire          io_flush,
+  input  wire          io_cpu_prefetch_isValid,
+  output reg           io_cpu_prefetch_haltIt,
+  input  wire [31:0]   io_cpu_prefetch_pc,
+  input  wire          io_cpu_fetch_isValid,
+  input  wire          io_cpu_fetch_isStuck,
+  input  wire          io_cpu_fetch_isRemoved,
+  input  wire [31:0]   io_cpu_fetch_pc,
+  output wire [31:0]   io_cpu_fetch_data,
+  input  wire [31:0]   io_cpu_fetch_mmuRsp_physicalAddress,
+  input  wire          io_cpu_fetch_mmuRsp_isIoAccess,
+  input  wire          io_cpu_fetch_mmuRsp_isPaging,
+  input  wire          io_cpu_fetch_mmuRsp_allowRead,
+  input  wire          io_cpu_fetch_mmuRsp_allowWrite,
+  input  wire          io_cpu_fetch_mmuRsp_allowExecute,
+  input  wire          io_cpu_fetch_mmuRsp_exception,
+  input  wire          io_cpu_fetch_mmuRsp_refilling,
+  input  wire          io_cpu_fetch_mmuRsp_bypassTranslation,
+  output wire [31:0]   io_cpu_fetch_physicalAddress,
+  input  wire          io_cpu_decode_isValid,
+  input  wire          io_cpu_decode_isStuck,
+  input  wire [31:0]   io_cpu_decode_pc,
+  output wire [31:0]   io_cpu_decode_physicalAddress,
+  output wire [31:0]   io_cpu_decode_data,
+  output wire          io_cpu_decode_cacheMiss,
+  output wire          io_cpu_decode_error,
+  output wire          io_cpu_decode_mmuRefilling,
+  output wire          io_cpu_decode_mmuException,
+  input  wire          io_cpu_decode_isUser,
+  input  wire          io_cpu_fill_valid,
+  input  wire [31:0]   io_cpu_fill_payload,
+  output wire          io_mem_cmd_valid,
+  input  wire          io_mem_cmd_ready,
+  output wire [31:0]   io_mem_cmd_payload_address,
+  output wire [2:0]    io_mem_cmd_payload_size,
+  input  wire          io_mem_rsp_valid,
+  input  wire [31:0]   io_mem_rsp_payload_data,
+  input  wire          io_mem_rsp_payload_error,
+  input  wire          clk,
+  input  wire          reset
 );
 
   reg        [31:0]   _zz_banks_0_port1;
@@ -6038,7 +6078,7 @@ module InstructionCache (
   wire                when_InstructionCache_l351;
   reg                 lineLoader_cmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_Utils_l515;
+  wire                when_Utils_l560;
   reg                 lineLoader_wayToAllocate_willIncrement;
   wire                lineLoader_wayToAllocate_willClear;
   wire                lineLoader_wayToAllocate_willOverflowIfInc;
@@ -6153,12 +6193,12 @@ module InstructionCache (
   assign when_InstructionCache_l351 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
   assign io_mem_cmd_fire = (io_mem_cmd_valid && io_mem_cmd_ready);
   assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
-  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
+  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h00};
   assign io_mem_cmd_payload_size = 3'b101;
-  assign when_Utils_l515 = (! lineLoader_valid);
+  assign when_Utils_l560 = (! lineLoader_valid);
   always @(*) begin
     lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if(when_Utils_l515) begin
+    if(when_Utils_l560) begin
       lineLoader_wayToAllocate_willIncrement = 1'b1;
     end
   end
@@ -6249,7 +6289,7 @@ module InstructionCache (
     end
     _zz_when_InstructionCache_l342 <= lineLoader_flushCounter[7];
     if(when_InstructionCache_l351) begin
-      lineLoader_flushCounter <= 8'h0;
+      lineLoader_flushCounter <= 8'h00;
     end
     if(when_InstructionCache_l435) begin
       io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_Debug.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_Debug.v
@@ -1,46 +1,46 @@
-// Generator : SpinalHDL v1.7.1    git head : 0444bb76ab1d6e19f0ec46bc03c4769776deb7d5
+// Generator : SpinalHDL v1.9.4    git head : 270018552577f3bb8e5339ee2583c9c22d324215
 // Component : VexRiscv
-// Git hash  : 581fcb065adf7ea8b626f939ff51679d4c95872f
+// Git hash  : 63430af99f84cc1d11d58b556debe1cc3f238c67
 
 `timescale 1ns/1ps
 
 module VexRiscv (
-  input      [31:0]   externalResetVector,
-  input               timerInterrupt,
-  input               softwareInterrupt,
-  input      [31:0]   externalInterruptArray,
-  input               debug_bus_cmd_valid,
-  output reg          debug_bus_cmd_ready,
-  input               debug_bus_cmd_payload_wr,
-  input      [7:0]    debug_bus_cmd_payload_address,
-  input      [31:0]   debug_bus_cmd_payload_data,
-  output reg [31:0]   debug_bus_rsp_data,
-  output              debug_resetOut,
-  output reg          iBusWishbone_CYC,
-  output reg          iBusWishbone_STB,
-  input               iBusWishbone_ACK,
-  output              iBusWishbone_WE,
-  output     [29:0]   iBusWishbone_ADR,
-  input      [31:0]   iBusWishbone_DAT_MISO,
-  output     [31:0]   iBusWishbone_DAT_MOSI,
-  output     [3:0]    iBusWishbone_SEL,
-  input               iBusWishbone_ERR,
-  output     [2:0]    iBusWishbone_CTI,
-  output     [1:0]    iBusWishbone_BTE,
-  output              dBusWishbone_CYC,
-  output              dBusWishbone_STB,
-  input               dBusWishbone_ACK,
-  output              dBusWishbone_WE,
-  output     [29:0]   dBusWishbone_ADR,
-  input      [31:0]   dBusWishbone_DAT_MISO,
-  output     [31:0]   dBusWishbone_DAT_MOSI,
-  output     [3:0]    dBusWishbone_SEL,
-  input               dBusWishbone_ERR,
-  output     [2:0]    dBusWishbone_CTI,
-  output     [1:0]    dBusWishbone_BTE,
-  input               clk,
-  input               reset,
-  input               debugReset
+  input  wire [31:0]   externalResetVector,
+  input  wire          timerInterrupt,
+  input  wire          softwareInterrupt,
+  input  wire [31:0]   externalInterruptArray,
+  input  wire          debug_bus_cmd_valid,
+  output reg           debug_bus_cmd_ready,
+  input  wire          debug_bus_cmd_payload_wr,
+  input  wire [7:0]    debug_bus_cmd_payload_address,
+  input  wire [31:0]   debug_bus_cmd_payload_data,
+  output reg  [31:0]   debug_bus_rsp_data,
+  output wire          debug_resetOut,
+  output reg           iBusWishbone_CYC,
+  output reg           iBusWishbone_STB,
+  input  wire          iBusWishbone_ACK,
+  output wire          iBusWishbone_WE,
+  output wire [29:0]   iBusWishbone_ADR,
+  input  wire [31:0]   iBusWishbone_DAT_MISO,
+  output wire [31:0]   iBusWishbone_DAT_MOSI,
+  output wire [3:0]    iBusWishbone_SEL,
+  input  wire          iBusWishbone_ERR,
+  output wire [2:0]    iBusWishbone_CTI,
+  output wire [1:0]    iBusWishbone_BTE,
+  output wire          dBusWishbone_CYC,
+  output wire          dBusWishbone_STB,
+  input  wire          dBusWishbone_ACK,
+  output wire          dBusWishbone_WE,
+  output wire [29:0]   dBusWishbone_ADR,
+  input  wire [31:0]   dBusWishbone_DAT_MISO,
+  output wire [31:0]   dBusWishbone_DAT_MOSI,
+  output wire [3:0]    dBusWishbone_SEL,
+  input  wire          dBusWishbone_ERR,
+  output wire [2:0]    dBusWishbone_CTI,
+  output wire [1:0]    dBusWishbone_BTE,
+  input  wire          clk,
+  input  wire          reset,
+  input  wire          debugReset
 );
   localparam ShiftCtrlEnum_DISABLE_1 = 2'd0;
   localparam ShiftCtrlEnum_SLL_1 = 2'd1;
@@ -98,7 +98,6 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_flush_valid;
   wire                dataCache_1_io_cpu_flush_payload_singleLine;
   wire       [6:0]    dataCache_1_io_cpu_flush_payload_lineId;
-  wire                dataCache_1_io_mem_cmd_ready;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
@@ -126,6 +125,7 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_writeBack_exclusiveOk;
   wire                dataCache_1_io_cpu_flush_ready;
   wire                dataCache_1_io_cpu_redo;
+  wire                dataCache_1_io_cpu_writesPending;
   wire                dataCache_1_io_mem_cmd_valid;
   wire                dataCache_1_io_mem_cmd_payload_wr;
   wire                dataCache_1_io_mem_cmd_payload_uncached;
@@ -137,12 +137,11 @@ module VexRiscv (
   wire       [51:0]   _zz_memory_MUL_LOW;
   wire       [51:0]   _zz_memory_MUL_LOW_1;
   wire       [51:0]   _zz_memory_MUL_LOW_2;
-  wire       [51:0]   _zz_memory_MUL_LOW_3;
-  wire       [32:0]   _zz_memory_MUL_LOW_4;
-  wire       [51:0]   _zz_memory_MUL_LOW_5;
-  wire       [49:0]   _zz_memory_MUL_LOW_6;
-  wire       [51:0]   _zz_memory_MUL_LOW_7;
-  wire       [49:0]   _zz_memory_MUL_LOW_8;
+  wire       [32:0]   _zz_memory_MUL_LOW_3;
+  wire       [51:0]   _zz_memory_MUL_LOW_4;
+  wire       [49:0]   _zz_memory_MUL_LOW_5;
+  wire       [51:0]   _zz_memory_MUL_LOW_6;
+  wire       [49:0]   _zz_memory_MUL_LOW_7;
   wire       [31:0]   _zz_execute_SHIFT_RIGHT;
   wire       [32:0]   _zz_execute_SHIFT_RIGHT_1;
   wire       [32:0]   _zz_execute_SHIFT_RIGHT_2;
@@ -153,19 +152,19 @@ module VexRiscv (
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_2;
   wire                _zz_decode_LEGAL_INSTRUCTION_3;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_4;
-  wire       [13:0]   _zz_decode_LEGAL_INSTRUCTION_5;
+  wire       [12:0]   _zz_decode_LEGAL_INSTRUCTION_5;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_6;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_7;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_8;
   wire                _zz_decode_LEGAL_INSTRUCTION_9;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_10;
-  wire       [7:0]    _zz_decode_LEGAL_INSTRUCTION_11;
+  wire       [6:0]    _zz_decode_LEGAL_INSTRUCTION_11;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_12;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_13;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_14;
   wire                _zz_decode_LEGAL_INSTRUCTION_15;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_16;
-  wire       [1:0]    _zz_decode_LEGAL_INSTRUCTION_17;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_17;
   wire       [3:0]    _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1;
   reg        [31:0]   _zz_IBusCachedPlugin_jump_pcLoad_payload_5;
   wire       [1:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_6;
@@ -199,139 +198,125 @@ module VexRiscv (
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_6;
   wire       [25:0]   _zz__zz_decode_IS_RS2_SIGNED_7;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_8;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_9;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_10;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_9;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_10;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_11;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_12;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_12;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_13;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_14;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_15;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_14;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_15;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_16;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_17;
+  wire       [21:0]   _zz__zz_decode_IS_RS2_SIGNED_17;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_18;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_19;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_20;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_21;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_20;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_21;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_22;
-  wire       [21:0]   _zz__zz_decode_IS_RS2_SIGNED_23;
-  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_24;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_23;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_24;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_25;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_26;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_27;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_28;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_29;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_30;
+  wire       [17:0]   _zz__zz_decode_IS_RS2_SIGNED_26;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_27;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_28;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_29;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_30;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_31;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_32;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_33;
-  wire       [18:0]   _zz__zz_decode_IS_RS2_SIGNED_34;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_32;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_33;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_34;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_35;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_36;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_37;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_38;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_39;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_40;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_36;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_37;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_38;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_39;
+  wire       [13:0]   _zz__zz_decode_IS_RS2_SIGNED_40;
   wire                _zz__zz_decode_IS_RS2_SIGNED_41;
-  wire       [15:0]   _zz__zz_decode_IS_RS2_SIGNED_42;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_43;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_42;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_43;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_44;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_45;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_45;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_46;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_47;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_48;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_48;
   wire                _zz__zz_decode_IS_RS2_SIGNED_49;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_50;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_51;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_50;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_51;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_52;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_53;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_54;
-  wire       [12:0]   _zz__zz_decode_IS_RS2_SIGNED_55;
-  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_56;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_57;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_58;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_59;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_60;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_53;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_54;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_55;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_56;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_57;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_58;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_59;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_60;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_61;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_62;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_63;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_62;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_63;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_64;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_65;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_66;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_67;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_68;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_69;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_65;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_66;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_67;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_68;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_69;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_70;
-  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_71;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_72;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_71;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_72;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_73;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_74;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_75;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_76;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_77;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_78;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_74;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_75;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_76;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_77;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_78;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_79;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_80;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_81;
-  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_82;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_83;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_84;
+  wire       [9:0]    _zz__zz_decode_IS_RS2_SIGNED_80;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_81;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_82;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_83;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_84;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_85;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_86;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_86;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_87;
-  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_88;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_89;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_88;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_89;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_90;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_91;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_92;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_93;
-  wire       [9:0]    _zz__zz_decode_IS_RS2_SIGNED_94;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_95;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_96;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_97;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_98;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_99;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_92;
+  wire       [6:0]    _zz__zz_decode_IS_RS2_SIGNED_93;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_94;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_95;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_96;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_97;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_98;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_99;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_100;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_101;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_102;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_103;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_104;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_102;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_103;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_104;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_105;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_106;
-  wire       [6:0]    _zz__zz_decode_IS_RS2_SIGNED_107;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_107;
   wire                _zz__zz_decode_IS_RS2_SIGNED_108;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_109;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_110;
-  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_111;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_112;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_109;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_110;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_111;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_112;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_113;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_114;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_114;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_115;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_116;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_116;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_117;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_118;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_119;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_120;
-  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_121;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_122;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_123;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_124;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_125;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_126;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_119;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_120;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_121;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_122;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_123;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_124;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_125;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_126;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_127;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_128;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_129;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_130;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_131;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_132;
-  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_133;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_134;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_135;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_136;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_137;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_138;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_139;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_140;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_141;
   wire                _zz_RegFilePlugin_regFile_port;
   wire                _zz_decode_RegFilePlugin_rs1Data;
   wire                _zz_RegFilePlugin_regFile_port_1;
@@ -339,14 +324,12 @@ module VexRiscv (
   wire       [0:0]    _zz__zz_execute_REGFILE_WRITE_DATA;
   wire       [2:0]    _zz__zz_execute_SRC1;
   wire       [4:0]    _zz__zz_execute_SRC1_1;
-  wire       [11:0]   _zz__zz_execute_SRC2_3;
+  wire       [11:0]   _zz__zz_execute_SRC2_2;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_1;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_2;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_3;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_4;
-  wire       [31:0]   _zz_execute_SrcPlugin_addSub_5;
-  wire       [31:0]   _zz_execute_SrcPlugin_addSub_6;
   wire       [19:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_2;
   wire       [11:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_4;
   wire       [31:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_6;
@@ -498,7 +481,7 @@ module VexRiscv (
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_execute_SRC2;
+  wire       [31:0]   _zz_execute_to_memory_PC;
   wire       [1:0]    execute_SRC2_CTRL;
   wire       [1:0]    _zz_execute_SRC2_CTRL;
   wire       [1:0]    execute_SRC1_CTRL;
@@ -665,7 +648,7 @@ module VexRiscv (
   reg                 DBusCachedPlugin_exceptionBus_valid;
   reg        [3:0]    DBusCachedPlugin_exceptionBus_payload_code;
   wire       [31:0]   DBusCachedPlugin_exceptionBus_payload_badAddr;
-  reg                 _zz_when_DBusCachedPlugin_l393;
+  reg                 _zz_when_DBusCachedPlugin_l472;
   wire                decodeExceptionPort_valid;
   wire       [3:0]    decodeExceptionPort_payload_code;
   wire       [31:0]   decodeExceptionPort_payload_badAddr;
@@ -678,8 +661,9 @@ module VexRiscv (
   wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
   wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
   wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
-  wire                CsrPlugin_csrMapping_allowCsrSignal;
+  reg                 CsrPlugin_csrMapping_allowCsrSignal;
   wire                CsrPlugin_csrMapping_hazardFree;
+  wire                CsrPlugin_csrMapping_doForceFailCsr;
   wire                CsrPlugin_inWfi /* verilator public */ ;
   reg                 CsrPlugin_thirdPartyWake;
   reg                 CsrPlugin_jumpInterface_valid;
@@ -698,9 +682,10 @@ module VexRiscv (
   reg                 CsrPlugin_allowInterrupts;
   reg                 CsrPlugin_allowException;
   reg                 CsrPlugin_allowEbreakException;
-  reg                 IBusCachedPlugin_injectionPort_valid;
-  reg                 IBusCachedPlugin_injectionPort_ready;
-  wire       [31:0]   IBusCachedPlugin_injectionPort_payload;
+  wire                CsrPlugin_xretAwayFromMachine;
+  reg                 DebugPlugin_injectionPort_valid;
+  reg                 DebugPlugin_injectionPort_ready;
+  wire       [31:0]   DebugPlugin_injectionPort_payload;
   wire                IBusCachedPlugin_externalFlush;
   wire                IBusCachedPlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
@@ -720,14 +705,13 @@ module VexRiscv (
   reg                 IBusCachedPlugin_fetchPc_pcRegPropagate;
   reg                 IBusCachedPlugin_fetchPc_booted;
   reg                 IBusCachedPlugin_fetchPc_inc;
-  wire                when_Fetcher_l134;
-  wire                IBusCachedPlugin_fetchPc_output_fire_1;
-  wire                when_Fetcher_l134_1;
+  wire                when_Fetcher_l133;
+  wire                when_Fetcher_l133_1;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pc;
   wire                IBusCachedPlugin_fetchPc_redo_valid;
   wire       [31:0]   IBusCachedPlugin_fetchPc_redo_payload;
   reg                 IBusCachedPlugin_fetchPc_flushed;
-  wire                when_Fetcher_l161;
+  wire                when_Fetcher_l160;
   reg                 IBusCachedPlugin_iBusRsp_redoFetch;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_ready;
@@ -755,8 +739,8 @@ module VexRiscv (
   wire                _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready;
   wire                IBusCachedPlugin_iBusRsp_flush;
   wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
-  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
-  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid;
+  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1;
   wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
@@ -769,18 +753,18 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_output_payload_rsp_error;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   wire                IBusCachedPlugin_iBusRsp_output_payload_isRvc;
-  wire                when_Fetcher_l243;
-  wire                when_Fetcher_l323;
+  wire                when_Fetcher_l242;
+  wire                when_Fetcher_l322;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
-  wire                when_Fetcher_l332;
+  wire                when_Fetcher_l331;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
-  wire                when_Fetcher_l332_1;
+  wire                when_Fetcher_l331_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
-  wire                when_Fetcher_l332_2;
+  wire                when_Fetcher_l331_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
-  wire                when_Fetcher_l332_3;
+  wire                when_Fetcher_l331_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                when_Fetcher_l332_4;
+  wire                when_Fetcher_l331_4;
   wire                _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   reg        [18:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1;
   wire                _zz_2;
@@ -806,69 +790,70 @@ module VexRiscv (
   wire                IBusCachedPlugin_rsp_iBusRspOutputHalt;
   wire                IBusCachedPlugin_rsp_issueDetected;
   reg                 IBusCachedPlugin_rsp_redoFetch;
-  wire                when_IBusCachedPlugin_l239;
-  wire                when_IBusCachedPlugin_l244;
+  wire                when_IBusCachedPlugin_l245;
   wire                when_IBusCachedPlugin_l250;
   wire                when_IBusCachedPlugin_l256;
-  wire                when_IBusCachedPlugin_l267;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_valid;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_ready;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_address;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_data;
-  wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_size;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_last;
-  reg                 dataCache_1_io_mem_cmd_rValid;
-  reg                 dataCache_1_io_mem_cmd_rData_wr;
-  reg                 dataCache_1_io_mem_cmd_rData_uncached;
-  reg        [31:0]   dataCache_1_io_mem_cmd_rData_address;
-  reg        [31:0]   dataCache_1_io_mem_cmd_rData_data;
-  reg        [3:0]    dataCache_1_io_mem_cmd_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_rData_size;
-  reg                 dataCache_1_io_mem_cmd_rData_last;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
-  wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data;
-  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
-  wire                when_Stream_l368;
+  wire                when_IBusCachedPlugin_l262;
+  wire                when_IBusCachedPlugin_l273;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_valid;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+  wire       [3:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+  wire       [2:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_size;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rValidN;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rData_wr;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rData_uncached;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_rData_address;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_rData_data;
+  reg        [3:0]    toplevel_dataCache_1_io_mem_cmd_rData_mask;
+  reg        [2:0]    toplevel_dataCache_1_io_mem_cmd_rData_size;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rData_last;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
+  wire       [3:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
+  wire       [2:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_address;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_data;
+  reg        [3:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
+  reg        [2:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_size;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  wire                when_Stream_l369;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
-  wire                when_DBusCachedPlugin_l308;
+  wire                when_DBusCachedPlugin_l352;
   wire       [1:0]    execute_DBusCachedPlugin_size;
   reg        [31:0]   _zz_execute_MEMORY_STORE_DATA_RF;
-  wire                dataCache_1_io_cpu_flush_isStall;
-  wire                when_DBusCachedPlugin_l350;
-  wire                when_DBusCachedPlugin_l366;
-  wire                when_DBusCachedPlugin_l393;
-  wire                when_DBusCachedPlugin_l446;
-  wire                when_DBusCachedPlugin_l466;
+  wire                toplevel_dataCache_1_io_cpu_flush_isStall;
+  wire                when_DBusCachedPlugin_l394;
+  wire                when_DBusCachedPlugin_l410;
+  wire                when_DBusCachedPlugin_l472;
+  wire                when_DBusCachedPlugin_l533;
+  wire                when_DBusCachedPlugin_l553;
+  wire       [31:0]   writeBack_DBusCachedPlugin_rspData;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_0;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_1;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_2;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
   wire       [31:0]   writeBack_DBusCachedPlugin_rspRf;
-  wire       [1:0]    switch_Misc_l210;
+  wire       [1:0]    switch_Misc_l232;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_1;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated_2;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
-  wire                when_DBusCachedPlugin_l492;
+  wire                when_DBusCachedPlugin_l580;
   wire       [32:0]   _zz_decode_IS_RS2_SIGNED;
   wire                _zz_decode_IS_RS2_SIGNED_1;
   wire                _zz_decode_IS_RS2_SIGNED_2;
@@ -890,15 +875,15 @@ module VexRiscv (
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
   reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
   reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_7;
+  reg                 _zz_10;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
   reg        [31:0]   _zz_execute_REGFILE_WRITE_DATA;
   reg        [31:0]   _zz_execute_SRC1;
-  wire                _zz_execute_SRC2_1;
-  reg        [19:0]   _zz_execute_SRC2_2;
-  wire                _zz_execute_SRC2_3;
-  reg        [19:0]   _zz_execute_SRC2_4;
-  reg        [31:0]   _zz_execute_SRC2_5;
+  wire                _zz_execute_SRC2;
+  reg        [19:0]   _zz_execute_SRC2_1;
+  wire                _zz_execute_SRC2_2;
+  reg        [19:0]   _zz_execute_SRC2_3;
+  reg        [31:0]   _zz_execute_SRC2_4;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   wire       [4:0]    execute_FullBarrelShifterPlugin_amplitude;
@@ -935,7 +920,7 @@ module VexRiscv (
   wire                when_HazardSimplePlugin_l108;
   wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    switch_Misc_l210_1;
+  wire       [2:0]    switch_Misc_l232_1;
   reg                 _zz_execute_BRANCH_COND_RESULT;
   reg                 _zz_execute_BRANCH_COND_RESULT_1;
   wire                _zz_execute_BranchPlugin_missAlignedTarget;
@@ -974,9 +959,9 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_mtval;
   reg        [63:0]   CsrPlugin_mcycle;
   reg        [63:0]   CsrPlugin_minstret;
-  wire                _zz_when_CsrPlugin_l965;
-  wire                _zz_when_CsrPlugin_l965_1;
-  wire                _zz_when_CsrPlugin_l965_2;
+  wire                _zz_when_CsrPlugin_l1302;
+  wire                _zz_when_CsrPlugin_l1302_1;
+  wire                _zz_when_CsrPlugin_l1302_2;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -991,56 +976,59 @@ module VexRiscv (
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
   wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code;
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
-  wire                when_CsrPlugin_l922;
-  wire                when_CsrPlugin_l922_1;
-  wire                when_CsrPlugin_l922_2;
-  wire                when_CsrPlugin_l922_3;
-  wire                when_CsrPlugin_l935;
+  wire                when_CsrPlugin_l1259;
+  wire                when_CsrPlugin_l1259_1;
+  wire                when_CsrPlugin_l1259_2;
+  wire                when_CsrPlugin_l1259_3;
+  wire                when_CsrPlugin_l1272;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
-  wire                when_CsrPlugin_l959;
-  wire                when_CsrPlugin_l965;
-  wire                when_CsrPlugin_l965_1;
-  wire                when_CsrPlugin_l965_2;
+  wire                when_CsrPlugin_l1296;
+  wire                when_CsrPlugin_l1302;
+  wire                when_CsrPlugin_l1302_1;
+  wire                when_CsrPlugin_l1302_2;
   wire                CsrPlugin_exception;
   wire                CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
-  wire                when_CsrPlugin_l993;
-  wire                when_CsrPlugin_l993_1;
-  wire                when_CsrPlugin_l993_2;
-  wire                when_CsrPlugin_l998;
+  wire                when_CsrPlugin_l1335;
+  wire                when_CsrPlugin_l1335_1;
+  wire                when_CsrPlugin_l1335_2;
+  wire                when_CsrPlugin_l1340;
   reg                 CsrPlugin_pipelineLiberator_done;
-  wire                when_CsrPlugin_l1004;
+  wire                when_CsrPlugin_l1346;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
+  wire                CsrPlugin_trapCauseEbreakDebug;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
-  wire                when_CsrPlugin_l1032;
-  wire                when_CsrPlugin_l1077;
-  wire       [1:0]    switch_CsrPlugin_l1081;
+  wire                CsrPlugin_trapEnterDebug;
+  wire                when_CsrPlugin_l1390;
+  wire                when_CsrPlugin_l1398;
+  wire                when_CsrPlugin_l1456;
+  wire       [1:0]    switch_CsrPlugin_l1460;
   reg                 execute_CsrPlugin_wfiWake;
-  wire                when_CsrPlugin_l1129;
+  wire                when_CsrPlugin_l1527;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire                when_CsrPlugin_l1149;
-  wire                when_CsrPlugin_l1150;
-  wire                when_CsrPlugin_l1157;
+  wire                when_CsrPlugin_l1547;
+  wire                when_CsrPlugin_l1548;
+  wire                when_CsrPlugin_l1555;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   wire       [31:0]   execute_CsrPlugin_readToWriteData;
-  wire                switch_Misc_l210_2;
+  wire                switch_Misc_l232_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
-  wire                when_CsrPlugin_l1189;
-  wire                when_CsrPlugin_l1193;
+  wire                when_CsrPlugin_l1587;
+  wire                when_CsrPlugin_l1591;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg                 execute_MulPlugin_aSigned;
   reg                 execute_MulPlugin_bSigned;
@@ -1087,7 +1075,7 @@ module VexRiscv (
   reg        [32:0]   _zz_memory_DivPlugin_rs1_1;
   reg        [31:0]   externalInterruptArray_regNext;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit;
-  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
+  wire       [31:0]   _zz_externalInterrupt;
   reg                 DebugPlugin_firstCycle;
   reg                 DebugPlugin_secondCycle;
   reg                 DebugPlugin_resetIt;
@@ -1095,7 +1083,7 @@ module VexRiscv (
   reg                 DebugPlugin_stepIt;
   reg                 DebugPlugin_isPipBusy;
   reg                 DebugPlugin_godmode;
-  wire                when_DebugPlugin_l225;
+  wire                when_DebugPlugin_l238;
   reg                 DebugPlugin_haltedByBreak;
   reg                 DebugPlugin_debugUsed /* verilator public */ ;
   reg                 DebugPlugin_disableEbreak;
@@ -1105,22 +1093,22 @@ module VexRiscv (
   reg                 DebugPlugin_hardwareBreakpoints_1_valid;
   reg        [30:0]   DebugPlugin_hardwareBreakpoints_1_pc;
   reg        [31:0]   DebugPlugin_busReadDataReg;
-  reg                 _zz_when_DebugPlugin_l244;
-  wire                when_DebugPlugin_l244;
-  wire       [5:0]    switch_DebugPlugin_l267;
-  wire                when_DebugPlugin_l271;
-  wire                when_DebugPlugin_l271_1;
-  wire                when_DebugPlugin_l272;
-  wire                when_DebugPlugin_l272_1;
-  wire                when_DebugPlugin_l273;
-  wire                when_DebugPlugin_l274;
-  wire                when_DebugPlugin_l275;
-  wire                when_DebugPlugin_l275_1;
-  wire                when_DebugPlugin_l295;
-  wire                when_DebugPlugin_l298;
+  reg                 _zz_when_DebugPlugin_l257;
+  wire                when_DebugPlugin_l257;
+  wire       [5:0]    switch_DebugPlugin_l280;
+  wire                when_DebugPlugin_l284;
+  wire                when_DebugPlugin_l284_1;
+  wire                when_DebugPlugin_l285;
+  wire                when_DebugPlugin_l285_1;
+  wire                when_DebugPlugin_l286;
+  wire                when_DebugPlugin_l287;
+  wire                when_DebugPlugin_l288;
+  wire                when_DebugPlugin_l288_1;
+  wire                when_DebugPlugin_l308;
   wire                when_DebugPlugin_l311;
+  wire                when_DebugPlugin_l324;
   reg                 DebugPlugin_resetIt_regNext;
-  wire                when_DebugPlugin_l331;
+  wire                when_DebugPlugin_l344;
   wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
   wire                when_Pipeline_l124_1;
@@ -1253,30 +1241,31 @@ module VexRiscv (
   wire                when_Pipeline_l154_1;
   wire                when_Pipeline_l151_2;
   wire                when_Pipeline_l154_2;
-  reg        [2:0]    switch_Fetcher_l365;
-  wire                when_Fetcher_l381;
-  wire                when_CsrPlugin_l1277;
+  reg        [2:0]    IBusCachedPlugin_injector_port_state;
+  wire                when_Fetcher_l391;
+  wire                when_CsrPlugin_l1669;
   reg                 execute_CsrPlugin_csr_3264;
-  wire                when_CsrPlugin_l1277_1;
+  wire                when_CsrPlugin_l1669_1;
   reg                 execute_CsrPlugin_csr_768;
-  wire                when_CsrPlugin_l1277_2;
+  wire                when_CsrPlugin_l1669_2;
   reg                 execute_CsrPlugin_csr_836;
-  wire                when_CsrPlugin_l1277_3;
+  wire                when_CsrPlugin_l1669_3;
   reg                 execute_CsrPlugin_csr_772;
-  wire                when_CsrPlugin_l1277_4;
+  wire                when_CsrPlugin_l1669_4;
   reg                 execute_CsrPlugin_csr_773;
-  wire                when_CsrPlugin_l1277_5;
+  wire                when_CsrPlugin_l1669_5;
   reg                 execute_CsrPlugin_csr_833;
-  wire                when_CsrPlugin_l1277_6;
+  wire                when_CsrPlugin_l1669_6;
   reg                 execute_CsrPlugin_csr_834;
-  wire                when_CsrPlugin_l1277_7;
+  wire                when_CsrPlugin_l1669_7;
   reg                 execute_CsrPlugin_csr_835;
-  wire                when_CsrPlugin_l1277_8;
+  wire                when_CsrPlugin_l1669_8;
   reg                 execute_CsrPlugin_csr_3008;
-  wire                when_CsrPlugin_l1277_9;
+  wire                when_CsrPlugin_l1669_9;
   reg                 execute_CsrPlugin_csr_4032;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
+  wire       [1:0]    switch_CsrPlugin_l1031;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
-  wire       [1:0]    switch_CsrPlugin_l723;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_5;
@@ -1284,19 +1273,22 @@ module VexRiscv (
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_8;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_10;
-  wire                when_CsrPlugin_l1310;
-  wire                when_CsrPlugin_l1315;
+  wire                when_CsrPlugin_l1702;
+  wire       [11:0]   _zz_when_CsrPlugin_l1709;
+  wire                when_CsrPlugin_l1709;
+  reg                 when_CsrPlugin_l1719;
+  wire                when_CsrPlugin_l1717;
+  wire                when_CsrPlugin_l1725;
   reg        [2:0]    _zz_iBusWishbone_ADR;
   wire                when_InstructionCache_l239;
   reg                 _zz_iBus_rsp_valid;
   reg        [31:0]   iBusWishbone_DAT_MISO_regNext;
-  reg        [2:0]    _zz_dBus_cmd_ready;
+  reg        [2:0]    _zz_dBusWishbone_ADR;
+  wire                _zz_dBusWishbone_CYC;
+  wire                _zz_dBus_cmd_ready;
   wire                _zz_dBus_cmd_ready_1;
   wire                _zz_dBus_cmd_ready_2;
-  wire                _zz_dBus_cmd_ready_3;
-  wire                _zz_dBus_cmd_ready_4;
-  wire                _zz_dBus_cmd_ready_5;
+  wire                _zz_dBusWishbone_ADR_1;
   reg                 _zz_dBus_rsp_valid;
   reg        [31:0]   dBusWishbone_DAT_MISO_regNext;
   `ifndef SYNTHESIS
@@ -1383,20 +1375,19 @@ module VexRiscv (
   (* no_rw_check , ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
   assign _zz_when = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
-  assign _zz_memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW_1) + $signed(_zz_memory_MUL_LOW_5));
-  assign _zz_memory_MUL_LOW_1 = ($signed(_zz_memory_MUL_LOW_2) + $signed(_zz_memory_MUL_LOW_3));
-  assign _zz_memory_MUL_LOW_2 = 52'h0;
-  assign _zz_memory_MUL_LOW_4 = {1'b0,memory_MUL_LL};
-  assign _zz_memory_MUL_LOW_3 = {{19{_zz_memory_MUL_LOW_4[32]}}, _zz_memory_MUL_LOW_4};
-  assign _zz_memory_MUL_LOW_6 = ({16'd0,memory_MUL_LH} <<< 16);
-  assign _zz_memory_MUL_LOW_5 = {{2{_zz_memory_MUL_LOW_6[49]}}, _zz_memory_MUL_LOW_6};
-  assign _zz_memory_MUL_LOW_8 = ({16'd0,memory_MUL_HL} <<< 16);
-  assign _zz_memory_MUL_LOW_7 = {{2{_zz_memory_MUL_LOW_8[49]}}, _zz_memory_MUL_LOW_8};
+  assign _zz_memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW_1) + $signed(_zz_memory_MUL_LOW_4));
+  assign _zz_memory_MUL_LOW_1 = ($signed(52'h0000000000000) + $signed(_zz_memory_MUL_LOW_2));
+  assign _zz_memory_MUL_LOW_3 = {1'b0,memory_MUL_LL};
+  assign _zz_memory_MUL_LOW_2 = {{19{_zz_memory_MUL_LOW_3[32]}}, _zz_memory_MUL_LOW_3};
+  assign _zz_memory_MUL_LOW_5 = ({16'd0,memory_MUL_LH} <<< 5'd16);
+  assign _zz_memory_MUL_LOW_4 = {{2{_zz_memory_MUL_LOW_5[49]}}, _zz_memory_MUL_LOW_5};
+  assign _zz_memory_MUL_LOW_7 = ({16'd0,memory_MUL_HL} <<< 5'd16);
+  assign _zz_memory_MUL_LOW_6 = {{2{_zz_memory_MUL_LOW_7[49]}}, _zz_memory_MUL_LOW_7};
   assign _zz_execute_SHIFT_RIGHT_1 = ($signed(_zz_execute_SHIFT_RIGHT_2) >>> execute_FullBarrelShifterPlugin_amplitude);
   assign _zz_execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT_1[31 : 0];
   assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == ShiftCtrlEnum_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
-  assign _zz_decode_DO_EBREAK = (decode_PC >>> 1);
-  assign _zz_decode_DO_EBREAK_1 = (decode_PC >>> 1);
+  assign _zz_decode_DO_EBREAK = (decode_PC >>> 1'd1);
+  assign _zz_decode_DO_EBREAK_1 = (decode_PC >>> 1'd1);
   assign _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload - 4'b0001);
   assign _zz_IBusCachedPlugin_fetchPc_pc_1 = {IBusCachedPlugin_fetchPc_inc,2'b00};
   assign _zz_IBusCachedPlugin_fetchPc_pc = {29'd0, _zz_IBusCachedPlugin_fetchPc_pc_1};
@@ -1409,20 +1400,18 @@ module VexRiscv (
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
   assign _zz_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId_1;
-  assign _zz_io_cpu_flush_payload_lineId_1 = (execute_RS1 >>> 5);
+  assign _zz_io_cpu_flush_payload_lineId_1 = (execute_RS1 >>> 3'd5);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code_1 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
   assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
   assign _zz__zz_execute_SRC1 = 3'b100;
   assign _zz__zz_execute_SRC1_1 = execute_INSTRUCTION[19 : 15];
-  assign _zz__zz_execute_SRC2_3 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz__zz_execute_SRC2_2 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
   assign _zz_execute_SrcPlugin_addSub = ($signed(_zz_execute_SrcPlugin_addSub_1) + $signed(_zz_execute_SrcPlugin_addSub_4));
   assign _zz_execute_SrcPlugin_addSub_1 = ($signed(_zz_execute_SrcPlugin_addSub_2) + $signed(_zz_execute_SrcPlugin_addSub_3));
   assign _zz_execute_SrcPlugin_addSub_2 = execute_SRC1;
   assign _zz_execute_SrcPlugin_addSub_3 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? _zz_execute_SrcPlugin_addSub_5 : _zz_execute_SrcPlugin_addSub_6);
-  assign _zz_execute_SrcPlugin_addSub_5 = 32'h00000001;
-  assign _zz_execute_SrcPlugin_addSub_6 = 32'h0;
+  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? 32'h00000001 : 32'h00000000);
   assign _zz__zz_execute_BranchPlugin_missAlignedTarget_2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
   assign _zz__zz_execute_BranchPlugin_missAlignedTarget_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
   assign _zz__zz_execute_BranchPlugin_missAlignedTarget_6 = {_zz_execute_BranchPlugin_missAlignedTarget_1,execute_INSTRUCTION[31 : 20]};
@@ -1434,7 +1423,7 @@ module VexRiscv (
   assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code & (~ _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1));
   assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code - 2'b01);
   assign _zz_writeBack_MulPlugin_result = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
-  assign _zz_writeBack_MulPlugin_result_1 = ({32'd0,writeBack_MUL_HH} <<< 32);
+  assign _zz_writeBack_MulPlugin_result_1 = ({32'd0,writeBack_MUL_HH} <<< 6'd32);
   assign _zz__zz_decode_RS2_2 = writeBack_MUL_LOW[31 : 0];
   assign _zz__zz_decode_RS2_2_1 = writeBack_MulPlugin_result[63 : 32];
   assign _zz_memory_DivPlugin_div_counter_valueNext_1 = memory_DivPlugin_div_counter_willIncrement;
@@ -1452,30 +1441,30 @@ module VexRiscv (
   assign _zz_memory_DivPlugin_rs1_2 = {32'd0, _zz_memory_DivPlugin_rs1_3};
   assign _zz_memory_DivPlugin_rs2_2 = _zz_memory_DivPlugin_rs2;
   assign _zz_memory_DivPlugin_rs2_1 = {31'd0, _zz_memory_DivPlugin_rs2_2};
-  assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 5);
+  assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 3'd5);
   assign _zz_decode_RegFilePlugin_rs1Data = 1'b1;
   assign _zz_decode_RegFilePlugin_rs2Data = 1'b1;
   assign _zz_IBusCachedPlugin_jump_pcLoad_payload_6 = {_zz_IBusCachedPlugin_jump_pcLoad_payload_4,_zz_IBusCachedPlugin_jump_pcLoad_payload_3};
   assign _zz_writeBack_DBusCachedPlugin_rspShifted_1 = dataCache_1_io_cpu_writeBack_address[1 : 0];
   assign _zz_writeBack_DBusCachedPlugin_rspShifted_3 = dataCache_1_io_cpu_writeBack_address[1 : 1];
-  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000107f;
-  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00002073;
-  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000207f;
+  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000407f);
+  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00004063;
+  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000107f) == 32'h00000013);
   assign _zz_decode_LEGAL_INSTRUCTION_5 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_6) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_7 == _zz_decode_LEGAL_INSTRUCTION_8),{_zz_decode_LEGAL_INSTRUCTION_9,{_zz_decode_LEGAL_INSTRUCTION_10,_zz_decode_LEGAL_INSTRUCTION_11}}}}}};
   assign _zz_decode_LEGAL_INSTRUCTION_6 = 32'h0000505f;
   assign _zz_decode_LEGAL_INSTRUCTION_7 = (decode_INSTRUCTION & 32'h0000707b);
   assign _zz_decode_LEGAL_INSTRUCTION_8 = 32'h00000063;
   assign _zz_decode_LEGAL_INSTRUCTION_9 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
   assign _zz_decode_LEGAL_INSTRUCTION_10 = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
-  assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h00001013),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,{_zz_decode_LEGAL_INSTRUCTION_16,_zz_decode_LEGAL_INSTRUCTION_17}}}}}};
-  assign _zz_decode_LEGAL_INSTRUCTION_12 = 32'hfc00307f;
+  assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & 32'hbe00705f) == 32'h00005013),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h00001013),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,{_zz_decode_LEGAL_INSTRUCTION_16,_zz_decode_LEGAL_INSTRUCTION_17}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_12 = 32'hfe00305f;
   assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'hbe00707f);
-  assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h00005033;
-  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
-  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
-  assign _zz_decode_LEGAL_INSTRUCTION_17 = {((decode_INSTRUCTION & 32'hffefffff) == 32'h00000073),((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073)};
+  assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h00000033;
+  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
+  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hffefffff) == 32'h00000073);
+  assign _zz_decode_LEGAL_INSTRUCTION_17 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073);
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_4 = decode_INSTRUCTION[31];
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_5 = decode_INSTRUCTION[31];
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_6 = decode_INSTRUCTION[7];
@@ -1483,144 +1472,130 @@ module VexRiscv (
   assign _zz__zz_decode_IS_RS2_SIGNED_1 = ((decode_INSTRUCTION & 32'h02004074) == 32'h02000030);
   assign _zz__zz_decode_IS_RS2_SIGNED_2 = (|((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_3) == 32'h00000050));
   assign _zz__zz_decode_IS_RS2_SIGNED_4 = (|(_zz__zz_decode_IS_RS2_SIGNED_5 == _zz__zz_decode_IS_RS2_SIGNED_6));
-  assign _zz__zz_decode_IS_RS2_SIGNED_7 = {(|{_zz__zz_decode_IS_RS2_SIGNED_8,_zz__zz_decode_IS_RS2_SIGNED_10}),{(|_zz__zz_decode_IS_RS2_SIGNED_12),{_zz__zz_decode_IS_RS2_SIGNED_15,{_zz__zz_decode_IS_RS2_SIGNED_18,_zz__zz_decode_IS_RS2_SIGNED_23}}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_7 = {(|{_zz__zz_decode_IS_RS2_SIGNED_8,_zz__zz_decode_IS_RS2_SIGNED_9}),{(|_zz__zz_decode_IS_RS2_SIGNED_10),{_zz__zz_decode_IS_RS2_SIGNED_12,{_zz__zz_decode_IS_RS2_SIGNED_14,_zz__zz_decode_IS_RS2_SIGNED_17}}}};
   assign _zz__zz_decode_IS_RS2_SIGNED_3 = 32'h10103050;
   assign _zz__zz_decode_IS_RS2_SIGNED_5 = (decode_INSTRUCTION & 32'h10403050);
   assign _zz__zz_decode_IS_RS2_SIGNED_6 = 32'h10000050;
-  assign _zz__zz_decode_IS_RS2_SIGNED_8 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_9) == 32'h00001050);
-  assign _zz__zz_decode_IS_RS2_SIGNED_10 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_11) == 32'h00002050);
-  assign _zz__zz_decode_IS_RS2_SIGNED_12 = {_zz_decode_IS_RS2_SIGNED_4,(_zz__zz_decode_IS_RS2_SIGNED_13 == _zz__zz_decode_IS_RS2_SIGNED_14)};
-  assign _zz__zz_decode_IS_RS2_SIGNED_15 = (|(_zz__zz_decode_IS_RS2_SIGNED_16 == _zz__zz_decode_IS_RS2_SIGNED_17));
-  assign _zz__zz_decode_IS_RS2_SIGNED_18 = (|{_zz__zz_decode_IS_RS2_SIGNED_19,_zz__zz_decode_IS_RS2_SIGNED_21});
-  assign _zz__zz_decode_IS_RS2_SIGNED_23 = {(|_zz__zz_decode_IS_RS2_SIGNED_24),{_zz__zz_decode_IS_RS2_SIGNED_29,{_zz__zz_decode_IS_RS2_SIGNED_32,_zz__zz_decode_IS_RS2_SIGNED_34}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_9 = 32'h00001050;
-  assign _zz__zz_decode_IS_RS2_SIGNED_11 = 32'h00002050;
-  assign _zz__zz_decode_IS_RS2_SIGNED_13 = (decode_INSTRUCTION & 32'h0000001c);
-  assign _zz__zz_decode_IS_RS2_SIGNED_14 = 32'h00000004;
-  assign _zz__zz_decode_IS_RS2_SIGNED_16 = (decode_INSTRUCTION & 32'h00000058);
-  assign _zz__zz_decode_IS_RS2_SIGNED_17 = 32'h00000040;
-  assign _zz__zz_decode_IS_RS2_SIGNED_19 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_20) == 32'h00005010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_21 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_22) == 32'h00005020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_24 = {(_zz__zz_decode_IS_RS2_SIGNED_25 == _zz__zz_decode_IS_RS2_SIGNED_26),{_zz__zz_decode_IS_RS2_SIGNED_27,_zz__zz_decode_IS_RS2_SIGNED_28}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_29 = (|(_zz__zz_decode_IS_RS2_SIGNED_30 == _zz__zz_decode_IS_RS2_SIGNED_31));
-  assign _zz__zz_decode_IS_RS2_SIGNED_32 = (|_zz__zz_decode_IS_RS2_SIGNED_33);
-  assign _zz__zz_decode_IS_RS2_SIGNED_34 = {(|_zz__zz_decode_IS_RS2_SIGNED_35),{_zz__zz_decode_IS_RS2_SIGNED_37,{_zz__zz_decode_IS_RS2_SIGNED_40,_zz__zz_decode_IS_RS2_SIGNED_42}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_20 = 32'h00007034;
-  assign _zz__zz_decode_IS_RS2_SIGNED_22 = 32'h02007064;
-  assign _zz__zz_decode_IS_RS2_SIGNED_25 = (decode_INSTRUCTION & 32'h40003054);
-  assign _zz__zz_decode_IS_RS2_SIGNED_26 = 32'h40001010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_27 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00001010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_28 = ((decode_INSTRUCTION & 32'h02007054) == 32'h00001010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_30 = (decode_INSTRUCTION & 32'h00000064);
-  assign _zz__zz_decode_IS_RS2_SIGNED_31 = 32'h00000024;
-  assign _zz__zz_decode_IS_RS2_SIGNED_33 = ((decode_INSTRUCTION & 32'h00001000) == 32'h00001000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_35 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_36) == 32'h00002000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_37 = (|{_zz__zz_decode_IS_RS2_SIGNED_38,_zz__zz_decode_IS_RS2_SIGNED_39});
-  assign _zz__zz_decode_IS_RS2_SIGNED_40 = (|_zz__zz_decode_IS_RS2_SIGNED_41);
-  assign _zz__zz_decode_IS_RS2_SIGNED_42 = {(|_zz__zz_decode_IS_RS2_SIGNED_43),{_zz__zz_decode_IS_RS2_SIGNED_48,{_zz__zz_decode_IS_RS2_SIGNED_53,_zz__zz_decode_IS_RS2_SIGNED_55}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_36 = 32'h00003000;
-  assign _zz__zz_decode_IS_RS2_SIGNED_38 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_39 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00001000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_41 = ((decode_INSTRUCTION & 32'h00004048) == 32'h00004008);
-  assign _zz__zz_decode_IS_RS2_SIGNED_43 = {(_zz__zz_decode_IS_RS2_SIGNED_44 == _zz__zz_decode_IS_RS2_SIGNED_45),(_zz__zz_decode_IS_RS2_SIGNED_46 == _zz__zz_decode_IS_RS2_SIGNED_47)};
-  assign _zz__zz_decode_IS_RS2_SIGNED_48 = (|{_zz__zz_decode_IS_RS2_SIGNED_49,{_zz__zz_decode_IS_RS2_SIGNED_50,_zz__zz_decode_IS_RS2_SIGNED_51}});
-  assign _zz__zz_decode_IS_RS2_SIGNED_53 = (|_zz__zz_decode_IS_RS2_SIGNED_54);
-  assign _zz__zz_decode_IS_RS2_SIGNED_55 = {(|_zz__zz_decode_IS_RS2_SIGNED_56),{_zz__zz_decode_IS_RS2_SIGNED_67,{_zz__zz_decode_IS_RS2_SIGNED_80,_zz__zz_decode_IS_RS2_SIGNED_94}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_44 = (decode_INSTRUCTION & 32'h00000034);
-  assign _zz__zz_decode_IS_RS2_SIGNED_45 = 32'h00000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_46 = (decode_INSTRUCTION & 32'h00000064);
-  assign _zz__zz_decode_IS_RS2_SIGNED_47 = 32'h00000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_49 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_50 = _zz_decode_IS_RS2_SIGNED_2;
-  assign _zz__zz_decode_IS_RS2_SIGNED_51 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_52) == 32'h00000040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_54 = ((decode_INSTRUCTION & 32'h00000020) == 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_56 = {(_zz__zz_decode_IS_RS2_SIGNED_57 == _zz__zz_decode_IS_RS2_SIGNED_58),{_zz_decode_IS_RS2_SIGNED_3,{_zz__zz_decode_IS_RS2_SIGNED_59,_zz__zz_decode_IS_RS2_SIGNED_62}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_67 = (|{_zz_decode_IS_RS2_SIGNED_3,{_zz__zz_decode_IS_RS2_SIGNED_68,_zz__zz_decode_IS_RS2_SIGNED_71}});
-  assign _zz__zz_decode_IS_RS2_SIGNED_80 = (|{_zz__zz_decode_IS_RS2_SIGNED_81,_zz__zz_decode_IS_RS2_SIGNED_82});
-  assign _zz__zz_decode_IS_RS2_SIGNED_94 = {(|_zz__zz_decode_IS_RS2_SIGNED_95),{_zz__zz_decode_IS_RS2_SIGNED_98,{_zz__zz_decode_IS_RS2_SIGNED_103,_zz__zz_decode_IS_RS2_SIGNED_107}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_52 = 32'h00103040;
-  assign _zz__zz_decode_IS_RS2_SIGNED_57 = (decode_INSTRUCTION & 32'h00000040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_58 = 32'h00000040;
-  assign _zz__zz_decode_IS_RS2_SIGNED_59 = (_zz__zz_decode_IS_RS2_SIGNED_60 == _zz__zz_decode_IS_RS2_SIGNED_61);
-  assign _zz__zz_decode_IS_RS2_SIGNED_62 = {_zz__zz_decode_IS_RS2_SIGNED_63,_zz__zz_decode_IS_RS2_SIGNED_65};
-  assign _zz__zz_decode_IS_RS2_SIGNED_68 = (_zz__zz_decode_IS_RS2_SIGNED_69 == _zz__zz_decode_IS_RS2_SIGNED_70);
-  assign _zz__zz_decode_IS_RS2_SIGNED_71 = {_zz__zz_decode_IS_RS2_SIGNED_72,{_zz__zz_decode_IS_RS2_SIGNED_74,_zz__zz_decode_IS_RS2_SIGNED_77}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_81 = _zz_decode_IS_RS2_SIGNED_4;
-  assign _zz__zz_decode_IS_RS2_SIGNED_82 = {_zz__zz_decode_IS_RS2_SIGNED_83,{_zz__zz_decode_IS_RS2_SIGNED_85,_zz__zz_decode_IS_RS2_SIGNED_88}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_95 = {_zz_decode_IS_RS2_SIGNED_3,_zz__zz_decode_IS_RS2_SIGNED_96};
-  assign _zz__zz_decode_IS_RS2_SIGNED_98 = (|{_zz__zz_decode_IS_RS2_SIGNED_99,_zz__zz_decode_IS_RS2_SIGNED_100});
-  assign _zz__zz_decode_IS_RS2_SIGNED_103 = (|_zz__zz_decode_IS_RS2_SIGNED_104);
-  assign _zz__zz_decode_IS_RS2_SIGNED_107 = {_zz__zz_decode_IS_RS2_SIGNED_108,{_zz__zz_decode_IS_RS2_SIGNED_110,_zz__zz_decode_IS_RS2_SIGNED_121}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_60 = (decode_INSTRUCTION & 32'h00004020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_61 = 32'h00004020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_63 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_64) == 32'h00000010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_65 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_66) == 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_69 = (decode_INSTRUCTION & 32'h00002030);
-  assign _zz__zz_decode_IS_RS2_SIGNED_70 = 32'h00002010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_72 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_73) == 32'h00000010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_74 = (_zz__zz_decode_IS_RS2_SIGNED_75 == _zz__zz_decode_IS_RS2_SIGNED_76);
-  assign _zz__zz_decode_IS_RS2_SIGNED_77 = (_zz__zz_decode_IS_RS2_SIGNED_78 == _zz__zz_decode_IS_RS2_SIGNED_79);
-  assign _zz__zz_decode_IS_RS2_SIGNED_83 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_84) == 32'h00001010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_85 = (_zz__zz_decode_IS_RS2_SIGNED_86 == _zz__zz_decode_IS_RS2_SIGNED_87);
-  assign _zz__zz_decode_IS_RS2_SIGNED_88 = {_zz__zz_decode_IS_RS2_SIGNED_89,{_zz__zz_decode_IS_RS2_SIGNED_90,_zz__zz_decode_IS_RS2_SIGNED_92}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_96 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_97) == 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_99 = _zz_decode_IS_RS2_SIGNED_3;
-  assign _zz__zz_decode_IS_RS2_SIGNED_100 = (_zz__zz_decode_IS_RS2_SIGNED_101 == _zz__zz_decode_IS_RS2_SIGNED_102);
-  assign _zz__zz_decode_IS_RS2_SIGNED_104 = (_zz__zz_decode_IS_RS2_SIGNED_105 == _zz__zz_decode_IS_RS2_SIGNED_106);
-  assign _zz__zz_decode_IS_RS2_SIGNED_108 = (|_zz__zz_decode_IS_RS2_SIGNED_109);
-  assign _zz__zz_decode_IS_RS2_SIGNED_110 = (|_zz__zz_decode_IS_RS2_SIGNED_111);
-  assign _zz__zz_decode_IS_RS2_SIGNED_121 = {_zz__zz_decode_IS_RS2_SIGNED_122,{_zz__zz_decode_IS_RS2_SIGNED_125,_zz__zz_decode_IS_RS2_SIGNED_133}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_64 = 32'h00000030;
-  assign _zz__zz_decode_IS_RS2_SIGNED_66 = 32'h02000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_73 = 32'h00001030;
-  assign _zz__zz_decode_IS_RS2_SIGNED_75 = (decode_INSTRUCTION & 32'h02002060);
-  assign _zz__zz_decode_IS_RS2_SIGNED_76 = 32'h00002020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_78 = (decode_INSTRUCTION & 32'h02003020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_79 = 32'h00000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_84 = 32'h00001010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_86 = (decode_INSTRUCTION & 32'h00002010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_87 = 32'h00002010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_89 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_90 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_91) == 32'h00000004);
-  assign _zz__zz_decode_IS_RS2_SIGNED_92 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_93) == 32'h0);
-  assign _zz__zz_decode_IS_RS2_SIGNED_97 = 32'h00000070;
-  assign _zz__zz_decode_IS_RS2_SIGNED_101 = (decode_INSTRUCTION & 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_102 = 32'h0;
-  assign _zz__zz_decode_IS_RS2_SIGNED_105 = (decode_INSTRUCTION & 32'h00004014);
-  assign _zz__zz_decode_IS_RS2_SIGNED_106 = 32'h00004010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_109 = ((decode_INSTRUCTION & 32'h00006014) == 32'h00002010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_111 = {(_zz__zz_decode_IS_RS2_SIGNED_112 == _zz__zz_decode_IS_RS2_SIGNED_113),{_zz_decode_IS_RS2_SIGNED_2,{_zz__zz_decode_IS_RS2_SIGNED_114,_zz__zz_decode_IS_RS2_SIGNED_116}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_122 = (|(_zz__zz_decode_IS_RS2_SIGNED_123 == _zz__zz_decode_IS_RS2_SIGNED_124));
-  assign _zz__zz_decode_IS_RS2_SIGNED_125 = (|{_zz__zz_decode_IS_RS2_SIGNED_126,_zz__zz_decode_IS_RS2_SIGNED_128});
-  assign _zz__zz_decode_IS_RS2_SIGNED_133 = {(|_zz__zz_decode_IS_RS2_SIGNED_134),{_zz__zz_decode_IS_RS2_SIGNED_137,_zz__zz_decode_IS_RS2_SIGNED_139}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_91 = 32'h0000000c;
-  assign _zz__zz_decode_IS_RS2_SIGNED_93 = 32'h00000028;
-  assign _zz__zz_decode_IS_RS2_SIGNED_112 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz__zz_decode_IS_RS2_SIGNED_113 = 32'h0;
-  assign _zz__zz_decode_IS_RS2_SIGNED_114 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_115) == 32'h00002000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_116 = {(_zz__zz_decode_IS_RS2_SIGNED_117 == _zz__zz_decode_IS_RS2_SIGNED_118),(_zz__zz_decode_IS_RS2_SIGNED_119 == _zz__zz_decode_IS_RS2_SIGNED_120)};
-  assign _zz__zz_decode_IS_RS2_SIGNED_123 = (decode_INSTRUCTION & 32'h00000058);
-  assign _zz__zz_decode_IS_RS2_SIGNED_124 = 32'h0;
-  assign _zz__zz_decode_IS_RS2_SIGNED_126 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_127) == 32'h00000040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_128 = {(_zz__zz_decode_IS_RS2_SIGNED_129 == _zz__zz_decode_IS_RS2_SIGNED_130),(_zz__zz_decode_IS_RS2_SIGNED_131 == _zz__zz_decode_IS_RS2_SIGNED_132)};
-  assign _zz__zz_decode_IS_RS2_SIGNED_134 = {(_zz__zz_decode_IS_RS2_SIGNED_135 == _zz__zz_decode_IS_RS2_SIGNED_136),_zz_decode_IS_RS2_SIGNED_1};
-  assign _zz__zz_decode_IS_RS2_SIGNED_137 = (|{_zz__zz_decode_IS_RS2_SIGNED_138,_zz_decode_IS_RS2_SIGNED_1});
-  assign _zz__zz_decode_IS_RS2_SIGNED_139 = (|(_zz__zz_decode_IS_RS2_SIGNED_140 == _zz__zz_decode_IS_RS2_SIGNED_141));
-  assign _zz__zz_decode_IS_RS2_SIGNED_115 = 32'h00006004;
-  assign _zz__zz_decode_IS_RS2_SIGNED_117 = (decode_INSTRUCTION & 32'h00005004);
-  assign _zz__zz_decode_IS_RS2_SIGNED_118 = 32'h00001000;
-  assign _zz__zz_decode_IS_RS2_SIGNED_119 = (decode_INSTRUCTION & 32'h00004050);
-  assign _zz__zz_decode_IS_RS2_SIGNED_120 = 32'h00004000;
-  assign _zz__zz_decode_IS_RS2_SIGNED_127 = 32'h00000044;
-  assign _zz__zz_decode_IS_RS2_SIGNED_129 = (decode_INSTRUCTION & 32'h00002014);
-  assign _zz__zz_decode_IS_RS2_SIGNED_130 = 32'h00002010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_131 = (decode_INSTRUCTION & 32'h40000034);
-  assign _zz__zz_decode_IS_RS2_SIGNED_132 = 32'h40000030;
-  assign _zz__zz_decode_IS_RS2_SIGNED_135 = (decode_INSTRUCTION & 32'h00000014);
-  assign _zz__zz_decode_IS_RS2_SIGNED_136 = 32'h00000004;
-  assign _zz__zz_decode_IS_RS2_SIGNED_138 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000004);
-  assign _zz__zz_decode_IS_RS2_SIGNED_140 = (decode_INSTRUCTION & 32'h00005048);
-  assign _zz__zz_decode_IS_RS2_SIGNED_141 = 32'h00001008;
+  assign _zz__zz_decode_IS_RS2_SIGNED_8 = ((decode_INSTRUCTION & 32'h00001050) == 32'h00001050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_9 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_10 = {_zz_decode_IS_RS2_SIGNED_4,((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_11) == 32'h00000004)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_12 = (|((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_13) == 32'h00000040));
+  assign _zz__zz_decode_IS_RS2_SIGNED_14 = (|(_zz__zz_decode_IS_RS2_SIGNED_15 == _zz__zz_decode_IS_RS2_SIGNED_16));
+  assign _zz__zz_decode_IS_RS2_SIGNED_17 = {(|{_zz__zz_decode_IS_RS2_SIGNED_18,_zz__zz_decode_IS_RS2_SIGNED_19}),{(|_zz__zz_decode_IS_RS2_SIGNED_20),{_zz__zz_decode_IS_RS2_SIGNED_21,{_zz__zz_decode_IS_RS2_SIGNED_23,_zz__zz_decode_IS_RS2_SIGNED_26}}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_11 = 32'h0000001c;
+  assign _zz__zz_decode_IS_RS2_SIGNED_13 = 32'h00000058;
+  assign _zz__zz_decode_IS_RS2_SIGNED_15 = (decode_INSTRUCTION & 32'h02007054);
+  assign _zz__zz_decode_IS_RS2_SIGNED_16 = 32'h00005010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_18 = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_19 = ((decode_INSTRUCTION & 32'h02007054) == 32'h00001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_20 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
+  assign _zz__zz_decode_IS_RS2_SIGNED_21 = (|((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_22) == 32'h00001000));
+  assign _zz__zz_decode_IS_RS2_SIGNED_23 = (|(_zz__zz_decode_IS_RS2_SIGNED_24 == _zz__zz_decode_IS_RS2_SIGNED_25));
+  assign _zz__zz_decode_IS_RS2_SIGNED_26 = {(|{_zz__zz_decode_IS_RS2_SIGNED_27,_zz__zz_decode_IS_RS2_SIGNED_28}),{(|_zz__zz_decode_IS_RS2_SIGNED_29),{_zz__zz_decode_IS_RS2_SIGNED_30,{_zz__zz_decode_IS_RS2_SIGNED_35,_zz__zz_decode_IS_RS2_SIGNED_40}}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_22 = 32'h00001000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_24 = (decode_INSTRUCTION & 32'h00003000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_25 = 32'h00002000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_27 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_28 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00001000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_29 = ((decode_INSTRUCTION & 32'h00004048) == 32'h00004008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_30 = (|{(_zz__zz_decode_IS_RS2_SIGNED_31 == _zz__zz_decode_IS_RS2_SIGNED_32),(_zz__zz_decode_IS_RS2_SIGNED_33 == _zz__zz_decode_IS_RS2_SIGNED_34)});
+  assign _zz__zz_decode_IS_RS2_SIGNED_35 = (|{_zz__zz_decode_IS_RS2_SIGNED_36,{_zz__zz_decode_IS_RS2_SIGNED_37,_zz__zz_decode_IS_RS2_SIGNED_38}});
+  assign _zz__zz_decode_IS_RS2_SIGNED_40 = {(|_zz__zz_decode_IS_RS2_SIGNED_41),{(|_zz__zz_decode_IS_RS2_SIGNED_42),{_zz__zz_decode_IS_RS2_SIGNED_53,{_zz__zz_decode_IS_RS2_SIGNED_66,_zz__zz_decode_IS_RS2_SIGNED_80}}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_31 = (decode_INSTRUCTION & 32'h00000034);
+  assign _zz__zz_decode_IS_RS2_SIGNED_32 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_33 = (decode_INSTRUCTION & 32'h00000064);
+  assign _zz__zz_decode_IS_RS2_SIGNED_34 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_36 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_37 = _zz_decode_IS_RS2_SIGNED_2;
+  assign _zz__zz_decode_IS_RS2_SIGNED_38 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_39) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_41 = ((decode_INSTRUCTION & 32'h00000020) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_42 = {(_zz__zz_decode_IS_RS2_SIGNED_43 == _zz__zz_decode_IS_RS2_SIGNED_44),{_zz_decode_IS_RS2_SIGNED_3,{_zz__zz_decode_IS_RS2_SIGNED_45,_zz__zz_decode_IS_RS2_SIGNED_48}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_53 = (|{_zz_decode_IS_RS2_SIGNED_3,{_zz__zz_decode_IS_RS2_SIGNED_54,_zz__zz_decode_IS_RS2_SIGNED_57}});
+  assign _zz__zz_decode_IS_RS2_SIGNED_66 = (|{_zz__zz_decode_IS_RS2_SIGNED_67,_zz__zz_decode_IS_RS2_SIGNED_68});
+  assign _zz__zz_decode_IS_RS2_SIGNED_80 = {(|_zz__zz_decode_IS_RS2_SIGNED_81),{_zz__zz_decode_IS_RS2_SIGNED_84,{_zz__zz_decode_IS_RS2_SIGNED_89,_zz__zz_decode_IS_RS2_SIGNED_93}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_39 = 32'h00103040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_43 = (decode_INSTRUCTION & 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_44 = 32'h00000040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_45 = (_zz__zz_decode_IS_RS2_SIGNED_46 == _zz__zz_decode_IS_RS2_SIGNED_47);
+  assign _zz__zz_decode_IS_RS2_SIGNED_48 = {_zz__zz_decode_IS_RS2_SIGNED_49,_zz__zz_decode_IS_RS2_SIGNED_51};
+  assign _zz__zz_decode_IS_RS2_SIGNED_54 = (_zz__zz_decode_IS_RS2_SIGNED_55 == _zz__zz_decode_IS_RS2_SIGNED_56);
+  assign _zz__zz_decode_IS_RS2_SIGNED_57 = {_zz__zz_decode_IS_RS2_SIGNED_58,{_zz__zz_decode_IS_RS2_SIGNED_60,_zz__zz_decode_IS_RS2_SIGNED_63}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_67 = _zz_decode_IS_RS2_SIGNED_4;
+  assign _zz__zz_decode_IS_RS2_SIGNED_68 = {_zz__zz_decode_IS_RS2_SIGNED_69,{_zz__zz_decode_IS_RS2_SIGNED_71,_zz__zz_decode_IS_RS2_SIGNED_74}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_81 = {_zz_decode_IS_RS2_SIGNED_3,_zz__zz_decode_IS_RS2_SIGNED_82};
+  assign _zz__zz_decode_IS_RS2_SIGNED_84 = (|{_zz__zz_decode_IS_RS2_SIGNED_85,_zz__zz_decode_IS_RS2_SIGNED_86});
+  assign _zz__zz_decode_IS_RS2_SIGNED_89 = (|_zz__zz_decode_IS_RS2_SIGNED_90);
+  assign _zz__zz_decode_IS_RS2_SIGNED_93 = {_zz__zz_decode_IS_RS2_SIGNED_94,{_zz__zz_decode_IS_RS2_SIGNED_96,_zz__zz_decode_IS_RS2_SIGNED_107}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_46 = (decode_INSTRUCTION & 32'h00004020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_47 = 32'h00004020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_49 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_50) == 32'h00000010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_51 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_52) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_55 = (decode_INSTRUCTION & 32'h00002030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_56 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_58 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_59) == 32'h00000010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_60 = (_zz__zz_decode_IS_RS2_SIGNED_61 == _zz__zz_decode_IS_RS2_SIGNED_62);
+  assign _zz__zz_decode_IS_RS2_SIGNED_63 = (_zz__zz_decode_IS_RS2_SIGNED_64 == _zz__zz_decode_IS_RS2_SIGNED_65);
+  assign _zz__zz_decode_IS_RS2_SIGNED_69 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_70) == 32'h00001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_71 = (_zz__zz_decode_IS_RS2_SIGNED_72 == _zz__zz_decode_IS_RS2_SIGNED_73);
+  assign _zz__zz_decode_IS_RS2_SIGNED_74 = {_zz__zz_decode_IS_RS2_SIGNED_75,{_zz__zz_decode_IS_RS2_SIGNED_76,_zz__zz_decode_IS_RS2_SIGNED_78}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_82 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_83) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_85 = _zz_decode_IS_RS2_SIGNED_3;
+  assign _zz__zz_decode_IS_RS2_SIGNED_86 = (_zz__zz_decode_IS_RS2_SIGNED_87 == _zz__zz_decode_IS_RS2_SIGNED_88);
+  assign _zz__zz_decode_IS_RS2_SIGNED_90 = (_zz__zz_decode_IS_RS2_SIGNED_91 == _zz__zz_decode_IS_RS2_SIGNED_92);
+  assign _zz__zz_decode_IS_RS2_SIGNED_94 = (|_zz__zz_decode_IS_RS2_SIGNED_95);
+  assign _zz__zz_decode_IS_RS2_SIGNED_96 = (|_zz__zz_decode_IS_RS2_SIGNED_97);
+  assign _zz__zz_decode_IS_RS2_SIGNED_107 = {_zz__zz_decode_IS_RS2_SIGNED_108,{_zz__zz_decode_IS_RS2_SIGNED_111,_zz__zz_decode_IS_RS2_SIGNED_119}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_50 = 32'h00000030;
+  assign _zz__zz_decode_IS_RS2_SIGNED_52 = 32'h02000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_59 = 32'h00001030;
+  assign _zz__zz_decode_IS_RS2_SIGNED_61 = (decode_INSTRUCTION & 32'h02002060);
+  assign _zz__zz_decode_IS_RS2_SIGNED_62 = 32'h00002020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_64 = (decode_INSTRUCTION & 32'h02003020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_65 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_70 = 32'h00001010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_72 = (decode_INSTRUCTION & 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_73 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_75 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_76 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_77) == 32'h00000004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_78 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_79) == 32'h00000000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_83 = 32'h00000070;
+  assign _zz__zz_decode_IS_RS2_SIGNED_87 = (decode_INSTRUCTION & 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_88 = 32'h00000000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_91 = (decode_INSTRUCTION & 32'h00004014);
+  assign _zz__zz_decode_IS_RS2_SIGNED_92 = 32'h00004010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_95 = ((decode_INSTRUCTION & 32'h00006014) == 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_97 = {(_zz__zz_decode_IS_RS2_SIGNED_98 == _zz__zz_decode_IS_RS2_SIGNED_99),{_zz_decode_IS_RS2_SIGNED_2,{_zz__zz_decode_IS_RS2_SIGNED_100,_zz__zz_decode_IS_RS2_SIGNED_102}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_108 = (|(_zz__zz_decode_IS_RS2_SIGNED_109 == _zz__zz_decode_IS_RS2_SIGNED_110));
+  assign _zz__zz_decode_IS_RS2_SIGNED_111 = (|{_zz__zz_decode_IS_RS2_SIGNED_112,_zz__zz_decode_IS_RS2_SIGNED_114});
+  assign _zz__zz_decode_IS_RS2_SIGNED_119 = {(|_zz__zz_decode_IS_RS2_SIGNED_120),{_zz__zz_decode_IS_RS2_SIGNED_123,_zz__zz_decode_IS_RS2_SIGNED_125}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_77 = 32'h0000000c;
+  assign _zz__zz_decode_IS_RS2_SIGNED_79 = 32'h00000028;
+  assign _zz__zz_decode_IS_RS2_SIGNED_98 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz__zz_decode_IS_RS2_SIGNED_99 = 32'h00000000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_100 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_101) == 32'h00002000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_102 = {(_zz__zz_decode_IS_RS2_SIGNED_103 == _zz__zz_decode_IS_RS2_SIGNED_104),(_zz__zz_decode_IS_RS2_SIGNED_105 == _zz__zz_decode_IS_RS2_SIGNED_106)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_109 = (decode_INSTRUCTION & 32'h00000058);
+  assign _zz__zz_decode_IS_RS2_SIGNED_110 = 32'h00000000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_112 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_113) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_114 = {(_zz__zz_decode_IS_RS2_SIGNED_115 == _zz__zz_decode_IS_RS2_SIGNED_116),(_zz__zz_decode_IS_RS2_SIGNED_117 == _zz__zz_decode_IS_RS2_SIGNED_118)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_120 = {(_zz__zz_decode_IS_RS2_SIGNED_121 == _zz__zz_decode_IS_RS2_SIGNED_122),_zz_decode_IS_RS2_SIGNED_1};
+  assign _zz__zz_decode_IS_RS2_SIGNED_123 = (|{_zz__zz_decode_IS_RS2_SIGNED_124,_zz_decode_IS_RS2_SIGNED_1});
+  assign _zz__zz_decode_IS_RS2_SIGNED_125 = (|(_zz__zz_decode_IS_RS2_SIGNED_126 == _zz__zz_decode_IS_RS2_SIGNED_127));
+  assign _zz__zz_decode_IS_RS2_SIGNED_101 = 32'h00006004;
+  assign _zz__zz_decode_IS_RS2_SIGNED_103 = (decode_INSTRUCTION & 32'h00005004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_104 = 32'h00001000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_105 = (decode_INSTRUCTION & 32'h00004050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_106 = 32'h00004000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_113 = 32'h00000044;
+  assign _zz__zz_decode_IS_RS2_SIGNED_115 = (decode_INSTRUCTION & 32'h00002014);
+  assign _zz__zz_decode_IS_RS2_SIGNED_116 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_117 = (decode_INSTRUCTION & 32'h40000034);
+  assign _zz__zz_decode_IS_RS2_SIGNED_118 = 32'h40000030;
+  assign _zz__zz_decode_IS_RS2_SIGNED_121 = (decode_INSTRUCTION & 32'h00000014);
+  assign _zz__zz_decode_IS_RS2_SIGNED_122 = 32'h00000004;
+  assign _zz__zz_decode_IS_RS2_SIGNED_124 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_126 = (decode_INSTRUCTION & 32'h00005048);
+  assign _zz__zz_decode_IS_RS2_SIGNED_127 = 32'h00001008;
   assign _zz_execute_BranchPlugin_branch_src2_6 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_7 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_8 = execute_INSTRUCTION[7];
@@ -1681,8 +1656,8 @@ module VexRiscv (
     .io_mem_rsp_valid                      (iBus_rsp_valid                                            ), //i
     .io_mem_rsp_payload_data               (iBus_rsp_payload_data[31:0]                               ), //i
     .io_mem_rsp_payload_error              (iBus_rsp_payload_error                                    ), //i
-    ._zz_when_Fetcher_l401                 (switch_Fetcher_l365[2:0]                                  ), //i
-    ._zz_io_cpu_fetch_data_regNextWhen     (IBusCachedPlugin_injectionPort_payload[31:0]              ), //i
+    ._zz_when_Fetcher_l411                 (IBusCachedPlugin_injector_port_state[2:0]                 ), //i
+    ._zz_io_cpu_fetch_data_regNextWhen     (DebugPlugin_injectionPort_payload[31:0]                   ), //i
     .clk                                   (clk                                                       ), //i
     .reset                                 (reset                                                     )  //i
   );
@@ -1735,8 +1710,9 @@ module VexRiscv (
     .io_cpu_flush_ready                     (dataCache_1_io_cpu_flush_ready                   ), //o
     .io_cpu_flush_payload_singleLine        (dataCache_1_io_cpu_flush_payload_singleLine      ), //i
     .io_cpu_flush_payload_lineId            (dataCache_1_io_cpu_flush_payload_lineId[6:0]     ), //i
+    .io_cpu_writesPending                   (dataCache_1_io_cpu_writesPending                 ), //o
     .io_mem_cmd_valid                       (dataCache_1_io_mem_cmd_valid                     ), //o
-    .io_mem_cmd_ready                       (dataCache_1_io_mem_cmd_ready                     ), //i
+    .io_mem_cmd_ready                       (toplevel_dataCache_1_io_mem_cmd_rValidN          ), //i
     .io_mem_cmd_payload_wr                  (dataCache_1_io_mem_cmd_payload_wr                ), //o
     .io_mem_cmd_payload_uncached            (dataCache_1_io_mem_cmd_payload_uncached          ), //o
     .io_mem_cmd_payload_address             (dataCache_1_io_mem_cmd_payload_address[31:0]     ), //o
@@ -2444,7 +2420,7 @@ module VexRiscv (
   end
   `endif
 
-  assign memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW) + $signed(_zz_memory_MUL_LOW_7));
+  assign memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW) + $signed(_zz_memory_MUL_LOW_6));
   assign memory_MUL_HH = execute_to_memory_MUL_HH;
   assign execute_MUL_HH = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bHigh));
   assign execute_MUL_HL = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bSLow));
@@ -2458,7 +2434,7 @@ module VexRiscv (
   assign execute_MEMORY_STORE_DATA_RF = _zz_execute_MEMORY_STORE_DATA_RF;
   assign decode_DO_EBREAK = (((! DebugPlugin_haltIt) && (decode_IS_EBREAK || ((1'b0 || (DebugPlugin_hardwareBreakpoints_0_valid && (DebugPlugin_hardwareBreakpoints_0_pc == _zz_decode_DO_EBREAK))) || (DebugPlugin_hardwareBreakpoints_1_valid && (DebugPlugin_hardwareBreakpoints_1_pc == _zz_decode_DO_EBREAK_1))))) && DebugPlugin_allowEBreak);
   assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
-  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
+  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h00)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h00))));
   assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
   assign decode_IS_RS2_SIGNED = _zz_decode_IS_RS2_SIGNED[31];
@@ -2525,7 +2501,7 @@ module VexRiscv (
   assign decode_RS1_USE = _zz_decode_IS_RS2_SIGNED[5];
   always @(*) begin
     _zz_decode_RS2 = execute_REGFILE_WRITE_DATA;
-    if(when_CsrPlugin_l1189) begin
+    if(when_CsrPlugin_l1587) begin
       _zz_decode_RS2 = CsrPlugin_csrMapping_readDataSignal;
     end
   end
@@ -2621,7 +2597,7 @@ module VexRiscv (
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_execute_SRC2 = execute_PC;
+  assign _zz_execute_to_memory_PC = execute_PC;
   assign execute_SRC2_CTRL = _zz_execute_SRC2_CTRL;
   assign execute_SRC1_CTRL = _zz_execute_SRC1_CTRL;
   assign decode_SRC_USE_SUB_LESS = _zz_decode_IS_RS2_SIGNED[3];
@@ -2629,7 +2605,7 @@ module VexRiscv (
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
   assign execute_ALU_CTRL = _zz_execute_ALU_CTRL;
-  assign execute_SRC2 = _zz_execute_SRC2_5;
+  assign execute_SRC2 = _zz_execute_SRC2_4;
   assign execute_SRC1 = _zz_execute_SRC1;
   assign execute_ALU_BITWISE_CTRL = _zz_execute_ALU_BITWISE_CTRL;
   assign _zz_lastStageRegFileWrite_payload_address = writeBack_INSTRUCTION;
@@ -2649,10 +2625,10 @@ module VexRiscv (
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00001073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
+  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000107f) == 32'h00001073),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00002073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
   always @(*) begin
     _zz_decode_RS2_2 = writeBack_REGFILE_WRITE_DATA;
-    if(when_DBusCachedPlugin_l492) begin
+    if(when_DBusCachedPlugin_l580) begin
       _zz_decode_RS2_2 = writeBack_DBusCachedPlugin_rspFormated;
     end
     if(when_MulPlugin_l147) begin
@@ -2685,28 +2661,28 @@ module VexRiscv (
   assign decode_FLUSH_ALL = _zz_decode_IS_RS2_SIGNED[0];
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_4 = IBusCachedPlugin_rsp_issueDetected_3;
-    if(when_IBusCachedPlugin_l256) begin
+    if(when_IBusCachedPlugin_l262) begin
       IBusCachedPlugin_rsp_issueDetected_4 = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_3 = IBusCachedPlugin_rsp_issueDetected_2;
-    if(when_IBusCachedPlugin_l250) begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_rsp_issueDetected_3 = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
-    if(when_IBusCachedPlugin_l244) begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
-    if(when_IBusCachedPlugin_l239) begin
+    if(when_IBusCachedPlugin_l245) begin
       IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
@@ -2732,10 +2708,10 @@ module VexRiscv (
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
   always @(*) begin
     decode_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l308) begin
+    if(when_DBusCachedPlugin_l352) begin
       decode_arbitration_haltItself = 1'b1;
     end
-    case(switch_Fetcher_l365)
+    case(IBusCachedPlugin_injector_port_state)
       3'b010 : begin
         decode_arbitration_haltItself = 1'b1;
       end
@@ -2752,7 +2728,7 @@ module VexRiscv (
     if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(when_CsrPlugin_l1129) begin
+    if(when_CsrPlugin_l1527) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
@@ -2780,10 +2756,10 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l350) begin
+    if(when_DBusCachedPlugin_l394) begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(when_CsrPlugin_l1193) begin
+    if(when_CsrPlugin_l1591) begin
       if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
@@ -2792,10 +2768,10 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if(when_DBusCachedPlugin_l366) begin
+    if(when_DBusCachedPlugin_l410) begin
       execute_arbitration_haltByOther = 1'b1;
     end
-    if(when_DebugPlugin_l295) begin
+    if(when_DebugPlugin_l308) begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
@@ -2812,8 +2788,8 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_flushIt = 1'b0;
-    if(when_DebugPlugin_l295) begin
-      if(when_DebugPlugin_l298) begin
+    if(when_DebugPlugin_l308) begin
+      if(when_DebugPlugin_l311) begin
         execute_arbitration_flushIt = 1'b1;
       end
     end
@@ -2824,8 +2800,8 @@ module VexRiscv (
     if(CsrPlugin_selfException_valid) begin
       execute_arbitration_flushNext = 1'b1;
     end
-    if(when_DebugPlugin_l295) begin
-      if(when_DebugPlugin_l298) begin
+    if(when_DebugPlugin_l308) begin
+      if(when_DebugPlugin_l311) begin
         execute_arbitration_flushNext = 1'b1;
       end
     end
@@ -2864,7 +2840,7 @@ module VexRiscv (
 
   always @(*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l466) begin
+    if(when_DBusCachedPlugin_l553) begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
@@ -2895,10 +2871,10 @@ module VexRiscv (
     if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -2909,24 +2885,24 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @(*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(when_CsrPlugin_l935) begin
+    if(when_CsrPlugin_l1272) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_DebugPlugin_l295) begin
-      if(when_DebugPlugin_l298) begin
+    if(when_DebugPlugin_l308) begin
+      if(when_DebugPlugin_l311) begin
         IBusCachedPlugin_fetcherHalt = 1'b1;
       end
     end
     if(DebugPlugin_haltIt) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_DebugPlugin_l311) begin
+    if(when_DebugPlugin_l324) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
@@ -2934,15 +2910,15 @@ module VexRiscv (
   assign IBusCachedPlugin_forceNoDecodeCond = 1'b0;
   always @(*) begin
     IBusCachedPlugin_incomingInstruction = 1'b0;
-    if(when_Fetcher_l243) begin
+    if(when_Fetcher_l242) begin
       IBusCachedPlugin_incomingInstruction = 1'b1;
     end
   end
 
   always @(*) begin
-    _zz_when_DBusCachedPlugin_l393 = 1'b0;
+    _zz_when_DBusCachedPlugin_l472 = 1'b0;
     if(DebugPlugin_godmode) begin
-      _zz_when_DBusCachedPlugin_l393 = 1'b1;
+      _zz_when_DBusCachedPlugin_l472 = 1'b1;
     end
   end
 
@@ -2953,7 +2929,17 @@ module VexRiscv (
     end
   end
 
-  assign CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+  always @(*) begin
+    CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+    if(when_CsrPlugin_l1702) begin
+      CsrPlugin_csrMapping_allowCsrSignal = 1'b1;
+    end
+    if(when_CsrPlugin_l1709) begin
+      CsrPlugin_csrMapping_allowCsrSignal = 1'b1;
+    end
+  end
+
+  assign CsrPlugin_csrMapping_doForceFailCsr = 1'b0;
   assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
   assign CsrPlugin_inWfi = 1'b0;
   always @(*) begin
@@ -2965,21 +2951,21 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(when_CsrPlugin_l1077) begin
-      case(switch_CsrPlugin_l1081)
+    if(when_CsrPlugin_l1456) begin
+      case(switch_CsrPlugin_l1460)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -2998,7 +2984,7 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_allowInterrupts = 1'b1;
-    if(when_DebugPlugin_l331) begin
+    if(when_DebugPlugin_l344) begin
       CsrPlugin_allowInterrupts = 1'b0;
     end
   end
@@ -3017,6 +3003,7 @@ module VexRiscv (
     end
   end
 
+  assign CsrPlugin_xretAwayFromMachine = 1'b0;
   assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
   assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusCachedPlugin_redoBranch_valid,IBusCachedPlugin_predictionJumpInterface_valid}}} != 4'b0000);
   assign _zz_IBusCachedPlugin_jump_pcLoad_payload = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
@@ -3044,9 +3031,8 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l134 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
-  assign IBusCachedPlugin_fetchPc_output_fire_1 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
-  assign when_Fetcher_l134_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
+  assign when_Fetcher_l133 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l133_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
   always @(*) begin
     IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_IBusCachedPlugin_fetchPc_pc);
     if(IBusCachedPlugin_fetchPc_redo_valid) begin
@@ -3069,7 +3055,7 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l161 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
+  assign when_Fetcher_l160 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
   assign IBusCachedPlugin_fetchPc_output_valid = ((! IBusCachedPlugin_fetcherHalt) && IBusCachedPlugin_fetchPc_booted);
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
   always @(*) begin
@@ -3106,7 +3092,7 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_1_output_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b0;
-    if(when_IBusCachedPlugin_l267) begin
+    if(when_IBusCachedPlugin_l273) begin
       IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b1;
     end
   end
@@ -3119,9 +3105,9 @@ module VexRiscv (
   assign IBusCachedPlugin_fetchPc_redo_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_iBusRsp_flush = ((decode_arbitration_removeIt || (decode_arbitration_flushNext && (! decode_arbitration_isStuck))) || IBusCachedPlugin_iBusRsp_redoFetch);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
-  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1 = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
   assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid)) || IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready);
   assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
@@ -3131,18 +3117,18 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
   always @(*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
-    if(when_Fetcher_l323) begin
+    if(when_Fetcher_l322) begin
       IBusCachedPlugin_iBusRsp_readyForError = 1'b0;
     end
   end
 
-  assign when_Fetcher_l243 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
-  assign when_Fetcher_l323 = (! IBusCachedPlugin_pcValids_0);
-  assign when_Fetcher_l332 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
-  assign when_Fetcher_l332_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
-  assign when_Fetcher_l332_2 = (! execute_arbitration_isStuck);
-  assign when_Fetcher_l332_3 = (! memory_arbitration_isStuck);
-  assign when_Fetcher_l332_4 = (! writeBack_arbitration_isStuck);
+  assign when_Fetcher_l242 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
+  assign when_Fetcher_l322 = (! IBusCachedPlugin_pcValids_0);
+  assign when_Fetcher_l331 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l331_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
+  assign when_Fetcher_l331_2 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l331_3 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l331_4 = (! writeBack_arbitration_isStuck);
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
@@ -3150,7 +3136,7 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
   always @(*) begin
     decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
-    case(switch_Fetcher_l365)
+    case(IBusCachedPlugin_injector_port_state)
       3'b010 : begin
         decode_arbitration_isValid = 1'b1;
       end
@@ -3307,87 +3293,86 @@ module VexRiscv (
   assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
   always @(*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(when_IBusCachedPlugin_l239) begin
+    if(when_IBusCachedPlugin_l245) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(when_IBusCachedPlugin_l250) begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_cache_io_cpu_fill_valid = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
-    if(when_IBusCachedPlugin_l250) begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_cache_io_cpu_fill_valid = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_valid = 1'b0;
-    if(when_IBusCachedPlugin_l244) begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
-    if(when_IBusCachedPlugin_l256) begin
+    if(when_IBusCachedPlugin_l262) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_payload_code = 4'bxxxx;
-    if(when_IBusCachedPlugin_l244) begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b1100;
     end
-    if(when_IBusCachedPlugin_l256) begin
+    if(when_IBusCachedPlugin_l262) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b0001;
     end
   end
 
   assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_2_input_payload[31 : 2],2'b00};
-  assign when_IBusCachedPlugin_l239 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign when_IBusCachedPlugin_l244 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
-  assign when_IBusCachedPlugin_l250 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
-  assign when_IBusCachedPlugin_l256 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
-  assign when_IBusCachedPlugin_l267 = (IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt);
+  assign when_IBusCachedPlugin_l245 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign when_IBusCachedPlugin_l250 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign when_IBusCachedPlugin_l256 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
+  assign when_IBusCachedPlugin_l262 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
+  assign when_IBusCachedPlugin_l273 = (IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt);
   assign IBusCachedPlugin_iBusRsp_output_valid = IBusCachedPlugin_iBusRsp_stages_2_output_valid;
   assign IBusCachedPlugin_iBusRsp_stages_2_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
   assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_decode_data;
   assign IBusCachedPlugin_iBusRsp_output_payload_pc = IBusCachedPlugin_iBusRsp_stages_2_output_payload;
   assign IBusCachedPlugin_cache_io_flush = (decode_arbitration_isValid && decode_FLUSH_ALL);
-  assign dataCache_1_io_mem_cmd_ready = (! dataCache_1_io_mem_cmd_rValid);
-  assign dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || dataCache_1_io_mem_cmd_rValid);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_wr : dataCache_1_io_mem_cmd_payload_wr);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_uncached : dataCache_1_io_mem_cmd_payload_uncached);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_address = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_address : dataCache_1_io_mem_cmd_payload_address);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_data = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_data : dataCache_1_io_mem_cmd_payload_data);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_mask : dataCache_1_io_mem_cmd_payload_mask);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_size = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_size : dataCache_1_io_mem_cmd_payload_size);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_last : dataCache_1_io_mem_cmd_payload_last);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || (! toplevel_dataCache_1_io_mem_cmd_rValidN));
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_wr : toplevel_dataCache_1_io_mem_cmd_rData_wr);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_uncached : toplevel_dataCache_1_io_mem_cmd_rData_uncached);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_address = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_address : toplevel_dataCache_1_io_mem_cmd_rData_address);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_data = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_data : toplevel_dataCache_1_io_mem_cmd_rData_data);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_mask : toplevel_dataCache_1_io_mem_cmd_rData_mask);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_size = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_size : toplevel_dataCache_1_io_mem_cmd_rData_size);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_last = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_last : toplevel_dataCache_1_io_mem_cmd_rData_last);
   always @(*) begin
-    dataCache_1_io_mem_cmd_s2mPipe_ready = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
-    if(when_Stream_l368) begin
-      dataCache_1_io_mem_cmd_s2mPipe_ready = 1'b1;
+    toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
+    if(when_Stream_l369) begin
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l368 = (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_rValid;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_rData_address;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_rData_data;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size = dataCache_1_io_mem_cmd_s2mPipe_rData_size;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_rData_last;
-  assign dBus_cmd_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
-  assign dBus_cmd_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
-  assign dBus_cmd_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
-  assign dBus_cmd_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
-  assign dBus_cmd_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
-  assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  assign dBus_cmd_payload_size = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
-  assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  assign when_DBusCachedPlugin_l308 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
+  assign when_Stream_l369 = (! toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_address;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_data;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_size;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  assign dBus_cmd_valid = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
+  assign dBus_cmd_payload_wr = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
+  assign dBus_cmd_payload_uncached = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
+  assign dBus_cmd_payload_address = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
+  assign dBus_cmd_payload_data = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
+  assign dBus_cmd_payload_mask = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
+  assign dBus_cmd_payload_size = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
+  assign dBus_cmd_payload_last = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  assign when_DBusCachedPlugin_l352 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
   assign dataCache_1_io_cpu_execute_isValid = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
   assign dataCache_1_io_cpu_execute_address = execute_SRC_ADD;
@@ -3406,11 +3391,11 @@ module VexRiscv (
   end
 
   assign dataCache_1_io_cpu_flush_valid = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
-  assign dataCache_1_io_cpu_flush_payload_singleLine = (execute_INSTRUCTION[19 : 15] != 5'h0);
+  assign dataCache_1_io_cpu_flush_payload_singleLine = (execute_INSTRUCTION[19 : 15] != 5'h00);
   assign dataCache_1_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId[6:0];
-  assign dataCache_1_io_cpu_flush_isStall = (dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready));
-  assign when_DBusCachedPlugin_l350 = (dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
-  assign when_DBusCachedPlugin_l366 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
+  assign toplevel_dataCache_1_io_cpu_flush_isStall = (dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready));
+  assign when_DBusCachedPlugin_l394 = (toplevel_dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
+  assign when_DBusCachedPlugin_l410 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
   assign dataCache_1_io_cpu_memory_isValid = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
   assign dataCache_1_io_cpu_memory_address = memory_REGFILE_WRITE_DATA;
   assign DBusCachedPlugin_mmuBus_cmd_0_isValid = dataCache_1_io_cpu_memory_isValid;
@@ -3420,12 +3405,12 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
   always @(*) begin
     dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if(when_DBusCachedPlugin_l393) begin
+    if(when_DBusCachedPlugin_l472) begin
       dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = 1'b1;
     end
   end
 
-  assign when_DBusCachedPlugin_l393 = (_zz_when_DBusCachedPlugin_l393 && (! dataCache_1_io_cpu_memory_isWrite));
+  assign when_DBusCachedPlugin_l472 = (_zz_when_DBusCachedPlugin_l472 && (! dataCache_1_io_cpu_memory_isWrite));
   always @(*) begin
     dataCache_1_io_cpu_writeBack_isValid = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
     if(writeBack_arbitration_haltByOther) begin
@@ -3438,7 +3423,7 @@ module VexRiscv (
   assign dataCache_1_io_cpu_writeBack_storeData[31 : 0] = writeBack_MEMORY_STORE_DATA_RF;
   always @(*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(when_DBusCachedPlugin_l446) begin
+    if(when_DBusCachedPlugin_l533) begin
       if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
@@ -3448,7 +3433,7 @@ module VexRiscv (
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(when_DBusCachedPlugin_l446) begin
+    if(when_DBusCachedPlugin_l533) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
@@ -3467,7 +3452,7 @@ module VexRiscv (
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
-    if(when_DBusCachedPlugin_l446) begin
+    if(when_DBusCachedPlugin_l533) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code};
       end
@@ -3480,12 +3465,13 @@ module VexRiscv (
     end
   end
 
-  assign when_DBusCachedPlugin_l446 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign when_DBusCachedPlugin_l466 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
-  assign writeBack_DBusCachedPlugin_rspSplits_0 = dataCache_1_io_cpu_writeBack_data[7 : 0];
-  assign writeBack_DBusCachedPlugin_rspSplits_1 = dataCache_1_io_cpu_writeBack_data[15 : 8];
-  assign writeBack_DBusCachedPlugin_rspSplits_2 = dataCache_1_io_cpu_writeBack_data[23 : 16];
-  assign writeBack_DBusCachedPlugin_rspSplits_3 = dataCache_1_io_cpu_writeBack_data[31 : 24];
+  assign when_DBusCachedPlugin_l533 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l553 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
+  assign writeBack_DBusCachedPlugin_rspData = dataCache_1_io_cpu_writeBack_data;
+  assign writeBack_DBusCachedPlugin_rspSplits_0 = writeBack_DBusCachedPlugin_rspData[7 : 0];
+  assign writeBack_DBusCachedPlugin_rspSplits_1 = writeBack_DBusCachedPlugin_rspData[15 : 8];
+  assign writeBack_DBusCachedPlugin_rspSplits_2 = writeBack_DBusCachedPlugin_rspData[23 : 16];
+  assign writeBack_DBusCachedPlugin_rspSplits_3 = writeBack_DBusCachedPlugin_rspData[31 : 24];
   always @(*) begin
     writeBack_DBusCachedPlugin_rspShifted[7 : 0] = _zz_writeBack_DBusCachedPlugin_rspShifted;
     writeBack_DBusCachedPlugin_rspShifted[15 : 8] = _zz_writeBack_DBusCachedPlugin_rspShifted_2;
@@ -3494,7 +3480,7 @@ module VexRiscv (
   end
 
   assign writeBack_DBusCachedPlugin_rspRf = writeBack_DBusCachedPlugin_rspShifted[31 : 0];
-  assign switch_Misc_l210 = writeBack_INSTRUCTION[13 : 12];
+  assign switch_Misc_l232 = writeBack_INSTRUCTION[13 : 12];
   assign _zz_writeBack_DBusCachedPlugin_rspFormated = (writeBack_DBusCachedPlugin_rspRf[7] && (! writeBack_INSTRUCTION[14]));
   always @(*) begin
     _zz_writeBack_DBusCachedPlugin_rspFormated_1[31] = _zz_writeBack_DBusCachedPlugin_rspFormated;
@@ -3546,7 +3532,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    case(switch_Misc_l210)
+    case(switch_Misc_l232)
       2'b00 : begin
         writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_1;
       end
@@ -3559,7 +3545,7 @@ module VexRiscv (
     endcase
   end
 
-  assign when_DBusCachedPlugin_l492 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l580 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
   assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
@@ -3579,10 +3565,10 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign DBusCachedPlugin_mmuBus_busy = 1'b0;
   assign _zz_decode_IS_RS2_SIGNED_1 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_decode_IS_RS2_SIGNED_2 = ((decode_INSTRUCTION & 32'h00000018) == 32'h0);
+  assign _zz_decode_IS_RS2_SIGNED_2 = ((decode_INSTRUCTION & 32'h00000018) == 32'h00000000);
   assign _zz_decode_IS_RS2_SIGNED_3 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
   assign _zz_decode_IS_RS2_SIGNED_4 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_decode_IS_RS2_SIGNED_5 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
+  assign _zz_decode_IS_RS2_SIGNED_5 = ((decode_INSTRUCTION & 32'h00001000) == 32'h00000000);
   assign _zz_decode_IS_RS2_SIGNED = {(|((decode_INSTRUCTION & 32'h10103050) == 32'h00100050)),{(|_zz_decode_IS_RS2_SIGNED_5),{(|_zz_decode_IS_RS2_SIGNED_5),{(|_zz__zz_decode_IS_RS2_SIGNED),{(|_zz__zz_decode_IS_RS2_SIGNED_1),{_zz__zz_decode_IS_RS2_SIGNED_2,{_zz__zz_decode_IS_RS2_SIGNED_4,_zz__zz_decode_IS_RS2_SIGNED_7}}}}}}};
   assign _zz_decode_SRC1_CTRL_2 = _zz_decode_IS_RS2_SIGNED[2 : 1];
   assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
@@ -3601,29 +3587,29 @@ module VexRiscv (
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
-  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h0);
+  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h00);
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
   assign decode_RegFilePlugin_rs1Data = _zz_RegFilePlugin_regFile_port0;
   assign decode_RegFilePlugin_rs2Data = _zz_RegFilePlugin_regFile_port1;
   always @(*) begin
     lastStageRegFileWrite_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
-    if(_zz_7) begin
+    if(_zz_10) begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
   always @(*) begin
     lastStageRegFileWrite_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
-    if(_zz_7) begin
-      lastStageRegFileWrite_payload_address = 5'h0;
+    if(_zz_10) begin
+      lastStageRegFileWrite_payload_address = 5'h00;
     end
   end
 
   always @(*) begin
     lastStageRegFileWrite_payload_data = _zz_decode_RS2_2;
-    if(_zz_7) begin
-      lastStageRegFileWrite_payload_data = 32'h0;
+    if(_zz_10) begin
+      lastStageRegFileWrite_payload_data = 32'h00000000;
     end
   end
 
@@ -3664,7 +3650,7 @@ module VexRiscv (
         _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
       Src1CtrlEnum_IMU : begin
-        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h000};
       end
       default : begin
         _zz_execute_SRC1 = {27'd0, _zz__zz_execute_SRC1_1};
@@ -3672,67 +3658,67 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_execute_SRC2_1 = execute_INSTRUCTION[31];
+  assign _zz_execute_SRC2 = execute_INSTRUCTION[31];
   always @(*) begin
-    _zz_execute_SRC2_2[19] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[18] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[17] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[16] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[15] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[14] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[13] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[12] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[11] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[10] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[9] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[8] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[7] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[6] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[5] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[4] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[3] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[2] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[1] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[0] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_1[19] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[18] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[17] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[16] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[15] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[14] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[13] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[12] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[11] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[10] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[9] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[8] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[7] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[6] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[5] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[4] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[3] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[2] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[1] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[0] = _zz_execute_SRC2;
   end
 
-  assign _zz_execute_SRC2_3 = _zz__zz_execute_SRC2_3[11];
+  assign _zz_execute_SRC2_2 = _zz__zz_execute_SRC2_2[11];
   always @(*) begin
-    _zz_execute_SRC2_4[19] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[18] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[17] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[16] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[15] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[14] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[13] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[12] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[11] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[10] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[9] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[8] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[7] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[6] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[5] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[4] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[3] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[2] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[1] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[0] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_3[19] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[18] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[17] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[16] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[15] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[14] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[13] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[12] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[11] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[10] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[9] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[8] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[7] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[6] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[5] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[4] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[3] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[2] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[1] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[0] = _zz_execute_SRC2_2;
   end
 
   always @(*) begin
     case(execute_SRC2_CTRL)
       Src2CtrlEnum_RS : begin
-        _zz_execute_SRC2_5 = execute_RS2;
+        _zz_execute_SRC2_4 = execute_RS2;
       end
       Src2CtrlEnum_IMI : begin
-        _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
+        _zz_execute_SRC2_4 = {_zz_execute_SRC2_1,execute_INSTRUCTION[31 : 20]};
       end
       Src2CtrlEnum_IMS : begin
-        _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_execute_SRC2_4 = {_zz_execute_SRC2_3,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_execute_SRC2_5 = _zz_execute_SRC2;
+        _zz_execute_SRC2_4 = _zz_execute_to_memory_PC;
       end
     endcase
   end
@@ -3898,16 +3884,19 @@ module VexRiscv (
   assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
   assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign switch_Misc_l210_1 = execute_INSTRUCTION[14 : 12];
+  assign switch_Misc_l232_1 = execute_INSTRUCTION[14 : 12];
   always @(*) begin
-    casez(switch_Misc_l210_1)
+    case(switch_Misc_l232_1)
       3'b000 : begin
         _zz_execute_BRANCH_COND_RESULT = execute_BranchPlugin_eq;
       end
       3'b001 : begin
         _zz_execute_BRANCH_COND_RESULT = (! execute_BranchPlugin_eq);
       end
-      3'b1?1 : begin
+      3'b101 : begin
+        _zz_execute_BRANCH_COND_RESULT = (! execute_SRC_LESS);
+      end
+      3'b111 : begin
         _zz_execute_BRANCH_COND_RESULT = (! execute_SRC_LESS);
       end
       default : begin
@@ -4113,9 +4102,9 @@ module VexRiscv (
 
   assign CsrPlugin_misa_base = 2'b01;
   assign CsrPlugin_misa_extensions = 26'h0000042;
-  assign _zz_when_CsrPlugin_l965 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_when_CsrPlugin_l965_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_when_CsrPlugin_l965_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign _zz_when_CsrPlugin_l1302 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l1302_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l1302_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
   assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
@@ -4160,29 +4149,29 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l922 = (! decode_arbitration_isStuck);
-  assign when_CsrPlugin_l922_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l922_2 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l922_3 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l935 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
+  assign when_CsrPlugin_l1259 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l1272 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-  assign when_CsrPlugin_l959 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign when_CsrPlugin_l965 = ((_zz_when_CsrPlugin_l965 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l965_1 = ((_zz_when_CsrPlugin_l965_1 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l965_2 = ((_zz_when_CsrPlugin_l965_2 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1296 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l1302 = ((_zz_when_CsrPlugin_l1302 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1302_1 = ((_zz_when_CsrPlugin_l1302_1 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1302_2 = ((_zz_when_CsrPlugin_l1302_2 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_lastStageWasWfi = 1'b0;
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  assign when_CsrPlugin_l993 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l993_1 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l993_2 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l998 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  assign when_CsrPlugin_l1335 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1335_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l1335_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l1340 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
   always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(when_CsrPlugin_l1004) begin
+    if(when_CsrPlugin_l1346) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException) begin
@@ -4190,7 +4179,7 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l1004 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
+  assign when_CsrPlugin_l1346 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
   always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
@@ -4206,6 +4195,7 @@ module VexRiscv (
     end
   end
 
+  assign CsrPlugin_trapCauseEbreakDebug = 1'b0;
   always @(*) begin
     CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
@@ -4228,11 +4218,13 @@ module VexRiscv (
     endcase
   end
 
-  assign when_CsrPlugin_l1032 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign when_CsrPlugin_l1077 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
-  assign switch_CsrPlugin_l1081 = writeBack_INSTRUCTION[29 : 28];
+  assign CsrPlugin_trapEnterDebug = 1'b0;
+  assign when_CsrPlugin_l1390 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1398 = (! CsrPlugin_trapEnterDebug);
+  assign when_CsrPlugin_l1456 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign switch_CsrPlugin_l1460 = writeBack_INSTRUCTION[29 : 28];
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign when_CsrPlugin_l1129 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
+  assign when_CsrPlugin_l1527 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
   assign execute_CsrPlugin_blockedBySideEffects = ((|{writeBack_arbitration_isValid,memory_arbitration_isValid}) || 1'b0);
   always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
@@ -4279,18 +4271,18 @@ module VexRiscv (
     if(CsrPlugin_csrMapping_allowCsrSignal) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(when_CsrPlugin_l1315) begin
+    if(when_CsrPlugin_l1725) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if(when_CsrPlugin_l1149) begin
-      if(when_CsrPlugin_l1150) begin
+    if(when_CsrPlugin_l1547) begin
+      if(when_CsrPlugin_l1548) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
@@ -4298,14 +4290,14 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(when_CsrPlugin_l1157) begin
+    if(when_CsrPlugin_l1555) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(when_CsrPlugin_l1157) begin
+    if(when_CsrPlugin_l1555) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -4318,19 +4310,19 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  assign when_CsrPlugin_l1149 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
-  assign when_CsrPlugin_l1150 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
-  assign when_CsrPlugin_l1157 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
+  assign when_CsrPlugin_l1547 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign when_CsrPlugin_l1548 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1555 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
   always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -4339,9 +4331,9 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
   assign execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
-  assign switch_Misc_l210_2 = execute_INSTRUCTION[13];
+  assign switch_Misc_l232_2 = execute_INSTRUCTION[13];
   always @(*) begin
-    case(switch_Misc_l210_2)
+    case(switch_Misc_l232_2)
       1'b0 : begin
         _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
@@ -4352,8 +4344,8 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
-  assign when_CsrPlugin_l1189 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign when_CsrPlugin_l1193 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
+  assign when_CsrPlugin_l1587 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1591 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
@@ -4416,12 +4408,12 @@ module VexRiscv (
   assign memory_DivPlugin_div_counter_willOverflow = (memory_DivPlugin_div_counter_willOverflowIfInc && memory_DivPlugin_div_counter_willIncrement);
   always @(*) begin
     if(memory_DivPlugin_div_counter_willOverflow) begin
-      memory_DivPlugin_div_counter_valueNext = 6'h0;
+      memory_DivPlugin_div_counter_valueNext = 6'h00;
     end else begin
       memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_memory_DivPlugin_div_counter_valueNext);
     end
     if(memory_DivPlugin_div_counter_willClear) begin
-      memory_DivPlugin_div_counter_valueNext = 6'h0;
+      memory_DivPlugin_div_counter_valueNext = 6'h00;
     end
   end
 
@@ -4445,17 +4437,17 @@ module VexRiscv (
     _zz_memory_DivPlugin_rs1_1[31 : 0] = execute_RS1;
   end
 
-  assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
-  assign externalInterrupt = (|_zz_CsrPlugin_csrMapping_readDataInit_1);
-  assign when_DebugPlugin_l225 = (DebugPlugin_haltIt && (! DebugPlugin_isPipBusy));
+  assign _zz_externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
+  assign externalInterrupt = (|_zz_externalInterrupt);
+  assign when_DebugPlugin_l238 = (DebugPlugin_haltIt && (! DebugPlugin_isPipBusy));
   assign DebugPlugin_allowEBreak = (DebugPlugin_debugUsed && (! DebugPlugin_disableEbreak));
   always @(*) begin
     debug_bus_cmd_ready = 1'b1;
     if(debug_bus_cmd_valid) begin
-      case(switch_DebugPlugin_l267)
+      case(switch_DebugPlugin_l280)
         6'h01 : begin
           if(debug_bus_cmd_payload_wr) begin
-            debug_bus_cmd_ready = IBusCachedPlugin_injectionPort_ready;
+            debug_bus_cmd_ready = DebugPlugin_injectionPort_ready;
           end
         end
         default : begin
@@ -4466,7 +4458,7 @@ module VexRiscv (
 
   always @(*) begin
     debug_bus_rsp_data = DebugPlugin_busReadDataReg;
-    if(when_DebugPlugin_l244) begin
+    if(when_DebugPlugin_l257) begin
       debug_bus_rsp_data[0] = DebugPlugin_resetIt;
       debug_bus_rsp_data[1] = DebugPlugin_haltIt;
       debug_bus_rsp_data[2] = DebugPlugin_isPipBusy;
@@ -4475,14 +4467,14 @@ module VexRiscv (
     end
   end
 
-  assign when_DebugPlugin_l244 = (! _zz_when_DebugPlugin_l244);
+  assign when_DebugPlugin_l257 = (! _zz_when_DebugPlugin_l257);
   always @(*) begin
-    IBusCachedPlugin_injectionPort_valid = 1'b0;
+    DebugPlugin_injectionPort_valid = 1'b0;
     if(debug_bus_cmd_valid) begin
-      case(switch_DebugPlugin_l267)
+      case(switch_DebugPlugin_l280)
         6'h01 : begin
           if(debug_bus_cmd_payload_wr) begin
-            IBusCachedPlugin_injectionPort_valid = 1'b1;
+            DebugPlugin_injectionPort_valid = 1'b1;
           end
         end
         default : begin
@@ -4491,21 +4483,21 @@ module VexRiscv (
     end
   end
 
-  assign IBusCachedPlugin_injectionPort_payload = debug_bus_cmd_payload_data;
-  assign switch_DebugPlugin_l267 = debug_bus_cmd_payload_address[7 : 2];
-  assign when_DebugPlugin_l271 = debug_bus_cmd_payload_data[16];
-  assign when_DebugPlugin_l271_1 = debug_bus_cmd_payload_data[24];
-  assign when_DebugPlugin_l272 = debug_bus_cmd_payload_data[17];
-  assign when_DebugPlugin_l272_1 = debug_bus_cmd_payload_data[25];
-  assign when_DebugPlugin_l273 = debug_bus_cmd_payload_data[25];
-  assign when_DebugPlugin_l274 = debug_bus_cmd_payload_data[25];
-  assign when_DebugPlugin_l275 = debug_bus_cmd_payload_data[18];
-  assign when_DebugPlugin_l275_1 = debug_bus_cmd_payload_data[26];
-  assign when_DebugPlugin_l295 = (execute_arbitration_isValid && execute_DO_EBREAK);
-  assign when_DebugPlugin_l298 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
-  assign when_DebugPlugin_l311 = (DebugPlugin_stepIt && IBusCachedPlugin_incomingInstruction);
+  assign DebugPlugin_injectionPort_payload = debug_bus_cmd_payload_data;
+  assign switch_DebugPlugin_l280 = debug_bus_cmd_payload_address[7 : 2];
+  assign when_DebugPlugin_l284 = debug_bus_cmd_payload_data[16];
+  assign when_DebugPlugin_l284_1 = debug_bus_cmd_payload_data[24];
+  assign when_DebugPlugin_l285 = debug_bus_cmd_payload_data[17];
+  assign when_DebugPlugin_l285_1 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l286 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l287 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l288 = debug_bus_cmd_payload_data[18];
+  assign when_DebugPlugin_l288_1 = debug_bus_cmd_payload_data[26];
+  assign when_DebugPlugin_l308 = (execute_arbitration_isValid && execute_DO_EBREAK);
+  assign when_DebugPlugin_l311 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
+  assign when_DebugPlugin_l324 = (DebugPlugin_stepIt && IBusCachedPlugin_incomingInstruction);
   assign debug_resetOut = DebugPlugin_resetIt_regNext;
-  assign when_DebugPlugin_l331 = (DebugPlugin_haltIt || DebugPlugin_stepIt);
+  assign when_DebugPlugin_l344 = (DebugPlugin_haltIt || DebugPlugin_stepIt);
   assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
@@ -4623,102 +4615,112 @@ module VexRiscv (
   assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
   assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
   always @(*) begin
-    IBusCachedPlugin_injectionPort_ready = 1'b0;
-    case(switch_Fetcher_l365)
+    DebugPlugin_injectionPort_ready = 1'b0;
+    case(IBusCachedPlugin_injector_port_state)
       3'b100 : begin
-        IBusCachedPlugin_injectionPort_ready = 1'b1;
+        DebugPlugin_injectionPort_ready = 1'b1;
       end
       default : begin
       end
     endcase
   end
 
-  assign when_Fetcher_l381 = (! decode_arbitration_isStuck);
-  assign when_CsrPlugin_l1277 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_2 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_3 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_4 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_5 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_6 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_7 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_8 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_9 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l391 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l1669 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_8 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_9 = (! execute_arbitration_isStuck);
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_1 = 32'h00000000;
     if(execute_CsrPlugin_csr_3264) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_2[12 : 0] = 13'h1000;
-      _zz_CsrPlugin_csrMapping_readDataInit_2[25 : 20] = 6'h20;
+      _zz_CsrPlugin_csrMapping_readDataInit_1[12 : 0] = 13'h1000;
+      _zz_CsrPlugin_csrMapping_readDataInit_1[25 : 20] = 6'h20;
     end
   end
 
-  assign switch_CsrPlugin_l723 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
+  assign switch_CsrPlugin_l1031 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h00000000;
     if(execute_CsrPlugin_csr_768) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_3[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_3[3 : 3] = CsrPlugin_mstatus_MIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_3[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[12 : 11] = CsrPlugin_mstatus_MPP;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h00000000;
     if(execute_CsrPlugin_csr_836) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_4[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_4[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_4[3 : 3] = CsrPlugin_mip_MSIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[3 : 3] = CsrPlugin_mip_MSIP;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h00000000;
     if(execute_CsrPlugin_csr_772) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_5[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_5[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_5[3 : 3] = CsrPlugin_mie_MSIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[3 : 3] = CsrPlugin_mie_MSIE;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h00000000;
     if(execute_CsrPlugin_csr_833) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_6[31 : 0] = CsrPlugin_mepc;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[31 : 0] = CsrPlugin_mepc;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h00000000;
     if(execute_CsrPlugin_csr_834) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_7[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_CsrPlugin_csrMapping_readDataInit_7[3 : 0] = CsrPlugin_mcause_exceptionCode;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h00000000;
     if(execute_CsrPlugin_csr_835) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_8[31 : 0] = CsrPlugin_mtval;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[31 : 0] = CsrPlugin_mtval;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h00000000;
     if(execute_CsrPlugin_csr_3008) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_9[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
+      _zz_CsrPlugin_csrMapping_readDataInit_8[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_10 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h00000000;
     if(execute_CsrPlugin_csr_4032) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_10[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_1;
+      _zz_CsrPlugin_csrMapping_readDataInit_9[31 : 0] = _zz_externalInterrupt;
     end
   end
 
-  assign CsrPlugin_csrMapping_readDataInit = ((((_zz_CsrPlugin_csrMapping_readDataInit_2 | _zz_CsrPlugin_csrMapping_readDataInit_3) | (_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5)) | ((_zz_CsrPlugin_csrMapping_readDataInit_6 | _zz_CsrPlugin_csrMapping_readDataInit_7) | (_zz_CsrPlugin_csrMapping_readDataInit_8 | _zz_CsrPlugin_csrMapping_readDataInit_9))) | _zz_CsrPlugin_csrMapping_readDataInit_10);
-  assign when_CsrPlugin_l1310 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign when_CsrPlugin_l1315 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign CsrPlugin_csrMapping_readDataInit = ((((_zz_CsrPlugin_csrMapping_readDataInit_1 | _zz_CsrPlugin_csrMapping_readDataInit_2) | (_zz_CsrPlugin_csrMapping_readDataInit_3 | _zz_CsrPlugin_csrMapping_readDataInit_4)) | ((_zz_CsrPlugin_csrMapping_readDataInit_5 | _zz_CsrPlugin_csrMapping_readDataInit_6) | (_zz_CsrPlugin_csrMapping_readDataInit_7 | _zz_CsrPlugin_csrMapping_readDataInit_8))) | _zz_CsrPlugin_csrMapping_readDataInit_9);
+  assign when_CsrPlugin_l1702 = ((execute_arbitration_isValid && execute_IS_CSR) && (({execute_CsrPlugin_csrAddress[11 : 2],2'b00} == 12'h3a0) || ({execute_CsrPlugin_csrAddress[11 : 4],4'b0000} == 12'h3b0)));
+  assign _zz_when_CsrPlugin_l1709 = (execute_CsrPlugin_csrAddress & 12'hf60);
+  assign when_CsrPlugin_l1709 = (((execute_arbitration_isValid && execute_IS_CSR) && (5'h03 <= execute_CsrPlugin_csrAddress[4 : 0])) && (((_zz_when_CsrPlugin_l1709 == 12'hb00) || (((_zz_when_CsrPlugin_l1709 == 12'hc00) && (! execute_CsrPlugin_writeInstruction)) && (CsrPlugin_privilege == 2'b11))) || ((execute_CsrPlugin_csrAddress & 12'hfe0) == 12'h320)));
+  always @(*) begin
+    when_CsrPlugin_l1719 = CsrPlugin_csrMapping_doForceFailCsr;
+    if(when_CsrPlugin_l1717) begin
+      when_CsrPlugin_l1719 = 1'b1;
+    end
+  end
+
+  assign when_CsrPlugin_l1717 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1725 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
   assign iBusWishbone_ADR = {_zz_iBusWishbone_ADR_1,_zz_iBusWishbone_ADR};
   assign iBusWishbone_CTI = ((_zz_iBusWishbone_ADR == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
@@ -4744,20 +4746,20 @@ module VexRiscv (
   assign iBus_rsp_valid = _zz_iBus_rsp_valid;
   assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
   assign iBus_rsp_payload_error = 1'b0;
-  assign _zz_dBus_cmd_ready_5 = (dBus_cmd_payload_size == 3'b101);
-  assign _zz_dBus_cmd_ready_1 = dBus_cmd_valid;
-  assign _zz_dBus_cmd_ready_3 = dBus_cmd_payload_wr;
-  assign _zz_dBus_cmd_ready_4 = ((! _zz_dBus_cmd_ready_5) || (_zz_dBus_cmd_ready == 3'b111));
-  assign dBus_cmd_ready = (_zz_dBus_cmd_ready_2 && (_zz_dBus_cmd_ready_3 || _zz_dBus_cmd_ready_4));
-  assign dBusWishbone_ADR = ((_zz_dBus_cmd_ready_5 ? {{dBus_cmd_payload_address[31 : 5],_zz_dBus_cmd_ready},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
-  assign dBusWishbone_CTI = (_zz_dBus_cmd_ready_5 ? (_zz_dBus_cmd_ready_4 ? 3'b111 : 3'b010) : 3'b000);
+  assign _zz_dBusWishbone_ADR_1 = (dBus_cmd_payload_size == 3'b101);
+  assign _zz_dBusWishbone_CYC = dBus_cmd_valid;
+  assign _zz_dBus_cmd_ready_1 = dBus_cmd_payload_wr;
+  assign _zz_dBus_cmd_ready_2 = ((! _zz_dBusWishbone_ADR_1) || (_zz_dBusWishbone_ADR == 3'b111));
+  assign dBus_cmd_ready = (_zz_dBus_cmd_ready && (_zz_dBus_cmd_ready_1 || _zz_dBus_cmd_ready_2));
+  assign dBusWishbone_ADR = ((_zz_dBusWishbone_ADR_1 ? {{dBus_cmd_payload_address[31 : 5],_zz_dBusWishbone_ADR},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2'd2);
+  assign dBusWishbone_CTI = (_zz_dBusWishbone_ADR_1 ? (_zz_dBus_cmd_ready_2 ? 3'b111 : 3'b010) : 3'b000);
   assign dBusWishbone_BTE = 2'b00;
-  assign dBusWishbone_SEL = (_zz_dBus_cmd_ready_3 ? dBus_cmd_payload_mask : 4'b1111);
-  assign dBusWishbone_WE = _zz_dBus_cmd_ready_3;
+  assign dBusWishbone_SEL = (_zz_dBus_cmd_ready_1 ? dBus_cmd_payload_mask : 4'b1111);
+  assign dBusWishbone_WE = _zz_dBus_cmd_ready_1;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_payload_data;
-  assign _zz_dBus_cmd_ready_2 = (_zz_dBus_cmd_ready_1 && dBusWishbone_ACK);
-  assign dBusWishbone_CYC = _zz_dBus_cmd_ready_1;
-  assign dBusWishbone_STB = _zz_dBus_cmd_ready_1;
+  assign _zz_dBus_cmd_ready = (_zz_dBusWishbone_CYC && dBusWishbone_ACK);
+  assign dBusWishbone_CYC = _zz_dBusWishbone_CYC;
+  assign dBusWishbone_STB = _zz_dBusWishbone_CYC;
   assign dBus_rsp_valid = _zz_dBus_rsp_valid;
   assign dBus_rsp_payload_data = dBusWishbone_DAT_MISO_regNext;
   assign dBus_rsp_payload_error = 1'b0;
@@ -4767,18 +4769,18 @@ module VexRiscv (
       IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
-      _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+      _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= 1'b0;
       _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= 32'h0;
-      dataCache_1_io_mem_cmd_rValid <= 1'b0;
-      dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= 32'h0;
-      _zz_7 <= 1'b1;
+      IBusCachedPlugin_rspCounter <= 32'h00000000;
+      toplevel_dataCache_1_io_mem_cmd_rValidN <= 1'b1;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
+      DBusCachedPlugin_rspCounter <= 32'h00000000;
+      _zz_10 <= 1'b1;
       HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
       CsrPlugin_mstatus_MIE <= 1'b0;
       CsrPlugin_mstatus_MPIE <= 1'b0;
@@ -4786,8 +4788,8 @@ module VexRiscv (
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
-      CsrPlugin_mcycle <= 64'h0;
-      CsrPlugin_minstret <= 64'h0;
+      CsrPlugin_mcycle <= 64'h0000000000000000;
+      CsrPlugin_minstret <= 64'h0000000000000000;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= 1'b0;
@@ -4798,15 +4800,15 @@ module VexRiscv (
       CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
-      memory_DivPlugin_div_counter_value <= 6'h0;
-      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h0;
+      memory_DivPlugin_div_counter_value <= 6'h00;
+      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h00000000;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
-      switch_Fetcher_l365 <= 3'b000;
+      IBusCachedPlugin_injector_port_state <= 3'b000;
       _zz_iBusWishbone_ADR <= 3'b000;
       _zz_iBus_rsp_valid <= 1'b0;
-      _zz_dBus_cmd_ready <= 3'b000;
+      _zz_dBusWishbone_ADR <= 3'b000;
       _zz_dBus_rsp_valid <= 1'b0;
     end else begin
       if(IBusCachedPlugin_fetchPc_correction) begin
@@ -4816,23 +4818,23 @@ module VexRiscv (
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusCachedPlugin_fetchPc_booted <= 1'b1;
-      if(when_Fetcher_l134) begin
+      if(when_Fetcher_l133) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_output_fire_1) begin
+      if(IBusCachedPlugin_fetchPc_output_fire) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b1;
       end
-      if(when_Fetcher_l134_1) begin
+      if(when_Fetcher_l133_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(when_Fetcher_l161) begin
+      if(when_Fetcher_l160) begin
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
       if(IBusCachedPlugin_iBusRsp_flush) begin
-        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= 1'b0;
       end
       if(_zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready) begin
-        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
       if(IBusCachedPlugin_iBusRsp_flush) begin
         _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
@@ -4843,13 +4845,13 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if(when_Fetcher_l332) begin
+      if(when_Fetcher_l331) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(when_Fetcher_l332_1) begin
+      if(when_Fetcher_l331_1) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= IBusCachedPlugin_injector_nextPcCalc_valids_0;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -4858,7 +4860,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(when_Fetcher_l332_2) begin
+      if(when_Fetcher_l331_2) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= IBusCachedPlugin_injector_nextPcCalc_valids_1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -4867,7 +4869,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(when_Fetcher_l332_3) begin
+      if(when_Fetcher_l331_3) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -4876,7 +4878,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if(when_Fetcher_l332_4) begin
+      if(when_Fetcher_l331_4) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= IBusCachedPlugin_injector_nextPcCalc_valids_3;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -4886,67 +4888,67 @@ module VexRiscv (
         IBusCachedPlugin_rspCounter <= (IBusCachedPlugin_rspCounter + 32'h00000001);
       end
       if(dataCache_1_io_mem_cmd_valid) begin
-        dataCache_1_io_mem_cmd_rValid <= 1'b1;
+        toplevel_dataCache_1_io_mem_cmd_rValidN <= 1'b0;
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
-        dataCache_1_io_mem_cmd_rValid <= 1'b0;
+      if(toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+        toplevel_dataCache_1_io_mem_cmd_rValidN <= 1'b1;
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
-        dataCache_1_io_mem_cmd_s2mPipe_rValid <= dataCache_1_io_mem_cmd_s2mPipe_valid;
+      if(toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+        toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_valid;
       end
       if(dBus_rsp_valid) begin
         DBusCachedPlugin_rspCounter <= (DBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      _zz_7 <= 1'b0;
+      _zz_10 <= 1'b0;
       HazardSimplePlugin_writeBackBuffer_valid <= HazardSimplePlugin_writeBackWrites_valid;
       CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
       if(writeBack_arbitration_isFiring) begin
         CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
       end
-      if(when_CsrPlugin_l922) begin
+      if(when_CsrPlugin_l1259) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if(when_CsrPlugin_l922_1) begin
+      if(when_CsrPlugin_l1259_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if(when_CsrPlugin_l922_2) begin
+      if(when_CsrPlugin_l1259_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if(when_CsrPlugin_l922_3) begin
+      if(when_CsrPlugin_l1259_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(when_CsrPlugin_l959) begin
-        if(when_CsrPlugin_l965) begin
+      if(when_CsrPlugin_l1296) begin
+        if(when_CsrPlugin_l1302) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_1) begin
+        if(when_CsrPlugin_l1302_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_2) begin
+        if(when_CsrPlugin_l1302_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
       if(CsrPlugin_pipelineLiberator_active) begin
-        if(when_CsrPlugin_l993) begin
+        if(when_CsrPlugin_l1335) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if(when_CsrPlugin_l993_1) begin
+        if(when_CsrPlugin_l1335_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if(when_CsrPlugin_l993_2) begin
+        if(when_CsrPlugin_l1335_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(when_CsrPlugin_l998) begin
+      if(when_CsrPlugin_l1340) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
@@ -4955,19 +4957,21 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(when_CsrPlugin_l1032) begin
-        case(CsrPlugin_targetPrivilege)
-          2'b11 : begin
-            CsrPlugin_mstatus_MIE <= 1'b0;
-            CsrPlugin_mstatus_MPIE <= CsrPlugin_mstatus_MIE;
-            CsrPlugin_mstatus_MPP <= CsrPlugin_privilege;
-          end
-          default : begin
-          end
-        endcase
+      if(when_CsrPlugin_l1390) begin
+        if(when_CsrPlugin_l1398) begin
+          case(CsrPlugin_targetPrivilege)
+            2'b11 : begin
+              CsrPlugin_mstatus_MIE <= 1'b0;
+              CsrPlugin_mstatus_MPIE <= CsrPlugin_mstatus_MIE;
+              CsrPlugin_mstatus_MPP <= CsrPlugin_privilege;
+            end
+            default : begin
+            end
+          endcase
+        end
       end
-      if(when_CsrPlugin_l1077) begin
-        case(switch_CsrPlugin_l1081)
+      if(when_CsrPlugin_l1456) begin
+        case(switch_CsrPlugin_l1460)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -4977,7 +4981,7 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l965_2,{_zz_when_CsrPlugin_l965_1,_zz_when_CsrPlugin_l965}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l1302_2,{_zz_when_CsrPlugin_l1302_1,_zz_when_CsrPlugin_l1302}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
       if(when_Pipeline_l151) begin
         execute_arbitration_isValid <= 1'b0;
@@ -4997,25 +5001,25 @@ module VexRiscv (
       if(when_Pipeline_l154_2) begin
         writeBack_arbitration_isValid <= memory_arbitration_isValid;
       end
-      case(switch_Fetcher_l365)
+      case(IBusCachedPlugin_injector_port_state)
         3'b000 : begin
-          if(IBusCachedPlugin_injectionPort_valid) begin
-            switch_Fetcher_l365 <= 3'b001;
+          if(DebugPlugin_injectionPort_valid) begin
+            IBusCachedPlugin_injector_port_state <= 3'b001;
           end
         end
         3'b001 : begin
-          switch_Fetcher_l365 <= 3'b010;
+          IBusCachedPlugin_injector_port_state <= 3'b010;
         end
         3'b010 : begin
-          switch_Fetcher_l365 <= 3'b011;
+          IBusCachedPlugin_injector_port_state <= 3'b011;
         end
         3'b011 : begin
-          if(when_Fetcher_l381) begin
-            switch_Fetcher_l365 <= 3'b100;
+          if(when_Fetcher_l391) begin
+            IBusCachedPlugin_injector_port_state <= 3'b100;
           end
         end
         3'b100 : begin
-          switch_Fetcher_l365 <= 3'b000;
+          IBusCachedPlugin_injector_port_state <= 3'b000;
         end
         default : begin
         end
@@ -5024,7 +5028,7 @@ module VexRiscv (
         if(execute_CsrPlugin_writeEnable) begin
           CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
           CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
-          case(switch_CsrPlugin_l723)
+          case(switch_CsrPlugin_l1031)
             2'b11 : begin
               CsrPlugin_mstatus_MPP <= 2'b11;
             end
@@ -5051,13 +5055,13 @@ module VexRiscv (
         end
       end
       _zz_iBus_rsp_valid <= (iBusWishbone_CYC && iBusWishbone_ACK);
-      if((_zz_dBus_cmd_ready_1 && _zz_dBus_cmd_ready_2)) begin
-        _zz_dBus_cmd_ready <= (_zz_dBus_cmd_ready + 3'b001);
-        if(_zz_dBus_cmd_ready_4) begin
-          _zz_dBus_cmd_ready <= 3'b000;
+      if((_zz_dBusWishbone_CYC && _zz_dBus_cmd_ready)) begin
+        _zz_dBusWishbone_ADR <= (_zz_dBusWishbone_ADR + 3'b001);
+        if(_zz_dBus_cmd_ready_2) begin
+          _zz_dBusWishbone_ADR <= 3'b000;
         end
       end
-      _zz_dBus_rsp_valid <= ((_zz_dBus_cmd_ready_1 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
+      _zz_dBus_rsp_valid <= ((_zz_dBusWishbone_CYC && (! dBusWishbone_WE)) && dBusWishbone_ACK);
     end
   end
 
@@ -5071,23 +5075,23 @@ module VexRiscv (
     if(IBusCachedPlugin_iBusRsp_stages_2_input_ready) begin
       IBusCachedPlugin_s2_tightlyCoupledHit <= IBusCachedPlugin_s1_tightlyCoupledHit;
     end
-    if(dataCache_1_io_mem_cmd_ready) begin
-      dataCache_1_io_mem_cmd_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
-      dataCache_1_io_mem_cmd_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
-      dataCache_1_io_mem_cmd_rData_address <= dataCache_1_io_mem_cmd_payload_address;
-      dataCache_1_io_mem_cmd_rData_data <= dataCache_1_io_mem_cmd_payload_data;
-      dataCache_1_io_mem_cmd_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
-      dataCache_1_io_mem_cmd_rData_size <= dataCache_1_io_mem_cmd_payload_size;
-      dataCache_1_io_mem_cmd_rData_last <= dataCache_1_io_mem_cmd_payload_last;
+    if(toplevel_dataCache_1_io_mem_cmd_rValidN) begin
+      toplevel_dataCache_1_io_mem_cmd_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
+      toplevel_dataCache_1_io_mem_cmd_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
+      toplevel_dataCache_1_io_mem_cmd_rData_address <= dataCache_1_io_mem_cmd_payload_address;
+      toplevel_dataCache_1_io_mem_cmd_rData_data <= dataCache_1_io_mem_cmd_payload_data;
+      toplevel_dataCache_1_io_mem_cmd_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
+      toplevel_dataCache_1_io_mem_cmd_rData_size <= dataCache_1_io_mem_cmd_payload_size;
+      toplevel_dataCache_1_io_mem_cmd_rData_last <= dataCache_1_io_mem_cmd_payload_last;
     end
-    if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
-      dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_address <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_data <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_size <= dataCache_1_io_mem_cmd_s2mPipe_payload_size;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_last <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+    if(toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_address <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_data <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_size <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_size;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_last <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_last;
     end
     HazardSimplePlugin_writeBackBuffer_payload_address <= HazardSimplePlugin_writeBackWrites_payload_address;
     HazardSimplePlugin_writeBackBuffer_payload_data <= HazardSimplePlugin_writeBackWrites_payload_data;
@@ -5110,33 +5114,35 @@ module VexRiscv (
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(when_CsrPlugin_l959) begin
-      if(when_CsrPlugin_l965) begin
+    if(when_CsrPlugin_l1296) begin
+      if(when_CsrPlugin_l1302) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l965_1) begin
+      if(when_CsrPlugin_l1302_1) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l965_2) begin
+      if(when_CsrPlugin_l1302_2) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(when_CsrPlugin_l1032) begin
-      case(CsrPlugin_targetPrivilege)
-        2'b11 : begin
-          CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
-          CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
-          CsrPlugin_mepc <= writeBack_PC;
-          if(CsrPlugin_hadException) begin
-            CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
+    if(when_CsrPlugin_l1390) begin
+      if(when_CsrPlugin_l1398) begin
+        case(CsrPlugin_targetPrivilege)
+          2'b11 : begin
+            CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
+            CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
+            CsrPlugin_mepc <= writeBack_PC;
+            if(CsrPlugin_hadException) begin
+              CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
+            end
           end
-        end
-        default : begin
-        end
-      endcase
+          default : begin
+          end
+        endcase
+      end
     end
     if(when_MulDivIterativePlugin_l126) begin
       memory_DivPlugin_div_done <= 1'b1;
@@ -5154,17 +5160,17 @@ module VexRiscv (
       end
     end
     if(when_MulDivIterativePlugin_l162) begin
-      memory_DivPlugin_accumulator <= 65'h0;
+      memory_DivPlugin_accumulator <= 65'h00000000000000000;
       memory_DivPlugin_rs1 <= ((_zz_memory_DivPlugin_rs1 ? (~ _zz_memory_DivPlugin_rs1_1) : _zz_memory_DivPlugin_rs1_1) + _zz_memory_DivPlugin_rs1_2);
       memory_DivPlugin_rs2 <= ((_zz_memory_DivPlugin_rs2 ? (~ execute_RS2) : execute_RS2) + _zz_memory_DivPlugin_rs2_1);
-      memory_DivPlugin_div_needRevert <= ((_zz_memory_DivPlugin_rs1 ^ (_zz_memory_DivPlugin_rs2 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
+      memory_DivPlugin_div_needRevert <= ((_zz_memory_DivPlugin_rs1 ^ (_zz_memory_DivPlugin_rs2 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h00000000) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
     end
     externalInterruptArray_regNext <= externalInterruptArray;
     if(when_Pipeline_l124) begin
       decode_to_execute_PC <= decode_PC;
     end
     if(when_Pipeline_l124_1) begin
-      execute_to_memory_PC <= _zz_execute_SRC2;
+      execute_to_memory_PC <= _zz_execute_to_memory_PC;
     end
     if(when_Pipeline_l124_2) begin
       memory_to_writeBack_PC <= memory_PC;
@@ -5349,34 +5355,34 @@ module VexRiscv (
     if(when_Pipeline_l124_62) begin
       memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
     end
-    if(when_CsrPlugin_l1277) begin
+    if(when_CsrPlugin_l1669) begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
     end
-    if(when_CsrPlugin_l1277_1) begin
+    if(when_CsrPlugin_l1669_1) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if(when_CsrPlugin_l1277_2) begin
+    if(when_CsrPlugin_l1669_2) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if(when_CsrPlugin_l1277_3) begin
+    if(when_CsrPlugin_l1669_3) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if(when_CsrPlugin_l1277_4) begin
+    if(when_CsrPlugin_l1669_4) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if(when_CsrPlugin_l1277_5) begin
+    if(when_CsrPlugin_l1669_5) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if(when_CsrPlugin_l1277_6) begin
+    if(when_CsrPlugin_l1669_6) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if(when_CsrPlugin_l1277_7) begin
+    if(when_CsrPlugin_l1669_7) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if(when_CsrPlugin_l1277_8) begin
+    if(when_CsrPlugin_l1669_8) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if(when_CsrPlugin_l1277_9) begin
+    if(when_CsrPlugin_l1669_9) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
     if(execute_CsrPlugin_csr_836) begin
@@ -5387,7 +5393,6 @@ module VexRiscv (
     if(execute_CsrPlugin_csr_773) begin
       if(execute_CsrPlugin_writeEnable) begin
         CsrPlugin_mtvec_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 2];
-        CsrPlugin_mtvec_mode <= CsrPlugin_csrMapping_writeDataSignal[1 : 0];
       end
     end
     if(execute_CsrPlugin_csr_833) begin
@@ -5409,9 +5414,9 @@ module VexRiscv (
     if(writeBack_arbitration_isValid) begin
       DebugPlugin_busReadDataReg <= _zz_decode_RS2_2;
     end
-    _zz_when_DebugPlugin_l244 <= debug_bus_cmd_payload_address[2];
+    _zz_when_DebugPlugin_l257 <= debug_bus_cmd_payload_address[2];
     if(debug_bus_cmd_valid) begin
-      case(switch_DebugPlugin_l267)
+      case(switch_DebugPlugin_l280)
         6'h10 : begin
           if(debug_bus_cmd_payload_wr) begin
             DebugPlugin_hardwareBreakpoints_0_pc <= debug_bus_cmd_payload_data[31 : 1];
@@ -5426,7 +5431,7 @@ module VexRiscv (
         end
       endcase
     end
-    if(when_DebugPlugin_l295) begin
+    if(when_DebugPlugin_l308) begin
       DebugPlugin_busReadDataReg <= execute_PC;
     end
     DebugPlugin_resetIt_regNext <= DebugPlugin_resetIt;
@@ -5444,39 +5449,39 @@ module VexRiscv (
       DebugPlugin_hardwareBreakpoints_0_valid <= 1'b0;
       DebugPlugin_hardwareBreakpoints_1_valid <= 1'b0;
     end else begin
-      if(when_DebugPlugin_l225) begin
+      if(when_DebugPlugin_l238) begin
         DebugPlugin_godmode <= 1'b1;
       end
       if(debug_bus_cmd_valid) begin
         DebugPlugin_debugUsed <= 1'b1;
       end
       if(debug_bus_cmd_valid) begin
-        case(switch_DebugPlugin_l267)
-          6'h0 : begin
+        case(switch_DebugPlugin_l280)
+          6'h00 : begin
             if(debug_bus_cmd_payload_wr) begin
               DebugPlugin_stepIt <= debug_bus_cmd_payload_data[4];
-              if(when_DebugPlugin_l271) begin
+              if(when_DebugPlugin_l284) begin
                 DebugPlugin_resetIt <= 1'b1;
               end
-              if(when_DebugPlugin_l271_1) begin
+              if(when_DebugPlugin_l284_1) begin
                 DebugPlugin_resetIt <= 1'b0;
               end
-              if(when_DebugPlugin_l272) begin
+              if(when_DebugPlugin_l285) begin
                 DebugPlugin_haltIt <= 1'b1;
               end
-              if(when_DebugPlugin_l272_1) begin
+              if(when_DebugPlugin_l285_1) begin
                 DebugPlugin_haltIt <= 1'b0;
               end
-              if(when_DebugPlugin_l273) begin
+              if(when_DebugPlugin_l286) begin
                 DebugPlugin_haltedByBreak <= 1'b0;
               end
-              if(when_DebugPlugin_l274) begin
+              if(when_DebugPlugin_l287) begin
                 DebugPlugin_godmode <= 1'b0;
               end
-              if(when_DebugPlugin_l275) begin
+              if(when_DebugPlugin_l288) begin
                 DebugPlugin_disableEbreak <= 1'b1;
               end
-              if(when_DebugPlugin_l275_1) begin
+              if(when_DebugPlugin_l288_1) begin
                 DebugPlugin_disableEbreak <= 1'b0;
               end
             end
@@ -5495,13 +5500,13 @@ module VexRiscv (
           end
         endcase
       end
-      if(when_DebugPlugin_l295) begin
-        if(when_DebugPlugin_l298) begin
+      if(when_DebugPlugin_l308) begin
+        if(when_DebugPlugin_l311) begin
           DebugPlugin_haltIt <= 1'b1;
           DebugPlugin_haltedByBreak <= 1'b1;
         end
       end
-      if(when_DebugPlugin_l311) begin
+      if(when_DebugPlugin_l324) begin
         if(decode_arbitration_isValid) begin
           DebugPlugin_haltIt <= 1'b1;
         end
@@ -5513,76 +5518,75 @@ module VexRiscv (
 endmodule
 
 module DataCache (
-  input               io_cpu_execute_isValid,
-  input      [31:0]   io_cpu_execute_address,
-  output reg          io_cpu_execute_haltIt,
-  input               io_cpu_execute_args_wr,
-  input      [1:0]    io_cpu_execute_args_size,
-  input               io_cpu_execute_args_totalyConsistent,
-  output              io_cpu_execute_refilling,
-  input               io_cpu_memory_isValid,
-  input               io_cpu_memory_isStuck,
-  output              io_cpu_memory_isWrite,
-  input      [31:0]   io_cpu_memory_address,
-  input      [31:0]   io_cpu_memory_mmuRsp_physicalAddress,
-  input               io_cpu_memory_mmuRsp_isIoAccess,
-  input               io_cpu_memory_mmuRsp_isPaging,
-  input               io_cpu_memory_mmuRsp_allowRead,
-  input               io_cpu_memory_mmuRsp_allowWrite,
-  input               io_cpu_memory_mmuRsp_allowExecute,
-  input               io_cpu_memory_mmuRsp_exception,
-  input               io_cpu_memory_mmuRsp_refilling,
-  input               io_cpu_memory_mmuRsp_bypassTranslation,
-  input               io_cpu_writeBack_isValid,
-  input               io_cpu_writeBack_isStuck,
-  input               io_cpu_writeBack_isFiring,
-  input               io_cpu_writeBack_isUser,
-  output reg          io_cpu_writeBack_haltIt,
-  output              io_cpu_writeBack_isWrite,
-  input      [31:0]   io_cpu_writeBack_storeData,
-  output reg [31:0]   io_cpu_writeBack_data,
-  input      [31:0]   io_cpu_writeBack_address,
-  output              io_cpu_writeBack_mmuException,
-  output              io_cpu_writeBack_unalignedAccess,
-  output reg          io_cpu_writeBack_accessError,
-  output              io_cpu_writeBack_keepMemRspData,
-  input               io_cpu_writeBack_fence_SW,
-  input               io_cpu_writeBack_fence_SR,
-  input               io_cpu_writeBack_fence_SO,
-  input               io_cpu_writeBack_fence_SI,
-  input               io_cpu_writeBack_fence_PW,
-  input               io_cpu_writeBack_fence_PR,
-  input               io_cpu_writeBack_fence_PO,
-  input               io_cpu_writeBack_fence_PI,
-  input      [3:0]    io_cpu_writeBack_fence_FM,
-  output              io_cpu_writeBack_exclusiveOk,
-  output reg          io_cpu_redo,
-  input               io_cpu_flush_valid,
-  output              io_cpu_flush_ready,
-  input               io_cpu_flush_payload_singleLine,
-  input      [6:0]    io_cpu_flush_payload_lineId,
-  output reg          io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output reg          io_mem_cmd_payload_wr,
-  output              io_mem_cmd_payload_uncached,
-  output reg [31:0]   io_mem_cmd_payload_address,
-  output     [31:0]   io_mem_cmd_payload_data,
-  output     [3:0]    io_mem_cmd_payload_mask,
-  output reg [2:0]    io_mem_cmd_payload_size,
-  output              io_mem_cmd_payload_last,
-  input               io_mem_rsp_valid,
-  input               io_mem_rsp_payload_last,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input               clk,
-  input               reset
+  input  wire          io_cpu_execute_isValid,
+  input  wire [31:0]   io_cpu_execute_address,
+  output reg           io_cpu_execute_haltIt,
+  input  wire          io_cpu_execute_args_wr,
+  input  wire [1:0]    io_cpu_execute_args_size,
+  input  wire          io_cpu_execute_args_totalyConsistent,
+  output wire          io_cpu_execute_refilling,
+  input  wire          io_cpu_memory_isValid,
+  input  wire          io_cpu_memory_isStuck,
+  output wire          io_cpu_memory_isWrite,
+  input  wire [31:0]   io_cpu_memory_address,
+  input  wire [31:0]   io_cpu_memory_mmuRsp_physicalAddress,
+  input  wire          io_cpu_memory_mmuRsp_isIoAccess,
+  input  wire          io_cpu_memory_mmuRsp_isPaging,
+  input  wire          io_cpu_memory_mmuRsp_allowRead,
+  input  wire          io_cpu_memory_mmuRsp_allowWrite,
+  input  wire          io_cpu_memory_mmuRsp_allowExecute,
+  input  wire          io_cpu_memory_mmuRsp_exception,
+  input  wire          io_cpu_memory_mmuRsp_refilling,
+  input  wire          io_cpu_memory_mmuRsp_bypassTranslation,
+  input  wire          io_cpu_writeBack_isValid,
+  input  wire          io_cpu_writeBack_isStuck,
+  input  wire          io_cpu_writeBack_isFiring,
+  input  wire          io_cpu_writeBack_isUser,
+  output reg           io_cpu_writeBack_haltIt,
+  output wire          io_cpu_writeBack_isWrite,
+  input  wire [31:0]   io_cpu_writeBack_storeData,
+  output reg  [31:0]   io_cpu_writeBack_data,
+  input  wire [31:0]   io_cpu_writeBack_address,
+  output wire          io_cpu_writeBack_mmuException,
+  output wire          io_cpu_writeBack_unalignedAccess,
+  output reg           io_cpu_writeBack_accessError,
+  output wire          io_cpu_writeBack_keepMemRspData,
+  input  wire          io_cpu_writeBack_fence_SW,
+  input  wire          io_cpu_writeBack_fence_SR,
+  input  wire          io_cpu_writeBack_fence_SO,
+  input  wire          io_cpu_writeBack_fence_SI,
+  input  wire          io_cpu_writeBack_fence_PW,
+  input  wire          io_cpu_writeBack_fence_PR,
+  input  wire          io_cpu_writeBack_fence_PO,
+  input  wire          io_cpu_writeBack_fence_PI,
+  input  wire [3:0]    io_cpu_writeBack_fence_FM,
+  output wire          io_cpu_writeBack_exclusiveOk,
+  output reg           io_cpu_redo,
+  input  wire          io_cpu_flush_valid,
+  output wire          io_cpu_flush_ready,
+  input  wire          io_cpu_flush_payload_singleLine,
+  input  wire [6:0]    io_cpu_flush_payload_lineId,
+  output wire          io_cpu_writesPending,
+  output reg           io_mem_cmd_valid,
+  input  wire          io_mem_cmd_ready,
+  output reg           io_mem_cmd_payload_wr,
+  output wire          io_mem_cmd_payload_uncached,
+  output reg  [31:0]   io_mem_cmd_payload_address,
+  output wire [31:0]   io_mem_cmd_payload_data,
+  output wire [3:0]    io_mem_cmd_payload_mask,
+  output reg  [2:0]    io_mem_cmd_payload_size,
+  output wire          io_mem_cmd_payload_last,
+  input  wire          io_mem_rsp_valid,
+  input  wire          io_mem_rsp_payload_last,
+  input  wire [31:0]   io_mem_rsp_payload_data,
+  input  wire          io_mem_rsp_payload_error,
+  input  wire          clk,
+  input  wire          reset
 );
 
   reg        [21:0]   _zz_ways_0_tags_port0;
   reg        [31:0]   _zz_ways_0_data_port0;
   wire       [21:0]   _zz_ways_0_tags_port;
-  wire       [9:0]    _zz_stage0_dataColisions;
-  wire       [9:0]    _zz__zz_stageA_dataColisions;
   wire       [0:0]    _zz_when;
   wire       [2:0]    _zz_loader_counter_valueNext;
   wire       [0:0]    _zz_loader_counter_valueNext_1;
@@ -5619,40 +5623,40 @@ module DataCache (
   wire                _zz_ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRsp;
-  wire                when_DataCache_l642;
   wire                when_DataCache_l645;
-  wire                when_DataCache_l664;
+  wire                when_DataCache_l648;
+  wire                when_DataCache_l667;
   wire                rspSync;
   wire                rspLast;
   reg                 memCmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_DataCache_l686;
+  wire                when_DataCache_l689;
   reg        [3:0]    _zz_stage0_mask;
   wire       [3:0]    stage0_mask;
   wire       [0:0]    stage0_dataColisions;
   wire       [0:0]    stage0_wayInvalidate;
   wire                stage0_isAmo;
-  wire                when_DataCache_l771;
+  wire                when_DataCache_l776;
   reg                 stageA_request_wr;
   reg        [1:0]    stageA_request_size;
   reg                 stageA_request_totalyConsistent;
-  wire                when_DataCache_l771_1;
+  wire                when_DataCache_l776_1;
   reg        [3:0]    stageA_mask;
   wire                stageA_isAmo;
   wire                stageA_isLrsc;
   wire       [0:0]    stageA_wayHits;
-  wire                when_DataCache_l771_2;
+  wire                when_DataCache_l776_2;
   reg        [0:0]    stageA_wayInvalidate;
-  wire                when_DataCache_l771_3;
+  wire                when_DataCache_l776_3;
   reg        [0:0]    stage0_dataColisions_regNextWhen;
   wire       [0:0]    _zz_stageA_dataColisions;
   wire       [0:0]    stageA_dataColisions;
-  wire                when_DataCache_l822;
+  wire                when_DataCache_l827;
   reg                 stageB_request_wr;
   reg        [1:0]    stageB_request_size;
   reg                 stageB_request_totalyConsistent;
   reg                 stageB_mmuRspFreeze;
-  wire                when_DataCache_l824;
+  wire                when_DataCache_l829;
   reg        [31:0]   stageB_mmuRsp_physicalAddress;
   reg                 stageB_mmuRsp_isIoAccess;
   reg                 stageB_mmuRsp_isPaging;
@@ -5662,52 +5666,54 @@ module DataCache (
   reg                 stageB_mmuRsp_exception;
   reg                 stageB_mmuRsp_refilling;
   reg                 stageB_mmuRsp_bypassTranslation;
-  wire                when_DataCache_l821;
+  wire                when_DataCache_l826;
   reg                 stageB_tagsReadRsp_0_valid;
   reg                 stageB_tagsReadRsp_0_error;
   reg        [19:0]   stageB_tagsReadRsp_0_address;
-  wire                when_DataCache_l821_1;
+  wire                when_DataCache_l826_1;
   reg        [31:0]   stageB_dataReadRsp_0;
-  wire                when_DataCache_l820;
+  wire                when_DataCache_l825;
   reg        [0:0]    stageB_wayInvalidate;
   wire                stageB_consistancyHazard;
-  wire                when_DataCache_l820_1;
+  wire                when_DataCache_l825_1;
   reg        [0:0]    stageB_dataColisions;
-  wire                when_DataCache_l820_2;
+  wire                when_DataCache_l825_2;
   reg                 stageB_unaligned;
-  wire                when_DataCache_l820_3;
+  wire                when_DataCache_l825_3;
   reg        [0:0]    stageB_waysHitsBeforeInvalidate;
   wire       [0:0]    stageB_waysHits;
   wire                stageB_waysHit;
   wire       [31:0]   stageB_dataMux;
-  wire                when_DataCache_l820_4;
+  wire                when_DataCache_l825_4;
   reg        [3:0]    stageB_mask;
   reg                 stageB_loaderValid;
   wire       [31:0]   stageB_ioMemRspMuxed;
   reg                 stageB_flusher_waitDone;
   wire                stageB_flusher_hold;
   reg        [7:0]    stageB_flusher_counter;
-  wire                when_DataCache_l850;
-  wire                when_DataCache_l856;
+  wire                when_DataCache_l855;
+  wire                when_DataCache_l861;
+  wire                when_DataCache_l863;
   reg                 stageB_flusher_start;
+  wire                when_DataCache_l877;
   wire                stageB_isAmo;
   wire                stageB_isAmoCached;
   wire                stageB_isExternalLsrc;
   wire                stageB_isExternalAmo;
   wire       [31:0]   stageB_requestDataBypass;
   reg                 stageB_cpuWriteToCache;
-  wire                when_DataCache_l926;
+  wire                when_DataCache_l931;
   wire                stageB_badPermissions;
   wire                stageB_loadStoreFault;
   wire                stageB_bypassCache;
-  wire                when_DataCache_l995;
-  wire                when_DataCache_l1004;
+  wire                when_DataCache_l1000;
   wire                when_DataCache_l1009;
-  wire                when_DataCache_l1020;
-  wire                when_DataCache_l1032;
-  wire                when_DataCache_l991;
-  wire                when_DataCache_l1066;
-  wire                when_DataCache_l1075;
+  wire                when_DataCache_l1014;
+  wire                when_DataCache_l1025;
+  wire                when_DataCache_l1037;
+  wire                when_DataCache_l996;
+  wire                when_DataCache_l1072;
+  wire                when_DataCache_l1081;
   reg                 loader_valid;
   reg                 loader_counter_willIncrement;
   wire                loader_counter_willClear;
@@ -5719,12 +5725,12 @@ module DataCache (
   reg                 loader_error;
   wire                loader_kill;
   reg                 loader_killReg;
-  wire                when_DataCache_l1090;
+  wire                when_DataCache_l1097;
   wire                loader_done;
-  wire                when_DataCache_l1118;
-  reg                 loader_valid_regNext;
-  wire                when_DataCache_l1122;
   wire                when_DataCache_l1125;
+  reg                 loader_valid_regNext;
+  wire                when_DataCache_l1129;
+  wire                when_DataCache_l1132;
   (* no_rw_check , ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
   (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
   (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
@@ -5735,8 +5741,6 @@ module DataCache (
   reg [7:0] _zz_ways_0_datasymbol_read_2;
   reg [7:0] _zz_ways_0_datasymbol_read_3;
 
-  assign _zz_stage0_dataColisions = (io_cpu_execute_address[11 : 2] >>> 0);
-  assign _zz__zz_stageA_dataColisions = (io_cpu_memory_address[11 : 2] >>> 0);
   assign _zz_when = 1'b1;
   assign _zz_loader_counter_valueNext_1 = loader_counter_willIncrement;
   assign _zz_loader_counter_valueNext = {2'd0, _zz_loader_counter_valueNext_1};
@@ -5783,14 +5787,14 @@ module DataCache (
 
   always @(*) begin
     _zz_1 = 1'b0;
-    if(when_DataCache_l645) begin
+    if(when_DataCache_l648) begin
       _zz_1 = 1'b1;
     end
   end
 
   always @(*) begin
     _zz_2 = 1'b0;
-    if(when_DataCache_l642) begin
+    if(when_DataCache_l645) begin
       _zz_2 = 1'b1;
     end
   end
@@ -5804,43 +5808,45 @@ module DataCache (
   assign _zz_ways_0_dataReadRspMem = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
   assign ways_0_dataReadRspMem = _zz_ways_0_data_port0;
   assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
-  assign when_DataCache_l642 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
-  assign when_DataCache_l645 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
+  assign when_DataCache_l645 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
+  assign when_DataCache_l648 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
   always @(*) begin
     tagsReadCmd_valid = 1'b0;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       tagsReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     tagsReadCmd_payload = 7'bxxxxxxx;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
     end
   end
 
   always @(*) begin
     dataReadCmd_valid = 1'b0;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       dataReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     dataReadCmd_payload = 10'bxxxxxxxxxx;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       dataReadCmd_payload = io_cpu_execute_address[11 : 2];
     end
   end
 
   always @(*) begin
     tagsWriteCmd_valid = 1'b0;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_valid = 1'b1;
     end
-    if(when_DataCache_l1066) begin
-      tagsWriteCmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        tagsWriteCmd_valid = 1'b0;
+      end
     end
     if(loader_done) begin
       tagsWriteCmd_valid = 1'b1;
@@ -5849,7 +5855,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_way = 1'bx;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_payload_way = 1'b1;
     end
     if(loader_done) begin
@@ -5859,7 +5865,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_address = 7'bxxxxxxx;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_payload_address = stageB_flusher_counter[6:0];
     end
     if(loader_done) begin
@@ -5869,7 +5875,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_data_valid = 1'bx;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_payload_data_valid = 1'b0;
     end
     if(loader_done) begin
@@ -5894,14 +5900,16 @@ module DataCache (
   always @(*) begin
     dataWriteCmd_valid = 1'b0;
     if(stageB_cpuWriteToCache) begin
-      if(when_DataCache_l926) begin
+      if(when_DataCache_l931) begin
         dataWriteCmd_valid = 1'b1;
       end
     end
-    if(when_DataCache_l1066) begin
-      dataWriteCmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        dataWriteCmd_valid = 1'b0;
+      end
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_valid = 1'b1;
     end
   end
@@ -5911,7 +5919,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_way = stageB_waysHits;
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_way = loader_waysAllocator;
     end
   end
@@ -5921,7 +5929,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
     end
   end
@@ -5931,7 +5939,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_data = io_mem_rsp_payload_data;
     end
   end
@@ -5944,15 +5952,15 @@ module DataCache (
         dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
       end
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_mask = 4'b1111;
     end
   end
 
-  assign when_DataCache_l664 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  assign when_DataCache_l667 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
   always @(*) begin
     io_cpu_execute_haltIt = 1'b0;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       io_cpu_execute_haltIt = 1'b1;
     end
   end
@@ -5960,7 +5968,7 @@ module DataCache (
   assign rspSync = 1'b1;
   assign rspLast = 1'b1;
   assign io_mem_cmd_fire = (io_mem_cmd_valid && io_mem_cmd_ready);
-  assign when_DataCache_l686 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l689 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     _zz_stage0_mask = 4'bxxxx;
     case(io_cpu_execute_args_size)
@@ -5979,45 +5987,45 @@ module DataCache (
   end
 
   assign stage0_mask = (_zz_stage0_mask <<< io_cpu_execute_address[1 : 0]);
-  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_stage0_dataColisions)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_execute_address[11 : 2])) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stage0_wayInvalidate = 1'b0;
   assign stage0_isAmo = 1'b0;
-  assign when_DataCache_l771 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l771_1 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l776 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l776_1 = (! io_cpu_memory_isStuck);
   assign io_cpu_memory_isWrite = stageA_request_wr;
   assign stageA_isAmo = 1'b0;
   assign stageA_isLrsc = 1'b0;
   assign stageA_wayHits = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign when_DataCache_l771_2 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l771_3 = (! io_cpu_memory_isStuck);
-  assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz__zz_stageA_dataColisions)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign when_DataCache_l776_2 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l776_3 = (! io_cpu_memory_isStuck);
+  assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_memory_address[11 : 2])) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_stageA_dataColisions);
-  assign when_DataCache_l822 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l827 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_mmuRspFreeze = 1'b0;
-    if(when_DataCache_l1125) begin
+    if(when_DataCache_l1132) begin
       stageB_mmuRspFreeze = 1'b1;
     end
   end
 
-  assign when_DataCache_l824 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
-  assign when_DataCache_l821 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l821_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l820 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l829 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
+  assign when_DataCache_l826 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l826_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825 = (! io_cpu_writeBack_isStuck);
   assign stageB_consistancyHazard = 1'b0;
-  assign when_DataCache_l820_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l820_2 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l820_3 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_2 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_3 = (! io_cpu_writeBack_isStuck);
   assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
   assign stageB_waysHit = (|stageB_waysHits);
   assign stageB_dataMux = stageB_dataReadRsp_0;
-  assign when_DataCache_l820_4 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_4 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_loaderValid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
             if(io_mem_cmd_ready) begin
               stageB_loaderValid = 1'b1;
             end
@@ -6025,8 +6033,10 @@ module DataCache (
         end
       end
     end
-    if(when_DataCache_l1066) begin
-      stageB_loaderValid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        stageB_loaderValid = 1'b0;
+      end
     end
   end
 
@@ -6035,28 +6045,32 @@ module DataCache (
     io_cpu_writeBack_haltIt = 1'b1;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l991) begin
-          if(when_DataCache_l995) begin
+        if(when_DataCache_l996) begin
+          if(when_DataCache_l1000) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
         end else begin
-          if(when_DataCache_l1004) begin
-            if(when_DataCache_l1009) begin
+          if(when_DataCache_l1009) begin
+            if(when_DataCache_l1014) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1066) begin
-      io_cpu_writeBack_haltIt = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        io_cpu_writeBack_haltIt = 1'b0;
+      end
     end
   end
 
   assign stageB_flusher_hold = 1'b0;
-  assign when_DataCache_l850 = (! stageB_flusher_counter[7]);
-  assign when_DataCache_l856 = (! stageB_flusher_hold);
+  assign when_DataCache_l855 = (! stageB_flusher_counter[7]);
+  assign when_DataCache_l861 = (! stageB_flusher_hold);
+  assign when_DataCache_l863 = (io_cpu_flush_valid && io_cpu_flush_payload_singleLine);
   assign io_cpu_flush_ready = (stageB_flusher_waitDone && stageB_flusher_counter[7]);
+  assign when_DataCache_l877 = (io_cpu_flush_valid && io_cpu_flush_payload_singleLine);
   assign stageB_isAmo = 1'b0;
   assign stageB_isAmoCached = 1'b0;
   assign stageB_isExternalLsrc = 1'b0;
@@ -6066,8 +6080,8 @@ module DataCache (
     stageB_cpuWriteToCache = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(when_DataCache_l1009) begin
             stageB_cpuWriteToCache = 1'b1;
           end
         end
@@ -6075,26 +6089,28 @@ module DataCache (
     end
   end
 
-  assign when_DataCache_l926 = (stageB_request_wr && stageB_waysHit);
+  assign when_DataCache_l931 = (stageB_request_wr && stageB_waysHit);
   assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_isAmo)));
   assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
   always @(*) begin
     io_cpu_redo = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(when_DataCache_l1004) begin
-            if(when_DataCache_l1020) begin
+        if(!when_DataCache_l996) begin
+          if(when_DataCache_l1009) begin
+            if(when_DataCache_l1025) begin
               io_cpu_redo = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1075) begin
-      io_cpu_redo = 1'b1;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1081) begin
+        io_cpu_redo = 1'b1;
+      end
     end
-    if(when_DataCache_l1122) begin
+    if(when_DataCache_l1129) begin
       io_cpu_redo = 1'b1;
     end
   end
@@ -6115,23 +6131,25 @@ module DataCache (
     io_mem_cmd_valid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l991) begin
+        if(when_DataCache_l996) begin
           io_mem_cmd_valid = (! memCmdSent);
         end else begin
-          if(when_DataCache_l1004) begin
+          if(when_DataCache_l1009) begin
             if(stageB_request_wr) begin
               io_mem_cmd_valid = 1'b1;
             end
           end else begin
-            if(when_DataCache_l1032) begin
+            if(when_DataCache_l1037) begin
               io_mem_cmd_valid = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1066) begin
-      io_mem_cmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        io_mem_cmd_valid = 1'b0;
+      end
     end
   end
 
@@ -6139,9 +6157,9 @@ module DataCache (
     io_mem_cmd_payload_address = stageB_mmuRsp_physicalAddress;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
-            io_mem_cmd_payload_address[4 : 0] = 5'h0;
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
+            io_mem_cmd_payload_address[4 : 0] = 5'h00;
           end
         end
       end
@@ -6153,8 +6171,8 @@ module DataCache (
     io_mem_cmd_payload_wr = stageB_request_wr;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
             io_mem_cmd_payload_wr = 1'b0;
           end
         end
@@ -6169,8 +6187,8 @@ module DataCache (
     io_mem_cmd_payload_size = {1'd0, stageB_request_size};
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
             io_mem_cmd_payload_size = 3'b101;
           end
         end
@@ -6180,12 +6198,12 @@ module DataCache (
 
   assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
   assign io_cpu_writeBack_keepMemRspData = 1'b0;
-  assign when_DataCache_l995 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
-  assign when_DataCache_l1004 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
-  assign when_DataCache_l1009 = ((! stageB_request_wr) || io_mem_cmd_ready);
-  assign when_DataCache_l1020 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
-  assign when_DataCache_l1032 = (! memCmdSent);
-  assign when_DataCache_l991 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  assign when_DataCache_l1000 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
+  assign when_DataCache_l1009 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
+  assign when_DataCache_l1014 = ((! stageB_request_wr) || io_mem_cmd_ready);
+  assign when_DataCache_l1025 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
+  assign when_DataCache_l1037 = (! memCmdSent);
+  assign when_DataCache_l996 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
   always @(*) begin
     if(stageB_bypassCache) begin
       io_cpu_writeBack_data = stageB_ioMemRspMuxed;
@@ -6194,11 +6212,11 @@ module DataCache (
     end
   end
 
-  assign when_DataCache_l1066 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign when_DataCache_l1075 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
+  assign when_DataCache_l1072 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign when_DataCache_l1081 = (stageB_mmuRsp_refilling || stageB_consistancyHazard);
   always @(*) begin
     loader_counter_willIncrement = 1'b0;
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       loader_counter_willIncrement = 1'b1;
     end
   end
@@ -6214,12 +6232,12 @@ module DataCache (
   end
 
   assign loader_kill = 1'b0;
-  assign when_DataCache_l1090 = ((loader_valid && io_mem_rsp_valid) && rspLast);
+  assign when_DataCache_l1097 = ((loader_valid && io_mem_rsp_valid) && rspLast);
   assign loader_done = loader_counter_willOverflow;
-  assign when_DataCache_l1118 = (! loader_valid);
-  assign when_DataCache_l1122 = (loader_valid && (! loader_valid_regNext));
+  assign when_DataCache_l1125 = (! loader_valid);
+  assign when_DataCache_l1129 = (loader_valid && (! loader_valid_regNext));
   assign io_cpu_execute_refilling = loader_valid;
-  assign when_DataCache_l1125 = (stageB_loaderValid || loader_valid);
+  assign when_DataCache_l1132 = (stageB_loaderValid || loader_valid);
   always @(posedge clk) begin
     tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
     tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
@@ -6227,26 +6245,26 @@ module DataCache (
     tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
     tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
     tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if(when_DataCache_l771) begin
+    if(when_DataCache_l776) begin
       stageA_request_wr <= io_cpu_execute_args_wr;
       stageA_request_size <= io_cpu_execute_args_size;
       stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
     end
-    if(when_DataCache_l771_1) begin
+    if(when_DataCache_l776_1) begin
       stageA_mask <= stage0_mask;
     end
-    if(when_DataCache_l771_2) begin
+    if(when_DataCache_l776_2) begin
       stageA_wayInvalidate <= stage0_wayInvalidate;
     end
-    if(when_DataCache_l771_3) begin
+    if(when_DataCache_l776_3) begin
       stage0_dataColisions_regNextWhen <= stage0_dataColisions;
     end
-    if(when_DataCache_l822) begin
+    if(when_DataCache_l827) begin
       stageB_request_wr <= stageA_request_wr;
       stageB_request_size <= stageA_request_size;
       stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
     end
-    if(when_DataCache_l824) begin
+    if(when_DataCache_l829) begin
       stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
       stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
       stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
@@ -6257,27 +6275,27 @@ module DataCache (
       stageB_mmuRsp_refilling <= io_cpu_memory_mmuRsp_refilling;
       stageB_mmuRsp_bypassTranslation <= io_cpu_memory_mmuRsp_bypassTranslation;
     end
-    if(when_DataCache_l821) begin
+    if(when_DataCache_l826) begin
       stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
       stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
       stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
     end
-    if(when_DataCache_l821_1) begin
+    if(when_DataCache_l826_1) begin
       stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
     end
-    if(when_DataCache_l820) begin
+    if(when_DataCache_l825) begin
       stageB_wayInvalidate <= stageA_wayInvalidate;
     end
-    if(when_DataCache_l820_1) begin
+    if(when_DataCache_l825_1) begin
       stageB_dataColisions <= stageA_dataColisions;
     end
-    if(when_DataCache_l820_2) begin
+    if(when_DataCache_l825_2) begin
       stageB_unaligned <= ({((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)),((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0))} != 2'b00);
     end
-    if(when_DataCache_l820_3) begin
+    if(when_DataCache_l825_3) begin
       stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
     end
-    if(when_DataCache_l820_4) begin
+    if(when_DataCache_l825_4) begin
       stageB_mask <= stageA_mask;
     end
     loader_valid_regNext <= loader_valid;
@@ -6287,7 +6305,7 @@ module DataCache (
     if(reset) begin
       memCmdSent <= 1'b0;
       stageB_flusher_waitDone <= 1'b0;
-      stageB_flusher_counter <= 8'h0;
+      stageB_flusher_counter <= 8'h00;
       stageB_flusher_start <= 1'b1;
       loader_valid <= 1'b0;
       loader_counter_value <= 3'b000;
@@ -6298,16 +6316,16 @@ module DataCache (
       if(io_mem_cmd_fire) begin
         memCmdSent <= 1'b1;
       end
-      if(when_DataCache_l686) begin
+      if(when_DataCache_l689) begin
         memCmdSent <= 1'b0;
       end
       if(io_cpu_flush_ready) begin
         stageB_flusher_waitDone <= 1'b0;
       end
-      if(when_DataCache_l850) begin
-        if(when_DataCache_l856) begin
+      if(when_DataCache_l855) begin
+        if(when_DataCache_l861) begin
           stageB_flusher_counter <= (stageB_flusher_counter + 8'h01);
-          if(io_cpu_flush_payload_singleLine) begin
+          if(when_DataCache_l863) begin
             stageB_flusher_counter[7] <= 1'b1;
           end
         end
@@ -6315,17 +6333,17 @@ module DataCache (
       stageB_flusher_start <= (((((((! stageB_flusher_waitDone) && (! stageB_flusher_start)) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
       if(stageB_flusher_start) begin
         stageB_flusher_waitDone <= 1'b1;
-        stageB_flusher_counter <= 8'h0;
-        if(io_cpu_flush_payload_singleLine) begin
+        stageB_flusher_counter <= 8'h00;
+        if(when_DataCache_l877) begin
           stageB_flusher_counter <= {1'b0,io_cpu_flush_payload_lineId};
         end
       end
       `ifndef SYNTHESIS
         `ifdef FORMAL
-          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))); // DataCache.scala:L1077
+          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))); // DataCache.scala:L1084
         `else
           if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-            $display("ERROR writeBack stuck by another plugin is not allowed"); // DataCache.scala:L1077
+            $display("ERROR writeBack stuck by another plugin is not allowed"); // DataCache.scala:L1084
           end
         `endif
       `endif
@@ -6336,7 +6354,7 @@ module DataCache (
       if(loader_kill) begin
         loader_killReg <= 1'b1;
       end
-      if(when_DataCache_l1090) begin
+      if(when_DataCache_l1097) begin
         loader_error <= (loader_error || io_mem_rsp_payload_error);
       end
       if(loader_done) begin
@@ -6344,7 +6362,7 @@ module DataCache (
         loader_error <= 1'b0;
         loader_killReg <= 1'b0;
       end
-      if(when_DataCache_l1118) begin
+      if(when_DataCache_l1125) begin
         loader_waysAllocator <= _zz_loader_waysAllocator[0:0];
       end
     end
@@ -6354,48 +6372,48 @@ module DataCache (
 endmodule
 
 module InstructionCache (
-  input               io_flush,
-  input               io_cpu_prefetch_isValid,
-  output reg          io_cpu_prefetch_haltIt,
-  input      [31:0]   io_cpu_prefetch_pc,
-  input               io_cpu_fetch_isValid,
-  input               io_cpu_fetch_isStuck,
-  input               io_cpu_fetch_isRemoved,
-  input      [31:0]   io_cpu_fetch_pc,
-  output     [31:0]   io_cpu_fetch_data,
-  input      [31:0]   io_cpu_fetch_mmuRsp_physicalAddress,
-  input               io_cpu_fetch_mmuRsp_isIoAccess,
-  input               io_cpu_fetch_mmuRsp_isPaging,
-  input               io_cpu_fetch_mmuRsp_allowRead,
-  input               io_cpu_fetch_mmuRsp_allowWrite,
-  input               io_cpu_fetch_mmuRsp_allowExecute,
-  input               io_cpu_fetch_mmuRsp_exception,
-  input               io_cpu_fetch_mmuRsp_refilling,
-  input               io_cpu_fetch_mmuRsp_bypassTranslation,
-  output     [31:0]   io_cpu_fetch_physicalAddress,
-  input               io_cpu_decode_isValid,
-  input               io_cpu_decode_isStuck,
-  input      [31:0]   io_cpu_decode_pc,
-  output     [31:0]   io_cpu_decode_physicalAddress,
-  output     [31:0]   io_cpu_decode_data,
-  output              io_cpu_decode_cacheMiss,
-  output              io_cpu_decode_error,
-  output              io_cpu_decode_mmuRefilling,
-  output              io_cpu_decode_mmuException,
-  input               io_cpu_decode_isUser,
-  input               io_cpu_fill_valid,
-  input      [31:0]   io_cpu_fill_payload,
-  output              io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output     [31:0]   io_mem_cmd_payload_address,
-  output     [2:0]    io_mem_cmd_payload_size,
-  input               io_mem_rsp_valid,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input      [2:0]    _zz_when_Fetcher_l401,
-  input      [31:0]   _zz_io_cpu_fetch_data_regNextWhen,
-  input               clk,
-  input               reset
+  input  wire          io_flush,
+  input  wire          io_cpu_prefetch_isValid,
+  output reg           io_cpu_prefetch_haltIt,
+  input  wire [31:0]   io_cpu_prefetch_pc,
+  input  wire          io_cpu_fetch_isValid,
+  input  wire          io_cpu_fetch_isStuck,
+  input  wire          io_cpu_fetch_isRemoved,
+  input  wire [31:0]   io_cpu_fetch_pc,
+  output wire [31:0]   io_cpu_fetch_data,
+  input  wire [31:0]   io_cpu_fetch_mmuRsp_physicalAddress,
+  input  wire          io_cpu_fetch_mmuRsp_isIoAccess,
+  input  wire          io_cpu_fetch_mmuRsp_isPaging,
+  input  wire          io_cpu_fetch_mmuRsp_allowRead,
+  input  wire          io_cpu_fetch_mmuRsp_allowWrite,
+  input  wire          io_cpu_fetch_mmuRsp_allowExecute,
+  input  wire          io_cpu_fetch_mmuRsp_exception,
+  input  wire          io_cpu_fetch_mmuRsp_refilling,
+  input  wire          io_cpu_fetch_mmuRsp_bypassTranslation,
+  output wire [31:0]   io_cpu_fetch_physicalAddress,
+  input  wire          io_cpu_decode_isValid,
+  input  wire          io_cpu_decode_isStuck,
+  input  wire [31:0]   io_cpu_decode_pc,
+  output wire [31:0]   io_cpu_decode_physicalAddress,
+  output wire [31:0]   io_cpu_decode_data,
+  output wire          io_cpu_decode_cacheMiss,
+  output wire          io_cpu_decode_error,
+  output wire          io_cpu_decode_mmuRefilling,
+  output wire          io_cpu_decode_mmuException,
+  input  wire          io_cpu_decode_isUser,
+  input  wire          io_cpu_fill_valid,
+  input  wire [31:0]   io_cpu_fill_payload,
+  output wire          io_mem_cmd_valid,
+  input  wire          io_mem_cmd_ready,
+  output wire [31:0]   io_mem_cmd_payload_address,
+  output wire [2:0]    io_mem_cmd_payload_size,
+  input  wire          io_mem_rsp_valid,
+  input  wire [31:0]   io_mem_rsp_payload_data,
+  input  wire          io_mem_rsp_payload_error,
+  input  wire [2:0]    _zz_when_Fetcher_l411,
+  input  wire [31:0]   _zz_io_cpu_fetch_data_regNextWhen,
+  input  wire          clk,
+  input  wire          reset
 );
 
   reg        [31:0]   _zz_banks_0_port1;
@@ -6415,7 +6433,7 @@ module InstructionCache (
   wire                when_InstructionCache_l351;
   reg                 lineLoader_cmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_Utils_l515;
+  wire                when_Utils_l560;
   reg                 lineLoader_wayToAllocate_willIncrement;
   wire                lineLoader_wayToAllocate_willClear;
   wire                lineLoader_wayToAllocate_willOverflowIfInc;
@@ -6461,7 +6479,7 @@ module InstructionCache (
   reg                 decodeStage_hit_valid;
   wire                when_InstructionCache_l459_2;
   reg                 decodeStage_hit_error;
-  wire                when_Fetcher_l401;
+  wire                when_Fetcher_l411;
   (* no_rw_check , ram_style = "block" *) reg [31:0] banks_0 [0:1023];
   (* no_rw_check , ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
 
@@ -6531,12 +6549,12 @@ module InstructionCache (
   assign when_InstructionCache_l351 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
   assign io_mem_cmd_fire = (io_mem_cmd_valid && io_mem_cmd_ready);
   assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
-  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
+  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h00};
   assign io_mem_cmd_payload_size = 3'b101;
-  assign when_Utils_l515 = (! lineLoader_valid);
+  assign when_Utils_l560 = (! lineLoader_valid);
   always @(*) begin
     lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if(when_Utils_l515) begin
+    if(when_Utils_l560) begin
       lineLoader_wayToAllocate_willIncrement = 1'b1;
     end
   end
@@ -6580,7 +6598,7 @@ module InstructionCache (
   assign io_cpu_decode_mmuRefilling = decodeStage_mmuRsp_refilling;
   assign io_cpu_decode_mmuException = (((! decodeStage_mmuRsp_refilling) && decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute)));
   assign io_cpu_decode_physicalAddress = decodeStage_mmuRsp_physicalAddress;
-  assign when_Fetcher_l401 = (_zz_when_Fetcher_l401 != 3'b000);
+  assign when_Fetcher_l411 = (_zz_when_Fetcher_l411 != 3'b000);
   always @(posedge clk) begin
     if(reset) begin
       lineLoader_valid <= 1'b0;
@@ -6628,7 +6646,7 @@ module InstructionCache (
     end
     _zz_when_InstructionCache_l342 <= lineLoader_flushCounter[7];
     if(when_InstructionCache_l351) begin
-      lineLoader_flushCounter <= 8'h0;
+      lineLoader_flushCounter <= 8'h00;
     end
     if(when_InstructionCache_l435) begin
       io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;
@@ -6650,7 +6668,7 @@ module InstructionCache (
     if(when_InstructionCache_l459_2) begin
       decodeStage_hit_error <= fetchStage_hit_error;
     end
-    if(when_Fetcher_l401) begin
+    if(when_Fetcher_l411) begin
       io_cpu_fetch_data_regNextWhen <= _zz_io_cpu_fetch_data_regNextWhen;
     end
   end

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_Full.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_Full.v
@@ -1,38 +1,38 @@
-// Generator : SpinalHDL v1.7.1    git head : 0444bb76ab1d6e19f0ec46bc03c4769776deb7d5
+// Generator : SpinalHDL v1.9.4    git head : 270018552577f3bb8e5339ee2583c9c22d324215
 // Component : VexRiscv
-// Git hash  : 581fcb065adf7ea8b626f939ff51679d4c95872f
+// Git hash  : 63430af99f84cc1d11d58b556debe1cc3f238c67
 
 `timescale 1ns/1ps
 
 module VexRiscv (
-  input      [31:0]   externalResetVector,
-  input               timerInterrupt,
-  input               softwareInterrupt,
-  input      [31:0]   externalInterruptArray,
-  output reg          iBusWishbone_CYC,
-  output reg          iBusWishbone_STB,
-  input               iBusWishbone_ACK,
-  output              iBusWishbone_WE,
-  output     [29:0]   iBusWishbone_ADR,
-  input      [31:0]   iBusWishbone_DAT_MISO,
-  output     [31:0]   iBusWishbone_DAT_MOSI,
-  output     [3:0]    iBusWishbone_SEL,
-  input               iBusWishbone_ERR,
-  output     [2:0]    iBusWishbone_CTI,
-  output     [1:0]    iBusWishbone_BTE,
-  output              dBusWishbone_CYC,
-  output              dBusWishbone_STB,
-  input               dBusWishbone_ACK,
-  output              dBusWishbone_WE,
-  output     [29:0]   dBusWishbone_ADR,
-  input      [31:0]   dBusWishbone_DAT_MISO,
-  output     [31:0]   dBusWishbone_DAT_MOSI,
-  output     [3:0]    dBusWishbone_SEL,
-  input               dBusWishbone_ERR,
-  output     [2:0]    dBusWishbone_CTI,
-  output     [1:0]    dBusWishbone_BTE,
-  input               clk,
-  input               reset
+  input  wire [31:0]   externalResetVector,
+  input  wire          timerInterrupt,
+  input  wire          softwareInterrupt,
+  input  wire [31:0]   externalInterruptArray,
+  output reg           iBusWishbone_CYC,
+  output reg           iBusWishbone_STB,
+  input  wire          iBusWishbone_ACK,
+  output wire          iBusWishbone_WE,
+  output wire [29:0]   iBusWishbone_ADR,
+  input  wire [31:0]   iBusWishbone_DAT_MISO,
+  output wire [31:0]   iBusWishbone_DAT_MOSI,
+  output wire [3:0]    iBusWishbone_SEL,
+  input  wire          iBusWishbone_ERR,
+  output wire [2:0]    iBusWishbone_CTI,
+  output wire [1:0]    iBusWishbone_BTE,
+  output wire          dBusWishbone_CYC,
+  output wire          dBusWishbone_STB,
+  input  wire          dBusWishbone_ACK,
+  output wire          dBusWishbone_WE,
+  output wire [29:0]   dBusWishbone_ADR,
+  input  wire [31:0]   dBusWishbone_DAT_MISO,
+  output wire [31:0]   dBusWishbone_DAT_MOSI,
+  output wire [3:0]    dBusWishbone_SEL,
+  input  wire          dBusWishbone_ERR,
+  output wire [2:0]    dBusWishbone_CTI,
+  output wire [1:0]    dBusWishbone_BTE,
+  input  wire          clk,
+  input  wire          reset
 );
   localparam ShiftCtrlEnum_DISABLE_1 = 2'd0;
   localparam ShiftCtrlEnum_SLL_1 = 2'd1;
@@ -91,7 +91,6 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_flush_valid;
   wire                dataCache_1_io_cpu_flush_payload_singleLine;
   wire       [6:0]    dataCache_1_io_cpu_flush_payload_lineId;
-  wire                dataCache_1_io_mem_cmd_ready;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
@@ -119,6 +118,7 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_writeBack_exclusiveOk;
   wire                dataCache_1_io_cpu_flush_ready;
   wire                dataCache_1_io_cpu_redo;
+  wire                dataCache_1_io_cpu_writesPending;
   wire                dataCache_1_io_mem_cmd_valid;
   wire                dataCache_1_io_mem_cmd_payload_wr;
   wire                dataCache_1_io_mem_cmd_payload_uncached;
@@ -130,12 +130,11 @@ module VexRiscv (
   wire       [51:0]   _zz_memory_MUL_LOW;
   wire       [51:0]   _zz_memory_MUL_LOW_1;
   wire       [51:0]   _zz_memory_MUL_LOW_2;
-  wire       [51:0]   _zz_memory_MUL_LOW_3;
-  wire       [32:0]   _zz_memory_MUL_LOW_4;
-  wire       [51:0]   _zz_memory_MUL_LOW_5;
-  wire       [49:0]   _zz_memory_MUL_LOW_6;
-  wire       [51:0]   _zz_memory_MUL_LOW_7;
-  wire       [49:0]   _zz_memory_MUL_LOW_8;
+  wire       [32:0]   _zz_memory_MUL_LOW_3;
+  wire       [51:0]   _zz_memory_MUL_LOW_4;
+  wire       [49:0]   _zz_memory_MUL_LOW_5;
+  wire       [51:0]   _zz_memory_MUL_LOW_6;
+  wire       [49:0]   _zz_memory_MUL_LOW_7;
   wire       [31:0]   _zz_execute_SHIFT_RIGHT;
   wire       [32:0]   _zz_execute_SHIFT_RIGHT_1;
   wire       [32:0]   _zz_execute_SHIFT_RIGHT_2;
@@ -144,19 +143,19 @@ module VexRiscv (
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_2;
   wire                _zz_decode_LEGAL_INSTRUCTION_3;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_4;
-  wire       [13:0]   _zz_decode_LEGAL_INSTRUCTION_5;
+  wire       [12:0]   _zz_decode_LEGAL_INSTRUCTION_5;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_6;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_7;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_8;
   wire                _zz_decode_LEGAL_INSTRUCTION_9;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_10;
-  wire       [7:0]    _zz_decode_LEGAL_INSTRUCTION_11;
+  wire       [6:0]    _zz_decode_LEGAL_INSTRUCTION_11;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_12;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_13;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_14;
   wire                _zz_decode_LEGAL_INSTRUCTION_15;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_16;
-  wire       [1:0]    _zz_decode_LEGAL_INSTRUCTION_17;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_17;
   wire       [3:0]    _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1;
   reg        [31:0]   _zz_IBusCachedPlugin_jump_pcLoad_payload_5;
   wire       [1:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_6;
@@ -197,134 +196,124 @@ module VexRiscv (
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_13;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_14;
   wire                _zz__zz_decode_IS_RS2_SIGNED_15;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_16;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_17;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_16;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_17;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_18;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_19;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_20;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_21;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_22;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_23;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_20;
+  wire       [20:0]   _zz__zz_decode_IS_RS2_SIGNED_21;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_22;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_23;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_24;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_25;
-  wire       [20:0]   _zz__zz_decode_IS_RS2_SIGNED_26;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_27;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_28;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_29;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_30;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_31;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_32;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_33;
-  wire       [17:0]   _zz__zz_decode_IS_RS2_SIGNED_34;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_35;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_25;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_26;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_27;
+  wire       [17:0]   _zz__zz_decode_IS_RS2_SIGNED_28;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_29;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_30;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_31;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_32;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_33;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_34;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_35;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_36;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_37;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_37;
   wire                _zz__zz_decode_IS_RS2_SIGNED_38;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_39;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_40;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_41;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_42;
-  wire       [14:0]   _zz__zz_decode_IS_RS2_SIGNED_43;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_44;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_39;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_40;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_41;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_42;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_43;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_44;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_45;
-  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_46;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_47;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_48;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_49;
+  wire       [13:0]   _zz__zz_decode_IS_RS2_SIGNED_46;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_47;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_48;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_49;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_50;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_51;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_52;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_53;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_54;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_55;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_54;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_55;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_56;
   wire                _zz__zz_decode_IS_RS2_SIGNED_57;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_58;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_59;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_58;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_59;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_60;
-  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_61;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_62;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_63;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_64;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_61;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_62;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_63;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_64;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_65;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_66;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_67;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_66;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_67;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_68;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_69;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_70;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_71;
-  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_72;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_73;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_74;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_75;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_69;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_70;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_71;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_72;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_73;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_74;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_75;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_76;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_77;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_78;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_79;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_80;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_77;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_78;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_79;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_80;
   wire                _zz__zz_decode_IS_RS2_SIGNED_81;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_82;
-  wire       [10:0]   _zz__zz_decode_IS_RS2_SIGNED_83;
-  wire       [5:0]    _zz__zz_decode_IS_RS2_SIGNED_84;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_85;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_86;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_87;
-  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_88;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_89;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_90;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_82;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_83;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_84;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_85;
+  wire       [9:0]    _zz__zz_decode_IS_RS2_SIGNED_86;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_87;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_88;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_89;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_90;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_91;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_92;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_92;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_93;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_94;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_95;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_96;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_97;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_98;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_99;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_100;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_101;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_94;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_95;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_96;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_97;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_98;
+  wire       [6:0]    _zz__zz_decode_IS_RS2_SIGNED_99;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_100;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_101;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_102;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_103;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_104;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_103;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_104;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_105;
-  wire       [7:0]    _zz__zz_decode_IS_RS2_SIGNED_106;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_107;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_108;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_106;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_107;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_108;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_109;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_110;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_111;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_110;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_111;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_112;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_113;
-  wire       [5:0]    _zz__zz_decode_IS_RS2_SIGNED_114;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_115;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_116;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_117;
-  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_118;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_119;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_120;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_113;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_114;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_115;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_116;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_117;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_118;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_119;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_120;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_121;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_122;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_122;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_123;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_124;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_125;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_126;
-  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_127;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_128;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_124;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_125;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_126;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_127;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_128;
   wire                _zz__zz_decode_IS_RS2_SIGNED_129;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_130;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_131;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_132;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_130;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_131;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_132;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_133;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_134;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_135;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_136;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_137;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_138;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_139;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_140;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_141;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_142;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_143;
   wire                _zz_RegFilePlugin_regFile_port;
   wire                _zz_decode_RegFilePlugin_rs1Data;
   wire                _zz_RegFilePlugin_regFile_port_1;
@@ -332,14 +321,12 @@ module VexRiscv (
   wire       [0:0]    _zz__zz_execute_REGFILE_WRITE_DATA;
   wire       [2:0]    _zz__zz_execute_SRC1;
   wire       [4:0]    _zz__zz_execute_SRC1_1;
-  wire       [11:0]   _zz__zz_execute_SRC2_3;
+  wire       [11:0]   _zz__zz_execute_SRC2_2;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_1;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_2;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_3;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_4;
-  wire       [31:0]   _zz_execute_SrcPlugin_addSub_5;
-  wire       [31:0]   _zz_execute_SrcPlugin_addSub_6;
   wire       [19:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_2;
   wire       [11:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_4;
   wire       [31:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_6;
@@ -373,7 +360,7 @@ module VexRiscv (
   wire       [0:0]    _zz_memory_DivPlugin_rs1_3;
   wire       [31:0]   _zz_memory_DivPlugin_rs2_1;
   wire       [0:0]    _zz_memory_DivPlugin_rs2_2;
-  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_25;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_24;
   wire       [26:0]   _zz_iBusWishbone_ADR_1;
   wire       [51:0]   memory_MUL_LOW;
   wire       [33:0]   memory_MUL_HH;
@@ -489,7 +476,7 @@ module VexRiscv (
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_execute_SRC2;
+  wire       [31:0]   _zz_execute_to_memory_PC;
   wire       [1:0]    execute_SRC2_CTRL;
   wire       [1:0]    _zz_execute_SRC2_CTRL;
   wire       [1:0]    execute_SRC1_CTRL;
@@ -668,8 +655,9 @@ module VexRiscv (
   wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
   wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
   wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
-  wire                CsrPlugin_csrMapping_allowCsrSignal;
+  reg                 CsrPlugin_csrMapping_allowCsrSignal;
   wire                CsrPlugin_csrMapping_hazardFree;
+  wire                CsrPlugin_csrMapping_doForceFailCsr;
   reg                 CsrPlugin_inWfi /* verilator public */ ;
   wire                CsrPlugin_thirdPartyWake;
   reg                 CsrPlugin_jumpInterface_valid;
@@ -688,6 +676,7 @@ module VexRiscv (
   wire                CsrPlugin_allowInterrupts;
   wire                CsrPlugin_allowException;
   wire                CsrPlugin_allowEbreakException;
+  wire                CsrPlugin_xretAwayFromMachine;
   wire                IBusCachedPlugin_externalFlush;
   wire                IBusCachedPlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
@@ -707,14 +696,13 @@ module VexRiscv (
   reg                 IBusCachedPlugin_fetchPc_pcRegPropagate;
   reg                 IBusCachedPlugin_fetchPc_booted;
   reg                 IBusCachedPlugin_fetchPc_inc;
-  wire                when_Fetcher_l134;
-  wire                IBusCachedPlugin_fetchPc_output_fire_1;
-  wire                when_Fetcher_l134_1;
+  wire                when_Fetcher_l133;
+  wire                when_Fetcher_l133_1;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pc;
   wire                IBusCachedPlugin_fetchPc_redo_valid;
   wire       [31:0]   IBusCachedPlugin_fetchPc_redo_payload;
   reg                 IBusCachedPlugin_fetchPc_flushed;
-  wire                when_Fetcher_l161;
+  wire                when_Fetcher_l160;
   reg                 IBusCachedPlugin_iBusRsp_redoFetch;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_ready;
@@ -742,8 +730,8 @@ module VexRiscv (
   wire                _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready;
   wire                IBusCachedPlugin_iBusRsp_flush;
   wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
-  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
-  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid;
+  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1;
   wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
@@ -756,18 +744,18 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_output_payload_rsp_error;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   wire                IBusCachedPlugin_iBusRsp_output_payload_isRvc;
-  wire                when_Fetcher_l243;
-  wire                when_Fetcher_l323;
+  wire                when_Fetcher_l242;
+  wire                when_Fetcher_l322;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
-  wire                when_Fetcher_l332;
+  wire                when_Fetcher_l331;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
-  wire                when_Fetcher_l332_1;
+  wire                when_Fetcher_l331_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
-  wire                when_Fetcher_l332_2;
+  wire                when_Fetcher_l331_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
-  wire                when_Fetcher_l332_3;
+  wire                when_Fetcher_l331_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                when_Fetcher_l332_4;
+  wire                when_Fetcher_l331_4;
   wire                _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   reg        [18:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1;
   wire                _zz_2;
@@ -793,69 +781,70 @@ module VexRiscv (
   wire                IBusCachedPlugin_rsp_iBusRspOutputHalt;
   wire                IBusCachedPlugin_rsp_issueDetected;
   reg                 IBusCachedPlugin_rsp_redoFetch;
-  wire                when_IBusCachedPlugin_l239;
-  wire                when_IBusCachedPlugin_l244;
+  wire                when_IBusCachedPlugin_l245;
   wire                when_IBusCachedPlugin_l250;
   wire                when_IBusCachedPlugin_l256;
-  wire                when_IBusCachedPlugin_l267;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_valid;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_ready;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_address;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_data;
-  wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_size;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_last;
-  reg                 dataCache_1_io_mem_cmd_rValid;
-  reg                 dataCache_1_io_mem_cmd_rData_wr;
-  reg                 dataCache_1_io_mem_cmd_rData_uncached;
-  reg        [31:0]   dataCache_1_io_mem_cmd_rData_address;
-  reg        [31:0]   dataCache_1_io_mem_cmd_rData_data;
-  reg        [3:0]    dataCache_1_io_mem_cmd_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_rData_size;
-  reg                 dataCache_1_io_mem_cmd_rData_last;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
-  wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data;
-  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
-  wire                when_Stream_l368;
+  wire                when_IBusCachedPlugin_l262;
+  wire                when_IBusCachedPlugin_l273;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_valid;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+  wire       [3:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+  wire       [2:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_size;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rValidN;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rData_wr;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rData_uncached;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_rData_address;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_rData_data;
+  reg        [3:0]    toplevel_dataCache_1_io_mem_cmd_rData_mask;
+  reg        [2:0]    toplevel_dataCache_1_io_mem_cmd_rData_size;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rData_last;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
+  wire       [3:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
+  wire       [2:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_address;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_data;
+  reg        [3:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
+  reg        [2:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_size;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  wire                when_Stream_l369;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
-  wire                when_DBusCachedPlugin_l308;
+  wire                when_DBusCachedPlugin_l352;
   wire       [1:0]    execute_DBusCachedPlugin_size;
   reg        [31:0]   _zz_execute_MEMORY_STORE_DATA_RF;
-  wire                dataCache_1_io_cpu_flush_isStall;
-  wire                when_DBusCachedPlugin_l350;
-  wire                when_DBusCachedPlugin_l366;
-  wire                when_DBusCachedPlugin_l393;
-  wire                when_DBusCachedPlugin_l446;
-  wire                when_DBusCachedPlugin_l466;
+  wire                toplevel_dataCache_1_io_cpu_flush_isStall;
+  wire                when_DBusCachedPlugin_l394;
+  wire                when_DBusCachedPlugin_l410;
+  wire                when_DBusCachedPlugin_l472;
+  wire                when_DBusCachedPlugin_l533;
+  wire                when_DBusCachedPlugin_l553;
+  wire       [31:0]   writeBack_DBusCachedPlugin_rspData;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_0;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_1;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_2;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
   wire       [31:0]   writeBack_DBusCachedPlugin_rspRf;
-  wire       [1:0]    switch_Misc_l210;
+  wire       [1:0]    switch_Misc_l232;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_1;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated_2;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
-  wire                when_DBusCachedPlugin_l492;
+  wire                when_DBusCachedPlugin_l580;
   wire       [31:0]   _zz_decode_IS_RS2_SIGNED;
   wire                _zz_decode_IS_RS2_SIGNED_1;
   wire                _zz_decode_IS_RS2_SIGNED_2;
@@ -877,15 +866,15 @@ module VexRiscv (
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
   reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
   reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_7;
+  reg                 _zz_10;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
   reg        [31:0]   _zz_execute_REGFILE_WRITE_DATA;
   reg        [31:0]   _zz_execute_SRC1;
-  wire                _zz_execute_SRC2_1;
-  reg        [19:0]   _zz_execute_SRC2_2;
-  wire                _zz_execute_SRC2_3;
-  reg        [19:0]   _zz_execute_SRC2_4;
-  reg        [31:0]   _zz_execute_SRC2_5;
+  wire                _zz_execute_SRC2;
+  reg        [19:0]   _zz_execute_SRC2_1;
+  wire                _zz_execute_SRC2_2;
+  reg        [19:0]   _zz_execute_SRC2_3;
+  reg        [31:0]   _zz_execute_SRC2_4;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   wire       [4:0]    execute_FullBarrelShifterPlugin_amplitude;
@@ -922,7 +911,7 @@ module VexRiscv (
   wire                when_HazardSimplePlugin_l108;
   wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    switch_Misc_l210_1;
+  wire       [2:0]    switch_Misc_l232_1;
   reg                 _zz_execute_BRANCH_COND_RESULT;
   reg                 _zz_execute_BRANCH_COND_RESULT_1;
   wire                _zz_execute_BranchPlugin_missAlignedTarget;
@@ -942,8 +931,8 @@ module VexRiscv (
   wire                _zz_execute_BranchPlugin_branch_src2_4;
   reg        [18:0]   _zz_execute_BranchPlugin_branch_src2_5;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
-  reg        [1:0]    CsrPlugin_misa_base;
-  reg        [25:0]   CsrPlugin_misa_extensions;
+  wire       [1:0]    CsrPlugin_misa_base;
+  wire       [25:0]   CsrPlugin_misa_extensions;
   reg        [1:0]    CsrPlugin_mtvec_mode;
   reg        [29:0]   CsrPlugin_mtvec_base;
   reg        [31:0]   CsrPlugin_mepc;
@@ -962,9 +951,9 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_mtval;
   reg        [63:0]   CsrPlugin_mcycle;
   reg        [63:0]   CsrPlugin_minstret;
-  wire                _zz_when_CsrPlugin_l965;
-  wire                _zz_when_CsrPlugin_l965_1;
-  wire                _zz_when_CsrPlugin_l965_2;
+  wire                _zz_when_CsrPlugin_l1302;
+  wire                _zz_when_CsrPlugin_l1302_1;
+  wire                _zz_when_CsrPlugin_l1302_2;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -979,59 +968,62 @@ module VexRiscv (
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
   wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code;
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
-  wire                when_CsrPlugin_l922;
-  wire                when_CsrPlugin_l922_1;
-  wire                when_CsrPlugin_l922_2;
-  wire                when_CsrPlugin_l922_3;
-  wire                when_CsrPlugin_l935;
+  wire                when_CsrPlugin_l1259;
+  wire                when_CsrPlugin_l1259_1;
+  wire                when_CsrPlugin_l1259_2;
+  wire                when_CsrPlugin_l1259_3;
+  wire                when_CsrPlugin_l1272;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
-  wire                when_CsrPlugin_l959;
-  wire                when_CsrPlugin_l965;
-  wire                when_CsrPlugin_l965_1;
-  wire                when_CsrPlugin_l965_2;
+  wire                when_CsrPlugin_l1296;
+  wire                when_CsrPlugin_l1302;
+  wire                when_CsrPlugin_l1302_1;
+  wire                when_CsrPlugin_l1302_2;
   wire                CsrPlugin_exception;
   reg                 CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
-  wire                when_CsrPlugin_l993;
-  wire                when_CsrPlugin_l993_1;
-  wire                when_CsrPlugin_l993_2;
-  wire                when_CsrPlugin_l998;
+  wire                when_CsrPlugin_l1335;
+  wire                when_CsrPlugin_l1335_1;
+  wire                when_CsrPlugin_l1335_2;
+  wire                when_CsrPlugin_l1340;
   reg                 CsrPlugin_pipelineLiberator_done;
-  wire                when_CsrPlugin_l1004;
+  wire                when_CsrPlugin_l1346;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
+  wire                CsrPlugin_trapCauseEbreakDebug;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
-  wire                when_CsrPlugin_l1032;
-  wire                when_CsrPlugin_l1077;
-  wire       [1:0]    switch_CsrPlugin_l1081;
+  wire                CsrPlugin_trapEnterDebug;
+  wire                when_CsrPlugin_l1390;
+  wire                when_CsrPlugin_l1398;
+  wire                when_CsrPlugin_l1456;
+  wire       [1:0]    switch_CsrPlugin_l1460;
   reg                 execute_CsrPlugin_wfiWake;
-  wire                when_CsrPlugin_l1121;
-  wire                when_CsrPlugin_l1123;
-  wire                when_CsrPlugin_l1129;
+  wire                when_CsrPlugin_l1519;
+  wire                when_CsrPlugin_l1521;
+  wire                when_CsrPlugin_l1527;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire                when_CsrPlugin_l1142;
-  wire                when_CsrPlugin_l1149;
-  wire                when_CsrPlugin_l1150;
-  wire                when_CsrPlugin_l1157;
+  wire                when_CsrPlugin_l1540;
+  wire                when_CsrPlugin_l1547;
+  wire                when_CsrPlugin_l1548;
+  wire                when_CsrPlugin_l1555;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   wire       [31:0]   execute_CsrPlugin_readToWriteData;
-  wire                switch_Misc_l210_2;
+  wire                switch_Misc_l232_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
-  wire                when_CsrPlugin_l1189;
-  wire                when_CsrPlugin_l1193;
+  wire                when_CsrPlugin_l1587;
+  wire                when_CsrPlugin_l1591;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg                 execute_MulPlugin_aSigned;
   reg                 execute_MulPlugin_bSigned;
@@ -1078,7 +1070,7 @@ module VexRiscv (
   reg        [32:0]   _zz_memory_DivPlugin_rs1_1;
   reg        [31:0]   externalInterruptArray_regNext;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit;
-  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
+  wire       [31:0]   _zz_externalInterrupt;
   wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
   wire                when_Pipeline_l124_1;
@@ -1209,60 +1201,61 @@ module VexRiscv (
   wire                when_Pipeline_l154_1;
   wire                when_Pipeline_l151_2;
   wire                when_Pipeline_l154_2;
-  wire                when_CsrPlugin_l1277;
+  wire                when_CsrPlugin_l1669;
   reg                 execute_CsrPlugin_csr_3264;
-  wire                when_CsrPlugin_l1277_1;
+  wire                when_CsrPlugin_l1669_1;
   reg                 execute_CsrPlugin_csr_3857;
-  wire                when_CsrPlugin_l1277_2;
+  wire                when_CsrPlugin_l1669_2;
   reg                 execute_CsrPlugin_csr_3858;
-  wire                when_CsrPlugin_l1277_3;
+  wire                when_CsrPlugin_l1669_3;
   reg                 execute_CsrPlugin_csr_3859;
-  wire                when_CsrPlugin_l1277_4;
+  wire                when_CsrPlugin_l1669_4;
   reg                 execute_CsrPlugin_csr_3860;
-  wire                when_CsrPlugin_l1277_5;
+  wire                when_CsrPlugin_l1669_5;
   reg                 execute_CsrPlugin_csr_769;
-  wire                when_CsrPlugin_l1277_6;
+  wire                when_CsrPlugin_l1669_6;
   reg                 execute_CsrPlugin_csr_768;
-  wire                when_CsrPlugin_l1277_7;
+  wire                when_CsrPlugin_l1669_7;
   reg                 execute_CsrPlugin_csr_836;
-  wire                when_CsrPlugin_l1277_8;
+  wire                when_CsrPlugin_l1669_8;
   reg                 execute_CsrPlugin_csr_772;
-  wire                when_CsrPlugin_l1277_9;
+  wire                when_CsrPlugin_l1669_9;
   reg                 execute_CsrPlugin_csr_773;
-  wire                when_CsrPlugin_l1277_10;
+  wire                when_CsrPlugin_l1669_10;
   reg                 execute_CsrPlugin_csr_833;
-  wire                when_CsrPlugin_l1277_11;
+  wire                when_CsrPlugin_l1669_11;
   reg                 execute_CsrPlugin_csr_832;
-  wire                when_CsrPlugin_l1277_12;
+  wire                when_CsrPlugin_l1669_12;
   reg                 execute_CsrPlugin_csr_834;
-  wire                when_CsrPlugin_l1277_13;
+  wire                when_CsrPlugin_l1669_13;
   reg                 execute_CsrPlugin_csr_835;
-  wire                when_CsrPlugin_l1277_14;
+  wire                when_CsrPlugin_l1669_14;
   reg                 execute_CsrPlugin_csr_2816;
-  wire                when_CsrPlugin_l1277_15;
+  wire                when_CsrPlugin_l1669_15;
   reg                 execute_CsrPlugin_csr_2944;
-  wire                when_CsrPlugin_l1277_16;
+  wire                when_CsrPlugin_l1669_16;
   reg                 execute_CsrPlugin_csr_2818;
-  wire                when_CsrPlugin_l1277_17;
+  wire                when_CsrPlugin_l1669_17;
   reg                 execute_CsrPlugin_csr_2946;
-  wire                when_CsrPlugin_l1277_18;
+  wire                when_CsrPlugin_l1669_18;
   reg                 execute_CsrPlugin_csr_3072;
-  wire                when_CsrPlugin_l1277_19;
+  wire                when_CsrPlugin_l1669_19;
   reg                 execute_CsrPlugin_csr_3200;
-  wire                when_CsrPlugin_l1277_20;
+  wire                when_CsrPlugin_l1669_20;
   reg                 execute_CsrPlugin_csr_3074;
-  wire                when_CsrPlugin_l1277_21;
+  wire                when_CsrPlugin_l1669_21;
   reg                 execute_CsrPlugin_csr_3202;
-  wire                when_CsrPlugin_l1277_22;
+  wire                when_CsrPlugin_l1669_22;
   reg                 execute_CsrPlugin_csr_3008;
-  wire                when_CsrPlugin_l1277_23;
+  wire                when_CsrPlugin_l1669_23;
   reg                 execute_CsrPlugin_csr_4032;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_5;
+  wire       [1:0]    switch_CsrPlugin_l1031;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_6;
-  wire       [1:0]    switch_CsrPlugin_l723;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_8;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
@@ -1280,19 +1273,22 @@ module VexRiscv (
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_21;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_22;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_23;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_24;
-  wire                when_CsrPlugin_l1310;
-  wire                when_CsrPlugin_l1315;
+  wire                when_CsrPlugin_l1702;
+  wire       [11:0]   _zz_when_CsrPlugin_l1709;
+  wire                when_CsrPlugin_l1709;
+  reg                 when_CsrPlugin_l1719;
+  wire                when_CsrPlugin_l1717;
+  wire                when_CsrPlugin_l1725;
   reg        [2:0]    _zz_iBusWishbone_ADR;
   wire                when_InstructionCache_l239;
   reg                 _zz_iBus_rsp_valid;
   reg        [31:0]   iBusWishbone_DAT_MISO_regNext;
-  reg        [2:0]    _zz_dBus_cmd_ready;
+  reg        [2:0]    _zz_dBusWishbone_ADR;
+  wire                _zz_dBusWishbone_CYC;
+  wire                _zz_dBus_cmd_ready;
   wire                _zz_dBus_cmd_ready_1;
   wire                _zz_dBus_cmd_ready_2;
-  wire                _zz_dBus_cmd_ready_3;
-  wire                _zz_dBus_cmd_ready_4;
-  wire                _zz_dBus_cmd_ready_5;
+  wire                _zz_dBusWishbone_ADR_1;
   reg                 _zz_dBus_rsp_valid;
   reg        [31:0]   dBusWishbone_DAT_MISO_regNext;
   `ifndef SYNTHESIS
@@ -1379,15 +1375,14 @@ module VexRiscv (
   (* no_rw_check , ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
   assign _zz_when = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
-  assign _zz_memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW_1) + $signed(_zz_memory_MUL_LOW_5));
-  assign _zz_memory_MUL_LOW_1 = ($signed(_zz_memory_MUL_LOW_2) + $signed(_zz_memory_MUL_LOW_3));
-  assign _zz_memory_MUL_LOW_2 = 52'h0;
-  assign _zz_memory_MUL_LOW_4 = {1'b0,memory_MUL_LL};
-  assign _zz_memory_MUL_LOW_3 = {{19{_zz_memory_MUL_LOW_4[32]}}, _zz_memory_MUL_LOW_4};
-  assign _zz_memory_MUL_LOW_6 = ({16'd0,memory_MUL_LH} <<< 16);
-  assign _zz_memory_MUL_LOW_5 = {{2{_zz_memory_MUL_LOW_6[49]}}, _zz_memory_MUL_LOW_6};
-  assign _zz_memory_MUL_LOW_8 = ({16'd0,memory_MUL_HL} <<< 16);
-  assign _zz_memory_MUL_LOW_7 = {{2{_zz_memory_MUL_LOW_8[49]}}, _zz_memory_MUL_LOW_8};
+  assign _zz_memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW_1) + $signed(_zz_memory_MUL_LOW_4));
+  assign _zz_memory_MUL_LOW_1 = ($signed(52'h0000000000000) + $signed(_zz_memory_MUL_LOW_2));
+  assign _zz_memory_MUL_LOW_3 = {1'b0,memory_MUL_LL};
+  assign _zz_memory_MUL_LOW_2 = {{19{_zz_memory_MUL_LOW_3[32]}}, _zz_memory_MUL_LOW_3};
+  assign _zz_memory_MUL_LOW_5 = ({16'd0,memory_MUL_LH} <<< 5'd16);
+  assign _zz_memory_MUL_LOW_4 = {{2{_zz_memory_MUL_LOW_5[49]}}, _zz_memory_MUL_LOW_5};
+  assign _zz_memory_MUL_LOW_7 = ({16'd0,memory_MUL_HL} <<< 5'd16);
+  assign _zz_memory_MUL_LOW_6 = {{2{_zz_memory_MUL_LOW_7[49]}}, _zz_memory_MUL_LOW_7};
   assign _zz_execute_SHIFT_RIGHT_1 = ($signed(_zz_execute_SHIFT_RIGHT_2) >>> execute_FullBarrelShifterPlugin_amplitude);
   assign _zz_execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT_1[31 : 0];
   assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == ShiftCtrlEnum_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
@@ -1403,20 +1398,18 @@ module VexRiscv (
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
   assign _zz_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId_1;
-  assign _zz_io_cpu_flush_payload_lineId_1 = (execute_RS1 >>> 5);
+  assign _zz_io_cpu_flush_payload_lineId_1 = (execute_RS1 >>> 3'd5);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code_1 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
   assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
   assign _zz__zz_execute_SRC1 = 3'b100;
   assign _zz__zz_execute_SRC1_1 = execute_INSTRUCTION[19 : 15];
-  assign _zz__zz_execute_SRC2_3 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz__zz_execute_SRC2_2 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
   assign _zz_execute_SrcPlugin_addSub = ($signed(_zz_execute_SrcPlugin_addSub_1) + $signed(_zz_execute_SrcPlugin_addSub_4));
   assign _zz_execute_SrcPlugin_addSub_1 = ($signed(_zz_execute_SrcPlugin_addSub_2) + $signed(_zz_execute_SrcPlugin_addSub_3));
   assign _zz_execute_SrcPlugin_addSub_2 = execute_SRC1;
   assign _zz_execute_SrcPlugin_addSub_3 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? _zz_execute_SrcPlugin_addSub_5 : _zz_execute_SrcPlugin_addSub_6);
-  assign _zz_execute_SrcPlugin_addSub_5 = 32'h00000001;
-  assign _zz_execute_SrcPlugin_addSub_6 = 32'h0;
+  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? 32'h00000001 : 32'h00000000);
   assign _zz__zz_execute_BranchPlugin_missAlignedTarget_2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
   assign _zz__zz_execute_BranchPlugin_missAlignedTarget_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
   assign _zz__zz_execute_BranchPlugin_missAlignedTarget_6 = {_zz_execute_BranchPlugin_missAlignedTarget_1,execute_INSTRUCTION[31 : 20]};
@@ -1428,7 +1421,7 @@ module VexRiscv (
   assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code & (~ _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1));
   assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code - 2'b01);
   assign _zz_writeBack_MulPlugin_result = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
-  assign _zz_writeBack_MulPlugin_result_1 = ({32'd0,writeBack_MUL_HH} <<< 32);
+  assign _zz_writeBack_MulPlugin_result_1 = ({32'd0,writeBack_MUL_HH} <<< 6'd32);
   assign _zz__zz_decode_RS2_2 = writeBack_MUL_LOW[31 : 0];
   assign _zz__zz_decode_RS2_2_1 = writeBack_MulPlugin_result[63 : 32];
   assign _zz_memory_DivPlugin_div_counter_valueNext_1 = memory_DivPlugin_div_counter_willIncrement;
@@ -1446,30 +1439,30 @@ module VexRiscv (
   assign _zz_memory_DivPlugin_rs1_2 = {32'd0, _zz_memory_DivPlugin_rs1_3};
   assign _zz_memory_DivPlugin_rs2_2 = _zz_memory_DivPlugin_rs2;
   assign _zz_memory_DivPlugin_rs2_1 = {31'd0, _zz_memory_DivPlugin_rs2_2};
-  assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 5);
+  assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 3'd5);
   assign _zz_decode_RegFilePlugin_rs1Data = 1'b1;
   assign _zz_decode_RegFilePlugin_rs2Data = 1'b1;
   assign _zz_IBusCachedPlugin_jump_pcLoad_payload_6 = {_zz_IBusCachedPlugin_jump_pcLoad_payload_4,_zz_IBusCachedPlugin_jump_pcLoad_payload_3};
   assign _zz_writeBack_DBusCachedPlugin_rspShifted_1 = dataCache_1_io_cpu_writeBack_address[1 : 0];
   assign _zz_writeBack_DBusCachedPlugin_rspShifted_3 = dataCache_1_io_cpu_writeBack_address[1 : 1];
-  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000107f;
-  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00002073;
-  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000207f;
+  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000407f);
+  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00004063;
+  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000107f) == 32'h00000013);
   assign _zz_decode_LEGAL_INSTRUCTION_5 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_6) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_7 == _zz_decode_LEGAL_INSTRUCTION_8),{_zz_decode_LEGAL_INSTRUCTION_9,{_zz_decode_LEGAL_INSTRUCTION_10,_zz_decode_LEGAL_INSTRUCTION_11}}}}}};
   assign _zz_decode_LEGAL_INSTRUCTION_6 = 32'h0000505f;
   assign _zz_decode_LEGAL_INSTRUCTION_7 = (decode_INSTRUCTION & 32'h0000707b);
   assign _zz_decode_LEGAL_INSTRUCTION_8 = 32'h00000063;
   assign _zz_decode_LEGAL_INSTRUCTION_9 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
   assign _zz_decode_LEGAL_INSTRUCTION_10 = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
-  assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h00001013),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,{_zz_decode_LEGAL_INSTRUCTION_16,_zz_decode_LEGAL_INSTRUCTION_17}}}}}};
-  assign _zz_decode_LEGAL_INSTRUCTION_12 = 32'hfc00307f;
+  assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & 32'hbe00705f) == 32'h00005013),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h00001013),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,{_zz_decode_LEGAL_INSTRUCTION_16,_zz_decode_LEGAL_INSTRUCTION_17}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_12 = 32'hfe00305f;
   assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'hbe00707f);
-  assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h00005033;
-  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
-  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
-  assign _zz_decode_LEGAL_INSTRUCTION_17 = {((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073),((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073)};
+  assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h00000033;
+  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
+  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073);
+  assign _zz_decode_LEGAL_INSTRUCTION_17 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073);
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_4 = decode_INSTRUCTION[31];
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_5 = decode_INSTRUCTION[31];
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_6 = decode_INSTRUCTION[7];
@@ -1479,148 +1472,138 @@ module VexRiscv (
   assign _zz__zz_decode_IS_RS2_SIGNED_3 = ((decode_INSTRUCTION & 32'h00203050) == 32'h00000050);
   assign _zz__zz_decode_IS_RS2_SIGNED_4 = (|((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_5) == 32'h00000050));
   assign _zz__zz_decode_IS_RS2_SIGNED_6 = (|{_zz__zz_decode_IS_RS2_SIGNED_7,_zz__zz_decode_IS_RS2_SIGNED_8});
-  assign _zz__zz_decode_IS_RS2_SIGNED_9 = {(|{_zz__zz_decode_IS_RS2_SIGNED_10,_zz__zz_decode_IS_RS2_SIGNED_11}),{(|_zz__zz_decode_IS_RS2_SIGNED_13),{_zz__zz_decode_IS_RS2_SIGNED_15,{_zz__zz_decode_IS_RS2_SIGNED_18,_zz__zz_decode_IS_RS2_SIGNED_26}}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_9 = {(|{_zz__zz_decode_IS_RS2_SIGNED_10,_zz__zz_decode_IS_RS2_SIGNED_11}),{(|_zz__zz_decode_IS_RS2_SIGNED_13),{_zz__zz_decode_IS_RS2_SIGNED_15,{_zz__zz_decode_IS_RS2_SIGNED_18,_zz__zz_decode_IS_RS2_SIGNED_21}}}};
   assign _zz__zz_decode_IS_RS2_SIGNED_5 = 32'h00403050;
   assign _zz__zz_decode_IS_RS2_SIGNED_7 = ((decode_INSTRUCTION & 32'h00001050) == 32'h00001050);
   assign _zz__zz_decode_IS_RS2_SIGNED_8 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002050);
   assign _zz__zz_decode_IS_RS2_SIGNED_10 = _zz_decode_IS_RS2_SIGNED_4;
   assign _zz__zz_decode_IS_RS2_SIGNED_11 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_12) == 32'h00000004);
   assign _zz__zz_decode_IS_RS2_SIGNED_13 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_14) == 32'h00000040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_15 = (|{_zz__zz_decode_IS_RS2_SIGNED_16,_zz__zz_decode_IS_RS2_SIGNED_17});
-  assign _zz__zz_decode_IS_RS2_SIGNED_18 = (|{_zz__zz_decode_IS_RS2_SIGNED_19,_zz__zz_decode_IS_RS2_SIGNED_21});
-  assign _zz__zz_decode_IS_RS2_SIGNED_26 = {(|_zz__zz_decode_IS_RS2_SIGNED_27),{_zz__zz_decode_IS_RS2_SIGNED_29,{_zz__zz_decode_IS_RS2_SIGNED_32,_zz__zz_decode_IS_RS2_SIGNED_34}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_15 = (|(_zz__zz_decode_IS_RS2_SIGNED_16 == _zz__zz_decode_IS_RS2_SIGNED_17));
+  assign _zz__zz_decode_IS_RS2_SIGNED_18 = (|{_zz__zz_decode_IS_RS2_SIGNED_19,_zz__zz_decode_IS_RS2_SIGNED_20});
+  assign _zz__zz_decode_IS_RS2_SIGNED_21 = {(|_zz__zz_decode_IS_RS2_SIGNED_22),{_zz__zz_decode_IS_RS2_SIGNED_23,{_zz__zz_decode_IS_RS2_SIGNED_25,_zz__zz_decode_IS_RS2_SIGNED_28}}};
   assign _zz__zz_decode_IS_RS2_SIGNED_12 = 32'h0000001c;
   assign _zz__zz_decode_IS_RS2_SIGNED_14 = 32'h00000058;
-  assign _zz__zz_decode_IS_RS2_SIGNED_16 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00005010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_17 = ((decode_INSTRUCTION & 32'h02007064) == 32'h00005020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_19 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_20) == 32'h40001010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_21 = {(_zz__zz_decode_IS_RS2_SIGNED_22 == _zz__zz_decode_IS_RS2_SIGNED_23),(_zz__zz_decode_IS_RS2_SIGNED_24 == _zz__zz_decode_IS_RS2_SIGNED_25)};
-  assign _zz__zz_decode_IS_RS2_SIGNED_27 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_28) == 32'h00000024);
-  assign _zz__zz_decode_IS_RS2_SIGNED_29 = (|(_zz__zz_decode_IS_RS2_SIGNED_30 == _zz__zz_decode_IS_RS2_SIGNED_31));
-  assign _zz__zz_decode_IS_RS2_SIGNED_32 = (|_zz__zz_decode_IS_RS2_SIGNED_33);
-  assign _zz__zz_decode_IS_RS2_SIGNED_34 = {(|_zz__zz_decode_IS_RS2_SIGNED_35),{_zz__zz_decode_IS_RS2_SIGNED_38,{_zz__zz_decode_IS_RS2_SIGNED_40,_zz__zz_decode_IS_RS2_SIGNED_43}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_20 = 32'h40003054;
-  assign _zz__zz_decode_IS_RS2_SIGNED_22 = (decode_INSTRUCTION & 32'h00007034);
-  assign _zz__zz_decode_IS_RS2_SIGNED_23 = 32'h00001010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_24 = (decode_INSTRUCTION & 32'h02007054);
-  assign _zz__zz_decode_IS_RS2_SIGNED_25 = 32'h00001010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_28 = 32'h00000064;
-  assign _zz__zz_decode_IS_RS2_SIGNED_30 = (decode_INSTRUCTION & 32'h00001000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_31 = 32'h00001000;
-  assign _zz__zz_decode_IS_RS2_SIGNED_33 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_35 = {((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_36) == 32'h00002000),((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_37) == 32'h00001000)};
-  assign _zz__zz_decode_IS_RS2_SIGNED_38 = (|((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_39) == 32'h00004008));
-  assign _zz__zz_decode_IS_RS2_SIGNED_40 = (|{_zz__zz_decode_IS_RS2_SIGNED_41,_zz__zz_decode_IS_RS2_SIGNED_42});
-  assign _zz__zz_decode_IS_RS2_SIGNED_43 = {(|{_zz__zz_decode_IS_RS2_SIGNED_44,_zz__zz_decode_IS_RS2_SIGNED_46}),{(|_zz__zz_decode_IS_RS2_SIGNED_55),{_zz__zz_decode_IS_RS2_SIGNED_57,{_zz__zz_decode_IS_RS2_SIGNED_70,_zz__zz_decode_IS_RS2_SIGNED_83}}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_36 = 32'h00002010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_37 = 32'h00005000;
-  assign _zz__zz_decode_IS_RS2_SIGNED_39 = 32'h00004048;
-  assign _zz__zz_decode_IS_RS2_SIGNED_41 = ((decode_INSTRUCTION & 32'h00000034) == 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_42 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_44 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_45) == 32'h00002040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_46 = {(_zz__zz_decode_IS_RS2_SIGNED_47 == _zz__zz_decode_IS_RS2_SIGNED_48),{_zz__zz_decode_IS_RS2_SIGNED_49,{_zz__zz_decode_IS_RS2_SIGNED_51,_zz__zz_decode_IS_RS2_SIGNED_54}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_55 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_56) == 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_57 = (|{_zz__zz_decode_IS_RS2_SIGNED_58,{_zz__zz_decode_IS_RS2_SIGNED_60,_zz__zz_decode_IS_RS2_SIGNED_61}});
-  assign _zz__zz_decode_IS_RS2_SIGNED_70 = (|{_zz__zz_decode_IS_RS2_SIGNED_71,_zz__zz_decode_IS_RS2_SIGNED_72});
-  assign _zz__zz_decode_IS_RS2_SIGNED_83 = {(|_zz__zz_decode_IS_RS2_SIGNED_84),{_zz__zz_decode_IS_RS2_SIGNED_97,{_zz__zz_decode_IS_RS2_SIGNED_102,_zz__zz_decode_IS_RS2_SIGNED_106}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_45 = 32'h00002040;
-  assign _zz__zz_decode_IS_RS2_SIGNED_47 = (decode_INSTRUCTION & 32'h00001040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_48 = 32'h00001040;
-  assign _zz__zz_decode_IS_RS2_SIGNED_49 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_50) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_16 = (decode_INSTRUCTION & 32'h02007054);
+  assign _zz__zz_decode_IS_RS2_SIGNED_17 = 32'h00005010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_19 = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_20 = ((decode_INSTRUCTION & 32'h02007054) == 32'h00001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_22 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
+  assign _zz__zz_decode_IS_RS2_SIGNED_23 = (|((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_24) == 32'h00001000));
+  assign _zz__zz_decode_IS_RS2_SIGNED_25 = (|(_zz__zz_decode_IS_RS2_SIGNED_26 == _zz__zz_decode_IS_RS2_SIGNED_27));
+  assign _zz__zz_decode_IS_RS2_SIGNED_28 = {(|{_zz__zz_decode_IS_RS2_SIGNED_29,_zz__zz_decode_IS_RS2_SIGNED_30}),{(|_zz__zz_decode_IS_RS2_SIGNED_31),{_zz__zz_decode_IS_RS2_SIGNED_32,{_zz__zz_decode_IS_RS2_SIGNED_37,_zz__zz_decode_IS_RS2_SIGNED_46}}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_24 = 32'h00001000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_26 = (decode_INSTRUCTION & 32'h00003000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_27 = 32'h00002000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_29 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_30 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00001000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_31 = ((decode_INSTRUCTION & 32'h00004048) == 32'h00004008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_32 = (|{(_zz__zz_decode_IS_RS2_SIGNED_33 == _zz__zz_decode_IS_RS2_SIGNED_34),(_zz__zz_decode_IS_RS2_SIGNED_35 == _zz__zz_decode_IS_RS2_SIGNED_36)});
+  assign _zz__zz_decode_IS_RS2_SIGNED_37 = (|{_zz__zz_decode_IS_RS2_SIGNED_38,{_zz__zz_decode_IS_RS2_SIGNED_39,_zz__zz_decode_IS_RS2_SIGNED_41}});
+  assign _zz__zz_decode_IS_RS2_SIGNED_46 = {(|_zz__zz_decode_IS_RS2_SIGNED_47),{(|_zz__zz_decode_IS_RS2_SIGNED_48),{_zz__zz_decode_IS_RS2_SIGNED_59,{_zz__zz_decode_IS_RS2_SIGNED_72,_zz__zz_decode_IS_RS2_SIGNED_86}}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_33 = (decode_INSTRUCTION & 32'h00000034);
+  assign _zz__zz_decode_IS_RS2_SIGNED_34 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_35 = (decode_INSTRUCTION & 32'h00000064);
+  assign _zz__zz_decode_IS_RS2_SIGNED_36 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_38 = ((decode_INSTRUCTION & 32'h00002040) == 32'h00002040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_39 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_40) == 32'h00001040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_41 = {(_zz__zz_decode_IS_RS2_SIGNED_42 == _zz__zz_decode_IS_RS2_SIGNED_43),{_zz__zz_decode_IS_RS2_SIGNED_44,_zz_decode_IS_RS2_SIGNED_2}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_47 = ((decode_INSTRUCTION & 32'h00000020) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_48 = {(_zz__zz_decode_IS_RS2_SIGNED_49 == _zz__zz_decode_IS_RS2_SIGNED_50),{_zz_decode_IS_RS2_SIGNED_3,{_zz__zz_decode_IS_RS2_SIGNED_51,_zz__zz_decode_IS_RS2_SIGNED_54}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_59 = (|{_zz_decode_IS_RS2_SIGNED_3,{_zz__zz_decode_IS_RS2_SIGNED_60,_zz__zz_decode_IS_RS2_SIGNED_63}});
+  assign _zz__zz_decode_IS_RS2_SIGNED_72 = (|{_zz__zz_decode_IS_RS2_SIGNED_73,_zz__zz_decode_IS_RS2_SIGNED_74});
+  assign _zz__zz_decode_IS_RS2_SIGNED_86 = {(|_zz__zz_decode_IS_RS2_SIGNED_87),{_zz__zz_decode_IS_RS2_SIGNED_90,{_zz__zz_decode_IS_RS2_SIGNED_95,_zz__zz_decode_IS_RS2_SIGNED_99}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_40 = 32'h00001040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_42 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_43 = 32'h00000040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_44 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_45) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_49 = (decode_INSTRUCTION & 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_50 = 32'h00000040;
   assign _zz__zz_decode_IS_RS2_SIGNED_51 = (_zz__zz_decode_IS_RS2_SIGNED_52 == _zz__zz_decode_IS_RS2_SIGNED_53);
-  assign _zz__zz_decode_IS_RS2_SIGNED_54 = _zz_decode_IS_RS2_SIGNED_2;
-  assign _zz__zz_decode_IS_RS2_SIGNED_56 = 32'h00000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_58 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_59) == 32'h00000040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_60 = _zz_decode_IS_RS2_SIGNED_3;
-  assign _zz__zz_decode_IS_RS2_SIGNED_61 = {_zz__zz_decode_IS_RS2_SIGNED_62,{_zz__zz_decode_IS_RS2_SIGNED_64,_zz__zz_decode_IS_RS2_SIGNED_67}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_71 = _zz_decode_IS_RS2_SIGNED_3;
-  assign _zz__zz_decode_IS_RS2_SIGNED_72 = {_zz__zz_decode_IS_RS2_SIGNED_73,{_zz__zz_decode_IS_RS2_SIGNED_75,_zz__zz_decode_IS_RS2_SIGNED_78}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_84 = {_zz_decode_IS_RS2_SIGNED_4,{_zz__zz_decode_IS_RS2_SIGNED_85,_zz__zz_decode_IS_RS2_SIGNED_88}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_97 = (|{_zz__zz_decode_IS_RS2_SIGNED_98,_zz__zz_decode_IS_RS2_SIGNED_99});
+  assign _zz__zz_decode_IS_RS2_SIGNED_54 = {_zz__zz_decode_IS_RS2_SIGNED_55,_zz__zz_decode_IS_RS2_SIGNED_57};
+  assign _zz__zz_decode_IS_RS2_SIGNED_60 = (_zz__zz_decode_IS_RS2_SIGNED_61 == _zz__zz_decode_IS_RS2_SIGNED_62);
+  assign _zz__zz_decode_IS_RS2_SIGNED_63 = {_zz__zz_decode_IS_RS2_SIGNED_64,{_zz__zz_decode_IS_RS2_SIGNED_66,_zz__zz_decode_IS_RS2_SIGNED_69}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_73 = _zz_decode_IS_RS2_SIGNED_4;
+  assign _zz__zz_decode_IS_RS2_SIGNED_74 = {_zz__zz_decode_IS_RS2_SIGNED_75,{_zz__zz_decode_IS_RS2_SIGNED_77,_zz__zz_decode_IS_RS2_SIGNED_80}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_87 = {_zz_decode_IS_RS2_SIGNED_3,_zz__zz_decode_IS_RS2_SIGNED_88};
+  assign _zz__zz_decode_IS_RS2_SIGNED_90 = (|{_zz__zz_decode_IS_RS2_SIGNED_91,_zz__zz_decode_IS_RS2_SIGNED_92});
+  assign _zz__zz_decode_IS_RS2_SIGNED_95 = (|_zz__zz_decode_IS_RS2_SIGNED_96);
+  assign _zz__zz_decode_IS_RS2_SIGNED_99 = {_zz__zz_decode_IS_RS2_SIGNED_100,{_zz__zz_decode_IS_RS2_SIGNED_102,_zz__zz_decode_IS_RS2_SIGNED_113}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_45 = 32'h00400040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_52 = (decode_INSTRUCTION & 32'h00004020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_53 = 32'h00004020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_55 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_56) == 32'h00000010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_57 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_58) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_61 = (decode_INSTRUCTION & 32'h00002030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_62 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_64 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_65) == 32'h00000010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_66 = (_zz__zz_decode_IS_RS2_SIGNED_67 == _zz__zz_decode_IS_RS2_SIGNED_68);
+  assign _zz__zz_decode_IS_RS2_SIGNED_69 = (_zz__zz_decode_IS_RS2_SIGNED_70 == _zz__zz_decode_IS_RS2_SIGNED_71);
+  assign _zz__zz_decode_IS_RS2_SIGNED_75 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_76) == 32'h00001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_77 = (_zz__zz_decode_IS_RS2_SIGNED_78 == _zz__zz_decode_IS_RS2_SIGNED_79);
+  assign _zz__zz_decode_IS_RS2_SIGNED_80 = {_zz__zz_decode_IS_RS2_SIGNED_81,{_zz__zz_decode_IS_RS2_SIGNED_82,_zz__zz_decode_IS_RS2_SIGNED_84}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_88 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_89) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_91 = _zz_decode_IS_RS2_SIGNED_3;
+  assign _zz__zz_decode_IS_RS2_SIGNED_92 = (_zz__zz_decode_IS_RS2_SIGNED_93 == _zz__zz_decode_IS_RS2_SIGNED_94);
+  assign _zz__zz_decode_IS_RS2_SIGNED_96 = (_zz__zz_decode_IS_RS2_SIGNED_97 == _zz__zz_decode_IS_RS2_SIGNED_98);
+  assign _zz__zz_decode_IS_RS2_SIGNED_100 = (|_zz__zz_decode_IS_RS2_SIGNED_101);
   assign _zz__zz_decode_IS_RS2_SIGNED_102 = (|_zz__zz_decode_IS_RS2_SIGNED_103);
-  assign _zz__zz_decode_IS_RS2_SIGNED_106 = {_zz__zz_decode_IS_RS2_SIGNED_107,{_zz__zz_decode_IS_RS2_SIGNED_110,_zz__zz_decode_IS_RS2_SIGNED_114}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_50 = 32'h00000050;
-  assign _zz__zz_decode_IS_RS2_SIGNED_52 = (decode_INSTRUCTION & 32'h00400040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_53 = 32'h00000040;
-  assign _zz__zz_decode_IS_RS2_SIGNED_59 = 32'h00000040;
-  assign _zz__zz_decode_IS_RS2_SIGNED_62 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_63) == 32'h00004020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_64 = (_zz__zz_decode_IS_RS2_SIGNED_65 == _zz__zz_decode_IS_RS2_SIGNED_66);
-  assign _zz__zz_decode_IS_RS2_SIGNED_67 = (_zz__zz_decode_IS_RS2_SIGNED_68 == _zz__zz_decode_IS_RS2_SIGNED_69);
-  assign _zz__zz_decode_IS_RS2_SIGNED_73 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_74) == 32'h00002010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_75 = (_zz__zz_decode_IS_RS2_SIGNED_76 == _zz__zz_decode_IS_RS2_SIGNED_77);
-  assign _zz__zz_decode_IS_RS2_SIGNED_78 = {_zz__zz_decode_IS_RS2_SIGNED_79,_zz__zz_decode_IS_RS2_SIGNED_81};
-  assign _zz__zz_decode_IS_RS2_SIGNED_85 = (_zz__zz_decode_IS_RS2_SIGNED_86 == _zz__zz_decode_IS_RS2_SIGNED_87);
-  assign _zz__zz_decode_IS_RS2_SIGNED_88 = {_zz__zz_decode_IS_RS2_SIGNED_89,{_zz__zz_decode_IS_RS2_SIGNED_91,_zz__zz_decode_IS_RS2_SIGNED_94}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_98 = _zz_decode_IS_RS2_SIGNED_3;
-  assign _zz__zz_decode_IS_RS2_SIGNED_99 = (_zz__zz_decode_IS_RS2_SIGNED_100 == _zz__zz_decode_IS_RS2_SIGNED_101);
-  assign _zz__zz_decode_IS_RS2_SIGNED_103 = {_zz_decode_IS_RS2_SIGNED_3,_zz__zz_decode_IS_RS2_SIGNED_104};
-  assign _zz__zz_decode_IS_RS2_SIGNED_107 = (|_zz__zz_decode_IS_RS2_SIGNED_108);
-  assign _zz__zz_decode_IS_RS2_SIGNED_110 = (|_zz__zz_decode_IS_RS2_SIGNED_111);
-  assign _zz__zz_decode_IS_RS2_SIGNED_114 = {_zz__zz_decode_IS_RS2_SIGNED_115,{_zz__zz_decode_IS_RS2_SIGNED_124,_zz__zz_decode_IS_RS2_SIGNED_127}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_63 = 32'h00004020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_65 = (decode_INSTRUCTION & 32'h00000030);
-  assign _zz__zz_decode_IS_RS2_SIGNED_66 = 32'h00000010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_68 = (decode_INSTRUCTION & 32'h02000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_69 = 32'h00000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_74 = 32'h00002030;
-  assign _zz__zz_decode_IS_RS2_SIGNED_76 = (decode_INSTRUCTION & 32'h00001030);
-  assign _zz__zz_decode_IS_RS2_SIGNED_77 = 32'h00000010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_79 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_80) == 32'h00002020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_81 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_82) == 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_86 = (decode_INSTRUCTION & 32'h00001010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_87 = 32'h00001010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_89 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_90) == 32'h00002010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_91 = (_zz__zz_decode_IS_RS2_SIGNED_92 == _zz__zz_decode_IS_RS2_SIGNED_93);
-  assign _zz__zz_decode_IS_RS2_SIGNED_94 = {_zz__zz_decode_IS_RS2_SIGNED_95,_zz__zz_decode_IS_RS2_SIGNED_96};
-  assign _zz__zz_decode_IS_RS2_SIGNED_100 = (decode_INSTRUCTION & 32'h00000070);
-  assign _zz__zz_decode_IS_RS2_SIGNED_101 = 32'h00000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_104 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_105) == 32'h0);
-  assign _zz__zz_decode_IS_RS2_SIGNED_108 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_109) == 32'h00004010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_111 = (_zz__zz_decode_IS_RS2_SIGNED_112 == _zz__zz_decode_IS_RS2_SIGNED_113);
-  assign _zz__zz_decode_IS_RS2_SIGNED_115 = (|{_zz__zz_decode_IS_RS2_SIGNED_116,_zz__zz_decode_IS_RS2_SIGNED_118});
-  assign _zz__zz_decode_IS_RS2_SIGNED_124 = (|_zz__zz_decode_IS_RS2_SIGNED_125);
-  assign _zz__zz_decode_IS_RS2_SIGNED_127 = {_zz__zz_decode_IS_RS2_SIGNED_128,{_zz__zz_decode_IS_RS2_SIGNED_134,_zz__zz_decode_IS_RS2_SIGNED_138}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_80 = 32'h02002060;
-  assign _zz__zz_decode_IS_RS2_SIGNED_82 = 32'h02003020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_90 = 32'h00002010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_92 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz__zz_decode_IS_RS2_SIGNED_93 = 32'h00000010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_95 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
-  assign _zz__zz_decode_IS_RS2_SIGNED_96 = ((decode_INSTRUCTION & 32'h00000028) == 32'h0);
-  assign _zz__zz_decode_IS_RS2_SIGNED_105 = 32'h00000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_109 = 32'h00004014;
-  assign _zz__zz_decode_IS_RS2_SIGNED_112 = (decode_INSTRUCTION & 32'h00006014);
-  assign _zz__zz_decode_IS_RS2_SIGNED_113 = 32'h00002010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_116 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_117) == 32'h0);
-  assign _zz__zz_decode_IS_RS2_SIGNED_118 = {_zz_decode_IS_RS2_SIGNED_2,{_zz__zz_decode_IS_RS2_SIGNED_119,{_zz__zz_decode_IS_RS2_SIGNED_120,_zz__zz_decode_IS_RS2_SIGNED_122}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_125 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_126) == 32'h0);
-  assign _zz__zz_decode_IS_RS2_SIGNED_128 = (|{_zz__zz_decode_IS_RS2_SIGNED_129,{_zz__zz_decode_IS_RS2_SIGNED_130,_zz__zz_decode_IS_RS2_SIGNED_132}});
-  assign _zz__zz_decode_IS_RS2_SIGNED_134 = (|{_zz__zz_decode_IS_RS2_SIGNED_135,_zz__zz_decode_IS_RS2_SIGNED_137});
-  assign _zz__zz_decode_IS_RS2_SIGNED_138 = {(|_zz__zz_decode_IS_RS2_SIGNED_139),(|_zz__zz_decode_IS_RS2_SIGNED_142)};
-  assign _zz__zz_decode_IS_RS2_SIGNED_117 = 32'h00000044;
-  assign _zz__zz_decode_IS_RS2_SIGNED_119 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_120 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_121) == 32'h00001000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_122 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_123) == 32'h00004000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_126 = 32'h00000058;
-  assign _zz__zz_decode_IS_RS2_SIGNED_129 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_130 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_131) == 32'h00002010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_132 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_133) == 32'h40000030);
-  assign _zz__zz_decode_IS_RS2_SIGNED_135 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_136) == 32'h00000004);
-  assign _zz__zz_decode_IS_RS2_SIGNED_137 = _zz_decode_IS_RS2_SIGNED_1;
-  assign _zz__zz_decode_IS_RS2_SIGNED_139 = {(_zz__zz_decode_IS_RS2_SIGNED_140 == _zz__zz_decode_IS_RS2_SIGNED_141),_zz_decode_IS_RS2_SIGNED_1};
-  assign _zz__zz_decode_IS_RS2_SIGNED_142 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_143) == 32'h00001008);
-  assign _zz__zz_decode_IS_RS2_SIGNED_121 = 32'h00005004;
-  assign _zz__zz_decode_IS_RS2_SIGNED_123 = 32'h00004050;
-  assign _zz__zz_decode_IS_RS2_SIGNED_131 = 32'h00002014;
-  assign _zz__zz_decode_IS_RS2_SIGNED_133 = 32'h40000034;
-  assign _zz__zz_decode_IS_RS2_SIGNED_136 = 32'h00000014;
-  assign _zz__zz_decode_IS_RS2_SIGNED_140 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz__zz_decode_IS_RS2_SIGNED_141 = 32'h00000004;
-  assign _zz__zz_decode_IS_RS2_SIGNED_143 = 32'h00005048;
+  assign _zz__zz_decode_IS_RS2_SIGNED_113 = {_zz__zz_decode_IS_RS2_SIGNED_114,{_zz__zz_decode_IS_RS2_SIGNED_117,_zz__zz_decode_IS_RS2_SIGNED_125}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_56 = 32'h00000030;
+  assign _zz__zz_decode_IS_RS2_SIGNED_58 = 32'h02000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_65 = 32'h00001030;
+  assign _zz__zz_decode_IS_RS2_SIGNED_67 = (decode_INSTRUCTION & 32'h02002060);
+  assign _zz__zz_decode_IS_RS2_SIGNED_68 = 32'h00002020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_70 = (decode_INSTRUCTION & 32'h02003020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_71 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_76 = 32'h00001010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_78 = (decode_INSTRUCTION & 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_79 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_81 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_82 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_83) == 32'h00000004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_84 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_85) == 32'h00000000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_89 = 32'h00000070;
+  assign _zz__zz_decode_IS_RS2_SIGNED_93 = (decode_INSTRUCTION & 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_94 = 32'h00000000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_97 = (decode_INSTRUCTION & 32'h00004014);
+  assign _zz__zz_decode_IS_RS2_SIGNED_98 = 32'h00004010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_101 = ((decode_INSTRUCTION & 32'h00006014) == 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_103 = {(_zz__zz_decode_IS_RS2_SIGNED_104 == _zz__zz_decode_IS_RS2_SIGNED_105),{_zz_decode_IS_RS2_SIGNED_2,{_zz__zz_decode_IS_RS2_SIGNED_106,_zz__zz_decode_IS_RS2_SIGNED_108}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_114 = (|(_zz__zz_decode_IS_RS2_SIGNED_115 == _zz__zz_decode_IS_RS2_SIGNED_116));
+  assign _zz__zz_decode_IS_RS2_SIGNED_117 = (|{_zz__zz_decode_IS_RS2_SIGNED_118,_zz__zz_decode_IS_RS2_SIGNED_120});
+  assign _zz__zz_decode_IS_RS2_SIGNED_125 = {(|_zz__zz_decode_IS_RS2_SIGNED_126),{_zz__zz_decode_IS_RS2_SIGNED_129,_zz__zz_decode_IS_RS2_SIGNED_131}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_83 = 32'h0000000c;
+  assign _zz__zz_decode_IS_RS2_SIGNED_85 = 32'h00000028;
+  assign _zz__zz_decode_IS_RS2_SIGNED_104 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz__zz_decode_IS_RS2_SIGNED_105 = 32'h00000000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_106 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_107) == 32'h00002000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_108 = {(_zz__zz_decode_IS_RS2_SIGNED_109 == _zz__zz_decode_IS_RS2_SIGNED_110),(_zz__zz_decode_IS_RS2_SIGNED_111 == _zz__zz_decode_IS_RS2_SIGNED_112)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_115 = (decode_INSTRUCTION & 32'h00000058);
+  assign _zz__zz_decode_IS_RS2_SIGNED_116 = 32'h00000000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_118 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_119) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_120 = {(_zz__zz_decode_IS_RS2_SIGNED_121 == _zz__zz_decode_IS_RS2_SIGNED_122),(_zz__zz_decode_IS_RS2_SIGNED_123 == _zz__zz_decode_IS_RS2_SIGNED_124)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_126 = {(_zz__zz_decode_IS_RS2_SIGNED_127 == _zz__zz_decode_IS_RS2_SIGNED_128),_zz_decode_IS_RS2_SIGNED_1};
+  assign _zz__zz_decode_IS_RS2_SIGNED_129 = (|{_zz__zz_decode_IS_RS2_SIGNED_130,_zz_decode_IS_RS2_SIGNED_1});
+  assign _zz__zz_decode_IS_RS2_SIGNED_131 = (|(_zz__zz_decode_IS_RS2_SIGNED_132 == _zz__zz_decode_IS_RS2_SIGNED_133));
+  assign _zz__zz_decode_IS_RS2_SIGNED_107 = 32'h00006004;
+  assign _zz__zz_decode_IS_RS2_SIGNED_109 = (decode_INSTRUCTION & 32'h00005004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_110 = 32'h00001000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_111 = (decode_INSTRUCTION & 32'h00004050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_112 = 32'h00004000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_119 = 32'h00000044;
+  assign _zz__zz_decode_IS_RS2_SIGNED_121 = (decode_INSTRUCTION & 32'h00002014);
+  assign _zz__zz_decode_IS_RS2_SIGNED_122 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_123 = (decode_INSTRUCTION & 32'h40000034);
+  assign _zz__zz_decode_IS_RS2_SIGNED_124 = 32'h40000030;
+  assign _zz__zz_decode_IS_RS2_SIGNED_127 = (decode_INSTRUCTION & 32'h00000014);
+  assign _zz__zz_decode_IS_RS2_SIGNED_128 = 32'h00000004;
+  assign _zz__zz_decode_IS_RS2_SIGNED_130 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_132 = (decode_INSTRUCTION & 32'h00005048);
+  assign _zz__zz_decode_IS_RS2_SIGNED_133 = 32'h00001008;
   assign _zz_execute_BranchPlugin_branch_src2_6 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_7 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_8 = execute_INSTRUCTION[7];
-  assign _zz_CsrPlugin_csrMapping_readDataInit_25 = 32'h0;
+  assign _zz_CsrPlugin_csrMapping_readDataInit_24 = 32'h00000000;
   always @(posedge clk) begin
     if(_zz_decode_RegFilePlugin_rs1Data) begin
       _zz_RegFilePlugin_regFile_port0 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
@@ -1730,8 +1713,9 @@ module VexRiscv (
     .io_cpu_flush_ready                     (dataCache_1_io_cpu_flush_ready                   ), //o
     .io_cpu_flush_payload_singleLine        (dataCache_1_io_cpu_flush_payload_singleLine      ), //i
     .io_cpu_flush_payload_lineId            (dataCache_1_io_cpu_flush_payload_lineId[6:0]     ), //i
+    .io_cpu_writesPending                   (dataCache_1_io_cpu_writesPending                 ), //o
     .io_mem_cmd_valid                       (dataCache_1_io_mem_cmd_valid                     ), //o
-    .io_mem_cmd_ready                       (dataCache_1_io_mem_cmd_ready                     ), //i
+    .io_mem_cmd_ready                       (toplevel_dataCache_1_io_mem_cmd_rValidN          ), //i
     .io_mem_cmd_payload_wr                  (dataCache_1_io_mem_cmd_payload_wr                ), //o
     .io_mem_cmd_payload_uncached            (dataCache_1_io_mem_cmd_payload_uncached          ), //o
     .io_mem_cmd_payload_address             (dataCache_1_io_mem_cmd_payload_address[31:0]     ), //o
@@ -2458,7 +2442,7 @@ module VexRiscv (
   end
   `endif
 
-  assign memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW) + $signed(_zz_memory_MUL_LOW_7));
+  assign memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW) + $signed(_zz_memory_MUL_LOW_6));
   assign memory_MUL_HH = execute_to_memory_MUL_HH;
   assign execute_MUL_HH = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bHigh));
   assign execute_MUL_HL = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bSLow));
@@ -2471,7 +2455,7 @@ module VexRiscv (
   assign memory_MEMORY_STORE_DATA_RF = execute_to_memory_MEMORY_STORE_DATA_RF;
   assign execute_MEMORY_STORE_DATA_RF = _zz_execute_MEMORY_STORE_DATA_RF;
   assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
-  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
+  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h00)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h00))));
   assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
   assign decode_IS_RS2_SIGNED = _zz_decode_IS_RS2_SIGNED[31];
@@ -2536,7 +2520,7 @@ module VexRiscv (
   assign decode_RS1_USE = _zz_decode_IS_RS2_SIGNED[5];
   always @(*) begin
     _zz_decode_RS2 = execute_REGFILE_WRITE_DATA;
-    if(when_CsrPlugin_l1189) begin
+    if(when_CsrPlugin_l1587) begin
       _zz_decode_RS2 = CsrPlugin_csrMapping_readDataSignal;
     end
   end
@@ -2632,7 +2616,7 @@ module VexRiscv (
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_execute_SRC2 = execute_PC;
+  assign _zz_execute_to_memory_PC = execute_PC;
   assign execute_SRC2_CTRL = _zz_execute_SRC2_CTRL;
   assign execute_SRC1_CTRL = _zz_execute_SRC1_CTRL;
   assign decode_SRC_USE_SUB_LESS = _zz_decode_IS_RS2_SIGNED[3];
@@ -2640,7 +2624,7 @@ module VexRiscv (
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
   assign execute_ALU_CTRL = _zz_execute_ALU_CTRL;
-  assign execute_SRC2 = _zz_execute_SRC2_5;
+  assign execute_SRC2 = _zz_execute_SRC2_4;
   assign execute_SRC1 = _zz_execute_SRC1;
   assign execute_ALU_BITWISE_CTRL = _zz_execute_ALU_BITWISE_CTRL;
   assign _zz_lastStageRegFileWrite_payload_address = writeBack_INSTRUCTION;
@@ -2660,10 +2644,10 @@ module VexRiscv (
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00001073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
+  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000107f) == 32'h00001073),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00002073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
   always @(*) begin
     _zz_decode_RS2_2 = writeBack_REGFILE_WRITE_DATA;
-    if(when_DBusCachedPlugin_l492) begin
+    if(when_DBusCachedPlugin_l580) begin
       _zz_decode_RS2_2 = writeBack_DBusCachedPlugin_rspFormated;
     end
     if(when_MulPlugin_l147) begin
@@ -2696,28 +2680,28 @@ module VexRiscv (
   assign decode_FLUSH_ALL = _zz_decode_IS_RS2_SIGNED[0];
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_4 = IBusCachedPlugin_rsp_issueDetected_3;
-    if(when_IBusCachedPlugin_l256) begin
+    if(when_IBusCachedPlugin_l262) begin
       IBusCachedPlugin_rsp_issueDetected_4 = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_3 = IBusCachedPlugin_rsp_issueDetected_2;
-    if(when_IBusCachedPlugin_l250) begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_rsp_issueDetected_3 = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
-    if(when_IBusCachedPlugin_l244) begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
-    if(when_IBusCachedPlugin_l239) begin
+    if(when_IBusCachedPlugin_l245) begin
       IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
@@ -2743,7 +2727,7 @@ module VexRiscv (
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
   always @(*) begin
     decode_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l308) begin
+    if(when_DBusCachedPlugin_l352) begin
       decode_arbitration_haltItself = 1'b1;
     end
   end
@@ -2756,7 +2740,7 @@ module VexRiscv (
     if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(when_CsrPlugin_l1129) begin
+    if(when_CsrPlugin_l1527) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
@@ -2784,15 +2768,15 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l350) begin
+    if(when_DBusCachedPlugin_l394) begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(when_CsrPlugin_l1121) begin
-      if(when_CsrPlugin_l1123) begin
+    if(when_CsrPlugin_l1519) begin
+      if(when_CsrPlugin_l1521) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(when_CsrPlugin_l1193) begin
+    if(when_CsrPlugin_l1591) begin
       if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
@@ -2801,7 +2785,7 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if(when_DBusCachedPlugin_l366) begin
+    if(when_DBusCachedPlugin_l410) begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
@@ -2857,7 +2841,7 @@ module VexRiscv (
 
   always @(*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l466) begin
+    if(when_DBusCachedPlugin_l553) begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
@@ -2888,10 +2872,10 @@ module VexRiscv (
     if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -2902,13 +2886,13 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @(*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(when_CsrPlugin_l935) begin
+    if(when_CsrPlugin_l1272) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
@@ -2916,17 +2900,27 @@ module VexRiscv (
   assign IBusCachedPlugin_forceNoDecodeCond = 1'b0;
   always @(*) begin
     IBusCachedPlugin_incomingInstruction = 1'b0;
-    if(when_Fetcher_l243) begin
+    if(when_Fetcher_l242) begin
       IBusCachedPlugin_incomingInstruction = 1'b1;
     end
   end
 
   assign BranchPlugin_inDebugNoFetchFlag = 1'b0;
-  assign CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+  always @(*) begin
+    CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+    if(when_CsrPlugin_l1702) begin
+      CsrPlugin_csrMapping_allowCsrSignal = 1'b1;
+    end
+    if(when_CsrPlugin_l1709) begin
+      CsrPlugin_csrMapping_allowCsrSignal = 1'b1;
+    end
+  end
+
+  assign CsrPlugin_csrMapping_doForceFailCsr = 1'b0;
   assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
   always @(*) begin
     CsrPlugin_inWfi = 1'b0;
-    if(when_CsrPlugin_l1121) begin
+    if(when_CsrPlugin_l1519) begin
       CsrPlugin_inWfi = 1'b1;
     end
   end
@@ -2934,21 +2928,21 @@ module VexRiscv (
   assign CsrPlugin_thirdPartyWake = 1'b0;
   always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(when_CsrPlugin_l1077) begin
-      case(switch_CsrPlugin_l1081)
+    if(when_CsrPlugin_l1456) begin
+      case(switch_CsrPlugin_l1460)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -2962,6 +2956,7 @@ module VexRiscv (
   assign CsrPlugin_allowInterrupts = 1'b1;
   assign CsrPlugin_allowException = 1'b1;
   assign CsrPlugin_allowEbreakException = 1'b1;
+  assign CsrPlugin_xretAwayFromMachine = 1'b0;
   assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
   assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusCachedPlugin_redoBranch_valid,IBusCachedPlugin_predictionJumpInterface_valid}}} != 4'b0000);
   assign _zz_IBusCachedPlugin_jump_pcLoad_payload = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
@@ -2989,9 +2984,8 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l134 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
-  assign IBusCachedPlugin_fetchPc_output_fire_1 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
-  assign when_Fetcher_l134_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
+  assign when_Fetcher_l133 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l133_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
   always @(*) begin
     IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_IBusCachedPlugin_fetchPc_pc);
     if(IBusCachedPlugin_fetchPc_redo_valid) begin
@@ -3014,7 +3008,7 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l161 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
+  assign when_Fetcher_l160 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
   assign IBusCachedPlugin_fetchPc_output_valid = ((! IBusCachedPlugin_fetcherHalt) && IBusCachedPlugin_fetchPc_booted);
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
   always @(*) begin
@@ -3051,7 +3045,7 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_1_output_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b0;
-    if(when_IBusCachedPlugin_l267) begin
+    if(when_IBusCachedPlugin_l273) begin
       IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b1;
     end
   end
@@ -3064,9 +3058,9 @@ module VexRiscv (
   assign IBusCachedPlugin_fetchPc_redo_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_iBusRsp_flush = ((decode_arbitration_removeIt || (decode_arbitration_flushNext && (! decode_arbitration_isStuck))) || IBusCachedPlugin_iBusRsp_redoFetch);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
-  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1 = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
   assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid)) || IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready);
   assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
@@ -3076,18 +3070,18 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
   always @(*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
-    if(when_Fetcher_l323) begin
+    if(when_Fetcher_l322) begin
       IBusCachedPlugin_iBusRsp_readyForError = 1'b0;
     end
   end
 
-  assign when_Fetcher_l243 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
-  assign when_Fetcher_l323 = (! IBusCachedPlugin_pcValids_0);
-  assign when_Fetcher_l332 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
-  assign when_Fetcher_l332_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
-  assign when_Fetcher_l332_2 = (! execute_arbitration_isStuck);
-  assign when_Fetcher_l332_3 = (! memory_arbitration_isStuck);
-  assign when_Fetcher_l332_4 = (! writeBack_arbitration_isStuck);
+  assign when_Fetcher_l242 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
+  assign when_Fetcher_l322 = (! IBusCachedPlugin_pcValids_0);
+  assign when_Fetcher_l331 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l331_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
+  assign when_Fetcher_l331_2 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l331_3 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l331_4 = (! writeBack_arbitration_isStuck);
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
@@ -3242,87 +3236,86 @@ module VexRiscv (
   assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
   always @(*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(when_IBusCachedPlugin_l239) begin
+    if(when_IBusCachedPlugin_l245) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(when_IBusCachedPlugin_l250) begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_cache_io_cpu_fill_valid = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
-    if(when_IBusCachedPlugin_l250) begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_cache_io_cpu_fill_valid = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_valid = 1'b0;
-    if(when_IBusCachedPlugin_l244) begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
-    if(when_IBusCachedPlugin_l256) begin
+    if(when_IBusCachedPlugin_l262) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_payload_code = 4'bxxxx;
-    if(when_IBusCachedPlugin_l244) begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b1100;
     end
-    if(when_IBusCachedPlugin_l256) begin
+    if(when_IBusCachedPlugin_l262) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b0001;
     end
   end
 
   assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_2_input_payload[31 : 2],2'b00};
-  assign when_IBusCachedPlugin_l239 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign when_IBusCachedPlugin_l244 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
-  assign when_IBusCachedPlugin_l250 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
-  assign when_IBusCachedPlugin_l256 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
-  assign when_IBusCachedPlugin_l267 = (IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt);
+  assign when_IBusCachedPlugin_l245 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign when_IBusCachedPlugin_l250 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign when_IBusCachedPlugin_l256 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
+  assign when_IBusCachedPlugin_l262 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
+  assign when_IBusCachedPlugin_l273 = (IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt);
   assign IBusCachedPlugin_iBusRsp_output_valid = IBusCachedPlugin_iBusRsp_stages_2_output_valid;
   assign IBusCachedPlugin_iBusRsp_stages_2_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
   assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_decode_data;
   assign IBusCachedPlugin_iBusRsp_output_payload_pc = IBusCachedPlugin_iBusRsp_stages_2_output_payload;
   assign IBusCachedPlugin_cache_io_flush = (decode_arbitration_isValid && decode_FLUSH_ALL);
-  assign dataCache_1_io_mem_cmd_ready = (! dataCache_1_io_mem_cmd_rValid);
-  assign dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || dataCache_1_io_mem_cmd_rValid);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_wr : dataCache_1_io_mem_cmd_payload_wr);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_uncached : dataCache_1_io_mem_cmd_payload_uncached);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_address = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_address : dataCache_1_io_mem_cmd_payload_address);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_data = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_data : dataCache_1_io_mem_cmd_payload_data);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_mask : dataCache_1_io_mem_cmd_payload_mask);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_size = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_size : dataCache_1_io_mem_cmd_payload_size);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_last : dataCache_1_io_mem_cmd_payload_last);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || (! toplevel_dataCache_1_io_mem_cmd_rValidN));
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_wr : toplevel_dataCache_1_io_mem_cmd_rData_wr);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_uncached : toplevel_dataCache_1_io_mem_cmd_rData_uncached);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_address = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_address : toplevel_dataCache_1_io_mem_cmd_rData_address);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_data = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_data : toplevel_dataCache_1_io_mem_cmd_rData_data);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_mask : toplevel_dataCache_1_io_mem_cmd_rData_mask);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_size = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_size : toplevel_dataCache_1_io_mem_cmd_rData_size);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_last = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_last : toplevel_dataCache_1_io_mem_cmd_rData_last);
   always @(*) begin
-    dataCache_1_io_mem_cmd_s2mPipe_ready = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
-    if(when_Stream_l368) begin
-      dataCache_1_io_mem_cmd_s2mPipe_ready = 1'b1;
+    toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
+    if(when_Stream_l369) begin
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l368 = (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_rValid;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_rData_address;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_rData_data;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size = dataCache_1_io_mem_cmd_s2mPipe_rData_size;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_rData_last;
-  assign dBus_cmd_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
-  assign dBus_cmd_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
-  assign dBus_cmd_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
-  assign dBus_cmd_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
-  assign dBus_cmd_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
-  assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  assign dBus_cmd_payload_size = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
-  assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  assign when_DBusCachedPlugin_l308 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
+  assign when_Stream_l369 = (! toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_address;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_data;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_size;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  assign dBus_cmd_valid = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
+  assign dBus_cmd_payload_wr = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
+  assign dBus_cmd_payload_uncached = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
+  assign dBus_cmd_payload_address = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
+  assign dBus_cmd_payload_data = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
+  assign dBus_cmd_payload_mask = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
+  assign dBus_cmd_payload_size = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
+  assign dBus_cmd_payload_last = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  assign when_DBusCachedPlugin_l352 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
   assign dataCache_1_io_cpu_execute_isValid = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
   assign dataCache_1_io_cpu_execute_address = execute_SRC_ADD;
@@ -3341,11 +3334,11 @@ module VexRiscv (
   end
 
   assign dataCache_1_io_cpu_flush_valid = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
-  assign dataCache_1_io_cpu_flush_payload_singleLine = (execute_INSTRUCTION[19 : 15] != 5'h0);
+  assign dataCache_1_io_cpu_flush_payload_singleLine = (execute_INSTRUCTION[19 : 15] != 5'h00);
   assign dataCache_1_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId[6:0];
-  assign dataCache_1_io_cpu_flush_isStall = (dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready));
-  assign when_DBusCachedPlugin_l350 = (dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
-  assign when_DBusCachedPlugin_l366 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
+  assign toplevel_dataCache_1_io_cpu_flush_isStall = (dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready));
+  assign when_DBusCachedPlugin_l394 = (toplevel_dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
+  assign when_DBusCachedPlugin_l410 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
   assign dataCache_1_io_cpu_memory_isValid = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
   assign dataCache_1_io_cpu_memory_address = memory_REGFILE_WRITE_DATA;
   assign DBusCachedPlugin_mmuBus_cmd_0_isValid = dataCache_1_io_cpu_memory_isValid;
@@ -3355,12 +3348,12 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
   always @(*) begin
     dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if(when_DBusCachedPlugin_l393) begin
+    if(when_DBusCachedPlugin_l472) begin
       dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = 1'b1;
     end
   end
 
-  assign when_DBusCachedPlugin_l393 = (1'b0 && (! dataCache_1_io_cpu_memory_isWrite));
+  assign when_DBusCachedPlugin_l472 = (1'b0 && (! dataCache_1_io_cpu_memory_isWrite));
   always @(*) begin
     dataCache_1_io_cpu_writeBack_isValid = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
     if(writeBack_arbitration_haltByOther) begin
@@ -3373,7 +3366,7 @@ module VexRiscv (
   assign dataCache_1_io_cpu_writeBack_storeData[31 : 0] = writeBack_MEMORY_STORE_DATA_RF;
   always @(*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(when_DBusCachedPlugin_l446) begin
+    if(when_DBusCachedPlugin_l533) begin
       if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
@@ -3383,7 +3376,7 @@ module VexRiscv (
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(when_DBusCachedPlugin_l446) begin
+    if(when_DBusCachedPlugin_l533) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
@@ -3402,7 +3395,7 @@ module VexRiscv (
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
-    if(when_DBusCachedPlugin_l446) begin
+    if(when_DBusCachedPlugin_l533) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code};
       end
@@ -3415,12 +3408,13 @@ module VexRiscv (
     end
   end
 
-  assign when_DBusCachedPlugin_l446 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign when_DBusCachedPlugin_l466 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
-  assign writeBack_DBusCachedPlugin_rspSplits_0 = dataCache_1_io_cpu_writeBack_data[7 : 0];
-  assign writeBack_DBusCachedPlugin_rspSplits_1 = dataCache_1_io_cpu_writeBack_data[15 : 8];
-  assign writeBack_DBusCachedPlugin_rspSplits_2 = dataCache_1_io_cpu_writeBack_data[23 : 16];
-  assign writeBack_DBusCachedPlugin_rspSplits_3 = dataCache_1_io_cpu_writeBack_data[31 : 24];
+  assign when_DBusCachedPlugin_l533 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l553 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
+  assign writeBack_DBusCachedPlugin_rspData = dataCache_1_io_cpu_writeBack_data;
+  assign writeBack_DBusCachedPlugin_rspSplits_0 = writeBack_DBusCachedPlugin_rspData[7 : 0];
+  assign writeBack_DBusCachedPlugin_rspSplits_1 = writeBack_DBusCachedPlugin_rspData[15 : 8];
+  assign writeBack_DBusCachedPlugin_rspSplits_2 = writeBack_DBusCachedPlugin_rspData[23 : 16];
+  assign writeBack_DBusCachedPlugin_rspSplits_3 = writeBack_DBusCachedPlugin_rspData[31 : 24];
   always @(*) begin
     writeBack_DBusCachedPlugin_rspShifted[7 : 0] = _zz_writeBack_DBusCachedPlugin_rspShifted;
     writeBack_DBusCachedPlugin_rspShifted[15 : 8] = _zz_writeBack_DBusCachedPlugin_rspShifted_2;
@@ -3429,7 +3423,7 @@ module VexRiscv (
   end
 
   assign writeBack_DBusCachedPlugin_rspRf = writeBack_DBusCachedPlugin_rspShifted[31 : 0];
-  assign switch_Misc_l210 = writeBack_INSTRUCTION[13 : 12];
+  assign switch_Misc_l232 = writeBack_INSTRUCTION[13 : 12];
   assign _zz_writeBack_DBusCachedPlugin_rspFormated = (writeBack_DBusCachedPlugin_rspRf[7] && (! writeBack_INSTRUCTION[14]));
   always @(*) begin
     _zz_writeBack_DBusCachedPlugin_rspFormated_1[31] = _zz_writeBack_DBusCachedPlugin_rspFormated;
@@ -3481,7 +3475,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    case(switch_Misc_l210)
+    case(switch_Misc_l232)
       2'b00 : begin
         writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_1;
       end
@@ -3494,7 +3488,7 @@ module VexRiscv (
     endcase
   end
 
-  assign when_DBusCachedPlugin_l492 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l580 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
   assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
@@ -3514,10 +3508,10 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign DBusCachedPlugin_mmuBus_busy = 1'b0;
   assign _zz_decode_IS_RS2_SIGNED_1 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_decode_IS_RS2_SIGNED_2 = ((decode_INSTRUCTION & 32'h00000018) == 32'h0);
+  assign _zz_decode_IS_RS2_SIGNED_2 = ((decode_INSTRUCTION & 32'h00000018) == 32'h00000000);
   assign _zz_decode_IS_RS2_SIGNED_3 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
   assign _zz_decode_IS_RS2_SIGNED_4 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_decode_IS_RS2_SIGNED_5 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
+  assign _zz_decode_IS_RS2_SIGNED_5 = ((decode_INSTRUCTION & 32'h00001000) == 32'h00000000);
   assign _zz_decode_IS_RS2_SIGNED = {(|_zz_decode_IS_RS2_SIGNED_5),{(|_zz_decode_IS_RS2_SIGNED_5),{(|(_zz__zz_decode_IS_RS2_SIGNED == _zz__zz_decode_IS_RS2_SIGNED_1)),{(|_zz__zz_decode_IS_RS2_SIGNED_2),{(|_zz__zz_decode_IS_RS2_SIGNED_3),{_zz__zz_decode_IS_RS2_SIGNED_4,{_zz__zz_decode_IS_RS2_SIGNED_6,_zz__zz_decode_IS_RS2_SIGNED_9}}}}}}};
   assign _zz_decode_SRC1_CTRL_2 = _zz_decode_IS_RS2_SIGNED[2 : 1];
   assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
@@ -3536,29 +3530,29 @@ module VexRiscv (
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
-  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h0);
+  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h00);
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
   assign decode_RegFilePlugin_rs1Data = _zz_RegFilePlugin_regFile_port0;
   assign decode_RegFilePlugin_rs2Data = _zz_RegFilePlugin_regFile_port1;
   always @(*) begin
     lastStageRegFileWrite_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
-    if(_zz_7) begin
+    if(_zz_10) begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
   always @(*) begin
     lastStageRegFileWrite_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
-    if(_zz_7) begin
-      lastStageRegFileWrite_payload_address = 5'h0;
+    if(_zz_10) begin
+      lastStageRegFileWrite_payload_address = 5'h00;
     end
   end
 
   always @(*) begin
     lastStageRegFileWrite_payload_data = _zz_decode_RS2_2;
-    if(_zz_7) begin
-      lastStageRegFileWrite_payload_data = 32'h0;
+    if(_zz_10) begin
+      lastStageRegFileWrite_payload_data = 32'h00000000;
     end
   end
 
@@ -3599,7 +3593,7 @@ module VexRiscv (
         _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
       Src1CtrlEnum_IMU : begin
-        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h000};
       end
       default : begin
         _zz_execute_SRC1 = {27'd0, _zz__zz_execute_SRC1_1};
@@ -3607,67 +3601,67 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_execute_SRC2_1 = execute_INSTRUCTION[31];
+  assign _zz_execute_SRC2 = execute_INSTRUCTION[31];
   always @(*) begin
-    _zz_execute_SRC2_2[19] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[18] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[17] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[16] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[15] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[14] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[13] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[12] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[11] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[10] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[9] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[8] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[7] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[6] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[5] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[4] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[3] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[2] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[1] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[0] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_1[19] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[18] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[17] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[16] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[15] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[14] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[13] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[12] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[11] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[10] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[9] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[8] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[7] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[6] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[5] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[4] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[3] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[2] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[1] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[0] = _zz_execute_SRC2;
   end
 
-  assign _zz_execute_SRC2_3 = _zz__zz_execute_SRC2_3[11];
+  assign _zz_execute_SRC2_2 = _zz__zz_execute_SRC2_2[11];
   always @(*) begin
-    _zz_execute_SRC2_4[19] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[18] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[17] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[16] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[15] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[14] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[13] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[12] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[11] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[10] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[9] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[8] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[7] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[6] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[5] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[4] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[3] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[2] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[1] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[0] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_3[19] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[18] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[17] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[16] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[15] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[14] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[13] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[12] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[11] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[10] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[9] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[8] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[7] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[6] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[5] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[4] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[3] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[2] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[1] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[0] = _zz_execute_SRC2_2;
   end
 
   always @(*) begin
     case(execute_SRC2_CTRL)
       Src2CtrlEnum_RS : begin
-        _zz_execute_SRC2_5 = execute_RS2;
+        _zz_execute_SRC2_4 = execute_RS2;
       end
       Src2CtrlEnum_IMI : begin
-        _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
+        _zz_execute_SRC2_4 = {_zz_execute_SRC2_1,execute_INSTRUCTION[31 : 20]};
       end
       Src2CtrlEnum_IMS : begin
-        _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_execute_SRC2_4 = {_zz_execute_SRC2_3,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_execute_SRC2_5 = _zz_execute_SRC2;
+        _zz_execute_SRC2_4 = _zz_execute_to_memory_PC;
       end
     endcase
   end
@@ -3833,16 +3827,19 @@ module VexRiscv (
   assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
   assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign switch_Misc_l210_1 = execute_INSTRUCTION[14 : 12];
+  assign switch_Misc_l232_1 = execute_INSTRUCTION[14 : 12];
   always @(*) begin
-    casez(switch_Misc_l210_1)
+    case(switch_Misc_l232_1)
       3'b000 : begin
         _zz_execute_BRANCH_COND_RESULT = execute_BranchPlugin_eq;
       end
       3'b001 : begin
         _zz_execute_BRANCH_COND_RESULT = (! execute_BranchPlugin_eq);
       end
-      3'b1?1 : begin
+      3'b101 : begin
+        _zz_execute_BRANCH_COND_RESULT = (! execute_SRC_LESS);
+      end
+      3'b111 : begin
         _zz_execute_BRANCH_COND_RESULT = (! execute_SRC_LESS);
       end
       default : begin
@@ -4046,9 +4043,11 @@ module VexRiscv (
     end
   end
 
-  assign _zz_when_CsrPlugin_l965 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_when_CsrPlugin_l965_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_when_CsrPlugin_l965_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign CsrPlugin_misa_base = 2'b01;
+  assign CsrPlugin_misa_extensions = 26'h0000042;
+  assign _zz_when_CsrPlugin_l1302 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l1302_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l1302_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
   assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
@@ -4093,28 +4092,28 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l922 = (! decode_arbitration_isStuck);
-  assign when_CsrPlugin_l922_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l922_2 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l922_3 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l935 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
+  assign when_CsrPlugin_l1259 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l1272 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-  assign when_CsrPlugin_l959 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign when_CsrPlugin_l965 = ((_zz_when_CsrPlugin_l965 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l965_1 = ((_zz_when_CsrPlugin_l965_1 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l965_2 = ((_zz_when_CsrPlugin_l965_2 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1296 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l1302 = ((_zz_when_CsrPlugin_l1302 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1302_1 = ((_zz_when_CsrPlugin_l1302_1 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1302_2 = ((_zz_when_CsrPlugin_l1302_2 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  assign when_CsrPlugin_l993 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l993_1 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l993_2 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l998 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  assign when_CsrPlugin_l1335 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1335_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l1335_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l1340 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
   always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(when_CsrPlugin_l1004) begin
+    if(when_CsrPlugin_l1346) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException) begin
@@ -4122,7 +4121,7 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l1004 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
+  assign when_CsrPlugin_l1346 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
   always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
@@ -4138,6 +4137,7 @@ module VexRiscv (
     end
   end
 
+  assign CsrPlugin_trapCauseEbreakDebug = 1'b0;
   always @(*) begin
     CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
@@ -4160,13 +4160,15 @@ module VexRiscv (
     endcase
   end
 
-  assign when_CsrPlugin_l1032 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign when_CsrPlugin_l1077 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
-  assign switch_CsrPlugin_l1081 = writeBack_INSTRUCTION[29 : 28];
+  assign CsrPlugin_trapEnterDebug = 1'b0;
+  assign when_CsrPlugin_l1390 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1398 = (! CsrPlugin_trapEnterDebug);
+  assign when_CsrPlugin_l1456 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign switch_CsrPlugin_l1460 = writeBack_INSTRUCTION[29 : 28];
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign when_CsrPlugin_l1121 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_WFI));
-  assign when_CsrPlugin_l1123 = (! execute_CsrPlugin_wfiWake);
-  assign when_CsrPlugin_l1129 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
+  assign when_CsrPlugin_l1519 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_WFI));
+  assign when_CsrPlugin_l1521 = (! execute_CsrPlugin_wfiWake);
+  assign when_CsrPlugin_l1527 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
   assign execute_CsrPlugin_blockedBySideEffects = ((|{writeBack_arbitration_isValid,memory_arbitration_isValid}) || 1'b0);
   always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
@@ -4265,18 +4267,18 @@ module VexRiscv (
     if(CsrPlugin_csrMapping_allowCsrSignal) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(when_CsrPlugin_l1315) begin
+    if(when_CsrPlugin_l1725) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if(when_CsrPlugin_l1149) begin
-      if(when_CsrPlugin_l1150) begin
+    if(when_CsrPlugin_l1547) begin
+      if(when_CsrPlugin_l1548) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
@@ -4284,20 +4286,20 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(when_CsrPlugin_l1142) begin
+    if(when_CsrPlugin_l1540) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1157) begin
+    if(when_CsrPlugin_l1555) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(when_CsrPlugin_l1142) begin
+    if(when_CsrPlugin_l1540) begin
       CsrPlugin_selfException_payload_code = 4'b0010;
     end
-    if(when_CsrPlugin_l1157) begin
+    if(when_CsrPlugin_l1555) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -4310,20 +4312,20 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  assign when_CsrPlugin_l1142 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
-  assign when_CsrPlugin_l1149 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
-  assign when_CsrPlugin_l1150 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
-  assign when_CsrPlugin_l1157 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
+  assign when_CsrPlugin_l1540 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
+  assign when_CsrPlugin_l1547 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign when_CsrPlugin_l1548 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1555 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
   always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -4332,9 +4334,9 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
   assign execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
-  assign switch_Misc_l210_2 = execute_INSTRUCTION[13];
+  assign switch_Misc_l232_2 = execute_INSTRUCTION[13];
   always @(*) begin
-    case(switch_Misc_l210_2)
+    case(switch_Misc_l232_2)
       1'b0 : begin
         _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
@@ -4345,8 +4347,8 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
-  assign when_CsrPlugin_l1189 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign when_CsrPlugin_l1193 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
+  assign when_CsrPlugin_l1587 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1591 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
@@ -4409,12 +4411,12 @@ module VexRiscv (
   assign memory_DivPlugin_div_counter_willOverflow = (memory_DivPlugin_div_counter_willOverflowIfInc && memory_DivPlugin_div_counter_willIncrement);
   always @(*) begin
     if(memory_DivPlugin_div_counter_willOverflow) begin
-      memory_DivPlugin_div_counter_valueNext = 6'h0;
+      memory_DivPlugin_div_counter_valueNext = 6'h00;
     end else begin
       memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_memory_DivPlugin_div_counter_valueNext);
     end
     if(memory_DivPlugin_div_counter_willClear) begin
-      memory_DivPlugin_div_counter_valueNext = 6'h0;
+      memory_DivPlugin_div_counter_valueNext = 6'h00;
     end
   end
 
@@ -4438,8 +4440,8 @@ module VexRiscv (
     _zz_memory_DivPlugin_rs1_1[31 : 0] = execute_RS1;
   end
 
-  assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
-  assign externalInterrupt = (|_zz_CsrPlugin_csrMapping_readDataInit_1);
+  assign _zz_externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
+  assign externalInterrupt = (|_zz_externalInterrupt);
   assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
@@ -4555,205 +4557,214 @@ module VexRiscv (
   assign when_Pipeline_l154_1 = ((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt));
   assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
   assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
-  assign when_CsrPlugin_l1277 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_2 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_3 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_4 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_5 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_6 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_7 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_8 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_9 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_10 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_11 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_12 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_13 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_14 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_15 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_16 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_17 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_18 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_19 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_20 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_21 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_22 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_23 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_8 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_9 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_10 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_11 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_12 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_13 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_14 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_15 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_16 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_17 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_18 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_19 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_20 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_21 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_22 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_23 = (! execute_arbitration_isStuck);
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_1 = 32'h00000000;
     if(execute_CsrPlugin_csr_3264) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_2[12 : 0] = 13'h1000;
-      _zz_CsrPlugin_csrMapping_readDataInit_2[25 : 20] = 6'h20;
+      _zz_CsrPlugin_csrMapping_readDataInit_1[12 : 0] = 13'h1000;
+      _zz_CsrPlugin_csrMapping_readDataInit_1[25 : 20] = 6'h20;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h00000000;
     if(execute_CsrPlugin_csr_3857) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_3[3 : 0] = 4'b1011;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[3 : 0] = 4'b1011;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h00000000;
     if(execute_CsrPlugin_csr_3858) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_4[4 : 0] = 5'h16;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[4 : 0] = 5'h16;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h00000000;
     if(execute_CsrPlugin_csr_3859) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_5[5 : 0] = 6'h21;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[5 : 0] = 6'h21;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h00000000;
     if(execute_CsrPlugin_csr_769) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_6[31 : 30] = CsrPlugin_misa_base;
-      _zz_CsrPlugin_csrMapping_readDataInit_6[25 : 0] = CsrPlugin_misa_extensions;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[31 : 30] = CsrPlugin_misa_base;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[25 : 0] = CsrPlugin_misa_extensions;
     end
   end
 
-  assign switch_CsrPlugin_l723 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
+  assign switch_CsrPlugin_l1031 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h00000000;
     if(execute_CsrPlugin_csr_768) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_7[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_7[3 : 3] = CsrPlugin_mstatus_MIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_7[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[12 : 11] = CsrPlugin_mstatus_MPP;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h00000000;
     if(execute_CsrPlugin_csr_836) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_8[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_8[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_8[3 : 3] = CsrPlugin_mip_MSIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[3 : 3] = CsrPlugin_mip_MSIP;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h00000000;
     if(execute_CsrPlugin_csr_772) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_9[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_9[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_9[3 : 3] = CsrPlugin_mie_MSIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_8[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_8[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_8[3 : 3] = CsrPlugin_mie_MSIE;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_10 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h00000000;
     if(execute_CsrPlugin_csr_773) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_10[31 : 2] = CsrPlugin_mtvec_base;
-      _zz_CsrPlugin_csrMapping_readDataInit_10[1 : 0] = CsrPlugin_mtvec_mode;
+      _zz_CsrPlugin_csrMapping_readDataInit_9[31 : 2] = CsrPlugin_mtvec_base;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_11 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_10 = 32'h00000000;
     if(execute_CsrPlugin_csr_833) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_11[31 : 0] = CsrPlugin_mepc;
+      _zz_CsrPlugin_csrMapping_readDataInit_10[31 : 0] = CsrPlugin_mepc;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_12 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_11 = 32'h00000000;
     if(execute_CsrPlugin_csr_832) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_12[31 : 0] = CsrPlugin_mscratch;
+      _zz_CsrPlugin_csrMapping_readDataInit_11[31 : 0] = CsrPlugin_mscratch;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_13 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_12 = 32'h00000000;
     if(execute_CsrPlugin_csr_834) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_13[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_CsrPlugin_csrMapping_readDataInit_13[3 : 0] = CsrPlugin_mcause_exceptionCode;
+      _zz_CsrPlugin_csrMapping_readDataInit_12[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_CsrPlugin_csrMapping_readDataInit_12[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_14 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_13 = 32'h00000000;
     if(execute_CsrPlugin_csr_835) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_14[31 : 0] = CsrPlugin_mtval;
+      _zz_CsrPlugin_csrMapping_readDataInit_13[31 : 0] = CsrPlugin_mtval;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_15 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_14 = 32'h00000000;
     if(execute_CsrPlugin_csr_2816) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_15[31 : 0] = CsrPlugin_mcycle[31 : 0];
+      _zz_CsrPlugin_csrMapping_readDataInit_14[31 : 0] = CsrPlugin_mcycle[31 : 0];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_16 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_15 = 32'h00000000;
     if(execute_CsrPlugin_csr_2944) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_16[31 : 0] = CsrPlugin_mcycle[63 : 32];
+      _zz_CsrPlugin_csrMapping_readDataInit_15[31 : 0] = CsrPlugin_mcycle[63 : 32];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_17 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_16 = 32'h00000000;
     if(execute_CsrPlugin_csr_2818) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_17[31 : 0] = CsrPlugin_minstret[31 : 0];
+      _zz_CsrPlugin_csrMapping_readDataInit_16[31 : 0] = CsrPlugin_minstret[31 : 0];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_18 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_17 = 32'h00000000;
     if(execute_CsrPlugin_csr_2946) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_18[31 : 0] = CsrPlugin_minstret[63 : 32];
+      _zz_CsrPlugin_csrMapping_readDataInit_17[31 : 0] = CsrPlugin_minstret[63 : 32];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_19 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_18 = 32'h00000000;
     if(execute_CsrPlugin_csr_3072) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_19[31 : 0] = CsrPlugin_mcycle[31 : 0];
+      _zz_CsrPlugin_csrMapping_readDataInit_18[31 : 0] = CsrPlugin_mcycle[31 : 0];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_20 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_19 = 32'h00000000;
     if(execute_CsrPlugin_csr_3200) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_20[31 : 0] = CsrPlugin_mcycle[63 : 32];
+      _zz_CsrPlugin_csrMapping_readDataInit_19[31 : 0] = CsrPlugin_mcycle[63 : 32];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_21 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_20 = 32'h00000000;
     if(execute_CsrPlugin_csr_3074) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_21[31 : 0] = CsrPlugin_minstret[31 : 0];
+      _zz_CsrPlugin_csrMapping_readDataInit_20[31 : 0] = CsrPlugin_minstret[31 : 0];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_22 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_21 = 32'h00000000;
     if(execute_CsrPlugin_csr_3202) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_22[31 : 0] = CsrPlugin_minstret[63 : 32];
+      _zz_CsrPlugin_csrMapping_readDataInit_21[31 : 0] = CsrPlugin_minstret[63 : 32];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_23 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_22 = 32'h00000000;
     if(execute_CsrPlugin_csr_3008) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_23[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
+      _zz_CsrPlugin_csrMapping_readDataInit_22[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_24 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_23 = 32'h00000000;
     if(execute_CsrPlugin_csr_4032) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_24[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_1;
+      _zz_CsrPlugin_csrMapping_readDataInit_23[31 : 0] = _zz_externalInterrupt;
     end
   end
 
-  assign CsrPlugin_csrMapping_readDataInit = (((((_zz_CsrPlugin_csrMapping_readDataInit_2 | _zz_CsrPlugin_csrMapping_readDataInit_3) | (_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5)) | ((_zz_CsrPlugin_csrMapping_readDataInit_25 | _zz_CsrPlugin_csrMapping_readDataInit_6) | (_zz_CsrPlugin_csrMapping_readDataInit_7 | _zz_CsrPlugin_csrMapping_readDataInit_8))) | (((_zz_CsrPlugin_csrMapping_readDataInit_9 | _zz_CsrPlugin_csrMapping_readDataInit_10) | (_zz_CsrPlugin_csrMapping_readDataInit_11 | _zz_CsrPlugin_csrMapping_readDataInit_12)) | ((_zz_CsrPlugin_csrMapping_readDataInit_13 | _zz_CsrPlugin_csrMapping_readDataInit_14) | (_zz_CsrPlugin_csrMapping_readDataInit_15 | _zz_CsrPlugin_csrMapping_readDataInit_16)))) | (((_zz_CsrPlugin_csrMapping_readDataInit_17 | _zz_CsrPlugin_csrMapping_readDataInit_18) | (_zz_CsrPlugin_csrMapping_readDataInit_19 | _zz_CsrPlugin_csrMapping_readDataInit_20)) | ((_zz_CsrPlugin_csrMapping_readDataInit_21 | _zz_CsrPlugin_csrMapping_readDataInit_22) | (_zz_CsrPlugin_csrMapping_readDataInit_23 | _zz_CsrPlugin_csrMapping_readDataInit_24))));
-  assign when_CsrPlugin_l1310 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign when_CsrPlugin_l1315 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign CsrPlugin_csrMapping_readDataInit = (((((_zz_CsrPlugin_csrMapping_readDataInit_1 | _zz_CsrPlugin_csrMapping_readDataInit_2) | (_zz_CsrPlugin_csrMapping_readDataInit_3 | _zz_CsrPlugin_csrMapping_readDataInit_4)) | ((_zz_CsrPlugin_csrMapping_readDataInit_24 | _zz_CsrPlugin_csrMapping_readDataInit_5) | (_zz_CsrPlugin_csrMapping_readDataInit_6 | _zz_CsrPlugin_csrMapping_readDataInit_7))) | (((_zz_CsrPlugin_csrMapping_readDataInit_8 | _zz_CsrPlugin_csrMapping_readDataInit_9) | (_zz_CsrPlugin_csrMapping_readDataInit_10 | _zz_CsrPlugin_csrMapping_readDataInit_11)) | ((_zz_CsrPlugin_csrMapping_readDataInit_12 | _zz_CsrPlugin_csrMapping_readDataInit_13) | (_zz_CsrPlugin_csrMapping_readDataInit_14 | _zz_CsrPlugin_csrMapping_readDataInit_15)))) | (((_zz_CsrPlugin_csrMapping_readDataInit_16 | _zz_CsrPlugin_csrMapping_readDataInit_17) | (_zz_CsrPlugin_csrMapping_readDataInit_18 | _zz_CsrPlugin_csrMapping_readDataInit_19)) | ((_zz_CsrPlugin_csrMapping_readDataInit_20 | _zz_CsrPlugin_csrMapping_readDataInit_21) | (_zz_CsrPlugin_csrMapping_readDataInit_22 | _zz_CsrPlugin_csrMapping_readDataInit_23))));
+  assign when_CsrPlugin_l1702 = ((execute_arbitration_isValid && execute_IS_CSR) && (({execute_CsrPlugin_csrAddress[11 : 2],2'b00} == 12'h3a0) || ({execute_CsrPlugin_csrAddress[11 : 4],4'b0000} == 12'h3b0)));
+  assign _zz_when_CsrPlugin_l1709 = (execute_CsrPlugin_csrAddress & 12'hf60);
+  assign when_CsrPlugin_l1709 = (((execute_arbitration_isValid && execute_IS_CSR) && (5'h03 <= execute_CsrPlugin_csrAddress[4 : 0])) && (((_zz_when_CsrPlugin_l1709 == 12'hb00) || (((_zz_when_CsrPlugin_l1709 == 12'hc00) && (! execute_CsrPlugin_writeInstruction)) && (CsrPlugin_privilege == 2'b11))) || ((execute_CsrPlugin_csrAddress & 12'hfe0) == 12'h320)));
+  always @(*) begin
+    when_CsrPlugin_l1719 = CsrPlugin_csrMapping_doForceFailCsr;
+    if(when_CsrPlugin_l1717) begin
+      when_CsrPlugin_l1719 = 1'b1;
+    end
+  end
+
+  assign when_CsrPlugin_l1717 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1725 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
   assign iBusWishbone_ADR = {_zz_iBusWishbone_ADR_1,_zz_iBusWishbone_ADR};
   assign iBusWishbone_CTI = ((_zz_iBusWishbone_ADR == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
@@ -4779,20 +4790,20 @@ module VexRiscv (
   assign iBus_rsp_valid = _zz_iBus_rsp_valid;
   assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
   assign iBus_rsp_payload_error = 1'b0;
-  assign _zz_dBus_cmd_ready_5 = (dBus_cmd_payload_size == 3'b101);
-  assign _zz_dBus_cmd_ready_1 = dBus_cmd_valid;
-  assign _zz_dBus_cmd_ready_3 = dBus_cmd_payload_wr;
-  assign _zz_dBus_cmd_ready_4 = ((! _zz_dBus_cmd_ready_5) || (_zz_dBus_cmd_ready == 3'b111));
-  assign dBus_cmd_ready = (_zz_dBus_cmd_ready_2 && (_zz_dBus_cmd_ready_3 || _zz_dBus_cmd_ready_4));
-  assign dBusWishbone_ADR = ((_zz_dBus_cmd_ready_5 ? {{dBus_cmd_payload_address[31 : 5],_zz_dBus_cmd_ready},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
-  assign dBusWishbone_CTI = (_zz_dBus_cmd_ready_5 ? (_zz_dBus_cmd_ready_4 ? 3'b111 : 3'b010) : 3'b000);
+  assign _zz_dBusWishbone_ADR_1 = (dBus_cmd_payload_size == 3'b101);
+  assign _zz_dBusWishbone_CYC = dBus_cmd_valid;
+  assign _zz_dBus_cmd_ready_1 = dBus_cmd_payload_wr;
+  assign _zz_dBus_cmd_ready_2 = ((! _zz_dBusWishbone_ADR_1) || (_zz_dBusWishbone_ADR == 3'b111));
+  assign dBus_cmd_ready = (_zz_dBus_cmd_ready && (_zz_dBus_cmd_ready_1 || _zz_dBus_cmd_ready_2));
+  assign dBusWishbone_ADR = ((_zz_dBusWishbone_ADR_1 ? {{dBus_cmd_payload_address[31 : 5],_zz_dBusWishbone_ADR},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2'd2);
+  assign dBusWishbone_CTI = (_zz_dBusWishbone_ADR_1 ? (_zz_dBus_cmd_ready_2 ? 3'b111 : 3'b010) : 3'b000);
   assign dBusWishbone_BTE = 2'b00;
-  assign dBusWishbone_SEL = (_zz_dBus_cmd_ready_3 ? dBus_cmd_payload_mask : 4'b1111);
-  assign dBusWishbone_WE = _zz_dBus_cmd_ready_3;
+  assign dBusWishbone_SEL = (_zz_dBus_cmd_ready_1 ? dBus_cmd_payload_mask : 4'b1111);
+  assign dBusWishbone_WE = _zz_dBus_cmd_ready_1;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_payload_data;
-  assign _zz_dBus_cmd_ready_2 = (_zz_dBus_cmd_ready_1 && dBusWishbone_ACK);
-  assign dBusWishbone_CYC = _zz_dBus_cmd_ready_1;
-  assign dBusWishbone_STB = _zz_dBus_cmd_ready_1;
+  assign _zz_dBus_cmd_ready = (_zz_dBusWishbone_CYC && dBusWishbone_ACK);
+  assign dBusWishbone_CYC = _zz_dBusWishbone_CYC;
+  assign dBusWishbone_STB = _zz_dBusWishbone_CYC;
   assign dBus_rsp_valid = _zz_dBus_rsp_valid;
   assign dBus_rsp_payload_data = dBusWishbone_DAT_MISO_regNext;
   assign dBus_rsp_payload_error = 1'b0;
@@ -4802,29 +4813,27 @@ module VexRiscv (
       IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
-      _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+      _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= 1'b0;
       _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= 32'h0;
-      dataCache_1_io_mem_cmd_rValid <= 1'b0;
-      dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= 32'h0;
-      _zz_7 <= 1'b1;
+      IBusCachedPlugin_rspCounter <= 32'h00000000;
+      toplevel_dataCache_1_io_mem_cmd_rValidN <= 1'b1;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
+      DBusCachedPlugin_rspCounter <= 32'h00000000;
+      _zz_10 <= 1'b1;
       HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
-      CsrPlugin_misa_base <= 2'b01;
-      CsrPlugin_misa_extensions <= 26'h0000042;
       CsrPlugin_mstatus_MIE <= 1'b0;
       CsrPlugin_mstatus_MPIE <= 1'b0;
       CsrPlugin_mstatus_MPP <= 2'b11;
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
-      CsrPlugin_mcycle <= 64'h0;
-      CsrPlugin_minstret <= 64'h0;
+      CsrPlugin_mcycle <= 64'h0000000000000000;
+      CsrPlugin_minstret <= 64'h0000000000000000;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= 1'b0;
@@ -4836,14 +4845,14 @@ module VexRiscv (
       CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
-      memory_DivPlugin_div_counter_value <= 6'h0;
-      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h0;
+      memory_DivPlugin_div_counter_value <= 6'h00;
+      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h00000000;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
       _zz_iBusWishbone_ADR <= 3'b000;
       _zz_iBus_rsp_valid <= 1'b0;
-      _zz_dBus_cmd_ready <= 3'b000;
+      _zz_dBusWishbone_ADR <= 3'b000;
       _zz_dBus_rsp_valid <= 1'b0;
     end else begin
       if(IBusCachedPlugin_fetchPc_correction) begin
@@ -4853,23 +4862,23 @@ module VexRiscv (
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusCachedPlugin_fetchPc_booted <= 1'b1;
-      if(when_Fetcher_l134) begin
+      if(when_Fetcher_l133) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_output_fire_1) begin
+      if(IBusCachedPlugin_fetchPc_output_fire) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b1;
       end
-      if(when_Fetcher_l134_1) begin
+      if(when_Fetcher_l133_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(when_Fetcher_l161) begin
+      if(when_Fetcher_l160) begin
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
       if(IBusCachedPlugin_iBusRsp_flush) begin
-        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= 1'b0;
       end
       if(_zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready) begin
-        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
       if(IBusCachedPlugin_iBusRsp_flush) begin
         _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
@@ -4880,13 +4889,13 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if(when_Fetcher_l332) begin
+      if(when_Fetcher_l331) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(when_Fetcher_l332_1) begin
+      if(when_Fetcher_l331_1) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= IBusCachedPlugin_injector_nextPcCalc_valids_0;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -4895,7 +4904,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(when_Fetcher_l332_2) begin
+      if(when_Fetcher_l331_2) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= IBusCachedPlugin_injector_nextPcCalc_valids_1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -4904,7 +4913,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(when_Fetcher_l332_3) begin
+      if(when_Fetcher_l331_3) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -4913,7 +4922,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if(when_Fetcher_l332_4) begin
+      if(when_Fetcher_l331_4) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= IBusCachedPlugin_injector_nextPcCalc_valids_3;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -4923,68 +4932,68 @@ module VexRiscv (
         IBusCachedPlugin_rspCounter <= (IBusCachedPlugin_rspCounter + 32'h00000001);
       end
       if(dataCache_1_io_mem_cmd_valid) begin
-        dataCache_1_io_mem_cmd_rValid <= 1'b1;
+        toplevel_dataCache_1_io_mem_cmd_rValidN <= 1'b0;
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
-        dataCache_1_io_mem_cmd_rValid <= 1'b0;
+      if(toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+        toplevel_dataCache_1_io_mem_cmd_rValidN <= 1'b1;
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
-        dataCache_1_io_mem_cmd_s2mPipe_rValid <= dataCache_1_io_mem_cmd_s2mPipe_valid;
+      if(toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+        toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_valid;
       end
       if(dBus_rsp_valid) begin
         DBusCachedPlugin_rspCounter <= (DBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      _zz_7 <= 1'b0;
+      _zz_10 <= 1'b0;
       HazardSimplePlugin_writeBackBuffer_valid <= HazardSimplePlugin_writeBackWrites_valid;
       CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
       if(writeBack_arbitration_isFiring) begin
         CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
       end
-      if(when_CsrPlugin_l922) begin
+      if(when_CsrPlugin_l1259) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if(when_CsrPlugin_l922_1) begin
+      if(when_CsrPlugin_l1259_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if(when_CsrPlugin_l922_2) begin
+      if(when_CsrPlugin_l1259_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if(when_CsrPlugin_l922_3) begin
+      if(when_CsrPlugin_l1259_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(when_CsrPlugin_l959) begin
-        if(when_CsrPlugin_l965) begin
+      if(when_CsrPlugin_l1296) begin
+        if(when_CsrPlugin_l1302) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_1) begin
+        if(when_CsrPlugin_l1302_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_2) begin
+        if(when_CsrPlugin_l1302_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
       CsrPlugin_lastStageWasWfi <= (writeBack_arbitration_isFiring && (writeBack_ENV_CTRL == EnvCtrlEnum_WFI));
       if(CsrPlugin_pipelineLiberator_active) begin
-        if(when_CsrPlugin_l993) begin
+        if(when_CsrPlugin_l1335) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if(when_CsrPlugin_l993_1) begin
+        if(when_CsrPlugin_l1335_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if(when_CsrPlugin_l993_2) begin
+        if(when_CsrPlugin_l1335_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(when_CsrPlugin_l998) begin
+      if(when_CsrPlugin_l1340) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
@@ -4993,19 +5002,21 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(when_CsrPlugin_l1032) begin
-        case(CsrPlugin_targetPrivilege)
-          2'b11 : begin
-            CsrPlugin_mstatus_MIE <= 1'b0;
-            CsrPlugin_mstatus_MPIE <= CsrPlugin_mstatus_MIE;
-            CsrPlugin_mstatus_MPP <= CsrPlugin_privilege;
-          end
-          default : begin
-          end
-        endcase
+      if(when_CsrPlugin_l1390) begin
+        if(when_CsrPlugin_l1398) begin
+          case(CsrPlugin_targetPrivilege)
+            2'b11 : begin
+              CsrPlugin_mstatus_MIE <= 1'b0;
+              CsrPlugin_mstatus_MPIE <= CsrPlugin_mstatus_MIE;
+              CsrPlugin_mstatus_MPP <= CsrPlugin_privilege;
+            end
+            default : begin
+            end
+          endcase
+        end
       end
-      if(when_CsrPlugin_l1077) begin
-        case(switch_CsrPlugin_l1081)
+      if(when_CsrPlugin_l1456) begin
+        case(switch_CsrPlugin_l1460)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -5015,7 +5026,7 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l965_2,{_zz_when_CsrPlugin_l965_1,_zz_when_CsrPlugin_l965}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l1302_2,{_zz_when_CsrPlugin_l1302_1,_zz_when_CsrPlugin_l1302}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
       if(when_Pipeline_l151) begin
         execute_arbitration_isValid <= 1'b0;
@@ -5035,17 +5046,11 @@ module VexRiscv (
       if(when_Pipeline_l154_2) begin
         writeBack_arbitration_isValid <= memory_arbitration_isValid;
       end
-      if(execute_CsrPlugin_csr_769) begin
-        if(execute_CsrPlugin_writeEnable) begin
-          CsrPlugin_misa_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 30];
-          CsrPlugin_misa_extensions <= CsrPlugin_csrMapping_writeDataSignal[25 : 0];
-        end
-      end
       if(execute_CsrPlugin_csr_768) begin
         if(execute_CsrPlugin_writeEnable) begin
           CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
           CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
-          case(switch_CsrPlugin_l723)
+          case(switch_CsrPlugin_l1031)
             2'b11 : begin
               CsrPlugin_mstatus_MPP <= 2'b11;
             end
@@ -5092,13 +5097,13 @@ module VexRiscv (
         end
       end
       _zz_iBus_rsp_valid <= (iBusWishbone_CYC && iBusWishbone_ACK);
-      if((_zz_dBus_cmd_ready_1 && _zz_dBus_cmd_ready_2)) begin
-        _zz_dBus_cmd_ready <= (_zz_dBus_cmd_ready + 3'b001);
-        if(_zz_dBus_cmd_ready_4) begin
-          _zz_dBus_cmd_ready <= 3'b000;
+      if((_zz_dBusWishbone_CYC && _zz_dBus_cmd_ready)) begin
+        _zz_dBusWishbone_ADR <= (_zz_dBusWishbone_ADR + 3'b001);
+        if(_zz_dBus_cmd_ready_2) begin
+          _zz_dBusWishbone_ADR <= 3'b000;
         end
       end
-      _zz_dBus_rsp_valid <= ((_zz_dBus_cmd_ready_1 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
+      _zz_dBus_rsp_valid <= ((_zz_dBusWishbone_CYC && (! dBusWishbone_WE)) && dBusWishbone_ACK);
     end
   end
 
@@ -5112,23 +5117,23 @@ module VexRiscv (
     if(IBusCachedPlugin_iBusRsp_stages_2_input_ready) begin
       IBusCachedPlugin_s2_tightlyCoupledHit <= IBusCachedPlugin_s1_tightlyCoupledHit;
     end
-    if(dataCache_1_io_mem_cmd_ready) begin
-      dataCache_1_io_mem_cmd_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
-      dataCache_1_io_mem_cmd_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
-      dataCache_1_io_mem_cmd_rData_address <= dataCache_1_io_mem_cmd_payload_address;
-      dataCache_1_io_mem_cmd_rData_data <= dataCache_1_io_mem_cmd_payload_data;
-      dataCache_1_io_mem_cmd_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
-      dataCache_1_io_mem_cmd_rData_size <= dataCache_1_io_mem_cmd_payload_size;
-      dataCache_1_io_mem_cmd_rData_last <= dataCache_1_io_mem_cmd_payload_last;
+    if(toplevel_dataCache_1_io_mem_cmd_rValidN) begin
+      toplevel_dataCache_1_io_mem_cmd_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
+      toplevel_dataCache_1_io_mem_cmd_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
+      toplevel_dataCache_1_io_mem_cmd_rData_address <= dataCache_1_io_mem_cmd_payload_address;
+      toplevel_dataCache_1_io_mem_cmd_rData_data <= dataCache_1_io_mem_cmd_payload_data;
+      toplevel_dataCache_1_io_mem_cmd_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
+      toplevel_dataCache_1_io_mem_cmd_rData_size <= dataCache_1_io_mem_cmd_payload_size;
+      toplevel_dataCache_1_io_mem_cmd_rData_last <= dataCache_1_io_mem_cmd_payload_last;
     end
-    if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
-      dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_address <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_data <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_size <= dataCache_1_io_mem_cmd_s2mPipe_payload_size;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_last <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+    if(toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_address <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_data <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_size <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_size;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_last <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_last;
     end
     HazardSimplePlugin_writeBackBuffer_payload_address <= HazardSimplePlugin_writeBackWrites_payload_address;
     HazardSimplePlugin_writeBackBuffer_payload_data <= HazardSimplePlugin_writeBackWrites_payload_data;
@@ -5151,33 +5156,35 @@ module VexRiscv (
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(when_CsrPlugin_l959) begin
-      if(when_CsrPlugin_l965) begin
+    if(when_CsrPlugin_l1296) begin
+      if(when_CsrPlugin_l1302) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l965_1) begin
+      if(when_CsrPlugin_l1302_1) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l965_2) begin
+      if(when_CsrPlugin_l1302_2) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(when_CsrPlugin_l1032) begin
-      case(CsrPlugin_targetPrivilege)
-        2'b11 : begin
-          CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
-          CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
-          CsrPlugin_mepc <= writeBack_PC;
-          if(CsrPlugin_hadException) begin
-            CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
+    if(when_CsrPlugin_l1390) begin
+      if(when_CsrPlugin_l1398) begin
+        case(CsrPlugin_targetPrivilege)
+          2'b11 : begin
+            CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
+            CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
+            CsrPlugin_mepc <= writeBack_PC;
+            if(CsrPlugin_hadException) begin
+              CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
+            end
           end
-        end
-        default : begin
-        end
-      endcase
+          default : begin
+          end
+        endcase
+      end
     end
     if(when_MulDivIterativePlugin_l126) begin
       memory_DivPlugin_div_done <= 1'b1;
@@ -5195,17 +5202,17 @@ module VexRiscv (
       end
     end
     if(when_MulDivIterativePlugin_l162) begin
-      memory_DivPlugin_accumulator <= 65'h0;
+      memory_DivPlugin_accumulator <= 65'h00000000000000000;
       memory_DivPlugin_rs1 <= ((_zz_memory_DivPlugin_rs1 ? (~ _zz_memory_DivPlugin_rs1_1) : _zz_memory_DivPlugin_rs1_1) + _zz_memory_DivPlugin_rs1_2);
       memory_DivPlugin_rs2 <= ((_zz_memory_DivPlugin_rs2 ? (~ execute_RS2) : execute_RS2) + _zz_memory_DivPlugin_rs2_1);
-      memory_DivPlugin_div_needRevert <= ((_zz_memory_DivPlugin_rs1 ^ (_zz_memory_DivPlugin_rs2 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
+      memory_DivPlugin_div_needRevert <= ((_zz_memory_DivPlugin_rs1 ^ (_zz_memory_DivPlugin_rs2 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h00000000) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
     end
     externalInterruptArray_regNext <= externalInterruptArray;
     if(when_Pipeline_l124) begin
       decode_to_execute_PC <= decode_PC;
     end
     if(when_Pipeline_l124_1) begin
-      execute_to_memory_PC <= _zz_execute_SRC2;
+      execute_to_memory_PC <= _zz_execute_to_memory_PC;
     end
     if(when_Pipeline_l124_2) begin
       memory_to_writeBack_PC <= memory_PC;
@@ -5387,76 +5394,76 @@ module VexRiscv (
     if(when_Pipeline_l124_61) begin
       memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
     end
-    if(when_CsrPlugin_l1277) begin
+    if(when_CsrPlugin_l1669) begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
     end
-    if(when_CsrPlugin_l1277_1) begin
+    if(when_CsrPlugin_l1669_1) begin
       execute_CsrPlugin_csr_3857 <= (decode_INSTRUCTION[31 : 20] == 12'hf11);
     end
-    if(when_CsrPlugin_l1277_2) begin
+    if(when_CsrPlugin_l1669_2) begin
       execute_CsrPlugin_csr_3858 <= (decode_INSTRUCTION[31 : 20] == 12'hf12);
     end
-    if(when_CsrPlugin_l1277_3) begin
+    if(when_CsrPlugin_l1669_3) begin
       execute_CsrPlugin_csr_3859 <= (decode_INSTRUCTION[31 : 20] == 12'hf13);
     end
-    if(when_CsrPlugin_l1277_4) begin
+    if(when_CsrPlugin_l1669_4) begin
       execute_CsrPlugin_csr_3860 <= (decode_INSTRUCTION[31 : 20] == 12'hf14);
     end
-    if(when_CsrPlugin_l1277_5) begin
+    if(when_CsrPlugin_l1669_5) begin
       execute_CsrPlugin_csr_769 <= (decode_INSTRUCTION[31 : 20] == 12'h301);
     end
-    if(when_CsrPlugin_l1277_6) begin
+    if(when_CsrPlugin_l1669_6) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if(when_CsrPlugin_l1277_7) begin
+    if(when_CsrPlugin_l1669_7) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if(when_CsrPlugin_l1277_8) begin
+    if(when_CsrPlugin_l1669_8) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if(when_CsrPlugin_l1277_9) begin
+    if(when_CsrPlugin_l1669_9) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if(when_CsrPlugin_l1277_10) begin
+    if(when_CsrPlugin_l1669_10) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if(when_CsrPlugin_l1277_11) begin
+    if(when_CsrPlugin_l1669_11) begin
       execute_CsrPlugin_csr_832 <= (decode_INSTRUCTION[31 : 20] == 12'h340);
     end
-    if(when_CsrPlugin_l1277_12) begin
+    if(when_CsrPlugin_l1669_12) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if(when_CsrPlugin_l1277_13) begin
+    if(when_CsrPlugin_l1669_13) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if(when_CsrPlugin_l1277_14) begin
+    if(when_CsrPlugin_l1669_14) begin
       execute_CsrPlugin_csr_2816 <= (decode_INSTRUCTION[31 : 20] == 12'hb00);
     end
-    if(when_CsrPlugin_l1277_15) begin
+    if(when_CsrPlugin_l1669_15) begin
       execute_CsrPlugin_csr_2944 <= (decode_INSTRUCTION[31 : 20] == 12'hb80);
     end
-    if(when_CsrPlugin_l1277_16) begin
+    if(when_CsrPlugin_l1669_16) begin
       execute_CsrPlugin_csr_2818 <= (decode_INSTRUCTION[31 : 20] == 12'hb02);
     end
-    if(when_CsrPlugin_l1277_17) begin
+    if(when_CsrPlugin_l1669_17) begin
       execute_CsrPlugin_csr_2946 <= (decode_INSTRUCTION[31 : 20] == 12'hb82);
     end
-    if(when_CsrPlugin_l1277_18) begin
+    if(when_CsrPlugin_l1669_18) begin
       execute_CsrPlugin_csr_3072 <= (decode_INSTRUCTION[31 : 20] == 12'hc00);
     end
-    if(when_CsrPlugin_l1277_19) begin
+    if(when_CsrPlugin_l1669_19) begin
       execute_CsrPlugin_csr_3200 <= (decode_INSTRUCTION[31 : 20] == 12'hc80);
     end
-    if(when_CsrPlugin_l1277_20) begin
+    if(when_CsrPlugin_l1669_20) begin
       execute_CsrPlugin_csr_3074 <= (decode_INSTRUCTION[31 : 20] == 12'hc02);
     end
-    if(when_CsrPlugin_l1277_21) begin
+    if(when_CsrPlugin_l1669_21) begin
       execute_CsrPlugin_csr_3202 <= (decode_INSTRUCTION[31 : 20] == 12'hc82);
     end
-    if(when_CsrPlugin_l1277_22) begin
+    if(when_CsrPlugin_l1669_22) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if(when_CsrPlugin_l1277_23) begin
+    if(when_CsrPlugin_l1669_23) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
     if(execute_CsrPlugin_csr_836) begin
@@ -5467,7 +5474,6 @@ module VexRiscv (
     if(execute_CsrPlugin_csr_773) begin
       if(execute_CsrPlugin_writeEnable) begin
         CsrPlugin_mtvec_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 2];
-        CsrPlugin_mtvec_mode <= CsrPlugin_csrMapping_writeDataSignal[1 : 0];
       end
     end
     if(execute_CsrPlugin_csr_833) begin
@@ -5499,76 +5505,75 @@ module VexRiscv (
 endmodule
 
 module DataCache (
-  input               io_cpu_execute_isValid,
-  input      [31:0]   io_cpu_execute_address,
-  output reg          io_cpu_execute_haltIt,
-  input               io_cpu_execute_args_wr,
-  input      [1:0]    io_cpu_execute_args_size,
-  input               io_cpu_execute_args_totalyConsistent,
-  output              io_cpu_execute_refilling,
-  input               io_cpu_memory_isValid,
-  input               io_cpu_memory_isStuck,
-  output              io_cpu_memory_isWrite,
-  input      [31:0]   io_cpu_memory_address,
-  input      [31:0]   io_cpu_memory_mmuRsp_physicalAddress,
-  input               io_cpu_memory_mmuRsp_isIoAccess,
-  input               io_cpu_memory_mmuRsp_isPaging,
-  input               io_cpu_memory_mmuRsp_allowRead,
-  input               io_cpu_memory_mmuRsp_allowWrite,
-  input               io_cpu_memory_mmuRsp_allowExecute,
-  input               io_cpu_memory_mmuRsp_exception,
-  input               io_cpu_memory_mmuRsp_refilling,
-  input               io_cpu_memory_mmuRsp_bypassTranslation,
-  input               io_cpu_writeBack_isValid,
-  input               io_cpu_writeBack_isStuck,
-  input               io_cpu_writeBack_isFiring,
-  input               io_cpu_writeBack_isUser,
-  output reg          io_cpu_writeBack_haltIt,
-  output              io_cpu_writeBack_isWrite,
-  input      [31:0]   io_cpu_writeBack_storeData,
-  output reg [31:0]   io_cpu_writeBack_data,
-  input      [31:0]   io_cpu_writeBack_address,
-  output              io_cpu_writeBack_mmuException,
-  output              io_cpu_writeBack_unalignedAccess,
-  output reg          io_cpu_writeBack_accessError,
-  output              io_cpu_writeBack_keepMemRspData,
-  input               io_cpu_writeBack_fence_SW,
-  input               io_cpu_writeBack_fence_SR,
-  input               io_cpu_writeBack_fence_SO,
-  input               io_cpu_writeBack_fence_SI,
-  input               io_cpu_writeBack_fence_PW,
-  input               io_cpu_writeBack_fence_PR,
-  input               io_cpu_writeBack_fence_PO,
-  input               io_cpu_writeBack_fence_PI,
-  input      [3:0]    io_cpu_writeBack_fence_FM,
-  output              io_cpu_writeBack_exclusiveOk,
-  output reg          io_cpu_redo,
-  input               io_cpu_flush_valid,
-  output              io_cpu_flush_ready,
-  input               io_cpu_flush_payload_singleLine,
-  input      [6:0]    io_cpu_flush_payload_lineId,
-  output reg          io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output reg          io_mem_cmd_payload_wr,
-  output              io_mem_cmd_payload_uncached,
-  output reg [31:0]   io_mem_cmd_payload_address,
-  output     [31:0]   io_mem_cmd_payload_data,
-  output     [3:0]    io_mem_cmd_payload_mask,
-  output reg [2:0]    io_mem_cmd_payload_size,
-  output              io_mem_cmd_payload_last,
-  input               io_mem_rsp_valid,
-  input               io_mem_rsp_payload_last,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input               clk,
-  input               reset
+  input  wire          io_cpu_execute_isValid,
+  input  wire [31:0]   io_cpu_execute_address,
+  output reg           io_cpu_execute_haltIt,
+  input  wire          io_cpu_execute_args_wr,
+  input  wire [1:0]    io_cpu_execute_args_size,
+  input  wire          io_cpu_execute_args_totalyConsistent,
+  output wire          io_cpu_execute_refilling,
+  input  wire          io_cpu_memory_isValid,
+  input  wire          io_cpu_memory_isStuck,
+  output wire          io_cpu_memory_isWrite,
+  input  wire [31:0]   io_cpu_memory_address,
+  input  wire [31:0]   io_cpu_memory_mmuRsp_physicalAddress,
+  input  wire          io_cpu_memory_mmuRsp_isIoAccess,
+  input  wire          io_cpu_memory_mmuRsp_isPaging,
+  input  wire          io_cpu_memory_mmuRsp_allowRead,
+  input  wire          io_cpu_memory_mmuRsp_allowWrite,
+  input  wire          io_cpu_memory_mmuRsp_allowExecute,
+  input  wire          io_cpu_memory_mmuRsp_exception,
+  input  wire          io_cpu_memory_mmuRsp_refilling,
+  input  wire          io_cpu_memory_mmuRsp_bypassTranslation,
+  input  wire          io_cpu_writeBack_isValid,
+  input  wire          io_cpu_writeBack_isStuck,
+  input  wire          io_cpu_writeBack_isFiring,
+  input  wire          io_cpu_writeBack_isUser,
+  output reg           io_cpu_writeBack_haltIt,
+  output wire          io_cpu_writeBack_isWrite,
+  input  wire [31:0]   io_cpu_writeBack_storeData,
+  output reg  [31:0]   io_cpu_writeBack_data,
+  input  wire [31:0]   io_cpu_writeBack_address,
+  output wire          io_cpu_writeBack_mmuException,
+  output wire          io_cpu_writeBack_unalignedAccess,
+  output reg           io_cpu_writeBack_accessError,
+  output wire          io_cpu_writeBack_keepMemRspData,
+  input  wire          io_cpu_writeBack_fence_SW,
+  input  wire          io_cpu_writeBack_fence_SR,
+  input  wire          io_cpu_writeBack_fence_SO,
+  input  wire          io_cpu_writeBack_fence_SI,
+  input  wire          io_cpu_writeBack_fence_PW,
+  input  wire          io_cpu_writeBack_fence_PR,
+  input  wire          io_cpu_writeBack_fence_PO,
+  input  wire          io_cpu_writeBack_fence_PI,
+  input  wire [3:0]    io_cpu_writeBack_fence_FM,
+  output wire          io_cpu_writeBack_exclusiveOk,
+  output reg           io_cpu_redo,
+  input  wire          io_cpu_flush_valid,
+  output wire          io_cpu_flush_ready,
+  input  wire          io_cpu_flush_payload_singleLine,
+  input  wire [6:0]    io_cpu_flush_payload_lineId,
+  output wire          io_cpu_writesPending,
+  output reg           io_mem_cmd_valid,
+  input  wire          io_mem_cmd_ready,
+  output reg           io_mem_cmd_payload_wr,
+  output wire          io_mem_cmd_payload_uncached,
+  output reg  [31:0]   io_mem_cmd_payload_address,
+  output wire [31:0]   io_mem_cmd_payload_data,
+  output wire [3:0]    io_mem_cmd_payload_mask,
+  output reg  [2:0]    io_mem_cmd_payload_size,
+  output wire          io_mem_cmd_payload_last,
+  input  wire          io_mem_rsp_valid,
+  input  wire          io_mem_rsp_payload_last,
+  input  wire [31:0]   io_mem_rsp_payload_data,
+  input  wire          io_mem_rsp_payload_error,
+  input  wire          clk,
+  input  wire          reset
 );
 
   reg        [21:0]   _zz_ways_0_tags_port0;
   reg        [31:0]   _zz_ways_0_data_port0;
   wire       [21:0]   _zz_ways_0_tags_port;
-  wire       [9:0]    _zz_stage0_dataColisions;
-  wire       [9:0]    _zz__zz_stageA_dataColisions;
   wire       [0:0]    _zz_when;
   wire       [2:0]    _zz_loader_counter_valueNext;
   wire       [0:0]    _zz_loader_counter_valueNext_1;
@@ -5605,40 +5610,40 @@ module DataCache (
   wire                _zz_ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRsp;
-  wire                when_DataCache_l642;
   wire                when_DataCache_l645;
-  wire                when_DataCache_l664;
+  wire                when_DataCache_l648;
+  wire                when_DataCache_l667;
   wire                rspSync;
   wire                rspLast;
   reg                 memCmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_DataCache_l686;
+  wire                when_DataCache_l689;
   reg        [3:0]    _zz_stage0_mask;
   wire       [3:0]    stage0_mask;
   wire       [0:0]    stage0_dataColisions;
   wire       [0:0]    stage0_wayInvalidate;
   wire                stage0_isAmo;
-  wire                when_DataCache_l771;
+  wire                when_DataCache_l776;
   reg                 stageA_request_wr;
   reg        [1:0]    stageA_request_size;
   reg                 stageA_request_totalyConsistent;
-  wire                when_DataCache_l771_1;
+  wire                when_DataCache_l776_1;
   reg        [3:0]    stageA_mask;
   wire                stageA_isAmo;
   wire                stageA_isLrsc;
   wire       [0:0]    stageA_wayHits;
-  wire                when_DataCache_l771_2;
+  wire                when_DataCache_l776_2;
   reg        [0:0]    stageA_wayInvalidate;
-  wire                when_DataCache_l771_3;
+  wire                when_DataCache_l776_3;
   reg        [0:0]    stage0_dataColisions_regNextWhen;
   wire       [0:0]    _zz_stageA_dataColisions;
   wire       [0:0]    stageA_dataColisions;
-  wire                when_DataCache_l822;
+  wire                when_DataCache_l827;
   reg                 stageB_request_wr;
   reg        [1:0]    stageB_request_size;
   reg                 stageB_request_totalyConsistent;
   reg                 stageB_mmuRspFreeze;
-  wire                when_DataCache_l824;
+  wire                when_DataCache_l829;
   reg        [31:0]   stageB_mmuRsp_physicalAddress;
   reg                 stageB_mmuRsp_isIoAccess;
   reg                 stageB_mmuRsp_isPaging;
@@ -5648,52 +5653,54 @@ module DataCache (
   reg                 stageB_mmuRsp_exception;
   reg                 stageB_mmuRsp_refilling;
   reg                 stageB_mmuRsp_bypassTranslation;
-  wire                when_DataCache_l821;
+  wire                when_DataCache_l826;
   reg                 stageB_tagsReadRsp_0_valid;
   reg                 stageB_tagsReadRsp_0_error;
   reg        [19:0]   stageB_tagsReadRsp_0_address;
-  wire                when_DataCache_l821_1;
+  wire                when_DataCache_l826_1;
   reg        [31:0]   stageB_dataReadRsp_0;
-  wire                when_DataCache_l820;
+  wire                when_DataCache_l825;
   reg        [0:0]    stageB_wayInvalidate;
   wire                stageB_consistancyHazard;
-  wire                when_DataCache_l820_1;
+  wire                when_DataCache_l825_1;
   reg        [0:0]    stageB_dataColisions;
-  wire                when_DataCache_l820_2;
+  wire                when_DataCache_l825_2;
   reg                 stageB_unaligned;
-  wire                when_DataCache_l820_3;
+  wire                when_DataCache_l825_3;
   reg        [0:0]    stageB_waysHitsBeforeInvalidate;
   wire       [0:0]    stageB_waysHits;
   wire                stageB_waysHit;
   wire       [31:0]   stageB_dataMux;
-  wire                when_DataCache_l820_4;
+  wire                when_DataCache_l825_4;
   reg        [3:0]    stageB_mask;
   reg                 stageB_loaderValid;
   wire       [31:0]   stageB_ioMemRspMuxed;
   reg                 stageB_flusher_waitDone;
   wire                stageB_flusher_hold;
   reg        [7:0]    stageB_flusher_counter;
-  wire                when_DataCache_l850;
-  wire                when_DataCache_l856;
+  wire                when_DataCache_l855;
+  wire                when_DataCache_l861;
+  wire                when_DataCache_l863;
   reg                 stageB_flusher_start;
+  wire                when_DataCache_l877;
   wire                stageB_isAmo;
   wire                stageB_isAmoCached;
   wire                stageB_isExternalLsrc;
   wire                stageB_isExternalAmo;
   wire       [31:0]   stageB_requestDataBypass;
   reg                 stageB_cpuWriteToCache;
-  wire                when_DataCache_l926;
+  wire                when_DataCache_l931;
   wire                stageB_badPermissions;
   wire                stageB_loadStoreFault;
   wire                stageB_bypassCache;
-  wire                when_DataCache_l995;
-  wire                when_DataCache_l1004;
+  wire                when_DataCache_l1000;
   wire                when_DataCache_l1009;
-  wire                when_DataCache_l1020;
-  wire                when_DataCache_l1032;
-  wire                when_DataCache_l991;
-  wire                when_DataCache_l1066;
-  wire                when_DataCache_l1075;
+  wire                when_DataCache_l1014;
+  wire                when_DataCache_l1025;
+  wire                when_DataCache_l1037;
+  wire                when_DataCache_l996;
+  wire                when_DataCache_l1072;
+  wire                when_DataCache_l1081;
   reg                 loader_valid;
   reg                 loader_counter_willIncrement;
   wire                loader_counter_willClear;
@@ -5705,12 +5712,12 @@ module DataCache (
   reg                 loader_error;
   wire                loader_kill;
   reg                 loader_killReg;
-  wire                when_DataCache_l1090;
+  wire                when_DataCache_l1097;
   wire                loader_done;
-  wire                when_DataCache_l1118;
-  reg                 loader_valid_regNext;
-  wire                when_DataCache_l1122;
   wire                when_DataCache_l1125;
+  reg                 loader_valid_regNext;
+  wire                when_DataCache_l1129;
+  wire                when_DataCache_l1132;
   (* no_rw_check , ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
   (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
   (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
@@ -5721,8 +5728,6 @@ module DataCache (
   reg [7:0] _zz_ways_0_datasymbol_read_2;
   reg [7:0] _zz_ways_0_datasymbol_read_3;
 
-  assign _zz_stage0_dataColisions = (io_cpu_execute_address[11 : 2] >>> 0);
-  assign _zz__zz_stageA_dataColisions = (io_cpu_memory_address[11 : 2] >>> 0);
   assign _zz_when = 1'b1;
   assign _zz_loader_counter_valueNext_1 = loader_counter_willIncrement;
   assign _zz_loader_counter_valueNext = {2'd0, _zz_loader_counter_valueNext_1};
@@ -5769,14 +5774,14 @@ module DataCache (
 
   always @(*) begin
     _zz_1 = 1'b0;
-    if(when_DataCache_l645) begin
+    if(when_DataCache_l648) begin
       _zz_1 = 1'b1;
     end
   end
 
   always @(*) begin
     _zz_2 = 1'b0;
-    if(when_DataCache_l642) begin
+    if(when_DataCache_l645) begin
       _zz_2 = 1'b1;
     end
   end
@@ -5790,43 +5795,45 @@ module DataCache (
   assign _zz_ways_0_dataReadRspMem = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
   assign ways_0_dataReadRspMem = _zz_ways_0_data_port0;
   assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
-  assign when_DataCache_l642 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
-  assign when_DataCache_l645 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
+  assign when_DataCache_l645 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
+  assign when_DataCache_l648 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
   always @(*) begin
     tagsReadCmd_valid = 1'b0;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       tagsReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     tagsReadCmd_payload = 7'bxxxxxxx;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
     end
   end
 
   always @(*) begin
     dataReadCmd_valid = 1'b0;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       dataReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     dataReadCmd_payload = 10'bxxxxxxxxxx;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       dataReadCmd_payload = io_cpu_execute_address[11 : 2];
     end
   end
 
   always @(*) begin
     tagsWriteCmd_valid = 1'b0;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_valid = 1'b1;
     end
-    if(when_DataCache_l1066) begin
-      tagsWriteCmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        tagsWriteCmd_valid = 1'b0;
+      end
     end
     if(loader_done) begin
       tagsWriteCmd_valid = 1'b1;
@@ -5835,7 +5842,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_way = 1'bx;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_payload_way = 1'b1;
     end
     if(loader_done) begin
@@ -5845,7 +5852,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_address = 7'bxxxxxxx;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_payload_address = stageB_flusher_counter[6:0];
     end
     if(loader_done) begin
@@ -5855,7 +5862,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_data_valid = 1'bx;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_payload_data_valid = 1'b0;
     end
     if(loader_done) begin
@@ -5880,14 +5887,16 @@ module DataCache (
   always @(*) begin
     dataWriteCmd_valid = 1'b0;
     if(stageB_cpuWriteToCache) begin
-      if(when_DataCache_l926) begin
+      if(when_DataCache_l931) begin
         dataWriteCmd_valid = 1'b1;
       end
     end
-    if(when_DataCache_l1066) begin
-      dataWriteCmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        dataWriteCmd_valid = 1'b0;
+      end
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_valid = 1'b1;
     end
   end
@@ -5897,7 +5906,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_way = stageB_waysHits;
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_way = loader_waysAllocator;
     end
   end
@@ -5907,7 +5916,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
     end
   end
@@ -5917,7 +5926,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_data = io_mem_rsp_payload_data;
     end
   end
@@ -5930,15 +5939,15 @@ module DataCache (
         dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
       end
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_mask = 4'b1111;
     end
   end
 
-  assign when_DataCache_l664 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  assign when_DataCache_l667 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
   always @(*) begin
     io_cpu_execute_haltIt = 1'b0;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       io_cpu_execute_haltIt = 1'b1;
     end
   end
@@ -5946,7 +5955,7 @@ module DataCache (
   assign rspSync = 1'b1;
   assign rspLast = 1'b1;
   assign io_mem_cmd_fire = (io_mem_cmd_valid && io_mem_cmd_ready);
-  assign when_DataCache_l686 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l689 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     _zz_stage0_mask = 4'bxxxx;
     case(io_cpu_execute_args_size)
@@ -5965,45 +5974,45 @@ module DataCache (
   end
 
   assign stage0_mask = (_zz_stage0_mask <<< io_cpu_execute_address[1 : 0]);
-  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_stage0_dataColisions)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_execute_address[11 : 2])) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stage0_wayInvalidate = 1'b0;
   assign stage0_isAmo = 1'b0;
-  assign when_DataCache_l771 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l771_1 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l776 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l776_1 = (! io_cpu_memory_isStuck);
   assign io_cpu_memory_isWrite = stageA_request_wr;
   assign stageA_isAmo = 1'b0;
   assign stageA_isLrsc = 1'b0;
   assign stageA_wayHits = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign when_DataCache_l771_2 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l771_3 = (! io_cpu_memory_isStuck);
-  assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz__zz_stageA_dataColisions)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign when_DataCache_l776_2 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l776_3 = (! io_cpu_memory_isStuck);
+  assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_memory_address[11 : 2])) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_stageA_dataColisions);
-  assign when_DataCache_l822 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l827 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_mmuRspFreeze = 1'b0;
-    if(when_DataCache_l1125) begin
+    if(when_DataCache_l1132) begin
       stageB_mmuRspFreeze = 1'b1;
     end
   end
 
-  assign when_DataCache_l824 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
-  assign when_DataCache_l821 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l821_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l820 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l829 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
+  assign when_DataCache_l826 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l826_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825 = (! io_cpu_writeBack_isStuck);
   assign stageB_consistancyHazard = 1'b0;
-  assign when_DataCache_l820_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l820_2 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l820_3 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_2 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_3 = (! io_cpu_writeBack_isStuck);
   assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
   assign stageB_waysHit = (|stageB_waysHits);
   assign stageB_dataMux = stageB_dataReadRsp_0;
-  assign when_DataCache_l820_4 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_4 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_loaderValid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
             if(io_mem_cmd_ready) begin
               stageB_loaderValid = 1'b1;
             end
@@ -6011,8 +6020,10 @@ module DataCache (
         end
       end
     end
-    if(when_DataCache_l1066) begin
-      stageB_loaderValid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        stageB_loaderValid = 1'b0;
+      end
     end
   end
 
@@ -6021,28 +6032,32 @@ module DataCache (
     io_cpu_writeBack_haltIt = 1'b1;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l991) begin
-          if(when_DataCache_l995) begin
+        if(when_DataCache_l996) begin
+          if(when_DataCache_l1000) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
         end else begin
-          if(when_DataCache_l1004) begin
-            if(when_DataCache_l1009) begin
+          if(when_DataCache_l1009) begin
+            if(when_DataCache_l1014) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1066) begin
-      io_cpu_writeBack_haltIt = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        io_cpu_writeBack_haltIt = 1'b0;
+      end
     end
   end
 
   assign stageB_flusher_hold = 1'b0;
-  assign when_DataCache_l850 = (! stageB_flusher_counter[7]);
-  assign when_DataCache_l856 = (! stageB_flusher_hold);
+  assign when_DataCache_l855 = (! stageB_flusher_counter[7]);
+  assign when_DataCache_l861 = (! stageB_flusher_hold);
+  assign when_DataCache_l863 = (io_cpu_flush_valid && io_cpu_flush_payload_singleLine);
   assign io_cpu_flush_ready = (stageB_flusher_waitDone && stageB_flusher_counter[7]);
+  assign when_DataCache_l877 = (io_cpu_flush_valid && io_cpu_flush_payload_singleLine);
   assign stageB_isAmo = 1'b0;
   assign stageB_isAmoCached = 1'b0;
   assign stageB_isExternalLsrc = 1'b0;
@@ -6052,8 +6067,8 @@ module DataCache (
     stageB_cpuWriteToCache = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(when_DataCache_l1009) begin
             stageB_cpuWriteToCache = 1'b1;
           end
         end
@@ -6061,26 +6076,28 @@ module DataCache (
     end
   end
 
-  assign when_DataCache_l926 = (stageB_request_wr && stageB_waysHit);
+  assign when_DataCache_l931 = (stageB_request_wr && stageB_waysHit);
   assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_isAmo)));
   assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
   always @(*) begin
     io_cpu_redo = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(when_DataCache_l1004) begin
-            if(when_DataCache_l1020) begin
+        if(!when_DataCache_l996) begin
+          if(when_DataCache_l1009) begin
+            if(when_DataCache_l1025) begin
               io_cpu_redo = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1075) begin
-      io_cpu_redo = 1'b1;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1081) begin
+        io_cpu_redo = 1'b1;
+      end
     end
-    if(when_DataCache_l1122) begin
+    if(when_DataCache_l1129) begin
       io_cpu_redo = 1'b1;
     end
   end
@@ -6101,23 +6118,25 @@ module DataCache (
     io_mem_cmd_valid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l991) begin
+        if(when_DataCache_l996) begin
           io_mem_cmd_valid = (! memCmdSent);
         end else begin
-          if(when_DataCache_l1004) begin
+          if(when_DataCache_l1009) begin
             if(stageB_request_wr) begin
               io_mem_cmd_valid = 1'b1;
             end
           end else begin
-            if(when_DataCache_l1032) begin
+            if(when_DataCache_l1037) begin
               io_mem_cmd_valid = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1066) begin
-      io_mem_cmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        io_mem_cmd_valid = 1'b0;
+      end
     end
   end
 
@@ -6125,9 +6144,9 @@ module DataCache (
     io_mem_cmd_payload_address = stageB_mmuRsp_physicalAddress;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
-            io_mem_cmd_payload_address[4 : 0] = 5'h0;
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
+            io_mem_cmd_payload_address[4 : 0] = 5'h00;
           end
         end
       end
@@ -6139,8 +6158,8 @@ module DataCache (
     io_mem_cmd_payload_wr = stageB_request_wr;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
             io_mem_cmd_payload_wr = 1'b0;
           end
         end
@@ -6155,8 +6174,8 @@ module DataCache (
     io_mem_cmd_payload_size = {1'd0, stageB_request_size};
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
             io_mem_cmd_payload_size = 3'b101;
           end
         end
@@ -6166,12 +6185,12 @@ module DataCache (
 
   assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
   assign io_cpu_writeBack_keepMemRspData = 1'b0;
-  assign when_DataCache_l995 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
-  assign when_DataCache_l1004 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
-  assign when_DataCache_l1009 = ((! stageB_request_wr) || io_mem_cmd_ready);
-  assign when_DataCache_l1020 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
-  assign when_DataCache_l1032 = (! memCmdSent);
-  assign when_DataCache_l991 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  assign when_DataCache_l1000 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
+  assign when_DataCache_l1009 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
+  assign when_DataCache_l1014 = ((! stageB_request_wr) || io_mem_cmd_ready);
+  assign when_DataCache_l1025 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
+  assign when_DataCache_l1037 = (! memCmdSent);
+  assign when_DataCache_l996 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
   always @(*) begin
     if(stageB_bypassCache) begin
       io_cpu_writeBack_data = stageB_ioMemRspMuxed;
@@ -6180,11 +6199,11 @@ module DataCache (
     end
   end
 
-  assign when_DataCache_l1066 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign when_DataCache_l1075 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
+  assign when_DataCache_l1072 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign when_DataCache_l1081 = (stageB_mmuRsp_refilling || stageB_consistancyHazard);
   always @(*) begin
     loader_counter_willIncrement = 1'b0;
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       loader_counter_willIncrement = 1'b1;
     end
   end
@@ -6200,12 +6219,12 @@ module DataCache (
   end
 
   assign loader_kill = 1'b0;
-  assign when_DataCache_l1090 = ((loader_valid && io_mem_rsp_valid) && rspLast);
+  assign when_DataCache_l1097 = ((loader_valid && io_mem_rsp_valid) && rspLast);
   assign loader_done = loader_counter_willOverflow;
-  assign when_DataCache_l1118 = (! loader_valid);
-  assign when_DataCache_l1122 = (loader_valid && (! loader_valid_regNext));
+  assign when_DataCache_l1125 = (! loader_valid);
+  assign when_DataCache_l1129 = (loader_valid && (! loader_valid_regNext));
   assign io_cpu_execute_refilling = loader_valid;
-  assign when_DataCache_l1125 = (stageB_loaderValid || loader_valid);
+  assign when_DataCache_l1132 = (stageB_loaderValid || loader_valid);
   always @(posedge clk) begin
     tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
     tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
@@ -6213,26 +6232,26 @@ module DataCache (
     tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
     tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
     tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if(when_DataCache_l771) begin
+    if(when_DataCache_l776) begin
       stageA_request_wr <= io_cpu_execute_args_wr;
       stageA_request_size <= io_cpu_execute_args_size;
       stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
     end
-    if(when_DataCache_l771_1) begin
+    if(when_DataCache_l776_1) begin
       stageA_mask <= stage0_mask;
     end
-    if(when_DataCache_l771_2) begin
+    if(when_DataCache_l776_2) begin
       stageA_wayInvalidate <= stage0_wayInvalidate;
     end
-    if(when_DataCache_l771_3) begin
+    if(when_DataCache_l776_3) begin
       stage0_dataColisions_regNextWhen <= stage0_dataColisions;
     end
-    if(when_DataCache_l822) begin
+    if(when_DataCache_l827) begin
       stageB_request_wr <= stageA_request_wr;
       stageB_request_size <= stageA_request_size;
       stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
     end
-    if(when_DataCache_l824) begin
+    if(when_DataCache_l829) begin
       stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
       stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
       stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
@@ -6243,27 +6262,27 @@ module DataCache (
       stageB_mmuRsp_refilling <= io_cpu_memory_mmuRsp_refilling;
       stageB_mmuRsp_bypassTranslation <= io_cpu_memory_mmuRsp_bypassTranslation;
     end
-    if(when_DataCache_l821) begin
+    if(when_DataCache_l826) begin
       stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
       stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
       stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
     end
-    if(when_DataCache_l821_1) begin
+    if(when_DataCache_l826_1) begin
       stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
     end
-    if(when_DataCache_l820) begin
+    if(when_DataCache_l825) begin
       stageB_wayInvalidate <= stageA_wayInvalidate;
     end
-    if(when_DataCache_l820_1) begin
+    if(when_DataCache_l825_1) begin
       stageB_dataColisions <= stageA_dataColisions;
     end
-    if(when_DataCache_l820_2) begin
+    if(when_DataCache_l825_2) begin
       stageB_unaligned <= ({((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)),((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0))} != 2'b00);
     end
-    if(when_DataCache_l820_3) begin
+    if(when_DataCache_l825_3) begin
       stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
     end
-    if(when_DataCache_l820_4) begin
+    if(when_DataCache_l825_4) begin
       stageB_mask <= stageA_mask;
     end
     loader_valid_regNext <= loader_valid;
@@ -6273,7 +6292,7 @@ module DataCache (
     if(reset) begin
       memCmdSent <= 1'b0;
       stageB_flusher_waitDone <= 1'b0;
-      stageB_flusher_counter <= 8'h0;
+      stageB_flusher_counter <= 8'h00;
       stageB_flusher_start <= 1'b1;
       loader_valid <= 1'b0;
       loader_counter_value <= 3'b000;
@@ -6284,16 +6303,16 @@ module DataCache (
       if(io_mem_cmd_fire) begin
         memCmdSent <= 1'b1;
       end
-      if(when_DataCache_l686) begin
+      if(when_DataCache_l689) begin
         memCmdSent <= 1'b0;
       end
       if(io_cpu_flush_ready) begin
         stageB_flusher_waitDone <= 1'b0;
       end
-      if(when_DataCache_l850) begin
-        if(when_DataCache_l856) begin
+      if(when_DataCache_l855) begin
+        if(when_DataCache_l861) begin
           stageB_flusher_counter <= (stageB_flusher_counter + 8'h01);
-          if(io_cpu_flush_payload_singleLine) begin
+          if(when_DataCache_l863) begin
             stageB_flusher_counter[7] <= 1'b1;
           end
         end
@@ -6301,17 +6320,17 @@ module DataCache (
       stageB_flusher_start <= (((((((! stageB_flusher_waitDone) && (! stageB_flusher_start)) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
       if(stageB_flusher_start) begin
         stageB_flusher_waitDone <= 1'b1;
-        stageB_flusher_counter <= 8'h0;
-        if(io_cpu_flush_payload_singleLine) begin
+        stageB_flusher_counter <= 8'h00;
+        if(when_DataCache_l877) begin
           stageB_flusher_counter <= {1'b0,io_cpu_flush_payload_lineId};
         end
       end
       `ifndef SYNTHESIS
         `ifdef FORMAL
-          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))); // DataCache.scala:L1077
+          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))); // DataCache.scala:L1084
         `else
           if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-            $display("ERROR writeBack stuck by another plugin is not allowed"); // DataCache.scala:L1077
+            $display("ERROR writeBack stuck by another plugin is not allowed"); // DataCache.scala:L1084
           end
         `endif
       `endif
@@ -6322,7 +6341,7 @@ module DataCache (
       if(loader_kill) begin
         loader_killReg <= 1'b1;
       end
-      if(when_DataCache_l1090) begin
+      if(when_DataCache_l1097) begin
         loader_error <= (loader_error || io_mem_rsp_payload_error);
       end
       if(loader_done) begin
@@ -6330,7 +6349,7 @@ module DataCache (
         loader_error <= 1'b0;
         loader_killReg <= 1'b0;
       end
-      if(when_DataCache_l1118) begin
+      if(when_DataCache_l1125) begin
         loader_waysAllocator <= _zz_loader_waysAllocator[0:0];
       end
     end
@@ -6340,46 +6359,46 @@ module DataCache (
 endmodule
 
 module InstructionCache (
-  input               io_flush,
-  input               io_cpu_prefetch_isValid,
-  output reg          io_cpu_prefetch_haltIt,
-  input      [31:0]   io_cpu_prefetch_pc,
-  input               io_cpu_fetch_isValid,
-  input               io_cpu_fetch_isStuck,
-  input               io_cpu_fetch_isRemoved,
-  input      [31:0]   io_cpu_fetch_pc,
-  output     [31:0]   io_cpu_fetch_data,
-  input      [31:0]   io_cpu_fetch_mmuRsp_physicalAddress,
-  input               io_cpu_fetch_mmuRsp_isIoAccess,
-  input               io_cpu_fetch_mmuRsp_isPaging,
-  input               io_cpu_fetch_mmuRsp_allowRead,
-  input               io_cpu_fetch_mmuRsp_allowWrite,
-  input               io_cpu_fetch_mmuRsp_allowExecute,
-  input               io_cpu_fetch_mmuRsp_exception,
-  input               io_cpu_fetch_mmuRsp_refilling,
-  input               io_cpu_fetch_mmuRsp_bypassTranslation,
-  output     [31:0]   io_cpu_fetch_physicalAddress,
-  input               io_cpu_decode_isValid,
-  input               io_cpu_decode_isStuck,
-  input      [31:0]   io_cpu_decode_pc,
-  output     [31:0]   io_cpu_decode_physicalAddress,
-  output     [31:0]   io_cpu_decode_data,
-  output              io_cpu_decode_cacheMiss,
-  output              io_cpu_decode_error,
-  output              io_cpu_decode_mmuRefilling,
-  output              io_cpu_decode_mmuException,
-  input               io_cpu_decode_isUser,
-  input               io_cpu_fill_valid,
-  input      [31:0]   io_cpu_fill_payload,
-  output              io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output     [31:0]   io_mem_cmd_payload_address,
-  output     [2:0]    io_mem_cmd_payload_size,
-  input               io_mem_rsp_valid,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input               clk,
-  input               reset
+  input  wire          io_flush,
+  input  wire          io_cpu_prefetch_isValid,
+  output reg           io_cpu_prefetch_haltIt,
+  input  wire [31:0]   io_cpu_prefetch_pc,
+  input  wire          io_cpu_fetch_isValid,
+  input  wire          io_cpu_fetch_isStuck,
+  input  wire          io_cpu_fetch_isRemoved,
+  input  wire [31:0]   io_cpu_fetch_pc,
+  output wire [31:0]   io_cpu_fetch_data,
+  input  wire [31:0]   io_cpu_fetch_mmuRsp_physicalAddress,
+  input  wire          io_cpu_fetch_mmuRsp_isIoAccess,
+  input  wire          io_cpu_fetch_mmuRsp_isPaging,
+  input  wire          io_cpu_fetch_mmuRsp_allowRead,
+  input  wire          io_cpu_fetch_mmuRsp_allowWrite,
+  input  wire          io_cpu_fetch_mmuRsp_allowExecute,
+  input  wire          io_cpu_fetch_mmuRsp_exception,
+  input  wire          io_cpu_fetch_mmuRsp_refilling,
+  input  wire          io_cpu_fetch_mmuRsp_bypassTranslation,
+  output wire [31:0]   io_cpu_fetch_physicalAddress,
+  input  wire          io_cpu_decode_isValid,
+  input  wire          io_cpu_decode_isStuck,
+  input  wire [31:0]   io_cpu_decode_pc,
+  output wire [31:0]   io_cpu_decode_physicalAddress,
+  output wire [31:0]   io_cpu_decode_data,
+  output wire          io_cpu_decode_cacheMiss,
+  output wire          io_cpu_decode_error,
+  output wire          io_cpu_decode_mmuRefilling,
+  output wire          io_cpu_decode_mmuException,
+  input  wire          io_cpu_decode_isUser,
+  input  wire          io_cpu_fill_valid,
+  input  wire [31:0]   io_cpu_fill_payload,
+  output wire          io_mem_cmd_valid,
+  input  wire          io_mem_cmd_ready,
+  output wire [31:0]   io_mem_cmd_payload_address,
+  output wire [2:0]    io_mem_cmd_payload_size,
+  input  wire          io_mem_rsp_valid,
+  input  wire [31:0]   io_mem_rsp_payload_data,
+  input  wire          io_mem_rsp_payload_error,
+  input  wire          clk,
+  input  wire          reset
 );
 
   reg        [31:0]   _zz_banks_0_port1;
@@ -6399,7 +6418,7 @@ module InstructionCache (
   wire                when_InstructionCache_l351;
   reg                 lineLoader_cmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_Utils_l515;
+  wire                when_Utils_l560;
   reg                 lineLoader_wayToAllocate_willIncrement;
   wire                lineLoader_wayToAllocate_willClear;
   wire                lineLoader_wayToAllocate_willOverflowIfInc;
@@ -6514,12 +6533,12 @@ module InstructionCache (
   assign when_InstructionCache_l351 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
   assign io_mem_cmd_fire = (io_mem_cmd_valid && io_mem_cmd_ready);
   assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
-  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
+  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h00};
   assign io_mem_cmd_payload_size = 3'b101;
-  assign when_Utils_l515 = (! lineLoader_valid);
+  assign when_Utils_l560 = (! lineLoader_valid);
   always @(*) begin
     lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if(when_Utils_l515) begin
+    if(when_Utils_l560) begin
       lineLoader_wayToAllocate_willIncrement = 1'b1;
     end
   end
@@ -6610,7 +6629,7 @@ module InstructionCache (
     end
     _zz_when_InstructionCache_l342 <= lineLoader_flushCounter[7];
     if(when_InstructionCache_l351) begin
-      lineLoader_flushCounter <= 8'h0;
+      lineLoader_flushCounter <= 8'h00;
     end
     if(when_InstructionCache_l435) begin
       io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_FullCfu.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_FullCfu.v
@@ -1,46 +1,46 @@
-// Generator : SpinalHDL v1.7.1    git head : 0444bb76ab1d6e19f0ec46bc03c4769776deb7d5
+// Generator : SpinalHDL v1.9.4    git head : 270018552577f3bb8e5339ee2583c9c22d324215
 // Component : VexRiscv
-// Git hash  : 581fcb065adf7ea8b626f939ff51679d4c95872f
+// Git hash  : 63430af99f84cc1d11d58b556debe1cc3f238c67
 
 `timescale 1ns/1ps
 
 module VexRiscv (
-  input      [31:0]   externalResetVector,
-  input               timerInterrupt,
-  input               softwareInterrupt,
-  input      [31:0]   externalInterruptArray,
-  output              CfuPlugin_bus_cmd_valid,
-  input               CfuPlugin_bus_cmd_ready,
-  output     [9:0]    CfuPlugin_bus_cmd_payload_function_id,
-  output     [31:0]   CfuPlugin_bus_cmd_payload_inputs_0,
-  output     [31:0]   CfuPlugin_bus_cmd_payload_inputs_1,
-  input               CfuPlugin_bus_rsp_valid,
-  output              CfuPlugin_bus_rsp_ready,
-  input      [31:0]   CfuPlugin_bus_rsp_payload_outputs_0,
-  output reg          iBusWishbone_CYC,
-  output reg          iBusWishbone_STB,
-  input               iBusWishbone_ACK,
-  output              iBusWishbone_WE,
-  output     [29:0]   iBusWishbone_ADR,
-  input      [31:0]   iBusWishbone_DAT_MISO,
-  output     [31:0]   iBusWishbone_DAT_MOSI,
-  output     [3:0]    iBusWishbone_SEL,
-  input               iBusWishbone_ERR,
-  output     [2:0]    iBusWishbone_CTI,
-  output     [1:0]    iBusWishbone_BTE,
-  output              dBusWishbone_CYC,
-  output              dBusWishbone_STB,
-  input               dBusWishbone_ACK,
-  output              dBusWishbone_WE,
-  output     [29:0]   dBusWishbone_ADR,
-  input      [31:0]   dBusWishbone_DAT_MISO,
-  output     [31:0]   dBusWishbone_DAT_MOSI,
-  output     [3:0]    dBusWishbone_SEL,
-  input               dBusWishbone_ERR,
-  output     [2:0]    dBusWishbone_CTI,
-  output     [1:0]    dBusWishbone_BTE,
-  input               clk,
-  input               reset
+  input  wire [31:0]   externalResetVector,
+  input  wire          timerInterrupt,
+  input  wire          softwareInterrupt,
+  input  wire [31:0]   externalInterruptArray,
+  output wire          CfuPlugin_bus_cmd_valid,
+  input  wire          CfuPlugin_bus_cmd_ready,
+  output wire [9:0]    CfuPlugin_bus_cmd_payload_function_id,
+  output wire [31:0]   CfuPlugin_bus_cmd_payload_inputs_0,
+  output wire [31:0]   CfuPlugin_bus_cmd_payload_inputs_1,
+  input  wire          CfuPlugin_bus_rsp_valid,
+  output wire          CfuPlugin_bus_rsp_ready,
+  input  wire [31:0]   CfuPlugin_bus_rsp_payload_outputs_0,
+  output reg           iBusWishbone_CYC,
+  output reg           iBusWishbone_STB,
+  input  wire          iBusWishbone_ACK,
+  output wire          iBusWishbone_WE,
+  output wire [29:0]   iBusWishbone_ADR,
+  input  wire [31:0]   iBusWishbone_DAT_MISO,
+  output wire [31:0]   iBusWishbone_DAT_MOSI,
+  output wire [3:0]    iBusWishbone_SEL,
+  input  wire          iBusWishbone_ERR,
+  output wire [2:0]    iBusWishbone_CTI,
+  output wire [1:0]    iBusWishbone_BTE,
+  output wire          dBusWishbone_CYC,
+  output wire          dBusWishbone_STB,
+  input  wire          dBusWishbone_ACK,
+  output wire          dBusWishbone_WE,
+  output wire [29:0]   dBusWishbone_ADR,
+  input  wire [31:0]   dBusWishbone_DAT_MISO,
+  output wire [31:0]   dBusWishbone_DAT_MOSI,
+  output wire [3:0]    dBusWishbone_SEL,
+  input  wire          dBusWishbone_ERR,
+  output wire [2:0]    dBusWishbone_CTI,
+  output wire [1:0]    dBusWishbone_BTE,
+  input  wire          clk,
+  input  wire          reset
 );
   localparam ShiftCtrlEnum_DISABLE_1 = 2'd0;
   localparam ShiftCtrlEnum_SLL_1 = 2'd1;
@@ -101,7 +101,6 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_flush_valid;
   wire                dataCache_1_io_cpu_flush_payload_singleLine;
   wire       [6:0]    dataCache_1_io_cpu_flush_payload_lineId;
-  wire                dataCache_1_io_mem_cmd_ready;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
@@ -129,6 +128,7 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_writeBack_exclusiveOk;
   wire                dataCache_1_io_cpu_flush_ready;
   wire                dataCache_1_io_cpu_redo;
+  wire                dataCache_1_io_cpu_writesPending;
   wire                dataCache_1_io_mem_cmd_valid;
   wire                dataCache_1_io_mem_cmd_payload_wr;
   wire                dataCache_1_io_mem_cmd_payload_uncached;
@@ -140,12 +140,11 @@ module VexRiscv (
   wire       [51:0]   _zz_memory_MUL_LOW;
   wire       [51:0]   _zz_memory_MUL_LOW_1;
   wire       [51:0]   _zz_memory_MUL_LOW_2;
-  wire       [51:0]   _zz_memory_MUL_LOW_3;
-  wire       [32:0]   _zz_memory_MUL_LOW_4;
-  wire       [51:0]   _zz_memory_MUL_LOW_5;
-  wire       [49:0]   _zz_memory_MUL_LOW_6;
-  wire       [51:0]   _zz_memory_MUL_LOW_7;
-  wire       [49:0]   _zz_memory_MUL_LOW_8;
+  wire       [32:0]   _zz_memory_MUL_LOW_3;
+  wire       [51:0]   _zz_memory_MUL_LOW_4;
+  wire       [49:0]   _zz_memory_MUL_LOW_5;
+  wire       [51:0]   _zz_memory_MUL_LOW_6;
+  wire       [49:0]   _zz_memory_MUL_LOW_7;
   wire       [31:0]   _zz_execute_SHIFT_RIGHT;
   wire       [32:0]   _zz_execute_SHIFT_RIGHT_1;
   wire       [32:0]   _zz_execute_SHIFT_RIGHT_2;
@@ -154,19 +153,19 @@ module VexRiscv (
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_2;
   wire                _zz_decode_LEGAL_INSTRUCTION_3;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_4;
-  wire       [14:0]   _zz_decode_LEGAL_INSTRUCTION_5;
+  wire       [13:0]   _zz_decode_LEGAL_INSTRUCTION_5;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_6;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_7;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_8;
   wire                _zz_decode_LEGAL_INSTRUCTION_9;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_10;
-  wire       [8:0]    _zz_decode_LEGAL_INSTRUCTION_11;
+  wire       [7:0]    _zz_decode_LEGAL_INSTRUCTION_11;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_12;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_13;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_14;
   wire                _zz_decode_LEGAL_INSTRUCTION_15;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_16;
-  wire       [2:0]    _zz_decode_LEGAL_INSTRUCTION_17;
+  wire       [1:0]    _zz_decode_LEGAL_INSTRUCTION_17;
   wire       [3:0]    _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1;
   reg        [31:0]   _zz_IBusCachedPlugin_jump_pcLoad_payload_5;
   wire       [1:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_6;
@@ -191,161 +190,148 @@ module VexRiscv (
   wire       [1:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_1;
   reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_2;
   wire       [0:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_3;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6;
-  wire       [25:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22;
-  wire       [21:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23;
-  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33;
-  wire       [18:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41;
-  wire       [15:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42;
-  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53;
-  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63;
-  wire       [12:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64;
-  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93;
-  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106;
-  wire       [9:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116;
-  wire       [7:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124;
-  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154;
+  wire                _zz__zz_decode_CfuPlugin_CFU_ENABLE;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_1;
+  wire                _zz__zz_decode_CfuPlugin_CFU_ENABLE_2;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_3;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_4;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_5;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_6;
+  wire       [25:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_7;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_8;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_9;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_10;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_11;
+  wire                _zz__zz_decode_CfuPlugin_CFU_ENABLE_12;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_13;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_14;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_15;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_16;
+  wire       [21:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_17;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_18;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_19;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_20;
+  wire                _zz__zz_decode_CfuPlugin_CFU_ENABLE_21;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_22;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_23;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_24;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_25;
+  wire       [17:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_26;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_27;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_28;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_29;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_30;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_31;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_32;
+  wire                _zz__zz_decode_CfuPlugin_CFU_ENABLE_33;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_34;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_35;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_36;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_37;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_38;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_39;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_40;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_41;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_42;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_43;
+  wire                _zz__zz_decode_CfuPlugin_CFU_ENABLE_44;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_45;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_46;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_47;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_48;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_49;
+  wire       [13:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_50;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_51;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_52;
+  wire                _zz__zz_decode_CfuPlugin_CFU_ENABLE_53;
+  wire                _zz__zz_decode_CfuPlugin_CFU_ENABLE_54;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_55;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_56;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_57;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_58;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_59;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_60;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_61;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_62;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_63;
+  wire                _zz__zz_decode_CfuPlugin_CFU_ENABLE_64;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_65;
+  wire                _zz__zz_decode_CfuPlugin_CFU_ENABLE_66;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_67;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_68;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_69;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_70;
+  wire                _zz__zz_decode_CfuPlugin_CFU_ENABLE_71;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_72;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_73;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_74;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_75;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_76;
+  wire                _zz__zz_decode_CfuPlugin_CFU_ENABLE_77;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_78;
+  wire                _zz__zz_decode_CfuPlugin_CFU_ENABLE_79;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_80;
+  wire       [10:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_81;
+  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_82;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_83;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_84;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_85;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_86;
+  wire                _zz__zz_decode_CfuPlugin_CFU_ENABLE_87;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_88;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_89;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_90;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_91;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_92;
+  wire                _zz__zz_decode_CfuPlugin_CFU_ENABLE_93;
+  wire                _zz__zz_decode_CfuPlugin_CFU_ENABLE_94;
+  wire                _zz__zz_decode_CfuPlugin_CFU_ENABLE_95;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_96;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_97;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_98;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_99;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_100;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_101;
+  wire                _zz__zz_decode_CfuPlugin_CFU_ENABLE_102;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_103;
+  wire       [7:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_104;
+  wire                _zz__zz_decode_CfuPlugin_CFU_ENABLE_105;
+  wire                _zz__zz_decode_CfuPlugin_CFU_ENABLE_106;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_107;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_108;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_109;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_110;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_111;
+  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_112;
+  wire                _zz__zz_decode_CfuPlugin_CFU_ENABLE_113;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_114;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_115;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_116;
+  wire                _zz__zz_decode_CfuPlugin_CFU_ENABLE_117;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_118;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_119;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_120;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_121;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_122;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_123;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_124;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_125;
+  wire                _zz__zz_decode_CfuPlugin_CFU_ENABLE_126;
+  wire                _zz__zz_decode_CfuPlugin_CFU_ENABLE_127;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_128;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_129;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_130;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_131;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_132;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_133;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_134;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_135;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_136;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_137;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_138;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_139;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_140;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_141;
   wire                _zz_RegFilePlugin_regFile_port;
   wire                _zz_decode_RegFilePlugin_rs1Data;
   wire                _zz_RegFilePlugin_regFile_port_1;
@@ -353,14 +339,12 @@ module VexRiscv (
   wire       [0:0]    _zz__zz_execute_REGFILE_WRITE_DATA;
   wire       [2:0]    _zz__zz_execute_SRC1;
   wire       [4:0]    _zz__zz_execute_SRC1_1;
-  wire       [11:0]   _zz__zz_execute_SRC2_3;
+  wire       [11:0]   _zz__zz_execute_SRC2_2;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_1;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_2;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_3;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_4;
-  wire       [31:0]   _zz_execute_SrcPlugin_addSub_5;
-  wire       [31:0]   _zz_execute_SrcPlugin_addSub_6;
   wire       [19:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_2;
   wire       [11:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_4;
   wire       [31:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_6;
@@ -398,7 +382,7 @@ module VexRiscv (
   wire       [31:0]   _zz_memory_DivPlugin_rs2_1;
   wire       [0:0]    _zz_memory_DivPlugin_rs2_2;
   wire       [9:0]    _zz_execute_CfuPlugin_functionsIds_0;
-  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_25;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_24;
   wire       [26:0]   _zz_iBusWishbone_ADR_1;
   wire       [51:0]   memory_MUL_LOW;
   wire                writeBack_CfuPlugin_CFU_IN_FLIGHT;
@@ -480,9 +464,10 @@ module VexRiscv (
   wire                memory_CfuPlugin_CFU_IN_FLIGHT;
   wire       [0:0]    execute_CfuPlugin_CFU_INPUT_2_KIND;
   wire       [0:0]    _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
-  wire                execute_CfuPlugin_CFU_ENABLE;
   wire                writeBack_HAS_SIDE_EFFECT;
   wire                memory_HAS_SIDE_EFFECT;
+  wire                execute_LEGAL_INSTRUCTION;
+  reg                 execute_CfuPlugin_CFU_ENABLE;
   wire                execute_IS_RS1_SIGNED;
   wire                execute_IS_DIV;
   wire                execute_IS_RS2_SIGNED;
@@ -529,7 +514,7 @@ module VexRiscv (
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_execute_SRC2;
+  wire       [31:0]   _zz_execute_to_memory_PC;
   wire       [1:0]    execute_SRC2_CTRL;
   wire       [1:0]    _zz_execute_SRC2_CTRL;
   wire       [1:0]    execute_SRC1_CTRL;
@@ -709,8 +694,9 @@ module VexRiscv (
   wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
   wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
   wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
-  wire                CsrPlugin_csrMapping_allowCsrSignal;
+  reg                 CsrPlugin_csrMapping_allowCsrSignal;
   wire                CsrPlugin_csrMapping_hazardFree;
+  wire                CsrPlugin_csrMapping_doForceFailCsr;
   reg                 CsrPlugin_inWfi /* verilator public */ ;
   wire                CsrPlugin_thirdPartyWake;
   reg                 CsrPlugin_jumpInterface_valid;
@@ -729,6 +715,7 @@ module VexRiscv (
   wire                CsrPlugin_allowInterrupts;
   wire                CsrPlugin_allowException;
   wire                CsrPlugin_allowEbreakException;
+  wire                CsrPlugin_xretAwayFromMachine;
   wire                IBusCachedPlugin_externalFlush;
   wire                IBusCachedPlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
@@ -748,14 +735,13 @@ module VexRiscv (
   reg                 IBusCachedPlugin_fetchPc_pcRegPropagate;
   reg                 IBusCachedPlugin_fetchPc_booted;
   reg                 IBusCachedPlugin_fetchPc_inc;
-  wire                when_Fetcher_l134;
-  wire                IBusCachedPlugin_fetchPc_output_fire_1;
-  wire                when_Fetcher_l134_1;
+  wire                when_Fetcher_l133;
+  wire                when_Fetcher_l133_1;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pc;
   wire                IBusCachedPlugin_fetchPc_redo_valid;
   wire       [31:0]   IBusCachedPlugin_fetchPc_redo_payload;
   reg                 IBusCachedPlugin_fetchPc_flushed;
-  wire                when_Fetcher_l161;
+  wire                when_Fetcher_l160;
   reg                 IBusCachedPlugin_iBusRsp_redoFetch;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_ready;
@@ -783,8 +769,8 @@ module VexRiscv (
   wire                _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready;
   wire                IBusCachedPlugin_iBusRsp_flush;
   wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
-  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
-  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid;
+  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1;
   wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
@@ -797,18 +783,18 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_output_payload_rsp_error;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   wire                IBusCachedPlugin_iBusRsp_output_payload_isRvc;
-  wire                when_Fetcher_l243;
-  wire                when_Fetcher_l323;
+  wire                when_Fetcher_l242;
+  wire                when_Fetcher_l322;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
-  wire                when_Fetcher_l332;
+  wire                when_Fetcher_l331;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
-  wire                when_Fetcher_l332_1;
+  wire                when_Fetcher_l331_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
-  wire                when_Fetcher_l332_2;
+  wire                when_Fetcher_l331_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
-  wire                when_Fetcher_l332_3;
+  wire                when_Fetcher_l331_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                when_Fetcher_l332_4;
+  wire                when_Fetcher_l331_4;
   wire                _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   reg        [18:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1;
   wire                _zz_2;
@@ -834,76 +820,77 @@ module VexRiscv (
   wire                IBusCachedPlugin_rsp_iBusRspOutputHalt;
   wire                IBusCachedPlugin_rsp_issueDetected;
   reg                 IBusCachedPlugin_rsp_redoFetch;
-  wire                when_IBusCachedPlugin_l239;
-  wire                when_IBusCachedPlugin_l244;
+  wire                when_IBusCachedPlugin_l245;
   wire                when_IBusCachedPlugin_l250;
   wire                when_IBusCachedPlugin_l256;
-  wire                when_IBusCachedPlugin_l267;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_valid;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_ready;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_address;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_data;
-  wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_size;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_last;
-  reg                 dataCache_1_io_mem_cmd_rValid;
-  reg                 dataCache_1_io_mem_cmd_rData_wr;
-  reg                 dataCache_1_io_mem_cmd_rData_uncached;
-  reg        [31:0]   dataCache_1_io_mem_cmd_rData_address;
-  reg        [31:0]   dataCache_1_io_mem_cmd_rData_data;
-  reg        [3:0]    dataCache_1_io_mem_cmd_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_rData_size;
-  reg                 dataCache_1_io_mem_cmd_rData_last;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
-  wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data;
-  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
-  wire                when_Stream_l368;
+  wire                when_IBusCachedPlugin_l262;
+  wire                when_IBusCachedPlugin_l273;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_valid;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+  wire       [3:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+  wire       [2:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_size;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rValidN;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rData_wr;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rData_uncached;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_rData_address;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_rData_data;
+  reg        [3:0]    toplevel_dataCache_1_io_mem_cmd_rData_mask;
+  reg        [2:0]    toplevel_dataCache_1_io_mem_cmd_rData_size;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rData_last;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
+  wire       [3:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
+  wire       [2:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_address;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_data;
+  reg        [3:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
+  reg        [2:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_size;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  wire                when_Stream_l369;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
-  wire                when_DBusCachedPlugin_l308;
+  wire                when_DBusCachedPlugin_l352;
   wire       [1:0]    execute_DBusCachedPlugin_size;
   reg        [31:0]   _zz_execute_MEMORY_STORE_DATA_RF;
-  wire                dataCache_1_io_cpu_flush_isStall;
-  wire                when_DBusCachedPlugin_l350;
-  wire                when_DBusCachedPlugin_l366;
-  wire                when_DBusCachedPlugin_l393;
-  wire                when_DBusCachedPlugin_l446;
-  wire                when_DBusCachedPlugin_l466;
+  wire                toplevel_dataCache_1_io_cpu_flush_isStall;
+  wire                when_DBusCachedPlugin_l394;
+  wire                when_DBusCachedPlugin_l410;
+  wire                when_DBusCachedPlugin_l472;
+  wire                when_DBusCachedPlugin_l533;
+  wire                when_DBusCachedPlugin_l553;
+  wire       [31:0]   writeBack_DBusCachedPlugin_rspData;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_0;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_1;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_2;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
   wire       [31:0]   writeBack_DBusCachedPlugin_rspRf;
-  wire       [1:0]    switch_Misc_l210;
+  wire       [1:0]    switch_Misc_l232;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_1;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated_2;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
-  wire                when_DBusCachedPlugin_l492;
-  wire       [33:0]   _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2;
-  wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3;
-  wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
-  wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5;
-  wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6;
-  wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7;
-  wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8;
+  wire                when_DBusCachedPlugin_l580;
+  wire       [33:0]   _zz_decode_CfuPlugin_CFU_ENABLE;
+  wire                _zz_decode_CfuPlugin_CFU_ENABLE_1;
+  wire                _zz_decode_CfuPlugin_CFU_ENABLE_2;
+  wire                _zz_decode_CfuPlugin_CFU_ENABLE_3;
+  wire                _zz_decode_CfuPlugin_CFU_ENABLE_4;
+  wire                _zz_decode_CfuPlugin_CFU_ENABLE_5;
+  wire                _zz_decode_CfuPlugin_CFU_ENABLE_6;
   wire       [1:0]    _zz_decode_SRC1_CTRL_2;
   wire       [1:0]    _zz_decode_ALU_CTRL_2;
   wire       [1:0]    _zz_decode_SRC2_CTRL_2;
@@ -911,7 +898,7 @@ module VexRiscv (
   wire       [1:0]    _zz_decode_SHIFT_CTRL_2;
   wire       [1:0]    _zz_decode_BRANCH_CTRL_2;
   wire       [1:0]    _zz_decode_ENV_CTRL_2;
-  wire       [0:0]    _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9;
+  wire       [0:0]    _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2;
   wire                when_RegFilePlugin_l63;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
@@ -920,15 +907,15 @@ module VexRiscv (
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
   reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
   reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_7;
+  reg                 _zz_10;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
   reg        [31:0]   _zz_execute_REGFILE_WRITE_DATA;
   reg        [31:0]   _zz_execute_SRC1;
-  wire                _zz_execute_SRC2_1;
-  reg        [19:0]   _zz_execute_SRC2_2;
-  wire                _zz_execute_SRC2_3;
-  reg        [19:0]   _zz_execute_SRC2_4;
-  reg        [31:0]   _zz_execute_SRC2_5;
+  wire                _zz_execute_SRC2;
+  reg        [19:0]   _zz_execute_SRC2_1;
+  wire                _zz_execute_SRC2_2;
+  reg        [19:0]   _zz_execute_SRC2_3;
+  reg        [31:0]   _zz_execute_SRC2_4;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   wire       [4:0]    execute_FullBarrelShifterPlugin_amplitude;
@@ -965,7 +952,7 @@ module VexRiscv (
   wire                when_HazardSimplePlugin_l108;
   wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    switch_Misc_l210_1;
+  wire       [2:0]    switch_Misc_l232_1;
   reg                 _zz_execute_BRANCH_COND_RESULT;
   reg                 _zz_execute_BRANCH_COND_RESULT_1;
   wire                _zz_execute_BranchPlugin_missAlignedTarget;
@@ -985,9 +972,9 @@ module VexRiscv (
   wire                _zz_execute_BranchPlugin_branch_src2_4;
   reg        [18:0]   _zz_execute_BranchPlugin_branch_src2_5;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
-  wire                when_BranchPlugin_l302;
-  reg        [1:0]    CsrPlugin_misa_base;
-  reg        [25:0]   CsrPlugin_misa_extensions;
+  wire                when_BranchPlugin_l304;
+  wire       [1:0]    CsrPlugin_misa_base;
+  wire       [25:0]   CsrPlugin_misa_extensions;
   reg        [1:0]    CsrPlugin_mtvec_mode;
   reg        [29:0]   CsrPlugin_mtvec_base;
   reg        [31:0]   CsrPlugin_mepc;
@@ -1006,9 +993,9 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_mtval;
   reg        [63:0]   CsrPlugin_mcycle;
   reg        [63:0]   CsrPlugin_minstret;
-  wire                _zz_when_CsrPlugin_l965;
-  wire                _zz_when_CsrPlugin_l965_1;
-  wire                _zz_when_CsrPlugin_l965_2;
+  wire                _zz_when_CsrPlugin_l1302;
+  wire                _zz_when_CsrPlugin_l1302_1;
+  wire                _zz_when_CsrPlugin_l1302_2;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -1025,59 +1012,62 @@ module VexRiscv (
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
   wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_2;
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3;
-  wire                when_CsrPlugin_l922;
-  wire                when_CsrPlugin_l922_1;
-  wire                when_CsrPlugin_l922_2;
-  wire                when_CsrPlugin_l922_3;
-  wire                when_CsrPlugin_l935;
+  wire                when_CsrPlugin_l1259;
+  wire                when_CsrPlugin_l1259_1;
+  wire                when_CsrPlugin_l1259_2;
+  wire                when_CsrPlugin_l1259_3;
+  wire                when_CsrPlugin_l1272;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
-  wire                when_CsrPlugin_l959;
-  wire                when_CsrPlugin_l965;
-  wire                when_CsrPlugin_l965_1;
-  wire                when_CsrPlugin_l965_2;
+  wire                when_CsrPlugin_l1296;
+  wire                when_CsrPlugin_l1302;
+  wire                when_CsrPlugin_l1302_1;
+  wire                when_CsrPlugin_l1302_2;
   wire                CsrPlugin_exception;
   reg                 CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
-  wire                when_CsrPlugin_l993;
-  wire                when_CsrPlugin_l993_1;
-  wire                when_CsrPlugin_l993_2;
-  wire                when_CsrPlugin_l998;
+  wire                when_CsrPlugin_l1335;
+  wire                when_CsrPlugin_l1335_1;
+  wire                when_CsrPlugin_l1335_2;
+  wire                when_CsrPlugin_l1340;
   reg                 CsrPlugin_pipelineLiberator_done;
-  wire                when_CsrPlugin_l1004;
+  wire                when_CsrPlugin_l1346;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
+  wire                CsrPlugin_trapCauseEbreakDebug;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
-  wire                when_CsrPlugin_l1032;
-  wire                when_CsrPlugin_l1077;
-  wire       [1:0]    switch_CsrPlugin_l1081;
+  wire                CsrPlugin_trapEnterDebug;
+  wire                when_CsrPlugin_l1390;
+  wire                when_CsrPlugin_l1398;
+  wire                when_CsrPlugin_l1456;
+  wire       [1:0]    switch_CsrPlugin_l1460;
   reg                 execute_CsrPlugin_wfiWake;
-  wire                when_CsrPlugin_l1121;
-  wire                when_CsrPlugin_l1123;
-  wire                when_CsrPlugin_l1129;
+  wire                when_CsrPlugin_l1519;
+  wire                when_CsrPlugin_l1521;
+  wire                when_CsrPlugin_l1527;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire                when_CsrPlugin_l1142;
-  wire                when_CsrPlugin_l1149;
-  wire                when_CsrPlugin_l1150;
-  wire                when_CsrPlugin_l1157;
+  wire                when_CsrPlugin_l1540;
+  wire                when_CsrPlugin_l1547;
+  wire                when_CsrPlugin_l1548;
+  wire                when_CsrPlugin_l1555;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   wire       [31:0]   execute_CsrPlugin_readToWriteData;
-  wire                switch_Misc_l210_2;
+  wire                switch_Misc_l232_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
-  wire                when_CsrPlugin_l1189;
-  wire                when_CsrPlugin_l1193;
+  wire                when_CsrPlugin_l1587;
+  wire                when_CsrPlugin_l1591;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg                 execute_MulPlugin_aSigned;
   reg                 execute_MulPlugin_bSigned;
@@ -1124,16 +1114,17 @@ module VexRiscv (
   reg        [32:0]   _zz_memory_DivPlugin_rs1_1;
   reg        [31:0]   externalInterruptArray_regNext;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit;
-  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
+  wire       [31:0]   _zz_externalInterrupt;
+  wire                when_CfuPlugin_l192;
   wire                execute_CfuPlugin_hazard;
   wire                execute_CfuPlugin_scheduleWish;
   wire                execute_CfuPlugin_schedule;
-  wire                when_CfuPlugin_l194;
+  wire                when_CfuPlugin_l196;
   reg                 execute_CfuPlugin_hold;
   reg                 execute_CfuPlugin_fired;
   wire                CfuPlugin_bus_cmd_fire;
-  wire                when_CfuPlugin_l197;
-  wire                when_CfuPlugin_l201;
+  wire                when_CfuPlugin_l199;
+  wire                when_CfuPlugin_l203;
   wire       [9:0]    execute_CfuPlugin_functionsIds_0;
   wire                _zz_CfuPlugin_bus_cmd_payload_inputs_1;
   reg        [23:0]   _zz_CfuPlugin_bus_cmd_payload_inputs_1_1;
@@ -1141,9 +1132,9 @@ module VexRiscv (
   wire                memory_CfuPlugin_rsp_valid;
   reg                 memory_CfuPlugin_rsp_ready;
   wire       [31:0]   memory_CfuPlugin_rsp_payload_outputs_0;
-  reg                 CfuPlugin_bus_rsp_rValid;
+  reg                 CfuPlugin_bus_rsp_rValidN;
   reg        [31:0]   CfuPlugin_bus_rsp_rData_outputs_0;
-  wire                when_CfuPlugin_l237;
+  wire                when_CfuPlugin_l239;
   wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
   wire                when_Pipeline_l124_1;
@@ -1165,118 +1156,120 @@ module VexRiscv (
   wire                when_Pipeline_l124_9;
   reg                 decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
   wire                when_Pipeline_l124_10;
-  reg        [1:0]    decode_to_execute_SRC1_CTRL;
+  reg                 decode_to_execute_LEGAL_INSTRUCTION;
   wire                when_Pipeline_l124_11;
-  reg                 decode_to_execute_SRC_USE_SUB_LESS;
+  reg        [1:0]    decode_to_execute_SRC1_CTRL;
   wire                when_Pipeline_l124_12;
-  reg                 decode_to_execute_MEMORY_ENABLE;
+  reg                 decode_to_execute_SRC_USE_SUB_LESS;
   wire                when_Pipeline_l124_13;
-  reg                 execute_to_memory_MEMORY_ENABLE;
+  reg                 decode_to_execute_MEMORY_ENABLE;
   wire                when_Pipeline_l124_14;
-  reg                 memory_to_writeBack_MEMORY_ENABLE;
+  reg                 execute_to_memory_MEMORY_ENABLE;
   wire                when_Pipeline_l124_15;
-  reg        [1:0]    decode_to_execute_ALU_CTRL;
+  reg                 memory_to_writeBack_MEMORY_ENABLE;
   wire                when_Pipeline_l124_16;
-  reg        [1:0]    decode_to_execute_SRC2_CTRL;
+  reg        [1:0]    decode_to_execute_ALU_CTRL;
   wire                when_Pipeline_l124_17;
-  reg                 decode_to_execute_REGFILE_WRITE_VALID;
+  reg        [1:0]    decode_to_execute_SRC2_CTRL;
   wire                when_Pipeline_l124_18;
-  reg                 execute_to_memory_REGFILE_WRITE_VALID;
+  reg                 decode_to_execute_REGFILE_WRITE_VALID;
   wire                when_Pipeline_l124_19;
-  reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
+  reg                 execute_to_memory_REGFILE_WRITE_VALID;
   wire                when_Pipeline_l124_20;
-  reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
+  reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
   wire                when_Pipeline_l124_21;
-  reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
   wire                when_Pipeline_l124_22;
-  reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
+  reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
   wire                when_Pipeline_l124_23;
-  reg                 decode_to_execute_MEMORY_WR;
+  reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
   wire                when_Pipeline_l124_24;
-  reg                 execute_to_memory_MEMORY_WR;
+  reg                 decode_to_execute_MEMORY_WR;
   wire                when_Pipeline_l124_25;
-  reg                 memory_to_writeBack_MEMORY_WR;
+  reg                 execute_to_memory_MEMORY_WR;
   wire                when_Pipeline_l124_26;
-  reg                 decode_to_execute_HAS_SIDE_EFFECT;
+  reg                 memory_to_writeBack_MEMORY_WR;
   wire                when_Pipeline_l124_27;
-  reg                 execute_to_memory_HAS_SIDE_EFFECT;
+  reg                 decode_to_execute_HAS_SIDE_EFFECT;
   wire                when_Pipeline_l124_28;
-  reg                 memory_to_writeBack_HAS_SIDE_EFFECT;
+  reg                 execute_to_memory_HAS_SIDE_EFFECT;
   wire                when_Pipeline_l124_29;
-  reg                 decode_to_execute_MEMORY_MANAGMENT;
+  reg                 memory_to_writeBack_HAS_SIDE_EFFECT;
   wire                when_Pipeline_l124_30;
-  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
+  reg                 decode_to_execute_MEMORY_MANAGMENT;
   wire                when_Pipeline_l124_31;
-  reg        [1:0]    decode_to_execute_ALU_BITWISE_CTRL;
+  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
   wire                when_Pipeline_l124_32;
-  reg        [1:0]    decode_to_execute_SHIFT_CTRL;
+  reg        [1:0]    decode_to_execute_ALU_BITWISE_CTRL;
   wire                when_Pipeline_l124_33;
-  reg        [1:0]    execute_to_memory_SHIFT_CTRL;
+  reg        [1:0]    decode_to_execute_SHIFT_CTRL;
   wire                when_Pipeline_l124_34;
-  reg        [1:0]    decode_to_execute_BRANCH_CTRL;
+  reg        [1:0]    execute_to_memory_SHIFT_CTRL;
   wire                when_Pipeline_l124_35;
-  reg                 decode_to_execute_IS_CSR;
+  reg        [1:0]    decode_to_execute_BRANCH_CTRL;
   wire                when_Pipeline_l124_36;
-  reg        [1:0]    decode_to_execute_ENV_CTRL;
+  reg                 decode_to_execute_IS_CSR;
   wire                when_Pipeline_l124_37;
-  reg        [1:0]    execute_to_memory_ENV_CTRL;
+  reg        [1:0]    decode_to_execute_ENV_CTRL;
   wire                when_Pipeline_l124_38;
-  reg        [1:0]    memory_to_writeBack_ENV_CTRL;
+  reg        [1:0]    execute_to_memory_ENV_CTRL;
   wire                when_Pipeline_l124_39;
-  reg                 decode_to_execute_IS_MUL;
+  reg        [1:0]    memory_to_writeBack_ENV_CTRL;
   wire                when_Pipeline_l124_40;
-  reg                 execute_to_memory_IS_MUL;
+  reg                 decode_to_execute_IS_MUL;
   wire                when_Pipeline_l124_41;
-  reg                 memory_to_writeBack_IS_MUL;
+  reg                 execute_to_memory_IS_MUL;
   wire                when_Pipeline_l124_42;
-  reg                 decode_to_execute_IS_DIV;
+  reg                 memory_to_writeBack_IS_MUL;
   wire                when_Pipeline_l124_43;
-  reg                 execute_to_memory_IS_DIV;
+  reg                 decode_to_execute_IS_DIV;
   wire                when_Pipeline_l124_44;
-  reg                 decode_to_execute_IS_RS1_SIGNED;
+  reg                 execute_to_memory_IS_DIV;
   wire                when_Pipeline_l124_45;
-  reg                 decode_to_execute_IS_RS2_SIGNED;
+  reg                 decode_to_execute_IS_RS1_SIGNED;
   wire                when_Pipeline_l124_46;
-  reg                 decode_to_execute_CfuPlugin_CFU_ENABLE;
+  reg                 decode_to_execute_IS_RS2_SIGNED;
   wire                when_Pipeline_l124_47;
-  reg        [0:0]    decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  reg                 decode_to_execute_CfuPlugin_CFU_ENABLE;
   wire                when_Pipeline_l124_48;
-  reg        [31:0]   decode_to_execute_RS1;
+  reg        [0:0]    decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   wire                when_Pipeline_l124_49;
-  reg        [31:0]   decode_to_execute_RS2;
+  reg        [31:0]   decode_to_execute_RS1;
   wire                when_Pipeline_l124_50;
-  reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  reg        [31:0]   decode_to_execute_RS2;
   wire                when_Pipeline_l124_51;
-  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
+  reg                 decode_to_execute_SRC2_FORCE_ZERO;
   wire                when_Pipeline_l124_52;
-  reg                 decode_to_execute_CSR_WRITE_OPCODE;
+  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
   wire                when_Pipeline_l124_53;
-  reg                 decode_to_execute_CSR_READ_OPCODE;
+  reg                 decode_to_execute_CSR_WRITE_OPCODE;
   wire                when_Pipeline_l124_54;
-  reg        [31:0]   execute_to_memory_MEMORY_STORE_DATA_RF;
+  reg                 decode_to_execute_CSR_READ_OPCODE;
   wire                when_Pipeline_l124_55;
-  reg        [31:0]   memory_to_writeBack_MEMORY_STORE_DATA_RF;
+  reg        [31:0]   execute_to_memory_MEMORY_STORE_DATA_RF;
   wire                when_Pipeline_l124_56;
-  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
+  reg        [31:0]   memory_to_writeBack_MEMORY_STORE_DATA_RF;
   wire                when_Pipeline_l124_57;
-  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
   wire                when_Pipeline_l124_58;
-  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
+  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
   wire                when_Pipeline_l124_59;
-  reg        [31:0]   execute_to_memory_MUL_LL;
+  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
   wire                when_Pipeline_l124_60;
-  reg        [33:0]   execute_to_memory_MUL_LH;
+  reg        [31:0]   execute_to_memory_MUL_LL;
   wire                when_Pipeline_l124_61;
-  reg        [33:0]   execute_to_memory_MUL_HL;
+  reg        [33:0]   execute_to_memory_MUL_LH;
   wire                when_Pipeline_l124_62;
-  reg        [33:0]   execute_to_memory_MUL_HH;
+  reg        [33:0]   execute_to_memory_MUL_HL;
   wire                when_Pipeline_l124_63;
-  reg        [33:0]   memory_to_writeBack_MUL_HH;
+  reg        [33:0]   execute_to_memory_MUL_HH;
   wire                when_Pipeline_l124_64;
-  reg                 execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
+  reg        [33:0]   memory_to_writeBack_MUL_HH;
   wire                when_Pipeline_l124_65;
-  reg                 memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+  reg                 execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
   wire                when_Pipeline_l124_66;
+  reg                 memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+  wire                when_Pipeline_l124_67;
   reg        [51:0]   memory_to_writeBack_MUL_LOW;
   wire                when_Pipeline_l151;
   wire                when_Pipeline_l154;
@@ -1284,60 +1277,61 @@ module VexRiscv (
   wire                when_Pipeline_l154_1;
   wire                when_Pipeline_l151_2;
   wire                when_Pipeline_l154_2;
-  wire                when_CsrPlugin_l1277;
+  wire                when_CsrPlugin_l1669;
   reg                 execute_CsrPlugin_csr_3264;
-  wire                when_CsrPlugin_l1277_1;
+  wire                when_CsrPlugin_l1669_1;
   reg                 execute_CsrPlugin_csr_3857;
-  wire                when_CsrPlugin_l1277_2;
+  wire                when_CsrPlugin_l1669_2;
   reg                 execute_CsrPlugin_csr_3858;
-  wire                when_CsrPlugin_l1277_3;
+  wire                when_CsrPlugin_l1669_3;
   reg                 execute_CsrPlugin_csr_3859;
-  wire                when_CsrPlugin_l1277_4;
+  wire                when_CsrPlugin_l1669_4;
   reg                 execute_CsrPlugin_csr_3860;
-  wire                when_CsrPlugin_l1277_5;
+  wire                when_CsrPlugin_l1669_5;
   reg                 execute_CsrPlugin_csr_769;
-  wire                when_CsrPlugin_l1277_6;
+  wire                when_CsrPlugin_l1669_6;
   reg                 execute_CsrPlugin_csr_768;
-  wire                when_CsrPlugin_l1277_7;
+  wire                when_CsrPlugin_l1669_7;
   reg                 execute_CsrPlugin_csr_836;
-  wire                when_CsrPlugin_l1277_8;
+  wire                when_CsrPlugin_l1669_8;
   reg                 execute_CsrPlugin_csr_772;
-  wire                when_CsrPlugin_l1277_9;
+  wire                when_CsrPlugin_l1669_9;
   reg                 execute_CsrPlugin_csr_773;
-  wire                when_CsrPlugin_l1277_10;
+  wire                when_CsrPlugin_l1669_10;
   reg                 execute_CsrPlugin_csr_833;
-  wire                when_CsrPlugin_l1277_11;
+  wire                when_CsrPlugin_l1669_11;
   reg                 execute_CsrPlugin_csr_832;
-  wire                when_CsrPlugin_l1277_12;
+  wire                when_CsrPlugin_l1669_12;
   reg                 execute_CsrPlugin_csr_834;
-  wire                when_CsrPlugin_l1277_13;
+  wire                when_CsrPlugin_l1669_13;
   reg                 execute_CsrPlugin_csr_835;
-  wire                when_CsrPlugin_l1277_14;
+  wire                when_CsrPlugin_l1669_14;
   reg                 execute_CsrPlugin_csr_2816;
-  wire                when_CsrPlugin_l1277_15;
+  wire                when_CsrPlugin_l1669_15;
   reg                 execute_CsrPlugin_csr_2944;
-  wire                when_CsrPlugin_l1277_16;
+  wire                when_CsrPlugin_l1669_16;
   reg                 execute_CsrPlugin_csr_2818;
-  wire                when_CsrPlugin_l1277_17;
+  wire                when_CsrPlugin_l1669_17;
   reg                 execute_CsrPlugin_csr_2946;
-  wire                when_CsrPlugin_l1277_18;
+  wire                when_CsrPlugin_l1669_18;
   reg                 execute_CsrPlugin_csr_3072;
-  wire                when_CsrPlugin_l1277_19;
+  wire                when_CsrPlugin_l1669_19;
   reg                 execute_CsrPlugin_csr_3200;
-  wire                when_CsrPlugin_l1277_20;
+  wire                when_CsrPlugin_l1669_20;
   reg                 execute_CsrPlugin_csr_3074;
-  wire                when_CsrPlugin_l1277_21;
+  wire                when_CsrPlugin_l1669_21;
   reg                 execute_CsrPlugin_csr_3202;
-  wire                when_CsrPlugin_l1277_22;
+  wire                when_CsrPlugin_l1669_22;
   reg                 execute_CsrPlugin_csr_3008;
-  wire                when_CsrPlugin_l1277_23;
+  wire                when_CsrPlugin_l1669_23;
   reg                 execute_CsrPlugin_csr_4032;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_5;
+  wire       [1:0]    switch_CsrPlugin_l1031;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_6;
-  wire       [1:0]    switch_CsrPlugin_l723;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_8;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
@@ -1355,19 +1349,22 @@ module VexRiscv (
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_21;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_22;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_23;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_24;
-  wire                when_CsrPlugin_l1310;
-  wire                when_CsrPlugin_l1315;
+  wire                when_CsrPlugin_l1702;
+  wire       [11:0]   _zz_when_CsrPlugin_l1709;
+  wire                when_CsrPlugin_l1709;
+  reg                 when_CsrPlugin_l1719;
+  wire                when_CsrPlugin_l1717;
+  wire                when_CsrPlugin_l1725;
   reg        [2:0]    _zz_iBusWishbone_ADR;
   wire                when_InstructionCache_l239;
   reg                 _zz_iBus_rsp_valid;
   reg        [31:0]   iBusWishbone_DAT_MISO_regNext;
-  reg        [2:0]    _zz_dBus_cmd_ready;
+  reg        [2:0]    _zz_dBusWishbone_ADR;
+  wire                _zz_dBusWishbone_CYC;
+  wire                _zz_dBus_cmd_ready;
   wire                _zz_dBus_cmd_ready_1;
   wire                _zz_dBus_cmd_ready_2;
-  wire                _zz_dBus_cmd_ready_3;
-  wire                _zz_dBus_cmd_ready_4;
-  wire                _zz_dBus_cmd_ready_5;
+  wire                _zz_dBusWishbone_ADR_1;
   reg                 _zz_dBus_rsp_valid;
   reg        [31:0]   dBusWishbone_DAT_MISO_regNext;
   `ifndef SYNTHESIS
@@ -1446,7 +1443,7 @@ module VexRiscv (
   reg [71:0] _zz_decode_SHIFT_CTRL_2_string;
   reg [31:0] _zz_decode_BRANCH_CTRL_2_string;
   reg [39:0] _zz_decode_ENV_CTRL_2_string;
-  reg [39:0] _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string;
+  reg [39:0] _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_string;
   reg [95:0] decode_to_execute_SRC1_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
   reg [23:0] decode_to_execute_SRC2_CTRL_string;
@@ -1464,15 +1461,14 @@ module VexRiscv (
 
   assign _zz_when = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
   assign _zz_when_1 = ({CsrPlugin_selfException_valid,BranchPlugin_branchExceptionPort_valid} != 2'b00);
-  assign _zz_memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW_1) + $signed(_zz_memory_MUL_LOW_5));
-  assign _zz_memory_MUL_LOW_1 = ($signed(_zz_memory_MUL_LOW_2) + $signed(_zz_memory_MUL_LOW_3));
-  assign _zz_memory_MUL_LOW_2 = 52'h0;
-  assign _zz_memory_MUL_LOW_4 = {1'b0,memory_MUL_LL};
-  assign _zz_memory_MUL_LOW_3 = {{19{_zz_memory_MUL_LOW_4[32]}}, _zz_memory_MUL_LOW_4};
-  assign _zz_memory_MUL_LOW_6 = ({16'd0,memory_MUL_LH} <<< 16);
-  assign _zz_memory_MUL_LOW_5 = {{2{_zz_memory_MUL_LOW_6[49]}}, _zz_memory_MUL_LOW_6};
-  assign _zz_memory_MUL_LOW_8 = ({16'd0,memory_MUL_HL} <<< 16);
-  assign _zz_memory_MUL_LOW_7 = {{2{_zz_memory_MUL_LOW_8[49]}}, _zz_memory_MUL_LOW_8};
+  assign _zz_memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW_1) + $signed(_zz_memory_MUL_LOW_4));
+  assign _zz_memory_MUL_LOW_1 = ($signed(52'h0000000000000) + $signed(_zz_memory_MUL_LOW_2));
+  assign _zz_memory_MUL_LOW_3 = {1'b0,memory_MUL_LL};
+  assign _zz_memory_MUL_LOW_2 = {{19{_zz_memory_MUL_LOW_3[32]}}, _zz_memory_MUL_LOW_3};
+  assign _zz_memory_MUL_LOW_5 = ({16'd0,memory_MUL_LH} <<< 5'd16);
+  assign _zz_memory_MUL_LOW_4 = {{2{_zz_memory_MUL_LOW_5[49]}}, _zz_memory_MUL_LOW_5};
+  assign _zz_memory_MUL_LOW_7 = ({16'd0,memory_MUL_HL} <<< 5'd16);
+  assign _zz_memory_MUL_LOW_6 = {{2{_zz_memory_MUL_LOW_7[49]}}, _zz_memory_MUL_LOW_7};
   assign _zz_execute_SHIFT_RIGHT_1 = ($signed(_zz_execute_SHIFT_RIGHT_2) >>> execute_FullBarrelShifterPlugin_amplitude);
   assign _zz_execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT_1[31 : 0];
   assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == ShiftCtrlEnum_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
@@ -1488,20 +1484,18 @@ module VexRiscv (
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
   assign _zz_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId_1;
-  assign _zz_io_cpu_flush_payload_lineId_1 = (execute_RS1 >>> 5);
+  assign _zz_io_cpu_flush_payload_lineId_1 = (execute_RS1 >>> 3'd5);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code_1 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
   assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
   assign _zz__zz_execute_SRC1 = 3'b100;
   assign _zz__zz_execute_SRC1_1 = execute_INSTRUCTION[19 : 15];
-  assign _zz__zz_execute_SRC2_3 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz__zz_execute_SRC2_2 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
   assign _zz_execute_SrcPlugin_addSub = ($signed(_zz_execute_SrcPlugin_addSub_1) + $signed(_zz_execute_SrcPlugin_addSub_4));
   assign _zz_execute_SrcPlugin_addSub_1 = ($signed(_zz_execute_SrcPlugin_addSub_2) + $signed(_zz_execute_SrcPlugin_addSub_3));
   assign _zz_execute_SrcPlugin_addSub_2 = execute_SRC1;
   assign _zz_execute_SrcPlugin_addSub_3 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? _zz_execute_SrcPlugin_addSub_5 : _zz_execute_SrcPlugin_addSub_6);
-  assign _zz_execute_SrcPlugin_addSub_5 = 32'h00000001;
-  assign _zz_execute_SrcPlugin_addSub_6 = 32'h0;
+  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? 32'h00000001 : 32'h00000000);
   assign _zz__zz_execute_BranchPlugin_missAlignedTarget_2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
   assign _zz__zz_execute_BranchPlugin_missAlignedTarget_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
   assign _zz__zz_execute_BranchPlugin_missAlignedTarget_6 = {_zz_execute_BranchPlugin_missAlignedTarget_1,execute_INSTRUCTION[31 : 20]};
@@ -1515,7 +1509,7 @@ module VexRiscv (
   assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_2 & (~ _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3_1));
   assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_2 - 2'b01);
   assign _zz_writeBack_MulPlugin_result = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
-  assign _zz_writeBack_MulPlugin_result_1 = ({32'd0,writeBack_MUL_HH} <<< 32);
+  assign _zz_writeBack_MulPlugin_result_1 = ({32'd0,writeBack_MUL_HH} <<< 6'd32);
   assign _zz__zz_decode_RS2_2 = writeBack_MUL_LOW[31 : 0];
   assign _zz__zz_decode_RS2_2_1 = writeBack_MulPlugin_result[63 : 32];
   assign _zz_memory_DivPlugin_div_counter_valueNext_1 = memory_DivPlugin_div_counter_willIncrement;
@@ -1534,192 +1528,179 @@ module VexRiscv (
   assign _zz_memory_DivPlugin_rs2_2 = _zz_memory_DivPlugin_rs2;
   assign _zz_memory_DivPlugin_rs2_1 = {31'd0, _zz_memory_DivPlugin_rs2_2};
   assign _zz_execute_CfuPlugin_functionsIds_0 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[14 : 12]};
-  assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 5);
+  assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 3'd5);
   assign _zz_decode_RegFilePlugin_rs1Data = 1'b1;
   assign _zz_decode_RegFilePlugin_rs2Data = 1'b1;
   assign _zz_IBusCachedPlugin_jump_pcLoad_payload_6 = {_zz_IBusCachedPlugin_jump_pcLoad_payload_4,_zz_IBusCachedPlugin_jump_pcLoad_payload_3};
   assign _zz_writeBack_DBusCachedPlugin_rspShifted_1 = dataCache_1_io_cpu_writeBack_address[1 : 0];
   assign _zz_writeBack_DBusCachedPlugin_rspShifted_3 = dataCache_1_io_cpu_writeBack_address[1 : 1];
-  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000106f;
-  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000107f);
-  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00001073;
-  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002073);
-  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_decode_LEGAL_INSTRUCTION_5 = {((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013),{((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_6) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_7 == _zz_decode_LEGAL_INSTRUCTION_8),{_zz_decode_LEGAL_INSTRUCTION_9,{_zz_decode_LEGAL_INSTRUCTION_10,_zz_decode_LEGAL_INSTRUCTION_11}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000107f;
+  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000207f);
+  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00002073;
+  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
+  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION_5 = {((decode_INSTRUCTION & 32'h0000107f) == 32'h00000013),{((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_6) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_7 == _zz_decode_LEGAL_INSTRUCTION_8),{_zz_decode_LEGAL_INSTRUCTION_9,{_zz_decode_LEGAL_INSTRUCTION_10,_zz_decode_LEGAL_INSTRUCTION_11}}}}}};
   assign _zz_decode_LEGAL_INSTRUCTION_6 = 32'h0000207f;
   assign _zz_decode_LEGAL_INSTRUCTION_7 = (decode_INSTRUCTION & 32'h0000505f);
   assign _zz_decode_LEGAL_INSTRUCTION_8 = 32'h00000003;
   assign _zz_decode_LEGAL_INSTRUCTION_9 = ((decode_INSTRUCTION & 32'h0000707b) == 32'h00000063);
   assign _zz_decode_LEGAL_INSTRUCTION_10 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
   assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033),{((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h00005013),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,{_zz_decode_LEGAL_INSTRUCTION_16,_zz_decode_LEGAL_INSTRUCTION_17}}}}}};
-  assign _zz_decode_LEGAL_INSTRUCTION_12 = 32'hbc00707f;
-  assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'hfc00307f);
+  assign _zz_decode_LEGAL_INSTRUCTION_12 = 32'hbe00705f;
+  assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'hfe00305f);
   assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h00001013;
-  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00005033);
-  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
-  assign _zz_decode_LEGAL_INSTRUCTION_17 = {((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073),{((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073),((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073)}};
+  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
+  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
+  assign _zz_decode_LEGAL_INSTRUCTION_17 = {((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073),((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073)};
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_4 = decode_INSTRUCTION[31];
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_5 = decode_INSTRUCTION[31];
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_6 = decode_INSTRUCTION[7];
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = ((decode_INSTRUCTION & 32'h02004064) == 32'h02004020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1 = ((decode_INSTRUCTION & 32'h02004074) == 32'h02000030);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2 = (|((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3) == 32'h00000050));
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4 = (|(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6));
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7 = {(|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10}),{(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23}}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3 = 32'h00203050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5 = (decode_INSTRUCTION & 32'h00403050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6 = 32'h00000050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9) == 32'h00001050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11) == 32'h00002050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6,(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14)};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15 = (|(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17));
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21});
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9 = 32'h00001050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11 = 32'h00002050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13 = (decode_INSTRUCTION & 32'h0000001c);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14 = 32'h00000004;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16 = (decode_INSTRUCTION & 32'h00000058);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17 = 32'h00000040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20) == 32'h00005010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22) == 32'h00005020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29 = (|(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31));
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20 = 32'h00007034;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22 = 32'h02007064;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25 = (decode_INSTRUCTION & 32'h40003054);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26 = 32'h40001010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28 = ((decode_INSTRUCTION & 32'h02007054) == 32'h00001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30 = (decode_INSTRUCTION & 32'h00000064);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31 = 32'h00000024;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33 = ((decode_INSTRUCTION & 32'h00001000) == 32'h00001000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36) == 32'h00002000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39});
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36 = 32'h00003000;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00001000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41 = ((decode_INSTRUCTION & 32'h00004054) == 32'h00004004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54}});
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50) == 32'h00002040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82});
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45 = 32'h00000034;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47 = 32'h00000064;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50 = 32'h00002040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52 = (decode_INSTRUCTION & 32'h00001040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53 = 32'h00001040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56) == 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63 = 32'h00000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67) == 32'h00000008);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110});
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56 = 32'h00000050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58 = (decode_INSTRUCTION & 32'h00400040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59 = 32'h00000040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67 = 32'h00000008;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69 = (decode_INSTRUCTION & 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70 = 32'h00000040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84) == 32'h00002010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73 = (decode_INSTRUCTION & 32'h00004020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74 = 32'h00004020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77) == 32'h00000010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84 = 32'h00002030;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86 = (decode_INSTRUCTION & 32'h00001030);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87 = 32'h00000010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90) == 32'h00002020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96 = (decode_INSTRUCTION & 32'h00001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97 = 32'h00001010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100) == 32'h00002010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111 = (decode_INSTRUCTION & 32'h00000070);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112 = 32'h00000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120) == 32'h00004010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129});
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77 = 32'h00000030;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79 = 32'h02000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90 = 32'h02002060;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92 = 32'h02003020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100 = 32'h00002010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103 = 32'h00000010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106 = ((decode_INSTRUCTION & 32'h00000024) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116 = 32'h00000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120 = 32'h00004014;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123 = (decode_INSTRUCTION & 32'h00006014);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124 = 32'h00002010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143}});
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148});
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150),(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153)};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128 = 32'h00000044;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132) == 32'h00001000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134) == 32'h00004000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137 = 32'h00000058;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142) == 32'h00002010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144) == 32'h40000030);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147) == 32'h00000004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152),_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154) == 32'h00001004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132 = 32'h00005004;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134 = 32'h00004050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142 = 32'h00002014;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144 = 32'h40000034;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147 = 32'h00000014;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152 = 32'h00000004;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154 = 32'h00005054;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE = ((decode_INSTRUCTION & 32'h02004064) == 32'h02004020);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_1 = ((decode_INSTRUCTION & 32'h02004074) == 32'h02000030);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_2 = (|((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_3) == 32'h00000050));
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_4 = (|(_zz__zz_decode_CfuPlugin_CFU_ENABLE_5 == _zz__zz_decode_CfuPlugin_CFU_ENABLE_6));
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_7 = {(|{_zz__zz_decode_CfuPlugin_CFU_ENABLE_8,_zz__zz_decode_CfuPlugin_CFU_ENABLE_9}),{(|_zz__zz_decode_CfuPlugin_CFU_ENABLE_10),{_zz__zz_decode_CfuPlugin_CFU_ENABLE_12,{_zz__zz_decode_CfuPlugin_CFU_ENABLE_14,_zz__zz_decode_CfuPlugin_CFU_ENABLE_17}}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_3 = 32'h00203050;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_5 = (decode_INSTRUCTION & 32'h00403050);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_6 = 32'h00000050;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_8 = ((decode_INSTRUCTION & 32'h00001050) == 32'h00001050);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_9 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002050);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_10 = {_zz_decode_CfuPlugin_CFU_ENABLE_4,((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_11) == 32'h00000004)};
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_12 = (|((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_13) == 32'h00000040));
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_14 = (|(_zz__zz_decode_CfuPlugin_CFU_ENABLE_15 == _zz__zz_decode_CfuPlugin_CFU_ENABLE_16));
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_17 = {(|{_zz__zz_decode_CfuPlugin_CFU_ENABLE_18,_zz__zz_decode_CfuPlugin_CFU_ENABLE_19}),{(|_zz__zz_decode_CfuPlugin_CFU_ENABLE_20),{_zz__zz_decode_CfuPlugin_CFU_ENABLE_21,{_zz__zz_decode_CfuPlugin_CFU_ENABLE_23,_zz__zz_decode_CfuPlugin_CFU_ENABLE_26}}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_11 = 32'h0000001c;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_13 = 32'h00000058;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_15 = (decode_INSTRUCTION & 32'h02007054);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_16 = 32'h00005010;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_18 = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_19 = ((decode_INSTRUCTION & 32'h02007054) == 32'h00001010);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_20 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_21 = (|((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_22) == 32'h00001000));
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_23 = (|(_zz__zz_decode_CfuPlugin_CFU_ENABLE_24 == _zz__zz_decode_CfuPlugin_CFU_ENABLE_25));
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_26 = {(|{_zz__zz_decode_CfuPlugin_CFU_ENABLE_27,_zz__zz_decode_CfuPlugin_CFU_ENABLE_29}),{(|_zz__zz_decode_CfuPlugin_CFU_ENABLE_31),{_zz__zz_decode_CfuPlugin_CFU_ENABLE_33,{_zz__zz_decode_CfuPlugin_CFU_ENABLE_38,_zz__zz_decode_CfuPlugin_CFU_ENABLE_50}}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_22 = 32'h00001000;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_24 = (decode_INSTRUCTION & 32'h00003000);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_25 = 32'h00002000;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_27 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_28) == 32'h00002000);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_29 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_30) == 32'h00001000);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_31 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_32) == 32'h00004004);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_33 = (|{_zz_decode_CfuPlugin_CFU_ENABLE_5,{_zz__zz_decode_CfuPlugin_CFU_ENABLE_34,_zz__zz_decode_CfuPlugin_CFU_ENABLE_36}});
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_38 = (|{_zz__zz_decode_CfuPlugin_CFU_ENABLE_39,_zz__zz_decode_CfuPlugin_CFU_ENABLE_41});
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_50 = {(|_zz__zz_decode_CfuPlugin_CFU_ENABLE_51),{_zz__zz_decode_CfuPlugin_CFU_ENABLE_53,{_zz__zz_decode_CfuPlugin_CFU_ENABLE_68,_zz__zz_decode_CfuPlugin_CFU_ENABLE_81}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_28 = 32'h00002010;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_30 = 32'h00005000;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_32 = 32'h00004054;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_34 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_35) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_36 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_37) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_39 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_40) == 32'h00002040);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_41 = {(_zz__zz_decode_CfuPlugin_CFU_ENABLE_42 == _zz__zz_decode_CfuPlugin_CFU_ENABLE_43),{_zz__zz_decode_CfuPlugin_CFU_ENABLE_44,{_zz__zz_decode_CfuPlugin_CFU_ENABLE_46,_zz__zz_decode_CfuPlugin_CFU_ENABLE_49}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_51 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_52) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_53 = (|{_zz__zz_decode_CfuPlugin_CFU_ENABLE_54,{_zz__zz_decode_CfuPlugin_CFU_ENABLE_56,_zz__zz_decode_CfuPlugin_CFU_ENABLE_59}});
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_68 = (|{_zz__zz_decode_CfuPlugin_CFU_ENABLE_69,_zz__zz_decode_CfuPlugin_CFU_ENABLE_70});
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_81 = {(|_zz__zz_decode_CfuPlugin_CFU_ENABLE_82),{_zz__zz_decode_CfuPlugin_CFU_ENABLE_95,{_zz__zz_decode_CfuPlugin_CFU_ENABLE_100,_zz__zz_decode_CfuPlugin_CFU_ENABLE_104}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_35 = 32'h00000034;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_37 = 32'h00000064;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_40 = 32'h00002040;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_42 = (decode_INSTRUCTION & 32'h00001040);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_43 = 32'h00001040;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_44 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_45) == 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_46 = (_zz__zz_decode_CfuPlugin_CFU_ENABLE_47 == _zz__zz_decode_CfuPlugin_CFU_ENABLE_48);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_49 = _zz_decode_CfuPlugin_CFU_ENABLE_2;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_52 = 32'h00000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_54 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_55) == 32'h00000008);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_56 = (_zz__zz_decode_CfuPlugin_CFU_ENABLE_57 == _zz__zz_decode_CfuPlugin_CFU_ENABLE_58);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_59 = {_zz_decode_CfuPlugin_CFU_ENABLE_3,{_zz__zz_decode_CfuPlugin_CFU_ENABLE_60,_zz__zz_decode_CfuPlugin_CFU_ENABLE_63}};
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_69 = _zz_decode_CfuPlugin_CFU_ENABLE_3;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_70 = {_zz__zz_decode_CfuPlugin_CFU_ENABLE_71,{_zz__zz_decode_CfuPlugin_CFU_ENABLE_73,_zz__zz_decode_CfuPlugin_CFU_ENABLE_76}};
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_82 = {_zz_decode_CfuPlugin_CFU_ENABLE_4,{_zz__zz_decode_CfuPlugin_CFU_ENABLE_83,_zz__zz_decode_CfuPlugin_CFU_ENABLE_86}};
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_95 = (|{_zz__zz_decode_CfuPlugin_CFU_ENABLE_96,_zz__zz_decode_CfuPlugin_CFU_ENABLE_97});
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_100 = (|_zz__zz_decode_CfuPlugin_CFU_ENABLE_101);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_104 = {_zz__zz_decode_CfuPlugin_CFU_ENABLE_105,{_zz__zz_decode_CfuPlugin_CFU_ENABLE_108,_zz__zz_decode_CfuPlugin_CFU_ENABLE_112}};
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_45 = 32'h00000050;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_47 = (decode_INSTRUCTION & 32'h00400040);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_48 = 32'h00000040;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_55 = 32'h00000008;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_57 = (decode_INSTRUCTION & 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_58 = 32'h00000040;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_60 = (_zz__zz_decode_CfuPlugin_CFU_ENABLE_61 == _zz__zz_decode_CfuPlugin_CFU_ENABLE_62);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_63 = {_zz__zz_decode_CfuPlugin_CFU_ENABLE_64,_zz__zz_decode_CfuPlugin_CFU_ENABLE_66};
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_71 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_72) == 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_73 = (_zz__zz_decode_CfuPlugin_CFU_ENABLE_74 == _zz__zz_decode_CfuPlugin_CFU_ENABLE_75);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_76 = {_zz__zz_decode_CfuPlugin_CFU_ENABLE_77,_zz__zz_decode_CfuPlugin_CFU_ENABLE_79};
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_83 = (_zz__zz_decode_CfuPlugin_CFU_ENABLE_84 == _zz__zz_decode_CfuPlugin_CFU_ENABLE_85);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_86 = {_zz__zz_decode_CfuPlugin_CFU_ENABLE_87,{_zz__zz_decode_CfuPlugin_CFU_ENABLE_89,_zz__zz_decode_CfuPlugin_CFU_ENABLE_92}};
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_96 = _zz_decode_CfuPlugin_CFU_ENABLE_3;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_97 = (_zz__zz_decode_CfuPlugin_CFU_ENABLE_98 == _zz__zz_decode_CfuPlugin_CFU_ENABLE_99);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_101 = {_zz_decode_CfuPlugin_CFU_ENABLE_3,_zz__zz_decode_CfuPlugin_CFU_ENABLE_102};
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_105 = (|_zz__zz_decode_CfuPlugin_CFU_ENABLE_106);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_108 = (|_zz__zz_decode_CfuPlugin_CFU_ENABLE_109);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_112 = {_zz__zz_decode_CfuPlugin_CFU_ENABLE_113,{_zz__zz_decode_CfuPlugin_CFU_ENABLE_122,_zz__zz_decode_CfuPlugin_CFU_ENABLE_125}};
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_61 = (decode_INSTRUCTION & 32'h00004020);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_62 = 32'h00004020;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_64 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_65) == 32'h00000010);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_66 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_67) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_72 = 32'h00002030;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_74 = (decode_INSTRUCTION & 32'h00001030);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_75 = 32'h00000010;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_77 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_78) == 32'h00002020);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_79 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_80) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_84 = (decode_INSTRUCTION & 32'h00001010);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_85 = 32'h00001010;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_87 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_88) == 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_89 = (_zz__zz_decode_CfuPlugin_CFU_ENABLE_90 == _zz__zz_decode_CfuPlugin_CFU_ENABLE_91);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_92 = {_zz__zz_decode_CfuPlugin_CFU_ENABLE_93,_zz__zz_decode_CfuPlugin_CFU_ENABLE_94};
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_98 = (decode_INSTRUCTION & 32'h00000070);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_99 = 32'h00000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_102 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_103) == 32'h00000000);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_106 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_107) == 32'h00004010);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_109 = (_zz__zz_decode_CfuPlugin_CFU_ENABLE_110 == _zz__zz_decode_CfuPlugin_CFU_ENABLE_111);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_113 = (|{_zz__zz_decode_CfuPlugin_CFU_ENABLE_114,_zz__zz_decode_CfuPlugin_CFU_ENABLE_116});
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_122 = (|_zz__zz_decode_CfuPlugin_CFU_ENABLE_123);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_125 = {_zz__zz_decode_CfuPlugin_CFU_ENABLE_126,{_zz__zz_decode_CfuPlugin_CFU_ENABLE_132,_zz__zz_decode_CfuPlugin_CFU_ENABLE_136}};
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_65 = 32'h00000030;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_67 = 32'h02000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_78 = 32'h02002060;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_80 = 32'h02003020;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_88 = 32'h00002010;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_90 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_91 = 32'h00000010;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_93 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_94 = ((decode_INSTRUCTION & 32'h00000024) == 32'h00000000);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_103 = 32'h00000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_107 = 32'h00004014;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_110 = (decode_INSTRUCTION & 32'h00006014);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_111 = 32'h00002010;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_114 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_115) == 32'h00000000);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_116 = {_zz_decode_CfuPlugin_CFU_ENABLE_2,{_zz__zz_decode_CfuPlugin_CFU_ENABLE_117,{_zz__zz_decode_CfuPlugin_CFU_ENABLE_118,_zz__zz_decode_CfuPlugin_CFU_ENABLE_120}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_123 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_124) == 32'h00000000);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_126 = (|{_zz__zz_decode_CfuPlugin_CFU_ENABLE_127,{_zz__zz_decode_CfuPlugin_CFU_ENABLE_128,_zz__zz_decode_CfuPlugin_CFU_ENABLE_130}});
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_132 = (|{_zz__zz_decode_CfuPlugin_CFU_ENABLE_133,_zz__zz_decode_CfuPlugin_CFU_ENABLE_135});
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_136 = {(|_zz__zz_decode_CfuPlugin_CFU_ENABLE_137),(|_zz__zz_decode_CfuPlugin_CFU_ENABLE_140)};
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_115 = 32'h00000044;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_117 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_118 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_119) == 32'h00001000);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_120 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_121) == 32'h00004000);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_124 = 32'h00000058;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_127 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_128 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_129) == 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_130 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_131) == 32'h40000030);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_133 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_134) == 32'h00000004);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_135 = _zz_decode_CfuPlugin_CFU_ENABLE_1;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_137 = {(_zz__zz_decode_CfuPlugin_CFU_ENABLE_138 == _zz__zz_decode_CfuPlugin_CFU_ENABLE_139),_zz_decode_CfuPlugin_CFU_ENABLE_1};
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_140 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_141) == 32'h00001004);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_119 = 32'h00005004;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_121 = 32'h00004050;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_129 = 32'h00002014;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_131 = 32'h40000034;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_134 = 32'h00000014;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_138 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_139 = 32'h00000004;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_141 = 32'h00005054;
   assign _zz_execute_BranchPlugin_branch_src2_6 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_7 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_8 = execute_INSTRUCTION[7];
-  assign _zz_CsrPlugin_csrMapping_readDataInit_25 = 32'h0;
+  assign _zz_CsrPlugin_csrMapping_readDataInit_24 = 32'h00000000;
   always @(posedge clk) begin
     if(_zz_decode_RegFilePlugin_rs1Data) begin
       _zz_RegFilePlugin_regFile_port0 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
@@ -1829,8 +1810,9 @@ module VexRiscv (
     .io_cpu_flush_ready                     (dataCache_1_io_cpu_flush_ready                   ), //o
     .io_cpu_flush_payload_singleLine        (dataCache_1_io_cpu_flush_payload_singleLine      ), //i
     .io_cpu_flush_payload_lineId            (dataCache_1_io_cpu_flush_payload_lineId[6:0]     ), //i
+    .io_cpu_writesPending                   (dataCache_1_io_cpu_writesPending                 ), //o
     .io_mem_cmd_valid                       (dataCache_1_io_mem_cmd_valid                     ), //o
-    .io_mem_cmd_ready                       (dataCache_1_io_mem_cmd_ready                     ), //i
+    .io_mem_cmd_ready                       (toplevel_dataCache_1_io_mem_cmd_rValidN          ), //i
     .io_mem_cmd_payload_wr                  (dataCache_1_io_mem_cmd_payload_wr                ), //o
     .io_mem_cmd_payload_uncached            (dataCache_1_io_mem_cmd_payload_uncached          ), //o
     .io_mem_cmd_payload_address             (dataCache_1_io_mem_cmd_payload_address[31:0]     ), //o
@@ -2517,10 +2499,10 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9)
-      Input2Kind_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string = "RS   ";
-      Input2Kind_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string = "IMM_I";
-      default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string = "?????";
+    case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2)
+      Input2Kind_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_string = "IMM_I";
+      default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2620,7 +2602,7 @@ module VexRiscv (
   end
   `endif
 
-  assign memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW) + $signed(_zz_memory_MUL_LOW_7));
+  assign memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW) + $signed(_zz_memory_MUL_LOW_6));
   assign writeBack_CfuPlugin_CFU_IN_FLIGHT = memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
   assign execute_CfuPlugin_CFU_IN_FLIGHT = ((execute_CfuPlugin_schedule || execute_CfuPlugin_hold) || execute_CfuPlugin_fired);
   assign memory_MUL_HH = execute_to_memory_MUL_HH;
@@ -2633,38 +2615,38 @@ module VexRiscv (
   assign memory_MEMORY_STORE_DATA_RF = execute_to_memory_MEMORY_STORE_DATA_RF;
   assign execute_MEMORY_STORE_DATA_RF = _zz_execute_MEMORY_STORE_DATA_RF;
   assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
-  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
+  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h00)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h00))));
   assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
   assign decode_CfuPlugin_CFU_INPUT_2_KIND = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND;
   assign _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND = _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1;
-  assign decode_CfuPlugin_CFU_ENABLE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[32];
-  assign decode_IS_RS2_SIGNED = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[31];
-  assign decode_IS_RS1_SIGNED = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[30];
-  assign decode_IS_DIV = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[29];
+  assign decode_CfuPlugin_CFU_ENABLE = _zz_decode_CfuPlugin_CFU_ENABLE[32];
+  assign decode_IS_RS2_SIGNED = _zz_decode_CfuPlugin_CFU_ENABLE[31];
+  assign decode_IS_RS1_SIGNED = _zz_decode_CfuPlugin_CFU_ENABLE[30];
+  assign decode_IS_DIV = _zz_decode_CfuPlugin_CFU_ENABLE[29];
   assign memory_IS_MUL = execute_to_memory_IS_MUL;
   assign execute_IS_MUL = decode_to_execute_IS_MUL;
-  assign decode_IS_MUL = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[28];
+  assign decode_IS_MUL = _zz_decode_CfuPlugin_CFU_ENABLE[28];
   assign _zz_memory_to_writeBack_ENV_CTRL = _zz_memory_to_writeBack_ENV_CTRL_1;
   assign _zz_execute_to_memory_ENV_CTRL = _zz_execute_to_memory_ENV_CTRL_1;
   assign decode_ENV_CTRL = _zz_decode_ENV_CTRL;
   assign _zz_decode_to_execute_ENV_CTRL = _zz_decode_to_execute_ENV_CTRL_1;
-  assign decode_IS_CSR = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[25];
+  assign decode_IS_CSR = _zz_decode_CfuPlugin_CFU_ENABLE[25];
   assign _zz_decode_to_execute_BRANCH_CTRL = _zz_decode_to_execute_BRANCH_CTRL_1;
   assign _zz_execute_to_memory_SHIFT_CTRL = _zz_execute_to_memory_SHIFT_CTRL_1;
   assign decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL;
   assign _zz_decode_to_execute_SHIFT_CTRL = _zz_decode_to_execute_SHIFT_CTRL_1;
   assign decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL;
   assign _zz_decode_to_execute_ALU_BITWISE_CTRL = _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
-  assign decode_SRC_LESS_UNSIGNED = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[17];
-  assign decode_MEMORY_MANAGMENT = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[16];
+  assign decode_SRC_LESS_UNSIGNED = _zz_decode_CfuPlugin_CFU_ENABLE[17];
+  assign decode_MEMORY_MANAGMENT = _zz_decode_CfuPlugin_CFU_ENABLE[16];
   assign execute_HAS_SIDE_EFFECT = decode_to_execute_HAS_SIDE_EFFECT;
-  assign decode_HAS_SIDE_EFFECT = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[14];
+  assign decode_HAS_SIDE_EFFECT = _zz_decode_CfuPlugin_CFU_ENABLE[14];
   assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
-  assign decode_MEMORY_WR = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[13];
+  assign decode_MEMORY_WR = _zz_decode_CfuPlugin_CFU_ENABLE[13];
   assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[12];
-  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[11];
+  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_decode_CfuPlugin_CFU_ENABLE[12];
+  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_decode_CfuPlugin_CFU_ENABLE[11];
   assign decode_SRC2_CTRL = _zz_decode_SRC2_CTRL;
   assign _zz_decode_to_execute_SRC2_CTRL = _zz_decode_to_execute_SRC2_CTRL_1;
   assign decode_ALU_CTRL = _zz_decode_ALU_CTRL;
@@ -2693,9 +2675,16 @@ module VexRiscv (
 
   assign memory_CfuPlugin_CFU_IN_FLIGHT = execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
   assign execute_CfuPlugin_CFU_INPUT_2_KIND = _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
-  assign execute_CfuPlugin_CFU_ENABLE = decode_to_execute_CfuPlugin_CFU_ENABLE;
   assign writeBack_HAS_SIDE_EFFECT = memory_to_writeBack_HAS_SIDE_EFFECT;
   assign memory_HAS_SIDE_EFFECT = execute_to_memory_HAS_SIDE_EFFECT;
+  assign execute_LEGAL_INSTRUCTION = decode_to_execute_LEGAL_INSTRUCTION;
+  always @(*) begin
+    execute_CfuPlugin_CFU_ENABLE = decode_to_execute_CfuPlugin_CFU_ENABLE;
+    if(when_CfuPlugin_l192) begin
+      execute_CfuPlugin_CFU_ENABLE = 1'b0;
+    end
+  end
+
   assign execute_IS_RS1_SIGNED = decode_to_execute_IS_RS1_SIGNED;
   assign execute_IS_DIV = decode_to_execute_IS_DIV;
   assign execute_IS_RS2_SIGNED = decode_to_execute_IS_RS2_SIGNED;
@@ -2718,11 +2707,11 @@ module VexRiscv (
   assign execute_PREDICTION_HAD_BRANCHED2 = decode_to_execute_PREDICTION_HAD_BRANCHED2;
   assign execute_BRANCH_COND_RESULT = _zz_execute_BRANCH_COND_RESULT_1;
   assign execute_BRANCH_CTRL = _zz_execute_BRANCH_CTRL;
-  assign decode_RS2_USE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[15];
-  assign decode_RS1_USE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[5];
+  assign decode_RS2_USE = _zz_decode_CfuPlugin_CFU_ENABLE[15];
+  assign decode_RS1_USE = _zz_decode_CfuPlugin_CFU_ENABLE[5];
   always @(*) begin
     _zz_decode_RS2 = execute_REGFILE_WRITE_DATA;
-    if(when_CsrPlugin_l1189) begin
+    if(when_CsrPlugin_l1587) begin
       _zz_decode_RS2 = CsrPlugin_csrMapping_readDataSignal;
     end
   end
@@ -2821,15 +2810,15 @@ module VexRiscv (
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_execute_SRC2 = execute_PC;
+  assign _zz_execute_to_memory_PC = execute_PC;
   assign execute_SRC2_CTRL = _zz_execute_SRC2_CTRL;
   assign execute_SRC1_CTRL = _zz_execute_SRC1_CTRL;
-  assign decode_SRC_USE_SUB_LESS = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[3];
-  assign decode_SRC_ADD_ZERO = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[20];
+  assign decode_SRC_USE_SUB_LESS = _zz_decode_CfuPlugin_CFU_ENABLE[3];
+  assign decode_SRC_ADD_ZERO = _zz_decode_CfuPlugin_CFU_ENABLE[20];
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
   assign execute_ALU_CTRL = _zz_execute_ALU_CTRL;
-  assign execute_SRC2 = _zz_execute_SRC2_5;
+  assign execute_SRC2 = _zz_execute_SRC2_4;
   assign execute_SRC1 = _zz_execute_SRC1;
   assign execute_ALU_BITWISE_CTRL = _zz_execute_ALU_BITWISE_CTRL;
   assign _zz_lastStageRegFileWrite_payload_address = writeBack_INSTRUCTION;
@@ -2843,16 +2832,16 @@ module VexRiscv (
 
   assign decode_INSTRUCTION_ANTICIPATED = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusCachedPlugin_cache_io_cpu_fetch_data);
   always @(*) begin
-    decode_REGFILE_WRITE_VALID = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[10];
+    decode_REGFILE_WRITE_VALID = _zz_decode_CfuPlugin_CFU_ENABLE[10];
     if(when_RegFilePlugin_l63) begin
       decode_REGFILE_WRITE_VALID = 1'b0;
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000000b),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
+  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000000b),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00001073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
   always @(*) begin
     _zz_decode_RS2_2 = writeBack_REGFILE_WRITE_DATA;
-    if(when_DBusCachedPlugin_l492) begin
+    if(when_DBusCachedPlugin_l580) begin
       _zz_decode_RS2_2 = writeBack_DBusCachedPlugin_rspFormated;
     end
     if(when_MulPlugin_l147) begin
@@ -2881,32 +2870,32 @@ module VexRiscv (
   assign execute_SRC_ADD = execute_SrcPlugin_addSub;
   assign execute_MEMORY_ENABLE = decode_to_execute_MEMORY_ENABLE;
   assign execute_INSTRUCTION = decode_to_execute_INSTRUCTION;
-  assign decode_MEMORY_ENABLE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[4];
-  assign decode_FLUSH_ALL = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[0];
+  assign decode_MEMORY_ENABLE = _zz_decode_CfuPlugin_CFU_ENABLE[4];
+  assign decode_FLUSH_ALL = _zz_decode_CfuPlugin_CFU_ENABLE[0];
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_4 = IBusCachedPlugin_rsp_issueDetected_3;
-    if(when_IBusCachedPlugin_l256) begin
+    if(when_IBusCachedPlugin_l262) begin
       IBusCachedPlugin_rsp_issueDetected_4 = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_3 = IBusCachedPlugin_rsp_issueDetected_2;
-    if(when_IBusCachedPlugin_l250) begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_rsp_issueDetected_3 = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
-    if(when_IBusCachedPlugin_l244) begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
-    if(when_IBusCachedPlugin_l239) begin
+    if(when_IBusCachedPlugin_l245) begin
       IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
@@ -2932,7 +2921,7 @@ module VexRiscv (
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
   always @(*) begin
     decode_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l308) begin
+    if(when_DBusCachedPlugin_l352) begin
       decode_arbitration_haltItself = 1'b1;
     end
   end
@@ -2945,7 +2934,7 @@ module VexRiscv (
     if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(when_CsrPlugin_l1129) begin
+    if(when_CsrPlugin_l1527) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
@@ -2973,30 +2962,30 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l350) begin
+    if(when_DBusCachedPlugin_l394) begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(when_CsrPlugin_l1121) begin
-      if(when_CsrPlugin_l1123) begin
+    if(when_CsrPlugin_l1519) begin
+      if(when_CsrPlugin_l1521) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(when_CsrPlugin_l1193) begin
+    if(when_CsrPlugin_l1591) begin
       if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(when_CfuPlugin_l194) begin
+    if(when_CfuPlugin_l196) begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(when_CfuPlugin_l201) begin
+    if(when_CfuPlugin_l203) begin
       execute_arbitration_haltItself = 1'b1;
     end
   end
 
   always @(*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if(when_DBusCachedPlugin_l366) begin
+    if(when_DBusCachedPlugin_l410) begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
@@ -3030,7 +3019,7 @@ module VexRiscv (
       end
     end
     if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
-      if(when_CfuPlugin_l237) begin
+      if(when_CfuPlugin_l239) begin
         memory_arbitration_haltItself = 1'b1;
       end
     end
@@ -3048,7 +3037,7 @@ module VexRiscv (
   assign memory_arbitration_flushNext = 1'b0;
   always @(*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l466) begin
+    if(when_DBusCachedPlugin_l553) begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
@@ -3079,10 +3068,10 @@ module VexRiscv (
     if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -3093,13 +3082,13 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @(*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(when_CsrPlugin_l935) begin
+    if(when_CsrPlugin_l1272) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
@@ -3107,17 +3096,27 @@ module VexRiscv (
   assign IBusCachedPlugin_forceNoDecodeCond = 1'b0;
   always @(*) begin
     IBusCachedPlugin_incomingInstruction = 1'b0;
-    if(when_Fetcher_l243) begin
+    if(when_Fetcher_l242) begin
       IBusCachedPlugin_incomingInstruction = 1'b1;
     end
   end
 
   assign BranchPlugin_inDebugNoFetchFlag = 1'b0;
-  assign CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+  always @(*) begin
+    CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+    if(when_CsrPlugin_l1702) begin
+      CsrPlugin_csrMapping_allowCsrSignal = 1'b1;
+    end
+    if(when_CsrPlugin_l1709) begin
+      CsrPlugin_csrMapping_allowCsrSignal = 1'b1;
+    end
+  end
+
+  assign CsrPlugin_csrMapping_doForceFailCsr = 1'b0;
   assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
   always @(*) begin
     CsrPlugin_inWfi = 1'b0;
-    if(when_CsrPlugin_l1121) begin
+    if(when_CsrPlugin_l1519) begin
       CsrPlugin_inWfi = 1'b1;
     end
   end
@@ -3125,21 +3124,21 @@ module VexRiscv (
   assign CsrPlugin_thirdPartyWake = 1'b0;
   always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(when_CsrPlugin_l1077) begin
-      case(switch_CsrPlugin_l1081)
+    if(when_CsrPlugin_l1456) begin
+      case(switch_CsrPlugin_l1460)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -3153,6 +3152,7 @@ module VexRiscv (
   assign CsrPlugin_allowInterrupts = 1'b1;
   assign CsrPlugin_allowException = 1'b1;
   assign CsrPlugin_allowEbreakException = 1'b1;
+  assign CsrPlugin_xretAwayFromMachine = 1'b0;
   assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
   assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusCachedPlugin_redoBranch_valid,IBusCachedPlugin_predictionJumpInterface_valid}}} != 4'b0000);
   assign _zz_IBusCachedPlugin_jump_pcLoad_payload = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
@@ -3180,9 +3180,8 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l134 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
-  assign IBusCachedPlugin_fetchPc_output_fire_1 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
-  assign when_Fetcher_l134_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
+  assign when_Fetcher_l133 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l133_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
   always @(*) begin
     IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_IBusCachedPlugin_fetchPc_pc);
     if(IBusCachedPlugin_fetchPc_redo_valid) begin
@@ -3205,7 +3204,7 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l161 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
+  assign when_Fetcher_l160 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
   assign IBusCachedPlugin_fetchPc_output_valid = ((! IBusCachedPlugin_fetcherHalt) && IBusCachedPlugin_fetchPc_booted);
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
   always @(*) begin
@@ -3242,7 +3241,7 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_1_output_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b0;
-    if(when_IBusCachedPlugin_l267) begin
+    if(when_IBusCachedPlugin_l273) begin
       IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b1;
     end
   end
@@ -3255,9 +3254,9 @@ module VexRiscv (
   assign IBusCachedPlugin_fetchPc_redo_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_iBusRsp_flush = ((decode_arbitration_removeIt || (decode_arbitration_flushNext && (! decode_arbitration_isStuck))) || IBusCachedPlugin_iBusRsp_redoFetch);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
-  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1 = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
   assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid)) || IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready);
   assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
@@ -3267,18 +3266,18 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
   always @(*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
-    if(when_Fetcher_l323) begin
+    if(when_Fetcher_l322) begin
       IBusCachedPlugin_iBusRsp_readyForError = 1'b0;
     end
   end
 
-  assign when_Fetcher_l243 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
-  assign when_Fetcher_l323 = (! IBusCachedPlugin_pcValids_0);
-  assign when_Fetcher_l332 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
-  assign when_Fetcher_l332_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
-  assign when_Fetcher_l332_2 = (! execute_arbitration_isStuck);
-  assign when_Fetcher_l332_3 = (! memory_arbitration_isStuck);
-  assign when_Fetcher_l332_4 = (! writeBack_arbitration_isStuck);
+  assign when_Fetcher_l242 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
+  assign when_Fetcher_l322 = (! IBusCachedPlugin_pcValids_0);
+  assign when_Fetcher_l331 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l331_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
+  assign when_Fetcher_l331_2 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l331_3 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l331_4 = (! writeBack_arbitration_isStuck);
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
@@ -3433,87 +3432,86 @@ module VexRiscv (
   assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
   always @(*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(when_IBusCachedPlugin_l239) begin
+    if(when_IBusCachedPlugin_l245) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(when_IBusCachedPlugin_l250) begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_cache_io_cpu_fill_valid = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
-    if(when_IBusCachedPlugin_l250) begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_cache_io_cpu_fill_valid = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_valid = 1'b0;
-    if(when_IBusCachedPlugin_l244) begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
-    if(when_IBusCachedPlugin_l256) begin
+    if(when_IBusCachedPlugin_l262) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_payload_code = 4'bxxxx;
-    if(when_IBusCachedPlugin_l244) begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b1100;
     end
-    if(when_IBusCachedPlugin_l256) begin
+    if(when_IBusCachedPlugin_l262) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b0001;
     end
   end
 
   assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_2_input_payload[31 : 2],2'b00};
-  assign when_IBusCachedPlugin_l239 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign when_IBusCachedPlugin_l244 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
-  assign when_IBusCachedPlugin_l250 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
-  assign when_IBusCachedPlugin_l256 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
-  assign when_IBusCachedPlugin_l267 = (IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt);
+  assign when_IBusCachedPlugin_l245 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign when_IBusCachedPlugin_l250 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign when_IBusCachedPlugin_l256 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
+  assign when_IBusCachedPlugin_l262 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
+  assign when_IBusCachedPlugin_l273 = (IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt);
   assign IBusCachedPlugin_iBusRsp_output_valid = IBusCachedPlugin_iBusRsp_stages_2_output_valid;
   assign IBusCachedPlugin_iBusRsp_stages_2_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
   assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_decode_data;
   assign IBusCachedPlugin_iBusRsp_output_payload_pc = IBusCachedPlugin_iBusRsp_stages_2_output_payload;
   assign IBusCachedPlugin_cache_io_flush = (decode_arbitration_isValid && decode_FLUSH_ALL);
-  assign dataCache_1_io_mem_cmd_ready = (! dataCache_1_io_mem_cmd_rValid);
-  assign dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || dataCache_1_io_mem_cmd_rValid);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_wr : dataCache_1_io_mem_cmd_payload_wr);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_uncached : dataCache_1_io_mem_cmd_payload_uncached);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_address = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_address : dataCache_1_io_mem_cmd_payload_address);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_data = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_data : dataCache_1_io_mem_cmd_payload_data);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_mask : dataCache_1_io_mem_cmd_payload_mask);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_size = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_size : dataCache_1_io_mem_cmd_payload_size);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_last : dataCache_1_io_mem_cmd_payload_last);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || (! toplevel_dataCache_1_io_mem_cmd_rValidN));
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_wr : toplevel_dataCache_1_io_mem_cmd_rData_wr);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_uncached : toplevel_dataCache_1_io_mem_cmd_rData_uncached);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_address = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_address : toplevel_dataCache_1_io_mem_cmd_rData_address);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_data = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_data : toplevel_dataCache_1_io_mem_cmd_rData_data);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_mask : toplevel_dataCache_1_io_mem_cmd_rData_mask);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_size = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_size : toplevel_dataCache_1_io_mem_cmd_rData_size);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_last = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_last : toplevel_dataCache_1_io_mem_cmd_rData_last);
   always @(*) begin
-    dataCache_1_io_mem_cmd_s2mPipe_ready = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
-    if(when_Stream_l368) begin
-      dataCache_1_io_mem_cmd_s2mPipe_ready = 1'b1;
+    toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
+    if(when_Stream_l369) begin
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l368 = (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_rValid;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_rData_address;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_rData_data;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size = dataCache_1_io_mem_cmd_s2mPipe_rData_size;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_rData_last;
-  assign dBus_cmd_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
-  assign dBus_cmd_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
-  assign dBus_cmd_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
-  assign dBus_cmd_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
-  assign dBus_cmd_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
-  assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  assign dBus_cmd_payload_size = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
-  assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  assign when_DBusCachedPlugin_l308 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
+  assign when_Stream_l369 = (! toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_address;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_data;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_size;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  assign dBus_cmd_valid = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
+  assign dBus_cmd_payload_wr = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
+  assign dBus_cmd_payload_uncached = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
+  assign dBus_cmd_payload_address = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
+  assign dBus_cmd_payload_data = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
+  assign dBus_cmd_payload_mask = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
+  assign dBus_cmd_payload_size = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
+  assign dBus_cmd_payload_last = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  assign when_DBusCachedPlugin_l352 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
   assign dataCache_1_io_cpu_execute_isValid = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
   assign dataCache_1_io_cpu_execute_address = execute_SRC_ADD;
@@ -3532,11 +3530,11 @@ module VexRiscv (
   end
 
   assign dataCache_1_io_cpu_flush_valid = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
-  assign dataCache_1_io_cpu_flush_payload_singleLine = (execute_INSTRUCTION[19 : 15] != 5'h0);
+  assign dataCache_1_io_cpu_flush_payload_singleLine = (execute_INSTRUCTION[19 : 15] != 5'h00);
   assign dataCache_1_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId[6:0];
-  assign dataCache_1_io_cpu_flush_isStall = (dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready));
-  assign when_DBusCachedPlugin_l350 = (dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
-  assign when_DBusCachedPlugin_l366 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
+  assign toplevel_dataCache_1_io_cpu_flush_isStall = (dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready));
+  assign when_DBusCachedPlugin_l394 = (toplevel_dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
+  assign when_DBusCachedPlugin_l410 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
   assign dataCache_1_io_cpu_memory_isValid = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
   assign dataCache_1_io_cpu_memory_address = memory_REGFILE_WRITE_DATA;
   assign DBusCachedPlugin_mmuBus_cmd_0_isValid = dataCache_1_io_cpu_memory_isValid;
@@ -3546,12 +3544,12 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
   always @(*) begin
     dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if(when_DBusCachedPlugin_l393) begin
+    if(when_DBusCachedPlugin_l472) begin
       dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = 1'b1;
     end
   end
 
-  assign when_DBusCachedPlugin_l393 = (1'b0 && (! dataCache_1_io_cpu_memory_isWrite));
+  assign when_DBusCachedPlugin_l472 = (1'b0 && (! dataCache_1_io_cpu_memory_isWrite));
   always @(*) begin
     dataCache_1_io_cpu_writeBack_isValid = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
     if(writeBack_arbitration_haltByOther) begin
@@ -3564,7 +3562,7 @@ module VexRiscv (
   assign dataCache_1_io_cpu_writeBack_storeData[31 : 0] = writeBack_MEMORY_STORE_DATA_RF;
   always @(*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(when_DBusCachedPlugin_l446) begin
+    if(when_DBusCachedPlugin_l533) begin
       if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
@@ -3574,7 +3572,7 @@ module VexRiscv (
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(when_DBusCachedPlugin_l446) begin
+    if(when_DBusCachedPlugin_l533) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
@@ -3593,7 +3591,7 @@ module VexRiscv (
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
-    if(when_DBusCachedPlugin_l446) begin
+    if(when_DBusCachedPlugin_l533) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code};
       end
@@ -3606,12 +3604,13 @@ module VexRiscv (
     end
   end
 
-  assign when_DBusCachedPlugin_l446 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign when_DBusCachedPlugin_l466 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
-  assign writeBack_DBusCachedPlugin_rspSplits_0 = dataCache_1_io_cpu_writeBack_data[7 : 0];
-  assign writeBack_DBusCachedPlugin_rspSplits_1 = dataCache_1_io_cpu_writeBack_data[15 : 8];
-  assign writeBack_DBusCachedPlugin_rspSplits_2 = dataCache_1_io_cpu_writeBack_data[23 : 16];
-  assign writeBack_DBusCachedPlugin_rspSplits_3 = dataCache_1_io_cpu_writeBack_data[31 : 24];
+  assign when_DBusCachedPlugin_l533 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l553 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
+  assign writeBack_DBusCachedPlugin_rspData = dataCache_1_io_cpu_writeBack_data;
+  assign writeBack_DBusCachedPlugin_rspSplits_0 = writeBack_DBusCachedPlugin_rspData[7 : 0];
+  assign writeBack_DBusCachedPlugin_rspSplits_1 = writeBack_DBusCachedPlugin_rspData[15 : 8];
+  assign writeBack_DBusCachedPlugin_rspSplits_2 = writeBack_DBusCachedPlugin_rspData[23 : 16];
+  assign writeBack_DBusCachedPlugin_rspSplits_3 = writeBack_DBusCachedPlugin_rspData[31 : 24];
   always @(*) begin
     writeBack_DBusCachedPlugin_rspShifted[7 : 0] = _zz_writeBack_DBusCachedPlugin_rspShifted;
     writeBack_DBusCachedPlugin_rspShifted[15 : 8] = _zz_writeBack_DBusCachedPlugin_rspShifted_2;
@@ -3620,7 +3619,7 @@ module VexRiscv (
   end
 
   assign writeBack_DBusCachedPlugin_rspRf = writeBack_DBusCachedPlugin_rspShifted[31 : 0];
-  assign switch_Misc_l210 = writeBack_INSTRUCTION[13 : 12];
+  assign switch_Misc_l232 = writeBack_INSTRUCTION[13 : 12];
   assign _zz_writeBack_DBusCachedPlugin_rspFormated = (writeBack_DBusCachedPlugin_rspRf[7] && (! writeBack_INSTRUCTION[14]));
   always @(*) begin
     _zz_writeBack_DBusCachedPlugin_rspFormated_1[31] = _zz_writeBack_DBusCachedPlugin_rspFormated;
@@ -3672,7 +3671,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    case(switch_Misc_l210)
+    case(switch_Misc_l232)
       2'b00 : begin
         writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_1;
       end
@@ -3685,7 +3684,7 @@ module VexRiscv (
     endcase
   end
 
-  assign when_DBusCachedPlugin_l492 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l580 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
   assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
@@ -3704,55 +3703,55 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
   assign DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign DBusCachedPlugin_mmuBus_busy = 1'b0;
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4 = ((decode_INSTRUCTION & 32'h00000018) == 32'h0);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000008);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = {1'b0,{(|_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7),{(|_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8),{(|_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8),{(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2),{(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7}}}}}}}};
-  assign _zz_decode_SRC1_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[2 : 1];
+  assign _zz_decode_CfuPlugin_CFU_ENABLE_1 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
+  assign _zz_decode_CfuPlugin_CFU_ENABLE_2 = ((decode_INSTRUCTION & 32'h00000018) == 32'h00000000);
+  assign _zz_decode_CfuPlugin_CFU_ENABLE_3 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_decode_CfuPlugin_CFU_ENABLE_4 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_decode_CfuPlugin_CFU_ENABLE_5 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000008);
+  assign _zz_decode_CfuPlugin_CFU_ENABLE_6 = ((decode_INSTRUCTION & 32'h00001000) == 32'h00000000);
+  assign _zz_decode_CfuPlugin_CFU_ENABLE = {1'b0,{(|_zz_decode_CfuPlugin_CFU_ENABLE_5),{(|_zz_decode_CfuPlugin_CFU_ENABLE_6),{(|_zz_decode_CfuPlugin_CFU_ENABLE_6),{(|_zz__zz_decode_CfuPlugin_CFU_ENABLE),{(|_zz__zz_decode_CfuPlugin_CFU_ENABLE_1),{_zz__zz_decode_CfuPlugin_CFU_ENABLE_2,{_zz__zz_decode_CfuPlugin_CFU_ENABLE_4,_zz__zz_decode_CfuPlugin_CFU_ENABLE_7}}}}}}}};
+  assign _zz_decode_SRC1_CTRL_2 = _zz_decode_CfuPlugin_CFU_ENABLE[2 : 1];
   assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
-  assign _zz_decode_ALU_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[7 : 6];
+  assign _zz_decode_ALU_CTRL_2 = _zz_decode_CfuPlugin_CFU_ENABLE[7 : 6];
   assign _zz_decode_ALU_CTRL_1 = _zz_decode_ALU_CTRL_2;
-  assign _zz_decode_SRC2_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[9 : 8];
+  assign _zz_decode_SRC2_CTRL_2 = _zz_decode_CfuPlugin_CFU_ENABLE[9 : 8];
   assign _zz_decode_SRC2_CTRL_1 = _zz_decode_SRC2_CTRL_2;
-  assign _zz_decode_ALU_BITWISE_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[19 : 18];
+  assign _zz_decode_ALU_BITWISE_CTRL_2 = _zz_decode_CfuPlugin_CFU_ENABLE[19 : 18];
   assign _zz_decode_ALU_BITWISE_CTRL_1 = _zz_decode_ALU_BITWISE_CTRL_2;
-  assign _zz_decode_SHIFT_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[22 : 21];
+  assign _zz_decode_SHIFT_CTRL_2 = _zz_decode_CfuPlugin_CFU_ENABLE[22 : 21];
   assign _zz_decode_SHIFT_CTRL_1 = _zz_decode_SHIFT_CTRL_2;
-  assign _zz_decode_BRANCH_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[24 : 23];
+  assign _zz_decode_BRANCH_CTRL_2 = _zz_decode_CfuPlugin_CFU_ENABLE[24 : 23];
   assign _zz_decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_2;
-  assign _zz_decode_ENV_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[27 : 26];
+  assign _zz_decode_ENV_CTRL_2 = _zz_decode_CfuPlugin_CFU_ENABLE[27 : 26];
   assign _zz_decode_ENV_CTRL_1 = _zz_decode_ENV_CTRL_2;
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[33 : 33];
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9;
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = _zz_decode_CfuPlugin_CFU_ENABLE[33 : 33];
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
-  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h0);
+  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h00);
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
   assign decode_RegFilePlugin_rs1Data = _zz_RegFilePlugin_regFile_port0;
   assign decode_RegFilePlugin_rs2Data = _zz_RegFilePlugin_regFile_port1;
   always @(*) begin
     lastStageRegFileWrite_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
-    if(_zz_7) begin
+    if(_zz_10) begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
   always @(*) begin
     lastStageRegFileWrite_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
-    if(_zz_7) begin
-      lastStageRegFileWrite_payload_address = 5'h0;
+    if(_zz_10) begin
+      lastStageRegFileWrite_payload_address = 5'h00;
     end
   end
 
   always @(*) begin
     lastStageRegFileWrite_payload_data = _zz_decode_RS2_2;
-    if(_zz_7) begin
-      lastStageRegFileWrite_payload_data = 32'h0;
+    if(_zz_10) begin
+      lastStageRegFileWrite_payload_data = 32'h00000000;
     end
   end
 
@@ -3793,7 +3792,7 @@ module VexRiscv (
         _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
       Src1CtrlEnum_IMU : begin
-        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h000};
       end
       default : begin
         _zz_execute_SRC1 = {27'd0, _zz__zz_execute_SRC1_1};
@@ -3801,67 +3800,67 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_execute_SRC2_1 = execute_INSTRUCTION[31];
+  assign _zz_execute_SRC2 = execute_INSTRUCTION[31];
   always @(*) begin
-    _zz_execute_SRC2_2[19] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[18] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[17] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[16] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[15] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[14] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[13] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[12] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[11] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[10] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[9] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[8] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[7] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[6] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[5] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[4] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[3] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[2] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[1] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[0] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_1[19] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[18] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[17] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[16] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[15] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[14] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[13] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[12] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[11] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[10] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[9] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[8] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[7] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[6] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[5] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[4] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[3] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[2] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[1] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[0] = _zz_execute_SRC2;
   end
 
-  assign _zz_execute_SRC2_3 = _zz__zz_execute_SRC2_3[11];
+  assign _zz_execute_SRC2_2 = _zz__zz_execute_SRC2_2[11];
   always @(*) begin
-    _zz_execute_SRC2_4[19] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[18] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[17] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[16] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[15] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[14] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[13] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[12] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[11] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[10] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[9] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[8] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[7] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[6] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[5] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[4] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[3] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[2] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[1] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[0] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_3[19] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[18] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[17] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[16] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[15] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[14] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[13] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[12] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[11] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[10] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[9] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[8] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[7] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[6] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[5] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[4] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[3] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[2] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[1] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[0] = _zz_execute_SRC2_2;
   end
 
   always @(*) begin
     case(execute_SRC2_CTRL)
       Src2CtrlEnum_RS : begin
-        _zz_execute_SRC2_5 = execute_RS2;
+        _zz_execute_SRC2_4 = execute_RS2;
       end
       Src2CtrlEnum_IMI : begin
-        _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
+        _zz_execute_SRC2_4 = {_zz_execute_SRC2_1,execute_INSTRUCTION[31 : 20]};
       end
       Src2CtrlEnum_IMS : begin
-        _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_execute_SRC2_4 = {_zz_execute_SRC2_3,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_execute_SRC2_5 = _zz_execute_SRC2;
+        _zz_execute_SRC2_4 = _zz_execute_to_memory_PC;
       end
     endcase
   end
@@ -4027,16 +4026,19 @@ module VexRiscv (
   assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
   assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign switch_Misc_l210_1 = execute_INSTRUCTION[14 : 12];
+  assign switch_Misc_l232_1 = execute_INSTRUCTION[14 : 12];
   always @(*) begin
-    casez(switch_Misc_l210_1)
+    case(switch_Misc_l232_1)
       3'b000 : begin
         _zz_execute_BRANCH_COND_RESULT = execute_BranchPlugin_eq;
       end
       3'b001 : begin
         _zz_execute_BRANCH_COND_RESULT = (! execute_BranchPlugin_eq);
       end
-      3'b1?1 : begin
+      3'b101 : begin
+        _zz_execute_BRANCH_COND_RESULT = (! execute_SRC_LESS);
+      end
+      3'b111 : begin
         _zz_execute_BRANCH_COND_RESULT = (! execute_SRC_LESS);
       end
       default : begin
@@ -4231,14 +4233,14 @@ module VexRiscv (
   assign BranchPlugin_jumpInterface_payload = execute_BRANCH_CALC;
   always @(*) begin
     BranchPlugin_branchExceptionPort_valid = (execute_arbitration_isValid && (execute_BRANCH_DO && execute_BRANCH_CALC[1]));
-    if(when_BranchPlugin_l302) begin
+    if(when_BranchPlugin_l304) begin
       BranchPlugin_branchExceptionPort_valid = 1'b0;
     end
   end
 
   assign BranchPlugin_branchExceptionPort_payload_code = 4'b0000;
   assign BranchPlugin_branchExceptionPort_payload_badAddr = execute_BRANCH_CALC;
-  assign when_BranchPlugin_l302 = 1'b0;
+  assign when_BranchPlugin_l304 = 1'b0;
   assign IBusCachedPlugin_decodePrediction_rsp_wasWrong = BranchPlugin_jumpInterface_valid;
   always @(*) begin
     CsrPlugin_privilege = 2'b11;
@@ -4247,9 +4249,11 @@ module VexRiscv (
     end
   end
 
-  assign _zz_when_CsrPlugin_l965 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_when_CsrPlugin_l965_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_when_CsrPlugin_l965_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign CsrPlugin_misa_base = 2'b01;
+  assign CsrPlugin_misa_extensions = 26'h0000042;
+  assign _zz_when_CsrPlugin_l1302 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l1302_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l1302_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
   assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
@@ -4293,28 +4297,28 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l922 = (! decode_arbitration_isStuck);
-  assign when_CsrPlugin_l922_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l922_2 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l922_3 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l935 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
+  assign when_CsrPlugin_l1259 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l1272 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-  assign when_CsrPlugin_l959 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign when_CsrPlugin_l965 = ((_zz_when_CsrPlugin_l965 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l965_1 = ((_zz_when_CsrPlugin_l965_1 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l965_2 = ((_zz_when_CsrPlugin_l965_2 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1296 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l1302 = ((_zz_when_CsrPlugin_l1302 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1302_1 = ((_zz_when_CsrPlugin_l1302_1 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1302_2 = ((_zz_when_CsrPlugin_l1302_2 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  assign when_CsrPlugin_l993 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l993_1 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l993_2 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l998 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  assign when_CsrPlugin_l1335 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1335_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l1335_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l1340 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
   always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(when_CsrPlugin_l1004) begin
+    if(when_CsrPlugin_l1346) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException) begin
@@ -4322,7 +4326,7 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l1004 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
+  assign when_CsrPlugin_l1346 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
   always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
@@ -4338,6 +4342,7 @@ module VexRiscv (
     end
   end
 
+  assign CsrPlugin_trapCauseEbreakDebug = 1'b0;
   always @(*) begin
     CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
@@ -4360,13 +4365,15 @@ module VexRiscv (
     endcase
   end
 
-  assign when_CsrPlugin_l1032 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign when_CsrPlugin_l1077 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
-  assign switch_CsrPlugin_l1081 = writeBack_INSTRUCTION[29 : 28];
+  assign CsrPlugin_trapEnterDebug = 1'b0;
+  assign when_CsrPlugin_l1390 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1398 = (! CsrPlugin_trapEnterDebug);
+  assign when_CsrPlugin_l1456 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign switch_CsrPlugin_l1460 = writeBack_INSTRUCTION[29 : 28];
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign when_CsrPlugin_l1121 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_WFI));
-  assign when_CsrPlugin_l1123 = (! execute_CsrPlugin_wfiWake);
-  assign when_CsrPlugin_l1129 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
+  assign when_CsrPlugin_l1519 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_WFI));
+  assign when_CsrPlugin_l1521 = (! execute_CsrPlugin_wfiWake);
+  assign when_CsrPlugin_l1527 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
   assign execute_CsrPlugin_blockedBySideEffects = ((|{writeBack_arbitration_isValid,memory_arbitration_isValid}) || 1'b0);
   always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
@@ -4465,18 +4472,18 @@ module VexRiscv (
     if(CsrPlugin_csrMapping_allowCsrSignal) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(when_CsrPlugin_l1315) begin
+    if(when_CsrPlugin_l1725) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if(when_CsrPlugin_l1149) begin
-      if(when_CsrPlugin_l1150) begin
+    if(when_CsrPlugin_l1547) begin
+      if(when_CsrPlugin_l1548) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
@@ -4484,20 +4491,20 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(when_CsrPlugin_l1142) begin
+    if(when_CsrPlugin_l1540) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1157) begin
+    if(when_CsrPlugin_l1555) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(when_CsrPlugin_l1142) begin
+    if(when_CsrPlugin_l1540) begin
       CsrPlugin_selfException_payload_code = 4'b0010;
     end
-    if(when_CsrPlugin_l1157) begin
+    if(when_CsrPlugin_l1555) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -4510,20 +4517,20 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  assign when_CsrPlugin_l1142 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
-  assign when_CsrPlugin_l1149 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
-  assign when_CsrPlugin_l1150 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
-  assign when_CsrPlugin_l1157 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
+  assign when_CsrPlugin_l1540 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
+  assign when_CsrPlugin_l1547 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign when_CsrPlugin_l1548 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1555 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
   always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -4532,9 +4539,9 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
   assign execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
-  assign switch_Misc_l210_2 = execute_INSTRUCTION[13];
+  assign switch_Misc_l232_2 = execute_INSTRUCTION[13];
   always @(*) begin
-    case(switch_Misc_l210_2)
+    case(switch_Misc_l232_2)
       1'b0 : begin
         _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
@@ -4545,8 +4552,8 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
-  assign when_CsrPlugin_l1189 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign when_CsrPlugin_l1193 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
+  assign when_CsrPlugin_l1587 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1591 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
@@ -4609,12 +4616,12 @@ module VexRiscv (
   assign memory_DivPlugin_div_counter_willOverflow = (memory_DivPlugin_div_counter_willOverflowIfInc && memory_DivPlugin_div_counter_willIncrement);
   always @(*) begin
     if(memory_DivPlugin_div_counter_willOverflow) begin
-      memory_DivPlugin_div_counter_valueNext = 6'h0;
+      memory_DivPlugin_div_counter_valueNext = 6'h00;
     end else begin
       memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_memory_DivPlugin_div_counter_valueNext);
     end
     if(memory_DivPlugin_div_counter_willClear) begin
-      memory_DivPlugin_div_counter_valueNext = 6'h0;
+      memory_DivPlugin_div_counter_valueNext = 6'h00;
     end
   end
 
@@ -4638,16 +4645,17 @@ module VexRiscv (
     _zz_memory_DivPlugin_rs1_1[31 : 0] = execute_RS1;
   end
 
-  assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
-  assign externalInterrupt = (|_zz_CsrPlugin_csrMapping_readDataInit_1);
+  assign _zz_externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
+  assign externalInterrupt = (|_zz_externalInterrupt);
+  assign when_CfuPlugin_l192 = (! execute_LEGAL_INSTRUCTION);
   assign execute_CfuPlugin_hazard = ({(writeBack_arbitration_isValid && writeBack_HAS_SIDE_EFFECT),(memory_arbitration_isValid && memory_HAS_SIDE_EFFECT)} != 2'b00);
   assign execute_CfuPlugin_scheduleWish = (execute_arbitration_isValid && execute_CfuPlugin_CFU_ENABLE);
   assign execute_CfuPlugin_schedule = (execute_CfuPlugin_scheduleWish && (! execute_CfuPlugin_hazard));
-  assign when_CfuPlugin_l194 = (execute_CfuPlugin_scheduleWish && execute_CfuPlugin_hazard);
+  assign when_CfuPlugin_l196 = (execute_CfuPlugin_scheduleWish && execute_CfuPlugin_hazard);
   assign CfuPlugin_bus_cmd_fire = (CfuPlugin_bus_cmd_valid && CfuPlugin_bus_cmd_ready);
-  assign when_CfuPlugin_l197 = (! execute_arbitration_isStuck);
+  assign when_CfuPlugin_l199 = (! execute_arbitration_isStuck);
   assign CfuPlugin_bus_cmd_valid = ((execute_CfuPlugin_schedule || execute_CfuPlugin_hold) && (! execute_CfuPlugin_fired));
-  assign when_CfuPlugin_l201 = (CfuPlugin_bus_cmd_valid && (! CfuPlugin_bus_cmd_ready));
+  assign when_CfuPlugin_l203 = (CfuPlugin_bus_cmd_valid && (! CfuPlugin_bus_cmd_ready));
   assign execute_CfuPlugin_functionsIds_0 = _zz_execute_CfuPlugin_functionsIds_0;
   assign CfuPlugin_bus_cmd_payload_function_id = execute_CfuPlugin_functionsIds_0;
   assign CfuPlugin_bus_cmd_payload_inputs_0 = execute_RS1;
@@ -4691,9 +4699,9 @@ module VexRiscv (
   end
 
   assign CfuPlugin_bus_cmd_payload_inputs_1 = _zz_CfuPlugin_bus_cmd_payload_inputs_1_2;
-  assign CfuPlugin_bus_rsp_ready = (! CfuPlugin_bus_rsp_rValid);
-  assign memory_CfuPlugin_rsp_valid = (CfuPlugin_bus_rsp_valid || CfuPlugin_bus_rsp_rValid);
-  assign memory_CfuPlugin_rsp_payload_outputs_0 = (CfuPlugin_bus_rsp_rValid ? CfuPlugin_bus_rsp_rData_outputs_0 : CfuPlugin_bus_rsp_payload_outputs_0);
+  assign CfuPlugin_bus_rsp_ready = CfuPlugin_bus_rsp_rValidN;
+  assign memory_CfuPlugin_rsp_valid = (CfuPlugin_bus_rsp_valid || (! CfuPlugin_bus_rsp_rValidN));
+  assign memory_CfuPlugin_rsp_payload_outputs_0 = (CfuPlugin_bus_rsp_rValidN ? CfuPlugin_bus_rsp_payload_outputs_0 : CfuPlugin_bus_rsp_rData_outputs_0);
   always @(*) begin
     memory_CfuPlugin_rsp_ready = 1'b0;
     if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
@@ -4701,7 +4709,7 @@ module VexRiscv (
     end
   end
 
-  assign when_CfuPlugin_l237 = (! memory_CfuPlugin_rsp_valid);
+  assign when_CfuPlugin_l239 = (! memory_CfuPlugin_rsp_valid);
   assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
@@ -4712,93 +4720,94 @@ module VexRiscv (
   assign when_Pipeline_l124_7 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_8 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_9 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_10 = (! execute_arbitration_isStuck);
   assign _zz_decode_to_execute_SRC1_CTRL_1 = decode_SRC1_CTRL;
   assign _zz_decode_SRC1_CTRL = _zz_decode_SRC1_CTRL_1;
-  assign when_Pipeline_l124_10 = (! execute_arbitration_isStuck);
-  assign _zz_execute_SRC1_CTRL = decode_to_execute_SRC1_CTRL;
   assign when_Pipeline_l124_11 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SRC1_CTRL = decode_to_execute_SRC1_CTRL;
   assign when_Pipeline_l124_12 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_13 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_14 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_13 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_14 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_15 = (! writeBack_arbitration_isStuck);
   assign _zz_decode_to_execute_ALU_CTRL_1 = decode_ALU_CTRL;
   assign _zz_decode_ALU_CTRL = _zz_decode_ALU_CTRL_1;
-  assign when_Pipeline_l124_15 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_16 = (! execute_arbitration_isStuck);
   assign _zz_execute_ALU_CTRL = decode_to_execute_ALU_CTRL;
   assign _zz_decode_to_execute_SRC2_CTRL_1 = decode_SRC2_CTRL;
   assign _zz_decode_SRC2_CTRL = _zz_decode_SRC2_CTRL_1;
-  assign when_Pipeline_l124_16 = (! execute_arbitration_isStuck);
-  assign _zz_execute_SRC2_CTRL = decode_to_execute_SRC2_CTRL;
   assign when_Pipeline_l124_17 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_18 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_19 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_20 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SRC2_CTRL = decode_to_execute_SRC2_CTRL;
+  assign when_Pipeline_l124_18 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_19 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_20 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_21 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_22 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_23 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_24 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_25 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_26 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_27 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_28 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_22 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_23 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_24 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_25 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_26 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_27 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_28 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_29 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_30 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_31 = (! execute_arbitration_isStuck);
   assign _zz_decode_to_execute_ALU_BITWISE_CTRL_1 = decode_ALU_BITWISE_CTRL;
   assign _zz_decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL_1;
-  assign when_Pipeline_l124_31 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_32 = (! execute_arbitration_isStuck);
   assign _zz_execute_ALU_BITWISE_CTRL = decode_to_execute_ALU_BITWISE_CTRL;
   assign _zz_decode_to_execute_SHIFT_CTRL_1 = decode_SHIFT_CTRL;
   assign _zz_execute_to_memory_SHIFT_CTRL_1 = execute_SHIFT_CTRL;
   assign _zz_decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL_1;
-  assign when_Pipeline_l124_32 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_33 = (! execute_arbitration_isStuck);
   assign _zz_execute_SHIFT_CTRL = decode_to_execute_SHIFT_CTRL;
-  assign when_Pipeline_l124_33 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_34 = (! memory_arbitration_isStuck);
   assign _zz_memory_SHIFT_CTRL = execute_to_memory_SHIFT_CTRL;
   assign _zz_decode_to_execute_BRANCH_CTRL_1 = decode_BRANCH_CTRL;
   assign _zz_decode_BRANCH_CTRL_1 = _zz_decode_BRANCH_CTRL;
-  assign when_Pipeline_l124_34 = (! execute_arbitration_isStuck);
-  assign _zz_execute_BRANCH_CTRL = decode_to_execute_BRANCH_CTRL;
   assign when_Pipeline_l124_35 = (! execute_arbitration_isStuck);
+  assign _zz_execute_BRANCH_CTRL = decode_to_execute_BRANCH_CTRL;
+  assign when_Pipeline_l124_36 = (! execute_arbitration_isStuck);
   assign _zz_decode_to_execute_ENV_CTRL_1 = decode_ENV_CTRL;
   assign _zz_execute_to_memory_ENV_CTRL_1 = execute_ENV_CTRL;
   assign _zz_memory_to_writeBack_ENV_CTRL_1 = memory_ENV_CTRL;
   assign _zz_decode_ENV_CTRL = _zz_decode_ENV_CTRL_1;
-  assign when_Pipeline_l124_36 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_37 = (! execute_arbitration_isStuck);
   assign _zz_execute_ENV_CTRL = decode_to_execute_ENV_CTRL;
-  assign when_Pipeline_l124_37 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_38 = (! memory_arbitration_isStuck);
   assign _zz_memory_ENV_CTRL = execute_to_memory_ENV_CTRL;
-  assign when_Pipeline_l124_38 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_39 = (! writeBack_arbitration_isStuck);
   assign _zz_writeBack_ENV_CTRL = memory_to_writeBack_ENV_CTRL;
-  assign when_Pipeline_l124_39 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_40 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_41 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_42 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_43 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_44 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_40 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_41 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_42 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_43 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_44 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_45 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_46 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_47 = (! execute_arbitration_isStuck);
   assign _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1 = decode_CfuPlugin_CFU_INPUT_2_KIND;
   assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
-  assign when_Pipeline_l124_47 = (! execute_arbitration_isStuck);
-  assign _zz_execute_CfuPlugin_CFU_INPUT_2_KIND = decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   assign when_Pipeline_l124_48 = (! execute_arbitration_isStuck);
+  assign _zz_execute_CfuPlugin_CFU_INPUT_2_KIND = decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   assign when_Pipeline_l124_49 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_50 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_51 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_52 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_53 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_54 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_55 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_56 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_57 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_58 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_54 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_55 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_56 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_57 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_58 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_59 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_60 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_61 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_62 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_63 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_64 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_65 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_63 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_64 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_65 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_66 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_67 = (! writeBack_arbitration_isStuck);
   assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
   assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
   assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
@@ -4825,205 +4834,214 @@ module VexRiscv (
   assign when_Pipeline_l154_1 = ((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt));
   assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
   assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
-  assign when_CsrPlugin_l1277 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_2 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_3 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_4 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_5 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_6 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_7 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_8 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_9 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_10 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_11 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_12 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_13 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_14 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_15 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_16 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_17 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_18 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_19 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_20 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_21 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_22 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_23 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_8 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_9 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_10 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_11 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_12 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_13 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_14 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_15 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_16 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_17 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_18 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_19 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_20 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_21 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_22 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_23 = (! execute_arbitration_isStuck);
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_1 = 32'h00000000;
     if(execute_CsrPlugin_csr_3264) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_2[12 : 0] = 13'h1000;
-      _zz_CsrPlugin_csrMapping_readDataInit_2[25 : 20] = 6'h20;
+      _zz_CsrPlugin_csrMapping_readDataInit_1[12 : 0] = 13'h1000;
+      _zz_CsrPlugin_csrMapping_readDataInit_1[25 : 20] = 6'h20;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h00000000;
     if(execute_CsrPlugin_csr_3857) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_3[3 : 0] = 4'b1011;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[3 : 0] = 4'b1011;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h00000000;
     if(execute_CsrPlugin_csr_3858) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_4[4 : 0] = 5'h16;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[4 : 0] = 5'h16;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h00000000;
     if(execute_CsrPlugin_csr_3859) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_5[5 : 0] = 6'h21;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[5 : 0] = 6'h21;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h00000000;
     if(execute_CsrPlugin_csr_769) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_6[31 : 30] = CsrPlugin_misa_base;
-      _zz_CsrPlugin_csrMapping_readDataInit_6[25 : 0] = CsrPlugin_misa_extensions;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[31 : 30] = CsrPlugin_misa_base;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[25 : 0] = CsrPlugin_misa_extensions;
     end
   end
 
-  assign switch_CsrPlugin_l723 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
+  assign switch_CsrPlugin_l1031 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h00000000;
     if(execute_CsrPlugin_csr_768) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_7[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_7[3 : 3] = CsrPlugin_mstatus_MIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_7[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[12 : 11] = CsrPlugin_mstatus_MPP;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h00000000;
     if(execute_CsrPlugin_csr_836) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_8[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_8[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_8[3 : 3] = CsrPlugin_mip_MSIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[3 : 3] = CsrPlugin_mip_MSIP;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h00000000;
     if(execute_CsrPlugin_csr_772) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_9[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_9[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_9[3 : 3] = CsrPlugin_mie_MSIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_8[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_8[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_8[3 : 3] = CsrPlugin_mie_MSIE;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_10 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h00000000;
     if(execute_CsrPlugin_csr_773) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_10[31 : 2] = CsrPlugin_mtvec_base;
-      _zz_CsrPlugin_csrMapping_readDataInit_10[1 : 0] = CsrPlugin_mtvec_mode;
+      _zz_CsrPlugin_csrMapping_readDataInit_9[31 : 2] = CsrPlugin_mtvec_base;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_11 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_10 = 32'h00000000;
     if(execute_CsrPlugin_csr_833) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_11[31 : 0] = CsrPlugin_mepc;
+      _zz_CsrPlugin_csrMapping_readDataInit_10[31 : 0] = CsrPlugin_mepc;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_12 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_11 = 32'h00000000;
     if(execute_CsrPlugin_csr_832) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_12[31 : 0] = CsrPlugin_mscratch;
+      _zz_CsrPlugin_csrMapping_readDataInit_11[31 : 0] = CsrPlugin_mscratch;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_13 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_12 = 32'h00000000;
     if(execute_CsrPlugin_csr_834) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_13[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_CsrPlugin_csrMapping_readDataInit_13[3 : 0] = CsrPlugin_mcause_exceptionCode;
+      _zz_CsrPlugin_csrMapping_readDataInit_12[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_CsrPlugin_csrMapping_readDataInit_12[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_14 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_13 = 32'h00000000;
     if(execute_CsrPlugin_csr_835) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_14[31 : 0] = CsrPlugin_mtval;
+      _zz_CsrPlugin_csrMapping_readDataInit_13[31 : 0] = CsrPlugin_mtval;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_15 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_14 = 32'h00000000;
     if(execute_CsrPlugin_csr_2816) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_15[31 : 0] = CsrPlugin_mcycle[31 : 0];
+      _zz_CsrPlugin_csrMapping_readDataInit_14[31 : 0] = CsrPlugin_mcycle[31 : 0];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_16 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_15 = 32'h00000000;
     if(execute_CsrPlugin_csr_2944) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_16[31 : 0] = CsrPlugin_mcycle[63 : 32];
+      _zz_CsrPlugin_csrMapping_readDataInit_15[31 : 0] = CsrPlugin_mcycle[63 : 32];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_17 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_16 = 32'h00000000;
     if(execute_CsrPlugin_csr_2818) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_17[31 : 0] = CsrPlugin_minstret[31 : 0];
+      _zz_CsrPlugin_csrMapping_readDataInit_16[31 : 0] = CsrPlugin_minstret[31 : 0];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_18 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_17 = 32'h00000000;
     if(execute_CsrPlugin_csr_2946) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_18[31 : 0] = CsrPlugin_minstret[63 : 32];
+      _zz_CsrPlugin_csrMapping_readDataInit_17[31 : 0] = CsrPlugin_minstret[63 : 32];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_19 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_18 = 32'h00000000;
     if(execute_CsrPlugin_csr_3072) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_19[31 : 0] = CsrPlugin_mcycle[31 : 0];
+      _zz_CsrPlugin_csrMapping_readDataInit_18[31 : 0] = CsrPlugin_mcycle[31 : 0];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_20 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_19 = 32'h00000000;
     if(execute_CsrPlugin_csr_3200) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_20[31 : 0] = CsrPlugin_mcycle[63 : 32];
+      _zz_CsrPlugin_csrMapping_readDataInit_19[31 : 0] = CsrPlugin_mcycle[63 : 32];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_21 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_20 = 32'h00000000;
     if(execute_CsrPlugin_csr_3074) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_21[31 : 0] = CsrPlugin_minstret[31 : 0];
+      _zz_CsrPlugin_csrMapping_readDataInit_20[31 : 0] = CsrPlugin_minstret[31 : 0];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_22 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_21 = 32'h00000000;
     if(execute_CsrPlugin_csr_3202) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_22[31 : 0] = CsrPlugin_minstret[63 : 32];
+      _zz_CsrPlugin_csrMapping_readDataInit_21[31 : 0] = CsrPlugin_minstret[63 : 32];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_23 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_22 = 32'h00000000;
     if(execute_CsrPlugin_csr_3008) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_23[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
+      _zz_CsrPlugin_csrMapping_readDataInit_22[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_24 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_23 = 32'h00000000;
     if(execute_CsrPlugin_csr_4032) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_24[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_1;
+      _zz_CsrPlugin_csrMapping_readDataInit_23[31 : 0] = _zz_externalInterrupt;
     end
   end
 
-  assign CsrPlugin_csrMapping_readDataInit = (((((_zz_CsrPlugin_csrMapping_readDataInit_2 | _zz_CsrPlugin_csrMapping_readDataInit_3) | (_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5)) | ((_zz_CsrPlugin_csrMapping_readDataInit_25 | _zz_CsrPlugin_csrMapping_readDataInit_6) | (_zz_CsrPlugin_csrMapping_readDataInit_7 | _zz_CsrPlugin_csrMapping_readDataInit_8))) | (((_zz_CsrPlugin_csrMapping_readDataInit_9 | _zz_CsrPlugin_csrMapping_readDataInit_10) | (_zz_CsrPlugin_csrMapping_readDataInit_11 | _zz_CsrPlugin_csrMapping_readDataInit_12)) | ((_zz_CsrPlugin_csrMapping_readDataInit_13 | _zz_CsrPlugin_csrMapping_readDataInit_14) | (_zz_CsrPlugin_csrMapping_readDataInit_15 | _zz_CsrPlugin_csrMapping_readDataInit_16)))) | (((_zz_CsrPlugin_csrMapping_readDataInit_17 | _zz_CsrPlugin_csrMapping_readDataInit_18) | (_zz_CsrPlugin_csrMapping_readDataInit_19 | _zz_CsrPlugin_csrMapping_readDataInit_20)) | ((_zz_CsrPlugin_csrMapping_readDataInit_21 | _zz_CsrPlugin_csrMapping_readDataInit_22) | (_zz_CsrPlugin_csrMapping_readDataInit_23 | _zz_CsrPlugin_csrMapping_readDataInit_24))));
-  assign when_CsrPlugin_l1310 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign when_CsrPlugin_l1315 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign CsrPlugin_csrMapping_readDataInit = (((((_zz_CsrPlugin_csrMapping_readDataInit_1 | _zz_CsrPlugin_csrMapping_readDataInit_2) | (_zz_CsrPlugin_csrMapping_readDataInit_3 | _zz_CsrPlugin_csrMapping_readDataInit_4)) | ((_zz_CsrPlugin_csrMapping_readDataInit_24 | _zz_CsrPlugin_csrMapping_readDataInit_5) | (_zz_CsrPlugin_csrMapping_readDataInit_6 | _zz_CsrPlugin_csrMapping_readDataInit_7))) | (((_zz_CsrPlugin_csrMapping_readDataInit_8 | _zz_CsrPlugin_csrMapping_readDataInit_9) | (_zz_CsrPlugin_csrMapping_readDataInit_10 | _zz_CsrPlugin_csrMapping_readDataInit_11)) | ((_zz_CsrPlugin_csrMapping_readDataInit_12 | _zz_CsrPlugin_csrMapping_readDataInit_13) | (_zz_CsrPlugin_csrMapping_readDataInit_14 | _zz_CsrPlugin_csrMapping_readDataInit_15)))) | (((_zz_CsrPlugin_csrMapping_readDataInit_16 | _zz_CsrPlugin_csrMapping_readDataInit_17) | (_zz_CsrPlugin_csrMapping_readDataInit_18 | _zz_CsrPlugin_csrMapping_readDataInit_19)) | ((_zz_CsrPlugin_csrMapping_readDataInit_20 | _zz_CsrPlugin_csrMapping_readDataInit_21) | (_zz_CsrPlugin_csrMapping_readDataInit_22 | _zz_CsrPlugin_csrMapping_readDataInit_23))));
+  assign when_CsrPlugin_l1702 = ((execute_arbitration_isValid && execute_IS_CSR) && (({execute_CsrPlugin_csrAddress[11 : 2],2'b00} == 12'h3a0) || ({execute_CsrPlugin_csrAddress[11 : 4],4'b0000} == 12'h3b0)));
+  assign _zz_when_CsrPlugin_l1709 = (execute_CsrPlugin_csrAddress & 12'hf60);
+  assign when_CsrPlugin_l1709 = (((execute_arbitration_isValid && execute_IS_CSR) && (5'h03 <= execute_CsrPlugin_csrAddress[4 : 0])) && (((_zz_when_CsrPlugin_l1709 == 12'hb00) || (((_zz_when_CsrPlugin_l1709 == 12'hc00) && (! execute_CsrPlugin_writeInstruction)) && (CsrPlugin_privilege == 2'b11))) || ((execute_CsrPlugin_csrAddress & 12'hfe0) == 12'h320)));
+  always @(*) begin
+    when_CsrPlugin_l1719 = CsrPlugin_csrMapping_doForceFailCsr;
+    if(when_CsrPlugin_l1717) begin
+      when_CsrPlugin_l1719 = 1'b1;
+    end
+  end
+
+  assign when_CsrPlugin_l1717 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1725 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
   assign iBusWishbone_ADR = {_zz_iBusWishbone_ADR_1,_zz_iBusWishbone_ADR};
   assign iBusWishbone_CTI = ((_zz_iBusWishbone_ADR == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
@@ -5049,20 +5067,20 @@ module VexRiscv (
   assign iBus_rsp_valid = _zz_iBus_rsp_valid;
   assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
   assign iBus_rsp_payload_error = 1'b0;
-  assign _zz_dBus_cmd_ready_5 = (dBus_cmd_payload_size == 3'b101);
-  assign _zz_dBus_cmd_ready_1 = dBus_cmd_valid;
-  assign _zz_dBus_cmd_ready_3 = dBus_cmd_payload_wr;
-  assign _zz_dBus_cmd_ready_4 = ((! _zz_dBus_cmd_ready_5) || (_zz_dBus_cmd_ready == 3'b111));
-  assign dBus_cmd_ready = (_zz_dBus_cmd_ready_2 && (_zz_dBus_cmd_ready_3 || _zz_dBus_cmd_ready_4));
-  assign dBusWishbone_ADR = ((_zz_dBus_cmd_ready_5 ? {{dBus_cmd_payload_address[31 : 5],_zz_dBus_cmd_ready},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
-  assign dBusWishbone_CTI = (_zz_dBus_cmd_ready_5 ? (_zz_dBus_cmd_ready_4 ? 3'b111 : 3'b010) : 3'b000);
+  assign _zz_dBusWishbone_ADR_1 = (dBus_cmd_payload_size == 3'b101);
+  assign _zz_dBusWishbone_CYC = dBus_cmd_valid;
+  assign _zz_dBus_cmd_ready_1 = dBus_cmd_payload_wr;
+  assign _zz_dBus_cmd_ready_2 = ((! _zz_dBusWishbone_ADR_1) || (_zz_dBusWishbone_ADR == 3'b111));
+  assign dBus_cmd_ready = (_zz_dBus_cmd_ready && (_zz_dBus_cmd_ready_1 || _zz_dBus_cmd_ready_2));
+  assign dBusWishbone_ADR = ((_zz_dBusWishbone_ADR_1 ? {{dBus_cmd_payload_address[31 : 5],_zz_dBusWishbone_ADR},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2'd2);
+  assign dBusWishbone_CTI = (_zz_dBusWishbone_ADR_1 ? (_zz_dBus_cmd_ready_2 ? 3'b111 : 3'b010) : 3'b000);
   assign dBusWishbone_BTE = 2'b00;
-  assign dBusWishbone_SEL = (_zz_dBus_cmd_ready_3 ? dBus_cmd_payload_mask : 4'b1111);
-  assign dBusWishbone_WE = _zz_dBus_cmd_ready_3;
+  assign dBusWishbone_SEL = (_zz_dBus_cmd_ready_1 ? dBus_cmd_payload_mask : 4'b1111);
+  assign dBusWishbone_WE = _zz_dBus_cmd_ready_1;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_payload_data;
-  assign _zz_dBus_cmd_ready_2 = (_zz_dBus_cmd_ready_1 && dBusWishbone_ACK);
-  assign dBusWishbone_CYC = _zz_dBus_cmd_ready_1;
-  assign dBusWishbone_STB = _zz_dBus_cmd_ready_1;
+  assign _zz_dBus_cmd_ready = (_zz_dBusWishbone_CYC && dBusWishbone_ACK);
+  assign dBusWishbone_CYC = _zz_dBusWishbone_CYC;
+  assign dBusWishbone_STB = _zz_dBusWishbone_CYC;
   assign dBus_rsp_valid = _zz_dBus_rsp_valid;
   assign dBus_rsp_payload_data = dBusWishbone_DAT_MISO_regNext;
   assign dBus_rsp_payload_error = 1'b0;
@@ -5072,29 +5090,27 @@ module VexRiscv (
       IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
-      _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+      _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= 1'b0;
       _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= 32'h0;
-      dataCache_1_io_mem_cmd_rValid <= 1'b0;
-      dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= 32'h0;
-      _zz_7 <= 1'b1;
+      IBusCachedPlugin_rspCounter <= 32'h00000000;
+      toplevel_dataCache_1_io_mem_cmd_rValidN <= 1'b1;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
+      DBusCachedPlugin_rspCounter <= 32'h00000000;
+      _zz_10 <= 1'b1;
       HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
-      CsrPlugin_misa_base <= 2'b01;
-      CsrPlugin_misa_extensions <= 26'h0000042;
       CsrPlugin_mstatus_MIE <= 1'b0;
       CsrPlugin_mstatus_MPIE <= 1'b0;
       CsrPlugin_mstatus_MPP <= 2'b11;
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
-      CsrPlugin_mcycle <= 64'h0;
-      CsrPlugin_minstret <= 64'h0;
+      CsrPlugin_mcycle <= 64'h0000000000000000;
+      CsrPlugin_minstret <= 64'h0000000000000000;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= 1'b0;
@@ -5106,18 +5122,18 @@ module VexRiscv (
       CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
-      memory_DivPlugin_div_counter_value <= 6'h0;
-      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h0;
+      memory_DivPlugin_div_counter_value <= 6'h00;
+      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h00000000;
       execute_CfuPlugin_hold <= 1'b0;
       execute_CfuPlugin_fired <= 1'b0;
-      CfuPlugin_bus_rsp_rValid <= 1'b0;
+      CfuPlugin_bus_rsp_rValidN <= 1'b1;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
       execute_to_memory_CfuPlugin_CFU_IN_FLIGHT <= 1'b0;
       _zz_iBusWishbone_ADR <= 3'b000;
       _zz_iBus_rsp_valid <= 1'b0;
-      _zz_dBus_cmd_ready <= 3'b000;
+      _zz_dBusWishbone_ADR <= 3'b000;
       _zz_dBus_rsp_valid <= 1'b0;
     end else begin
       if(IBusCachedPlugin_fetchPc_correction) begin
@@ -5127,23 +5143,23 @@ module VexRiscv (
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusCachedPlugin_fetchPc_booted <= 1'b1;
-      if(when_Fetcher_l134) begin
+      if(when_Fetcher_l133) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_output_fire_1) begin
+      if(IBusCachedPlugin_fetchPc_output_fire) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b1;
       end
-      if(when_Fetcher_l134_1) begin
+      if(when_Fetcher_l133_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(when_Fetcher_l161) begin
+      if(when_Fetcher_l160) begin
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
       if(IBusCachedPlugin_iBusRsp_flush) begin
-        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= 1'b0;
       end
       if(_zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready) begin
-        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
       if(IBusCachedPlugin_iBusRsp_flush) begin
         _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
@@ -5154,13 +5170,13 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if(when_Fetcher_l332) begin
+      if(when_Fetcher_l331) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(when_Fetcher_l332_1) begin
+      if(when_Fetcher_l331_1) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= IBusCachedPlugin_injector_nextPcCalc_valids_0;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5169,7 +5185,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(when_Fetcher_l332_2) begin
+      if(when_Fetcher_l331_2) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= IBusCachedPlugin_injector_nextPcCalc_valids_1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5178,7 +5194,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(when_Fetcher_l332_3) begin
+      if(when_Fetcher_l331_3) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5187,7 +5203,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if(when_Fetcher_l332_4) begin
+      if(when_Fetcher_l331_4) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= IBusCachedPlugin_injector_nextPcCalc_valids_3;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5197,68 +5213,68 @@ module VexRiscv (
         IBusCachedPlugin_rspCounter <= (IBusCachedPlugin_rspCounter + 32'h00000001);
       end
       if(dataCache_1_io_mem_cmd_valid) begin
-        dataCache_1_io_mem_cmd_rValid <= 1'b1;
+        toplevel_dataCache_1_io_mem_cmd_rValidN <= 1'b0;
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
-        dataCache_1_io_mem_cmd_rValid <= 1'b0;
+      if(toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+        toplevel_dataCache_1_io_mem_cmd_rValidN <= 1'b1;
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
-        dataCache_1_io_mem_cmd_s2mPipe_rValid <= dataCache_1_io_mem_cmd_s2mPipe_valid;
+      if(toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+        toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_valid;
       end
       if(dBus_rsp_valid) begin
         DBusCachedPlugin_rspCounter <= (DBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      _zz_7 <= 1'b0;
+      _zz_10 <= 1'b0;
       HazardSimplePlugin_writeBackBuffer_valid <= HazardSimplePlugin_writeBackWrites_valid;
       CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
       if(writeBack_arbitration_isFiring) begin
         CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
       end
-      if(when_CsrPlugin_l922) begin
+      if(when_CsrPlugin_l1259) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if(when_CsrPlugin_l922_1) begin
+      if(when_CsrPlugin_l1259_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if(when_CsrPlugin_l922_2) begin
+      if(when_CsrPlugin_l1259_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if(when_CsrPlugin_l922_3) begin
+      if(when_CsrPlugin_l1259_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(when_CsrPlugin_l959) begin
-        if(when_CsrPlugin_l965) begin
+      if(when_CsrPlugin_l1296) begin
+        if(when_CsrPlugin_l1302) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_1) begin
+        if(when_CsrPlugin_l1302_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_2) begin
+        if(when_CsrPlugin_l1302_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
       CsrPlugin_lastStageWasWfi <= (writeBack_arbitration_isFiring && (writeBack_ENV_CTRL == EnvCtrlEnum_WFI));
       if(CsrPlugin_pipelineLiberator_active) begin
-        if(when_CsrPlugin_l993) begin
+        if(when_CsrPlugin_l1335) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if(when_CsrPlugin_l993_1) begin
+        if(when_CsrPlugin_l1335_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if(when_CsrPlugin_l993_2) begin
+        if(when_CsrPlugin_l1335_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(when_CsrPlugin_l998) begin
+      if(when_CsrPlugin_l1340) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
@@ -5267,19 +5283,21 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(when_CsrPlugin_l1032) begin
-        case(CsrPlugin_targetPrivilege)
-          2'b11 : begin
-            CsrPlugin_mstatus_MIE <= 1'b0;
-            CsrPlugin_mstatus_MPIE <= CsrPlugin_mstatus_MIE;
-            CsrPlugin_mstatus_MPP <= CsrPlugin_privilege;
-          end
-          default : begin
-          end
-        endcase
+      if(when_CsrPlugin_l1390) begin
+        if(when_CsrPlugin_l1398) begin
+          case(CsrPlugin_targetPrivilege)
+            2'b11 : begin
+              CsrPlugin_mstatus_MIE <= 1'b0;
+              CsrPlugin_mstatus_MPIE <= CsrPlugin_mstatus_MIE;
+              CsrPlugin_mstatus_MPP <= CsrPlugin_privilege;
+            end
+            default : begin
+            end
+          endcase
+        end
       end
-      if(when_CsrPlugin_l1077) begin
-        case(switch_CsrPlugin_l1081)
+      if(when_CsrPlugin_l1456) begin
+        case(switch_CsrPlugin_l1460)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -5289,7 +5307,7 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l965_2,{_zz_when_CsrPlugin_l965_1,_zz_when_CsrPlugin_l965}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l1302_2,{_zz_when_CsrPlugin_l1302_1,_zz_when_CsrPlugin_l1302}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
       if(execute_CfuPlugin_schedule) begin
         execute_CfuPlugin_hold <= 1'b1;
@@ -5300,16 +5318,16 @@ module VexRiscv (
       if(CfuPlugin_bus_cmd_fire) begin
         execute_CfuPlugin_fired <= 1'b1;
       end
-      if(when_CfuPlugin_l197) begin
+      if(when_CfuPlugin_l199) begin
         execute_CfuPlugin_fired <= 1'b0;
       end
       if(CfuPlugin_bus_rsp_valid) begin
-        CfuPlugin_bus_rsp_rValid <= 1'b1;
+        CfuPlugin_bus_rsp_rValidN <= 1'b0;
       end
       if(memory_CfuPlugin_rsp_ready) begin
-        CfuPlugin_bus_rsp_rValid <= 1'b0;
+        CfuPlugin_bus_rsp_rValidN <= 1'b1;
       end
-      if(when_Pipeline_l124_64) begin
+      if(when_Pipeline_l124_65) begin
         execute_to_memory_CfuPlugin_CFU_IN_FLIGHT <= _zz_execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
       end
       if(when_Pipeline_l151) begin
@@ -5330,17 +5348,11 @@ module VexRiscv (
       if(when_Pipeline_l154_2) begin
         writeBack_arbitration_isValid <= memory_arbitration_isValid;
       end
-      if(execute_CsrPlugin_csr_769) begin
-        if(execute_CsrPlugin_writeEnable) begin
-          CsrPlugin_misa_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 30];
-          CsrPlugin_misa_extensions <= CsrPlugin_csrMapping_writeDataSignal[25 : 0];
-        end
-      end
       if(execute_CsrPlugin_csr_768) begin
         if(execute_CsrPlugin_writeEnable) begin
           CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
           CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
-          case(switch_CsrPlugin_l723)
+          case(switch_CsrPlugin_l1031)
             2'b11 : begin
               CsrPlugin_mstatus_MPP <= 2'b11;
             end
@@ -5387,13 +5399,13 @@ module VexRiscv (
         end
       end
       _zz_iBus_rsp_valid <= (iBusWishbone_CYC && iBusWishbone_ACK);
-      if((_zz_dBus_cmd_ready_1 && _zz_dBus_cmd_ready_2)) begin
-        _zz_dBus_cmd_ready <= (_zz_dBus_cmd_ready + 3'b001);
-        if(_zz_dBus_cmd_ready_4) begin
-          _zz_dBus_cmd_ready <= 3'b000;
+      if((_zz_dBusWishbone_CYC && _zz_dBus_cmd_ready)) begin
+        _zz_dBusWishbone_ADR <= (_zz_dBusWishbone_ADR + 3'b001);
+        if(_zz_dBus_cmd_ready_2) begin
+          _zz_dBusWishbone_ADR <= 3'b000;
         end
       end
-      _zz_dBus_rsp_valid <= ((_zz_dBus_cmd_ready_1 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
+      _zz_dBus_rsp_valid <= ((_zz_dBusWishbone_CYC && (! dBusWishbone_WE)) && dBusWishbone_ACK);
     end
   end
 
@@ -5407,23 +5419,23 @@ module VexRiscv (
     if(IBusCachedPlugin_iBusRsp_stages_2_input_ready) begin
       IBusCachedPlugin_s2_tightlyCoupledHit <= IBusCachedPlugin_s1_tightlyCoupledHit;
     end
-    if(dataCache_1_io_mem_cmd_ready) begin
-      dataCache_1_io_mem_cmd_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
-      dataCache_1_io_mem_cmd_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
-      dataCache_1_io_mem_cmd_rData_address <= dataCache_1_io_mem_cmd_payload_address;
-      dataCache_1_io_mem_cmd_rData_data <= dataCache_1_io_mem_cmd_payload_data;
-      dataCache_1_io_mem_cmd_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
-      dataCache_1_io_mem_cmd_rData_size <= dataCache_1_io_mem_cmd_payload_size;
-      dataCache_1_io_mem_cmd_rData_last <= dataCache_1_io_mem_cmd_payload_last;
+    if(toplevel_dataCache_1_io_mem_cmd_rValidN) begin
+      toplevel_dataCache_1_io_mem_cmd_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
+      toplevel_dataCache_1_io_mem_cmd_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
+      toplevel_dataCache_1_io_mem_cmd_rData_address <= dataCache_1_io_mem_cmd_payload_address;
+      toplevel_dataCache_1_io_mem_cmd_rData_data <= dataCache_1_io_mem_cmd_payload_data;
+      toplevel_dataCache_1_io_mem_cmd_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
+      toplevel_dataCache_1_io_mem_cmd_rData_size <= dataCache_1_io_mem_cmd_payload_size;
+      toplevel_dataCache_1_io_mem_cmd_rData_last <= dataCache_1_io_mem_cmd_payload_last;
     end
-    if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
-      dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_address <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_data <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_size <= dataCache_1_io_mem_cmd_s2mPipe_payload_size;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_last <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+    if(toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_address <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_data <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_size <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_size;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_last <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_last;
     end
     HazardSimplePlugin_writeBackBuffer_payload_address <= HazardSimplePlugin_writeBackWrites_payload_address;
     HazardSimplePlugin_writeBackBuffer_payload_data <= HazardSimplePlugin_writeBackWrites_payload_data;
@@ -5442,33 +5454,35 @@ module VexRiscv (
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(when_CsrPlugin_l959) begin
-      if(when_CsrPlugin_l965) begin
+    if(when_CsrPlugin_l1296) begin
+      if(when_CsrPlugin_l1302) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l965_1) begin
+      if(when_CsrPlugin_l1302_1) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l965_2) begin
+      if(when_CsrPlugin_l1302_2) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(when_CsrPlugin_l1032) begin
-      case(CsrPlugin_targetPrivilege)
-        2'b11 : begin
-          CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
-          CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
-          CsrPlugin_mepc <= writeBack_PC;
-          if(CsrPlugin_hadException) begin
-            CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
+    if(when_CsrPlugin_l1390) begin
+      if(when_CsrPlugin_l1398) begin
+        case(CsrPlugin_targetPrivilege)
+          2'b11 : begin
+            CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
+            CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
+            CsrPlugin_mepc <= writeBack_PC;
+            if(CsrPlugin_hadException) begin
+              CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
+            end
           end
-        end
-        default : begin
-        end
-      endcase
+          default : begin
+          end
+        endcase
+      end
     end
     if(when_MulDivIterativePlugin_l126) begin
       memory_DivPlugin_div_done <= 1'b1;
@@ -5486,10 +5500,10 @@ module VexRiscv (
       end
     end
     if(when_MulDivIterativePlugin_l162) begin
-      memory_DivPlugin_accumulator <= 65'h0;
+      memory_DivPlugin_accumulator <= 65'h00000000000000000;
       memory_DivPlugin_rs1 <= ((_zz_memory_DivPlugin_rs1 ? (~ _zz_memory_DivPlugin_rs1_1) : _zz_memory_DivPlugin_rs1_1) + _zz_memory_DivPlugin_rs1_2);
       memory_DivPlugin_rs2 <= ((_zz_memory_DivPlugin_rs2 ? (~ execute_RS2) : execute_RS2) + _zz_memory_DivPlugin_rs2_1);
-      memory_DivPlugin_div_needRevert <= ((_zz_memory_DivPlugin_rs1 ^ (_zz_memory_DivPlugin_rs2 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
+      memory_DivPlugin_div_needRevert <= ((_zz_memory_DivPlugin_rs1 ^ (_zz_memory_DivPlugin_rs2 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h00000000) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
     end
     externalInterruptArray_regNext <= externalInterruptArray;
     if(CfuPlugin_bus_rsp_ready) begin
@@ -5499,7 +5513,7 @@ module VexRiscv (
       decode_to_execute_PC <= decode_PC;
     end
     if(when_Pipeline_l124_1) begin
-      execute_to_memory_PC <= _zz_execute_SRC2;
+      execute_to_memory_PC <= _zz_execute_to_memory_PC;
     end
     if(when_Pipeline_l124_2) begin
       memory_to_writeBack_PC <= memory_PC;
@@ -5526,243 +5540,246 @@ module VexRiscv (
       decode_to_execute_MEMORY_FORCE_CONSTISTENCY <= decode_MEMORY_FORCE_CONSTISTENCY;
     end
     if(when_Pipeline_l124_10) begin
-      decode_to_execute_SRC1_CTRL <= _zz_decode_to_execute_SRC1_CTRL;
+      decode_to_execute_LEGAL_INSTRUCTION <= decode_LEGAL_INSTRUCTION;
     end
     if(when_Pipeline_l124_11) begin
-      decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
+      decode_to_execute_SRC1_CTRL <= _zz_decode_to_execute_SRC1_CTRL;
     end
     if(when_Pipeline_l124_12) begin
-      decode_to_execute_MEMORY_ENABLE <= decode_MEMORY_ENABLE;
+      decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
     end
     if(when_Pipeline_l124_13) begin
-      execute_to_memory_MEMORY_ENABLE <= execute_MEMORY_ENABLE;
+      decode_to_execute_MEMORY_ENABLE <= decode_MEMORY_ENABLE;
     end
     if(when_Pipeline_l124_14) begin
-      memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
+      execute_to_memory_MEMORY_ENABLE <= execute_MEMORY_ENABLE;
     end
     if(when_Pipeline_l124_15) begin
-      decode_to_execute_ALU_CTRL <= _zz_decode_to_execute_ALU_CTRL;
+      memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
     end
     if(when_Pipeline_l124_16) begin
-      decode_to_execute_SRC2_CTRL <= _zz_decode_to_execute_SRC2_CTRL;
+      decode_to_execute_ALU_CTRL <= _zz_decode_to_execute_ALU_CTRL;
     end
     if(when_Pipeline_l124_17) begin
-      decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
+      decode_to_execute_SRC2_CTRL <= _zz_decode_to_execute_SRC2_CTRL;
     end
     if(when_Pipeline_l124_18) begin
-      execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
+      decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
     end
     if(when_Pipeline_l124_19) begin
-      memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
+      execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
     end
     if(when_Pipeline_l124_20) begin
-      decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
+      memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
     end
     if(when_Pipeline_l124_21) begin
-      decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
+      decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
     end
     if(when_Pipeline_l124_22) begin
-      execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
+      decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
     end
     if(when_Pipeline_l124_23) begin
-      decode_to_execute_MEMORY_WR <= decode_MEMORY_WR;
+      execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
     end
     if(when_Pipeline_l124_24) begin
-      execute_to_memory_MEMORY_WR <= execute_MEMORY_WR;
+      decode_to_execute_MEMORY_WR <= decode_MEMORY_WR;
     end
     if(when_Pipeline_l124_25) begin
-      memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
+      execute_to_memory_MEMORY_WR <= execute_MEMORY_WR;
     end
     if(when_Pipeline_l124_26) begin
-      decode_to_execute_HAS_SIDE_EFFECT <= decode_HAS_SIDE_EFFECT;
+      memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
     end
     if(when_Pipeline_l124_27) begin
-      execute_to_memory_HAS_SIDE_EFFECT <= execute_HAS_SIDE_EFFECT;
+      decode_to_execute_HAS_SIDE_EFFECT <= decode_HAS_SIDE_EFFECT;
     end
     if(when_Pipeline_l124_28) begin
-      memory_to_writeBack_HAS_SIDE_EFFECT <= memory_HAS_SIDE_EFFECT;
+      execute_to_memory_HAS_SIDE_EFFECT <= execute_HAS_SIDE_EFFECT;
     end
     if(when_Pipeline_l124_29) begin
-      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
+      memory_to_writeBack_HAS_SIDE_EFFECT <= memory_HAS_SIDE_EFFECT;
     end
     if(when_Pipeline_l124_30) begin
-      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
+      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
     end
     if(when_Pipeline_l124_31) begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
+      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
     end
     if(when_Pipeline_l124_32) begin
-      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
     end
     if(when_Pipeline_l124_33) begin
-      execute_to_memory_SHIFT_CTRL <= _zz_execute_to_memory_SHIFT_CTRL;
+      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
     end
     if(when_Pipeline_l124_34) begin
-      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
+      execute_to_memory_SHIFT_CTRL <= _zz_execute_to_memory_SHIFT_CTRL;
     end
     if(when_Pipeline_l124_35) begin
-      decode_to_execute_IS_CSR <= decode_IS_CSR;
+      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
     end
     if(when_Pipeline_l124_36) begin
-      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
+      decode_to_execute_IS_CSR <= decode_IS_CSR;
     end
     if(when_Pipeline_l124_37) begin
-      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
+      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
     end
     if(when_Pipeline_l124_38) begin
-      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
+      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
     end
     if(when_Pipeline_l124_39) begin
-      decode_to_execute_IS_MUL <= decode_IS_MUL;
+      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
     end
     if(when_Pipeline_l124_40) begin
-      execute_to_memory_IS_MUL <= execute_IS_MUL;
+      decode_to_execute_IS_MUL <= decode_IS_MUL;
     end
     if(when_Pipeline_l124_41) begin
-      memory_to_writeBack_IS_MUL <= memory_IS_MUL;
+      execute_to_memory_IS_MUL <= execute_IS_MUL;
     end
     if(when_Pipeline_l124_42) begin
-      decode_to_execute_IS_DIV <= decode_IS_DIV;
+      memory_to_writeBack_IS_MUL <= memory_IS_MUL;
     end
     if(when_Pipeline_l124_43) begin
-      execute_to_memory_IS_DIV <= execute_IS_DIV;
+      decode_to_execute_IS_DIV <= decode_IS_DIV;
     end
     if(when_Pipeline_l124_44) begin
-      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
+      execute_to_memory_IS_DIV <= execute_IS_DIV;
     end
     if(when_Pipeline_l124_45) begin
-      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
+      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
     end
     if(when_Pipeline_l124_46) begin
-      decode_to_execute_CfuPlugin_CFU_ENABLE <= decode_CfuPlugin_CFU_ENABLE;
+      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
     end
     if(when_Pipeline_l124_47) begin
-      decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND <= _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+      decode_to_execute_CfuPlugin_CFU_ENABLE <= decode_CfuPlugin_CFU_ENABLE;
     end
     if(when_Pipeline_l124_48) begin
-      decode_to_execute_RS1 <= decode_RS1;
+      decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND <= _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
     end
     if(when_Pipeline_l124_49) begin
-      decode_to_execute_RS2 <= decode_RS2;
+      decode_to_execute_RS1 <= decode_RS1;
     end
     if(when_Pipeline_l124_50) begin
-      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
+      decode_to_execute_RS2 <= decode_RS2;
     end
     if(when_Pipeline_l124_51) begin
-      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
+      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
     end
     if(when_Pipeline_l124_52) begin
-      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
+      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
     end
     if(when_Pipeline_l124_53) begin
-      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
+      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
     end
     if(when_Pipeline_l124_54) begin
-      execute_to_memory_MEMORY_STORE_DATA_RF <= execute_MEMORY_STORE_DATA_RF;
+      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
     end
     if(when_Pipeline_l124_55) begin
-      memory_to_writeBack_MEMORY_STORE_DATA_RF <= memory_MEMORY_STORE_DATA_RF;
+      execute_to_memory_MEMORY_STORE_DATA_RF <= execute_MEMORY_STORE_DATA_RF;
     end
     if(when_Pipeline_l124_56) begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_decode_RS2;
+      memory_to_writeBack_MEMORY_STORE_DATA_RF <= memory_MEMORY_STORE_DATA_RF;
     end
     if(when_Pipeline_l124_57) begin
-      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_decode_RS2_1;
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_decode_RS2;
     end
     if(when_Pipeline_l124_58) begin
-      execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_decode_RS2_1;
     end
     if(when_Pipeline_l124_59) begin
-      execute_to_memory_MUL_LL <= execute_MUL_LL;
+      execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
     end
     if(when_Pipeline_l124_60) begin
-      execute_to_memory_MUL_LH <= execute_MUL_LH;
+      execute_to_memory_MUL_LL <= execute_MUL_LL;
     end
     if(when_Pipeline_l124_61) begin
-      execute_to_memory_MUL_HL <= execute_MUL_HL;
+      execute_to_memory_MUL_LH <= execute_MUL_LH;
     end
     if(when_Pipeline_l124_62) begin
-      execute_to_memory_MUL_HH <= execute_MUL_HH;
+      execute_to_memory_MUL_HL <= execute_MUL_HL;
     end
     if(when_Pipeline_l124_63) begin
+      execute_to_memory_MUL_HH <= execute_MUL_HH;
+    end
+    if(when_Pipeline_l124_64) begin
       memory_to_writeBack_MUL_HH <= memory_MUL_HH;
     end
-    if(when_Pipeline_l124_65) begin
+    if(when_Pipeline_l124_66) begin
       memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT <= _zz_memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
     end
-    if(when_Pipeline_l124_66) begin
+    if(when_Pipeline_l124_67) begin
       memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
     end
-    if(when_CsrPlugin_l1277) begin
+    if(when_CsrPlugin_l1669) begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
     end
-    if(when_CsrPlugin_l1277_1) begin
+    if(when_CsrPlugin_l1669_1) begin
       execute_CsrPlugin_csr_3857 <= (decode_INSTRUCTION[31 : 20] == 12'hf11);
     end
-    if(when_CsrPlugin_l1277_2) begin
+    if(when_CsrPlugin_l1669_2) begin
       execute_CsrPlugin_csr_3858 <= (decode_INSTRUCTION[31 : 20] == 12'hf12);
     end
-    if(when_CsrPlugin_l1277_3) begin
+    if(when_CsrPlugin_l1669_3) begin
       execute_CsrPlugin_csr_3859 <= (decode_INSTRUCTION[31 : 20] == 12'hf13);
     end
-    if(when_CsrPlugin_l1277_4) begin
+    if(when_CsrPlugin_l1669_4) begin
       execute_CsrPlugin_csr_3860 <= (decode_INSTRUCTION[31 : 20] == 12'hf14);
     end
-    if(when_CsrPlugin_l1277_5) begin
+    if(when_CsrPlugin_l1669_5) begin
       execute_CsrPlugin_csr_769 <= (decode_INSTRUCTION[31 : 20] == 12'h301);
     end
-    if(when_CsrPlugin_l1277_6) begin
+    if(when_CsrPlugin_l1669_6) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if(when_CsrPlugin_l1277_7) begin
+    if(when_CsrPlugin_l1669_7) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if(when_CsrPlugin_l1277_8) begin
+    if(when_CsrPlugin_l1669_8) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if(when_CsrPlugin_l1277_9) begin
+    if(when_CsrPlugin_l1669_9) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if(when_CsrPlugin_l1277_10) begin
+    if(when_CsrPlugin_l1669_10) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if(when_CsrPlugin_l1277_11) begin
+    if(when_CsrPlugin_l1669_11) begin
       execute_CsrPlugin_csr_832 <= (decode_INSTRUCTION[31 : 20] == 12'h340);
     end
-    if(when_CsrPlugin_l1277_12) begin
+    if(when_CsrPlugin_l1669_12) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if(when_CsrPlugin_l1277_13) begin
+    if(when_CsrPlugin_l1669_13) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if(when_CsrPlugin_l1277_14) begin
+    if(when_CsrPlugin_l1669_14) begin
       execute_CsrPlugin_csr_2816 <= (decode_INSTRUCTION[31 : 20] == 12'hb00);
     end
-    if(when_CsrPlugin_l1277_15) begin
+    if(when_CsrPlugin_l1669_15) begin
       execute_CsrPlugin_csr_2944 <= (decode_INSTRUCTION[31 : 20] == 12'hb80);
     end
-    if(when_CsrPlugin_l1277_16) begin
+    if(when_CsrPlugin_l1669_16) begin
       execute_CsrPlugin_csr_2818 <= (decode_INSTRUCTION[31 : 20] == 12'hb02);
     end
-    if(when_CsrPlugin_l1277_17) begin
+    if(when_CsrPlugin_l1669_17) begin
       execute_CsrPlugin_csr_2946 <= (decode_INSTRUCTION[31 : 20] == 12'hb82);
     end
-    if(when_CsrPlugin_l1277_18) begin
+    if(when_CsrPlugin_l1669_18) begin
       execute_CsrPlugin_csr_3072 <= (decode_INSTRUCTION[31 : 20] == 12'hc00);
     end
-    if(when_CsrPlugin_l1277_19) begin
+    if(when_CsrPlugin_l1669_19) begin
       execute_CsrPlugin_csr_3200 <= (decode_INSTRUCTION[31 : 20] == 12'hc80);
     end
-    if(when_CsrPlugin_l1277_20) begin
+    if(when_CsrPlugin_l1669_20) begin
       execute_CsrPlugin_csr_3074 <= (decode_INSTRUCTION[31 : 20] == 12'hc02);
     end
-    if(when_CsrPlugin_l1277_21) begin
+    if(when_CsrPlugin_l1669_21) begin
       execute_CsrPlugin_csr_3202 <= (decode_INSTRUCTION[31 : 20] == 12'hc82);
     end
-    if(when_CsrPlugin_l1277_22) begin
+    if(when_CsrPlugin_l1669_22) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if(when_CsrPlugin_l1277_23) begin
+    if(when_CsrPlugin_l1669_23) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
     if(execute_CsrPlugin_csr_836) begin
@@ -5773,7 +5790,6 @@ module VexRiscv (
     if(execute_CsrPlugin_csr_773) begin
       if(execute_CsrPlugin_writeEnable) begin
         CsrPlugin_mtvec_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 2];
-        CsrPlugin_mtvec_mode <= CsrPlugin_csrMapping_writeDataSignal[1 : 0];
       end
     end
     if(execute_CsrPlugin_csr_833) begin
@@ -5805,76 +5821,75 @@ module VexRiscv (
 endmodule
 
 module DataCache (
-  input               io_cpu_execute_isValid,
-  input      [31:0]   io_cpu_execute_address,
-  output reg          io_cpu_execute_haltIt,
-  input               io_cpu_execute_args_wr,
-  input      [1:0]    io_cpu_execute_args_size,
-  input               io_cpu_execute_args_totalyConsistent,
-  output              io_cpu_execute_refilling,
-  input               io_cpu_memory_isValid,
-  input               io_cpu_memory_isStuck,
-  output              io_cpu_memory_isWrite,
-  input      [31:0]   io_cpu_memory_address,
-  input      [31:0]   io_cpu_memory_mmuRsp_physicalAddress,
-  input               io_cpu_memory_mmuRsp_isIoAccess,
-  input               io_cpu_memory_mmuRsp_isPaging,
-  input               io_cpu_memory_mmuRsp_allowRead,
-  input               io_cpu_memory_mmuRsp_allowWrite,
-  input               io_cpu_memory_mmuRsp_allowExecute,
-  input               io_cpu_memory_mmuRsp_exception,
-  input               io_cpu_memory_mmuRsp_refilling,
-  input               io_cpu_memory_mmuRsp_bypassTranslation,
-  input               io_cpu_writeBack_isValid,
-  input               io_cpu_writeBack_isStuck,
-  input               io_cpu_writeBack_isFiring,
-  input               io_cpu_writeBack_isUser,
-  output reg          io_cpu_writeBack_haltIt,
-  output              io_cpu_writeBack_isWrite,
-  input      [31:0]   io_cpu_writeBack_storeData,
-  output reg [31:0]   io_cpu_writeBack_data,
-  input      [31:0]   io_cpu_writeBack_address,
-  output              io_cpu_writeBack_mmuException,
-  output              io_cpu_writeBack_unalignedAccess,
-  output reg          io_cpu_writeBack_accessError,
-  output              io_cpu_writeBack_keepMemRspData,
-  input               io_cpu_writeBack_fence_SW,
-  input               io_cpu_writeBack_fence_SR,
-  input               io_cpu_writeBack_fence_SO,
-  input               io_cpu_writeBack_fence_SI,
-  input               io_cpu_writeBack_fence_PW,
-  input               io_cpu_writeBack_fence_PR,
-  input               io_cpu_writeBack_fence_PO,
-  input               io_cpu_writeBack_fence_PI,
-  input      [3:0]    io_cpu_writeBack_fence_FM,
-  output              io_cpu_writeBack_exclusiveOk,
-  output reg          io_cpu_redo,
-  input               io_cpu_flush_valid,
-  output              io_cpu_flush_ready,
-  input               io_cpu_flush_payload_singleLine,
-  input      [6:0]    io_cpu_flush_payload_lineId,
-  output reg          io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output reg          io_mem_cmd_payload_wr,
-  output              io_mem_cmd_payload_uncached,
-  output reg [31:0]   io_mem_cmd_payload_address,
-  output     [31:0]   io_mem_cmd_payload_data,
-  output     [3:0]    io_mem_cmd_payload_mask,
-  output reg [2:0]    io_mem_cmd_payload_size,
-  output              io_mem_cmd_payload_last,
-  input               io_mem_rsp_valid,
-  input               io_mem_rsp_payload_last,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input               clk,
-  input               reset
+  input  wire          io_cpu_execute_isValid,
+  input  wire [31:0]   io_cpu_execute_address,
+  output reg           io_cpu_execute_haltIt,
+  input  wire          io_cpu_execute_args_wr,
+  input  wire [1:0]    io_cpu_execute_args_size,
+  input  wire          io_cpu_execute_args_totalyConsistent,
+  output wire          io_cpu_execute_refilling,
+  input  wire          io_cpu_memory_isValid,
+  input  wire          io_cpu_memory_isStuck,
+  output wire          io_cpu_memory_isWrite,
+  input  wire [31:0]   io_cpu_memory_address,
+  input  wire [31:0]   io_cpu_memory_mmuRsp_physicalAddress,
+  input  wire          io_cpu_memory_mmuRsp_isIoAccess,
+  input  wire          io_cpu_memory_mmuRsp_isPaging,
+  input  wire          io_cpu_memory_mmuRsp_allowRead,
+  input  wire          io_cpu_memory_mmuRsp_allowWrite,
+  input  wire          io_cpu_memory_mmuRsp_allowExecute,
+  input  wire          io_cpu_memory_mmuRsp_exception,
+  input  wire          io_cpu_memory_mmuRsp_refilling,
+  input  wire          io_cpu_memory_mmuRsp_bypassTranslation,
+  input  wire          io_cpu_writeBack_isValid,
+  input  wire          io_cpu_writeBack_isStuck,
+  input  wire          io_cpu_writeBack_isFiring,
+  input  wire          io_cpu_writeBack_isUser,
+  output reg           io_cpu_writeBack_haltIt,
+  output wire          io_cpu_writeBack_isWrite,
+  input  wire [31:0]   io_cpu_writeBack_storeData,
+  output reg  [31:0]   io_cpu_writeBack_data,
+  input  wire [31:0]   io_cpu_writeBack_address,
+  output wire          io_cpu_writeBack_mmuException,
+  output wire          io_cpu_writeBack_unalignedAccess,
+  output reg           io_cpu_writeBack_accessError,
+  output wire          io_cpu_writeBack_keepMemRspData,
+  input  wire          io_cpu_writeBack_fence_SW,
+  input  wire          io_cpu_writeBack_fence_SR,
+  input  wire          io_cpu_writeBack_fence_SO,
+  input  wire          io_cpu_writeBack_fence_SI,
+  input  wire          io_cpu_writeBack_fence_PW,
+  input  wire          io_cpu_writeBack_fence_PR,
+  input  wire          io_cpu_writeBack_fence_PO,
+  input  wire          io_cpu_writeBack_fence_PI,
+  input  wire [3:0]    io_cpu_writeBack_fence_FM,
+  output wire          io_cpu_writeBack_exclusiveOk,
+  output reg           io_cpu_redo,
+  input  wire          io_cpu_flush_valid,
+  output wire          io_cpu_flush_ready,
+  input  wire          io_cpu_flush_payload_singleLine,
+  input  wire [6:0]    io_cpu_flush_payload_lineId,
+  output wire          io_cpu_writesPending,
+  output reg           io_mem_cmd_valid,
+  input  wire          io_mem_cmd_ready,
+  output reg           io_mem_cmd_payload_wr,
+  output wire          io_mem_cmd_payload_uncached,
+  output reg  [31:0]   io_mem_cmd_payload_address,
+  output wire [31:0]   io_mem_cmd_payload_data,
+  output wire [3:0]    io_mem_cmd_payload_mask,
+  output reg  [2:0]    io_mem_cmd_payload_size,
+  output wire          io_mem_cmd_payload_last,
+  input  wire          io_mem_rsp_valid,
+  input  wire          io_mem_rsp_payload_last,
+  input  wire [31:0]   io_mem_rsp_payload_data,
+  input  wire          io_mem_rsp_payload_error,
+  input  wire          clk,
+  input  wire          reset
 );
 
   reg        [21:0]   _zz_ways_0_tags_port0;
   reg        [31:0]   _zz_ways_0_data_port0;
   wire       [21:0]   _zz_ways_0_tags_port;
-  wire       [9:0]    _zz_stage0_dataColisions;
-  wire       [9:0]    _zz__zz_stageA_dataColisions;
   wire       [0:0]    _zz_when;
   wire       [2:0]    _zz_loader_counter_valueNext;
   wire       [0:0]    _zz_loader_counter_valueNext_1;
@@ -5911,40 +5926,40 @@ module DataCache (
   wire                _zz_ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRsp;
-  wire                when_DataCache_l642;
   wire                when_DataCache_l645;
-  wire                when_DataCache_l664;
+  wire                when_DataCache_l648;
+  wire                when_DataCache_l667;
   wire                rspSync;
   wire                rspLast;
   reg                 memCmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_DataCache_l686;
+  wire                when_DataCache_l689;
   reg        [3:0]    _zz_stage0_mask;
   wire       [3:0]    stage0_mask;
   wire       [0:0]    stage0_dataColisions;
   wire       [0:0]    stage0_wayInvalidate;
   wire                stage0_isAmo;
-  wire                when_DataCache_l771;
+  wire                when_DataCache_l776;
   reg                 stageA_request_wr;
   reg        [1:0]    stageA_request_size;
   reg                 stageA_request_totalyConsistent;
-  wire                when_DataCache_l771_1;
+  wire                when_DataCache_l776_1;
   reg        [3:0]    stageA_mask;
   wire                stageA_isAmo;
   wire                stageA_isLrsc;
   wire       [0:0]    stageA_wayHits;
-  wire                when_DataCache_l771_2;
+  wire                when_DataCache_l776_2;
   reg        [0:0]    stageA_wayInvalidate;
-  wire                when_DataCache_l771_3;
+  wire                when_DataCache_l776_3;
   reg        [0:0]    stage0_dataColisions_regNextWhen;
   wire       [0:0]    _zz_stageA_dataColisions;
   wire       [0:0]    stageA_dataColisions;
-  wire                when_DataCache_l822;
+  wire                when_DataCache_l827;
   reg                 stageB_request_wr;
   reg        [1:0]    stageB_request_size;
   reg                 stageB_request_totalyConsistent;
   reg                 stageB_mmuRspFreeze;
-  wire                when_DataCache_l824;
+  wire                when_DataCache_l829;
   reg        [31:0]   stageB_mmuRsp_physicalAddress;
   reg                 stageB_mmuRsp_isIoAccess;
   reg                 stageB_mmuRsp_isPaging;
@@ -5954,52 +5969,54 @@ module DataCache (
   reg                 stageB_mmuRsp_exception;
   reg                 stageB_mmuRsp_refilling;
   reg                 stageB_mmuRsp_bypassTranslation;
-  wire                when_DataCache_l821;
+  wire                when_DataCache_l826;
   reg                 stageB_tagsReadRsp_0_valid;
   reg                 stageB_tagsReadRsp_0_error;
   reg        [19:0]   stageB_tagsReadRsp_0_address;
-  wire                when_DataCache_l821_1;
+  wire                when_DataCache_l826_1;
   reg        [31:0]   stageB_dataReadRsp_0;
-  wire                when_DataCache_l820;
+  wire                when_DataCache_l825;
   reg        [0:0]    stageB_wayInvalidate;
   wire                stageB_consistancyHazard;
-  wire                when_DataCache_l820_1;
+  wire                when_DataCache_l825_1;
   reg        [0:0]    stageB_dataColisions;
-  wire                when_DataCache_l820_2;
+  wire                when_DataCache_l825_2;
   reg                 stageB_unaligned;
-  wire                when_DataCache_l820_3;
+  wire                when_DataCache_l825_3;
   reg        [0:0]    stageB_waysHitsBeforeInvalidate;
   wire       [0:0]    stageB_waysHits;
   wire                stageB_waysHit;
   wire       [31:0]   stageB_dataMux;
-  wire                when_DataCache_l820_4;
+  wire                when_DataCache_l825_4;
   reg        [3:0]    stageB_mask;
   reg                 stageB_loaderValid;
   wire       [31:0]   stageB_ioMemRspMuxed;
   reg                 stageB_flusher_waitDone;
   wire                stageB_flusher_hold;
   reg        [7:0]    stageB_flusher_counter;
-  wire                when_DataCache_l850;
-  wire                when_DataCache_l856;
+  wire                when_DataCache_l855;
+  wire                when_DataCache_l861;
+  wire                when_DataCache_l863;
   reg                 stageB_flusher_start;
+  wire                when_DataCache_l877;
   wire                stageB_isAmo;
   wire                stageB_isAmoCached;
   wire                stageB_isExternalLsrc;
   wire                stageB_isExternalAmo;
   wire       [31:0]   stageB_requestDataBypass;
   reg                 stageB_cpuWriteToCache;
-  wire                when_DataCache_l926;
+  wire                when_DataCache_l931;
   wire                stageB_badPermissions;
   wire                stageB_loadStoreFault;
   wire                stageB_bypassCache;
-  wire                when_DataCache_l995;
-  wire                when_DataCache_l1004;
+  wire                when_DataCache_l1000;
   wire                when_DataCache_l1009;
-  wire                when_DataCache_l1020;
-  wire                when_DataCache_l1032;
-  wire                when_DataCache_l991;
-  wire                when_DataCache_l1066;
-  wire                when_DataCache_l1075;
+  wire                when_DataCache_l1014;
+  wire                when_DataCache_l1025;
+  wire                when_DataCache_l1037;
+  wire                when_DataCache_l996;
+  wire                when_DataCache_l1072;
+  wire                when_DataCache_l1081;
   reg                 loader_valid;
   reg                 loader_counter_willIncrement;
   wire                loader_counter_willClear;
@@ -6011,12 +6028,12 @@ module DataCache (
   reg                 loader_error;
   wire                loader_kill;
   reg                 loader_killReg;
-  wire                when_DataCache_l1090;
+  wire                when_DataCache_l1097;
   wire                loader_done;
-  wire                when_DataCache_l1118;
-  reg                 loader_valid_regNext;
-  wire                when_DataCache_l1122;
   wire                when_DataCache_l1125;
+  reg                 loader_valid_regNext;
+  wire                when_DataCache_l1129;
+  wire                when_DataCache_l1132;
   (* no_rw_check , ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
   (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
   (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
@@ -6027,8 +6044,6 @@ module DataCache (
   reg [7:0] _zz_ways_0_datasymbol_read_2;
   reg [7:0] _zz_ways_0_datasymbol_read_3;
 
-  assign _zz_stage0_dataColisions = (io_cpu_execute_address[11 : 2] >>> 0);
-  assign _zz__zz_stageA_dataColisions = (io_cpu_memory_address[11 : 2] >>> 0);
   assign _zz_when = 1'b1;
   assign _zz_loader_counter_valueNext_1 = loader_counter_willIncrement;
   assign _zz_loader_counter_valueNext = {2'd0, _zz_loader_counter_valueNext_1};
@@ -6075,14 +6090,14 @@ module DataCache (
 
   always @(*) begin
     _zz_1 = 1'b0;
-    if(when_DataCache_l645) begin
+    if(when_DataCache_l648) begin
       _zz_1 = 1'b1;
     end
   end
 
   always @(*) begin
     _zz_2 = 1'b0;
-    if(when_DataCache_l642) begin
+    if(when_DataCache_l645) begin
       _zz_2 = 1'b1;
     end
   end
@@ -6096,43 +6111,45 @@ module DataCache (
   assign _zz_ways_0_dataReadRspMem = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
   assign ways_0_dataReadRspMem = _zz_ways_0_data_port0;
   assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
-  assign when_DataCache_l642 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
-  assign when_DataCache_l645 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
+  assign when_DataCache_l645 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
+  assign when_DataCache_l648 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
   always @(*) begin
     tagsReadCmd_valid = 1'b0;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       tagsReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     tagsReadCmd_payload = 7'bxxxxxxx;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
     end
   end
 
   always @(*) begin
     dataReadCmd_valid = 1'b0;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       dataReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     dataReadCmd_payload = 10'bxxxxxxxxxx;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       dataReadCmd_payload = io_cpu_execute_address[11 : 2];
     end
   end
 
   always @(*) begin
     tagsWriteCmd_valid = 1'b0;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_valid = 1'b1;
     end
-    if(when_DataCache_l1066) begin
-      tagsWriteCmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        tagsWriteCmd_valid = 1'b0;
+      end
     end
     if(loader_done) begin
       tagsWriteCmd_valid = 1'b1;
@@ -6141,7 +6158,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_way = 1'bx;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_payload_way = 1'b1;
     end
     if(loader_done) begin
@@ -6151,7 +6168,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_address = 7'bxxxxxxx;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_payload_address = stageB_flusher_counter[6:0];
     end
     if(loader_done) begin
@@ -6161,7 +6178,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_data_valid = 1'bx;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_payload_data_valid = 1'b0;
     end
     if(loader_done) begin
@@ -6186,14 +6203,16 @@ module DataCache (
   always @(*) begin
     dataWriteCmd_valid = 1'b0;
     if(stageB_cpuWriteToCache) begin
-      if(when_DataCache_l926) begin
+      if(when_DataCache_l931) begin
         dataWriteCmd_valid = 1'b1;
       end
     end
-    if(when_DataCache_l1066) begin
-      dataWriteCmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        dataWriteCmd_valid = 1'b0;
+      end
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_valid = 1'b1;
     end
   end
@@ -6203,7 +6222,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_way = stageB_waysHits;
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_way = loader_waysAllocator;
     end
   end
@@ -6213,7 +6232,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
     end
   end
@@ -6223,7 +6242,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_data = io_mem_rsp_payload_data;
     end
   end
@@ -6236,15 +6255,15 @@ module DataCache (
         dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
       end
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_mask = 4'b1111;
     end
   end
 
-  assign when_DataCache_l664 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  assign when_DataCache_l667 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
   always @(*) begin
     io_cpu_execute_haltIt = 1'b0;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       io_cpu_execute_haltIt = 1'b1;
     end
   end
@@ -6252,7 +6271,7 @@ module DataCache (
   assign rspSync = 1'b1;
   assign rspLast = 1'b1;
   assign io_mem_cmd_fire = (io_mem_cmd_valid && io_mem_cmd_ready);
-  assign when_DataCache_l686 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l689 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     _zz_stage0_mask = 4'bxxxx;
     case(io_cpu_execute_args_size)
@@ -6271,45 +6290,45 @@ module DataCache (
   end
 
   assign stage0_mask = (_zz_stage0_mask <<< io_cpu_execute_address[1 : 0]);
-  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_stage0_dataColisions)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_execute_address[11 : 2])) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stage0_wayInvalidate = 1'b0;
   assign stage0_isAmo = 1'b0;
-  assign when_DataCache_l771 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l771_1 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l776 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l776_1 = (! io_cpu_memory_isStuck);
   assign io_cpu_memory_isWrite = stageA_request_wr;
   assign stageA_isAmo = 1'b0;
   assign stageA_isLrsc = 1'b0;
   assign stageA_wayHits = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign when_DataCache_l771_2 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l771_3 = (! io_cpu_memory_isStuck);
-  assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz__zz_stageA_dataColisions)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign when_DataCache_l776_2 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l776_3 = (! io_cpu_memory_isStuck);
+  assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_memory_address[11 : 2])) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_stageA_dataColisions);
-  assign when_DataCache_l822 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l827 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_mmuRspFreeze = 1'b0;
-    if(when_DataCache_l1125) begin
+    if(when_DataCache_l1132) begin
       stageB_mmuRspFreeze = 1'b1;
     end
   end
 
-  assign when_DataCache_l824 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
-  assign when_DataCache_l821 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l821_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l820 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l829 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
+  assign when_DataCache_l826 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l826_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825 = (! io_cpu_writeBack_isStuck);
   assign stageB_consistancyHazard = 1'b0;
-  assign when_DataCache_l820_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l820_2 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l820_3 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_2 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_3 = (! io_cpu_writeBack_isStuck);
   assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
   assign stageB_waysHit = (|stageB_waysHits);
   assign stageB_dataMux = stageB_dataReadRsp_0;
-  assign when_DataCache_l820_4 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_4 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_loaderValid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
             if(io_mem_cmd_ready) begin
               stageB_loaderValid = 1'b1;
             end
@@ -6317,8 +6336,10 @@ module DataCache (
         end
       end
     end
-    if(when_DataCache_l1066) begin
-      stageB_loaderValid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        stageB_loaderValid = 1'b0;
+      end
     end
   end
 
@@ -6327,28 +6348,32 @@ module DataCache (
     io_cpu_writeBack_haltIt = 1'b1;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l991) begin
-          if(when_DataCache_l995) begin
+        if(when_DataCache_l996) begin
+          if(when_DataCache_l1000) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
         end else begin
-          if(when_DataCache_l1004) begin
-            if(when_DataCache_l1009) begin
+          if(when_DataCache_l1009) begin
+            if(when_DataCache_l1014) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1066) begin
-      io_cpu_writeBack_haltIt = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        io_cpu_writeBack_haltIt = 1'b0;
+      end
     end
   end
 
   assign stageB_flusher_hold = 1'b0;
-  assign when_DataCache_l850 = (! stageB_flusher_counter[7]);
-  assign when_DataCache_l856 = (! stageB_flusher_hold);
+  assign when_DataCache_l855 = (! stageB_flusher_counter[7]);
+  assign when_DataCache_l861 = (! stageB_flusher_hold);
+  assign when_DataCache_l863 = (io_cpu_flush_valid && io_cpu_flush_payload_singleLine);
   assign io_cpu_flush_ready = (stageB_flusher_waitDone && stageB_flusher_counter[7]);
+  assign when_DataCache_l877 = (io_cpu_flush_valid && io_cpu_flush_payload_singleLine);
   assign stageB_isAmo = 1'b0;
   assign stageB_isAmoCached = 1'b0;
   assign stageB_isExternalLsrc = 1'b0;
@@ -6358,8 +6383,8 @@ module DataCache (
     stageB_cpuWriteToCache = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(when_DataCache_l1009) begin
             stageB_cpuWriteToCache = 1'b1;
           end
         end
@@ -6367,26 +6392,28 @@ module DataCache (
     end
   end
 
-  assign when_DataCache_l926 = (stageB_request_wr && stageB_waysHit);
+  assign when_DataCache_l931 = (stageB_request_wr && stageB_waysHit);
   assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_isAmo)));
   assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
   always @(*) begin
     io_cpu_redo = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(when_DataCache_l1004) begin
-            if(when_DataCache_l1020) begin
+        if(!when_DataCache_l996) begin
+          if(when_DataCache_l1009) begin
+            if(when_DataCache_l1025) begin
               io_cpu_redo = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1075) begin
-      io_cpu_redo = 1'b1;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1081) begin
+        io_cpu_redo = 1'b1;
+      end
     end
-    if(when_DataCache_l1122) begin
+    if(when_DataCache_l1129) begin
       io_cpu_redo = 1'b1;
     end
   end
@@ -6407,23 +6434,25 @@ module DataCache (
     io_mem_cmd_valid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l991) begin
+        if(when_DataCache_l996) begin
           io_mem_cmd_valid = (! memCmdSent);
         end else begin
-          if(when_DataCache_l1004) begin
+          if(when_DataCache_l1009) begin
             if(stageB_request_wr) begin
               io_mem_cmd_valid = 1'b1;
             end
           end else begin
-            if(when_DataCache_l1032) begin
+            if(when_DataCache_l1037) begin
               io_mem_cmd_valid = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1066) begin
-      io_mem_cmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        io_mem_cmd_valid = 1'b0;
+      end
     end
   end
 
@@ -6431,9 +6460,9 @@ module DataCache (
     io_mem_cmd_payload_address = stageB_mmuRsp_physicalAddress;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
-            io_mem_cmd_payload_address[4 : 0] = 5'h0;
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
+            io_mem_cmd_payload_address[4 : 0] = 5'h00;
           end
         end
       end
@@ -6445,8 +6474,8 @@ module DataCache (
     io_mem_cmd_payload_wr = stageB_request_wr;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
             io_mem_cmd_payload_wr = 1'b0;
           end
         end
@@ -6461,8 +6490,8 @@ module DataCache (
     io_mem_cmd_payload_size = {1'd0, stageB_request_size};
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
             io_mem_cmd_payload_size = 3'b101;
           end
         end
@@ -6472,12 +6501,12 @@ module DataCache (
 
   assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
   assign io_cpu_writeBack_keepMemRspData = 1'b0;
-  assign when_DataCache_l995 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
-  assign when_DataCache_l1004 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
-  assign when_DataCache_l1009 = ((! stageB_request_wr) || io_mem_cmd_ready);
-  assign when_DataCache_l1020 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
-  assign when_DataCache_l1032 = (! memCmdSent);
-  assign when_DataCache_l991 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  assign when_DataCache_l1000 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
+  assign when_DataCache_l1009 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
+  assign when_DataCache_l1014 = ((! stageB_request_wr) || io_mem_cmd_ready);
+  assign when_DataCache_l1025 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
+  assign when_DataCache_l1037 = (! memCmdSent);
+  assign when_DataCache_l996 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
   always @(*) begin
     if(stageB_bypassCache) begin
       io_cpu_writeBack_data = stageB_ioMemRspMuxed;
@@ -6486,11 +6515,11 @@ module DataCache (
     end
   end
 
-  assign when_DataCache_l1066 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign when_DataCache_l1075 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
+  assign when_DataCache_l1072 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign when_DataCache_l1081 = (stageB_mmuRsp_refilling || stageB_consistancyHazard);
   always @(*) begin
     loader_counter_willIncrement = 1'b0;
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       loader_counter_willIncrement = 1'b1;
     end
   end
@@ -6506,12 +6535,12 @@ module DataCache (
   end
 
   assign loader_kill = 1'b0;
-  assign when_DataCache_l1090 = ((loader_valid && io_mem_rsp_valid) && rspLast);
+  assign when_DataCache_l1097 = ((loader_valid && io_mem_rsp_valid) && rspLast);
   assign loader_done = loader_counter_willOverflow;
-  assign when_DataCache_l1118 = (! loader_valid);
-  assign when_DataCache_l1122 = (loader_valid && (! loader_valid_regNext));
+  assign when_DataCache_l1125 = (! loader_valid);
+  assign when_DataCache_l1129 = (loader_valid && (! loader_valid_regNext));
   assign io_cpu_execute_refilling = loader_valid;
-  assign when_DataCache_l1125 = (stageB_loaderValid || loader_valid);
+  assign when_DataCache_l1132 = (stageB_loaderValid || loader_valid);
   always @(posedge clk) begin
     tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
     tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
@@ -6519,26 +6548,26 @@ module DataCache (
     tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
     tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
     tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if(when_DataCache_l771) begin
+    if(when_DataCache_l776) begin
       stageA_request_wr <= io_cpu_execute_args_wr;
       stageA_request_size <= io_cpu_execute_args_size;
       stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
     end
-    if(when_DataCache_l771_1) begin
+    if(when_DataCache_l776_1) begin
       stageA_mask <= stage0_mask;
     end
-    if(when_DataCache_l771_2) begin
+    if(when_DataCache_l776_2) begin
       stageA_wayInvalidate <= stage0_wayInvalidate;
     end
-    if(when_DataCache_l771_3) begin
+    if(when_DataCache_l776_3) begin
       stage0_dataColisions_regNextWhen <= stage0_dataColisions;
     end
-    if(when_DataCache_l822) begin
+    if(when_DataCache_l827) begin
       stageB_request_wr <= stageA_request_wr;
       stageB_request_size <= stageA_request_size;
       stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
     end
-    if(when_DataCache_l824) begin
+    if(when_DataCache_l829) begin
       stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
       stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
       stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
@@ -6549,27 +6578,27 @@ module DataCache (
       stageB_mmuRsp_refilling <= io_cpu_memory_mmuRsp_refilling;
       stageB_mmuRsp_bypassTranslation <= io_cpu_memory_mmuRsp_bypassTranslation;
     end
-    if(when_DataCache_l821) begin
+    if(when_DataCache_l826) begin
       stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
       stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
       stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
     end
-    if(when_DataCache_l821_1) begin
+    if(when_DataCache_l826_1) begin
       stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
     end
-    if(when_DataCache_l820) begin
+    if(when_DataCache_l825) begin
       stageB_wayInvalidate <= stageA_wayInvalidate;
     end
-    if(when_DataCache_l820_1) begin
+    if(when_DataCache_l825_1) begin
       stageB_dataColisions <= stageA_dataColisions;
     end
-    if(when_DataCache_l820_2) begin
+    if(when_DataCache_l825_2) begin
       stageB_unaligned <= ({((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)),((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0))} != 2'b00);
     end
-    if(when_DataCache_l820_3) begin
+    if(when_DataCache_l825_3) begin
       stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
     end
-    if(when_DataCache_l820_4) begin
+    if(when_DataCache_l825_4) begin
       stageB_mask <= stageA_mask;
     end
     loader_valid_regNext <= loader_valid;
@@ -6579,7 +6608,7 @@ module DataCache (
     if(reset) begin
       memCmdSent <= 1'b0;
       stageB_flusher_waitDone <= 1'b0;
-      stageB_flusher_counter <= 8'h0;
+      stageB_flusher_counter <= 8'h00;
       stageB_flusher_start <= 1'b1;
       loader_valid <= 1'b0;
       loader_counter_value <= 3'b000;
@@ -6590,16 +6619,16 @@ module DataCache (
       if(io_mem_cmd_fire) begin
         memCmdSent <= 1'b1;
       end
-      if(when_DataCache_l686) begin
+      if(when_DataCache_l689) begin
         memCmdSent <= 1'b0;
       end
       if(io_cpu_flush_ready) begin
         stageB_flusher_waitDone <= 1'b0;
       end
-      if(when_DataCache_l850) begin
-        if(when_DataCache_l856) begin
+      if(when_DataCache_l855) begin
+        if(when_DataCache_l861) begin
           stageB_flusher_counter <= (stageB_flusher_counter + 8'h01);
-          if(io_cpu_flush_payload_singleLine) begin
+          if(when_DataCache_l863) begin
             stageB_flusher_counter[7] <= 1'b1;
           end
         end
@@ -6607,17 +6636,17 @@ module DataCache (
       stageB_flusher_start <= (((((((! stageB_flusher_waitDone) && (! stageB_flusher_start)) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
       if(stageB_flusher_start) begin
         stageB_flusher_waitDone <= 1'b1;
-        stageB_flusher_counter <= 8'h0;
-        if(io_cpu_flush_payload_singleLine) begin
+        stageB_flusher_counter <= 8'h00;
+        if(when_DataCache_l877) begin
           stageB_flusher_counter <= {1'b0,io_cpu_flush_payload_lineId};
         end
       end
       `ifndef SYNTHESIS
         `ifdef FORMAL
-          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))); // DataCache.scala:L1077
+          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))); // DataCache.scala:L1084
         `else
           if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-            $display("ERROR writeBack stuck by another plugin is not allowed"); // DataCache.scala:L1077
+            $display("ERROR writeBack stuck by another plugin is not allowed"); // DataCache.scala:L1084
           end
         `endif
       `endif
@@ -6628,7 +6657,7 @@ module DataCache (
       if(loader_kill) begin
         loader_killReg <= 1'b1;
       end
-      if(when_DataCache_l1090) begin
+      if(when_DataCache_l1097) begin
         loader_error <= (loader_error || io_mem_rsp_payload_error);
       end
       if(loader_done) begin
@@ -6636,7 +6665,7 @@ module DataCache (
         loader_error <= 1'b0;
         loader_killReg <= 1'b0;
       end
-      if(when_DataCache_l1118) begin
+      if(when_DataCache_l1125) begin
         loader_waysAllocator <= _zz_loader_waysAllocator[0:0];
       end
     end
@@ -6646,46 +6675,46 @@ module DataCache (
 endmodule
 
 module InstructionCache (
-  input               io_flush,
-  input               io_cpu_prefetch_isValid,
-  output reg          io_cpu_prefetch_haltIt,
-  input      [31:0]   io_cpu_prefetch_pc,
-  input               io_cpu_fetch_isValid,
-  input               io_cpu_fetch_isStuck,
-  input               io_cpu_fetch_isRemoved,
-  input      [31:0]   io_cpu_fetch_pc,
-  output     [31:0]   io_cpu_fetch_data,
-  input      [31:0]   io_cpu_fetch_mmuRsp_physicalAddress,
-  input               io_cpu_fetch_mmuRsp_isIoAccess,
-  input               io_cpu_fetch_mmuRsp_isPaging,
-  input               io_cpu_fetch_mmuRsp_allowRead,
-  input               io_cpu_fetch_mmuRsp_allowWrite,
-  input               io_cpu_fetch_mmuRsp_allowExecute,
-  input               io_cpu_fetch_mmuRsp_exception,
-  input               io_cpu_fetch_mmuRsp_refilling,
-  input               io_cpu_fetch_mmuRsp_bypassTranslation,
-  output     [31:0]   io_cpu_fetch_physicalAddress,
-  input               io_cpu_decode_isValid,
-  input               io_cpu_decode_isStuck,
-  input      [31:0]   io_cpu_decode_pc,
-  output     [31:0]   io_cpu_decode_physicalAddress,
-  output     [31:0]   io_cpu_decode_data,
-  output              io_cpu_decode_cacheMiss,
-  output              io_cpu_decode_error,
-  output              io_cpu_decode_mmuRefilling,
-  output              io_cpu_decode_mmuException,
-  input               io_cpu_decode_isUser,
-  input               io_cpu_fill_valid,
-  input      [31:0]   io_cpu_fill_payload,
-  output              io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output     [31:0]   io_mem_cmd_payload_address,
-  output     [2:0]    io_mem_cmd_payload_size,
-  input               io_mem_rsp_valid,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input               clk,
-  input               reset
+  input  wire          io_flush,
+  input  wire          io_cpu_prefetch_isValid,
+  output reg           io_cpu_prefetch_haltIt,
+  input  wire [31:0]   io_cpu_prefetch_pc,
+  input  wire          io_cpu_fetch_isValid,
+  input  wire          io_cpu_fetch_isStuck,
+  input  wire          io_cpu_fetch_isRemoved,
+  input  wire [31:0]   io_cpu_fetch_pc,
+  output wire [31:0]   io_cpu_fetch_data,
+  input  wire [31:0]   io_cpu_fetch_mmuRsp_physicalAddress,
+  input  wire          io_cpu_fetch_mmuRsp_isIoAccess,
+  input  wire          io_cpu_fetch_mmuRsp_isPaging,
+  input  wire          io_cpu_fetch_mmuRsp_allowRead,
+  input  wire          io_cpu_fetch_mmuRsp_allowWrite,
+  input  wire          io_cpu_fetch_mmuRsp_allowExecute,
+  input  wire          io_cpu_fetch_mmuRsp_exception,
+  input  wire          io_cpu_fetch_mmuRsp_refilling,
+  input  wire          io_cpu_fetch_mmuRsp_bypassTranslation,
+  output wire [31:0]   io_cpu_fetch_physicalAddress,
+  input  wire          io_cpu_decode_isValid,
+  input  wire          io_cpu_decode_isStuck,
+  input  wire [31:0]   io_cpu_decode_pc,
+  output wire [31:0]   io_cpu_decode_physicalAddress,
+  output wire [31:0]   io_cpu_decode_data,
+  output wire          io_cpu_decode_cacheMiss,
+  output wire          io_cpu_decode_error,
+  output wire          io_cpu_decode_mmuRefilling,
+  output wire          io_cpu_decode_mmuException,
+  input  wire          io_cpu_decode_isUser,
+  input  wire          io_cpu_fill_valid,
+  input  wire [31:0]   io_cpu_fill_payload,
+  output wire          io_mem_cmd_valid,
+  input  wire          io_mem_cmd_ready,
+  output wire [31:0]   io_mem_cmd_payload_address,
+  output wire [2:0]    io_mem_cmd_payload_size,
+  input  wire          io_mem_rsp_valid,
+  input  wire [31:0]   io_mem_rsp_payload_data,
+  input  wire          io_mem_rsp_payload_error,
+  input  wire          clk,
+  input  wire          reset
 );
 
   reg        [31:0]   _zz_banks_0_port1;
@@ -6705,7 +6734,7 @@ module InstructionCache (
   wire                when_InstructionCache_l351;
   reg                 lineLoader_cmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_Utils_l515;
+  wire                when_Utils_l560;
   reg                 lineLoader_wayToAllocate_willIncrement;
   wire                lineLoader_wayToAllocate_willClear;
   wire                lineLoader_wayToAllocate_willOverflowIfInc;
@@ -6820,12 +6849,12 @@ module InstructionCache (
   assign when_InstructionCache_l351 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
   assign io_mem_cmd_fire = (io_mem_cmd_valid && io_mem_cmd_ready);
   assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
-  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
+  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h00};
   assign io_mem_cmd_payload_size = 3'b101;
-  assign when_Utils_l515 = (! lineLoader_valid);
+  assign when_Utils_l560 = (! lineLoader_valid);
   always @(*) begin
     lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if(when_Utils_l515) begin
+    if(when_Utils_l560) begin
       lineLoader_wayToAllocate_willIncrement = 1'b1;
     end
   end
@@ -6916,7 +6945,7 @@ module InstructionCache (
     end
     _zz_when_InstructionCache_l342 <= lineLoader_flushCounter[7];
     if(when_InstructionCache_l351) begin
-      lineLoader_flushCounter <= 8'h0;
+      lineLoader_flushCounter <= 8'h00;
     end
     if(when_InstructionCache_l435) begin
       io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_FullCfuDebug.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_FullCfuDebug.v
@@ -1,54 +1,54 @@
-// Generator : SpinalHDL v1.7.1    git head : 0444bb76ab1d6e19f0ec46bc03c4769776deb7d5
+// Generator : SpinalHDL v1.9.4    git head : 270018552577f3bb8e5339ee2583c9c22d324215
 // Component : VexRiscv
-// Git hash  : 581fcb065adf7ea8b626f939ff51679d4c95872f
+// Git hash  : 63430af99f84cc1d11d58b556debe1cc3f238c67
 
 `timescale 1ns/1ps
 
 module VexRiscv (
-  input      [31:0]   externalResetVector,
-  input               timerInterrupt,
-  input               softwareInterrupt,
-  input      [31:0]   externalInterruptArray,
-  input               debug_bus_cmd_valid,
-  output reg          debug_bus_cmd_ready,
-  input               debug_bus_cmd_payload_wr,
-  input      [7:0]    debug_bus_cmd_payload_address,
-  input      [31:0]   debug_bus_cmd_payload_data,
-  output reg [31:0]   debug_bus_rsp_data,
-  output              debug_resetOut,
-  output              CfuPlugin_bus_cmd_valid,
-  input               CfuPlugin_bus_cmd_ready,
-  output     [9:0]    CfuPlugin_bus_cmd_payload_function_id,
-  output     [31:0]   CfuPlugin_bus_cmd_payload_inputs_0,
-  output     [31:0]   CfuPlugin_bus_cmd_payload_inputs_1,
-  input               CfuPlugin_bus_rsp_valid,
-  output              CfuPlugin_bus_rsp_ready,
-  input      [31:0]   CfuPlugin_bus_rsp_payload_outputs_0,
-  output reg          iBusWishbone_CYC,
-  output reg          iBusWishbone_STB,
-  input               iBusWishbone_ACK,
-  output              iBusWishbone_WE,
-  output     [29:0]   iBusWishbone_ADR,
-  input      [31:0]   iBusWishbone_DAT_MISO,
-  output     [31:0]   iBusWishbone_DAT_MOSI,
-  output     [3:0]    iBusWishbone_SEL,
-  input               iBusWishbone_ERR,
-  output     [2:0]    iBusWishbone_CTI,
-  output     [1:0]    iBusWishbone_BTE,
-  output              dBusWishbone_CYC,
-  output              dBusWishbone_STB,
-  input               dBusWishbone_ACK,
-  output              dBusWishbone_WE,
-  output     [29:0]   dBusWishbone_ADR,
-  input      [31:0]   dBusWishbone_DAT_MISO,
-  output     [31:0]   dBusWishbone_DAT_MOSI,
-  output     [3:0]    dBusWishbone_SEL,
-  input               dBusWishbone_ERR,
-  output     [2:0]    dBusWishbone_CTI,
-  output     [1:0]    dBusWishbone_BTE,
-  input               clk,
-  input               reset,
-  input               debugReset
+  input  wire [31:0]   externalResetVector,
+  input  wire          timerInterrupt,
+  input  wire          softwareInterrupt,
+  input  wire [31:0]   externalInterruptArray,
+  input  wire          debug_bus_cmd_valid,
+  output reg           debug_bus_cmd_ready,
+  input  wire          debug_bus_cmd_payload_wr,
+  input  wire [7:0]    debug_bus_cmd_payload_address,
+  input  wire [31:0]   debug_bus_cmd_payload_data,
+  output reg  [31:0]   debug_bus_rsp_data,
+  output wire          debug_resetOut,
+  output wire          CfuPlugin_bus_cmd_valid,
+  input  wire          CfuPlugin_bus_cmd_ready,
+  output wire [9:0]    CfuPlugin_bus_cmd_payload_function_id,
+  output wire [31:0]   CfuPlugin_bus_cmd_payload_inputs_0,
+  output wire [31:0]   CfuPlugin_bus_cmd_payload_inputs_1,
+  input  wire          CfuPlugin_bus_rsp_valid,
+  output wire          CfuPlugin_bus_rsp_ready,
+  input  wire [31:0]   CfuPlugin_bus_rsp_payload_outputs_0,
+  output reg           iBusWishbone_CYC,
+  output reg           iBusWishbone_STB,
+  input  wire          iBusWishbone_ACK,
+  output wire          iBusWishbone_WE,
+  output wire [29:0]   iBusWishbone_ADR,
+  input  wire [31:0]   iBusWishbone_DAT_MISO,
+  output wire [31:0]   iBusWishbone_DAT_MOSI,
+  output wire [3:0]    iBusWishbone_SEL,
+  input  wire          iBusWishbone_ERR,
+  output wire [2:0]    iBusWishbone_CTI,
+  output wire [1:0]    iBusWishbone_BTE,
+  output wire          dBusWishbone_CYC,
+  output wire          dBusWishbone_STB,
+  input  wire          dBusWishbone_ACK,
+  output wire          dBusWishbone_WE,
+  output wire [29:0]   dBusWishbone_ADR,
+  input  wire [31:0]   dBusWishbone_DAT_MISO,
+  output wire [31:0]   dBusWishbone_DAT_MOSI,
+  output wire [3:0]    dBusWishbone_SEL,
+  input  wire          dBusWishbone_ERR,
+  output wire [2:0]    dBusWishbone_CTI,
+  output wire [1:0]    dBusWishbone_BTE,
+  input  wire          clk,
+  input  wire          reset,
+  input  wire          debugReset
 );
   localparam ShiftCtrlEnum_DISABLE_1 = 2'd0;
   localparam ShiftCtrlEnum_SLL_1 = 2'd1;
@@ -109,7 +109,6 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_flush_valid;
   wire                dataCache_1_io_cpu_flush_payload_singleLine;
   wire       [6:0]    dataCache_1_io_cpu_flush_payload_lineId;
-  wire                dataCache_1_io_mem_cmd_ready;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
@@ -137,6 +136,7 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_writeBack_exclusiveOk;
   wire                dataCache_1_io_cpu_flush_ready;
   wire                dataCache_1_io_cpu_redo;
+  wire                dataCache_1_io_cpu_writesPending;
   wire                dataCache_1_io_mem_cmd_valid;
   wire                dataCache_1_io_mem_cmd_payload_wr;
   wire                dataCache_1_io_mem_cmd_payload_uncached;
@@ -148,12 +148,11 @@ module VexRiscv (
   wire       [51:0]   _zz_memory_MUL_LOW;
   wire       [51:0]   _zz_memory_MUL_LOW_1;
   wire       [51:0]   _zz_memory_MUL_LOW_2;
-  wire       [51:0]   _zz_memory_MUL_LOW_3;
-  wire       [32:0]   _zz_memory_MUL_LOW_4;
-  wire       [51:0]   _zz_memory_MUL_LOW_5;
-  wire       [49:0]   _zz_memory_MUL_LOW_6;
-  wire       [51:0]   _zz_memory_MUL_LOW_7;
-  wire       [49:0]   _zz_memory_MUL_LOW_8;
+  wire       [32:0]   _zz_memory_MUL_LOW_3;
+  wire       [51:0]   _zz_memory_MUL_LOW_4;
+  wire       [49:0]   _zz_memory_MUL_LOW_5;
+  wire       [51:0]   _zz_memory_MUL_LOW_6;
+  wire       [49:0]   _zz_memory_MUL_LOW_7;
   wire       [31:0]   _zz_execute_SHIFT_RIGHT;
   wire       [32:0]   _zz_execute_SHIFT_RIGHT_1;
   wire       [32:0]   _zz_execute_SHIFT_RIGHT_2;
@@ -164,19 +163,19 @@ module VexRiscv (
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_2;
   wire                _zz_decode_LEGAL_INSTRUCTION_3;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_4;
-  wire       [14:0]   _zz_decode_LEGAL_INSTRUCTION_5;
+  wire       [13:0]   _zz_decode_LEGAL_INSTRUCTION_5;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_6;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_7;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_8;
   wire                _zz_decode_LEGAL_INSTRUCTION_9;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_10;
-  wire       [8:0]    _zz_decode_LEGAL_INSTRUCTION_11;
+  wire       [7:0]    _zz_decode_LEGAL_INSTRUCTION_11;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_12;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_13;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_14;
   wire                _zz_decode_LEGAL_INSTRUCTION_15;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_16;
-  wire       [2:0]    _zz_decode_LEGAL_INSTRUCTION_17;
+  wire       [1:0]    _zz_decode_LEGAL_INSTRUCTION_17;
   wire       [3:0]    _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1;
   reg        [31:0]   _zz_IBusCachedPlugin_jump_pcLoad_payload_5;
   wire       [1:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_6;
@@ -201,164 +200,153 @@ module VexRiscv (
   wire       [1:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_1;
   reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_2;
   wire       [0:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_3;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7;
-  wire       [26:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25;
-  wire       [21:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26;
-  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36;
-  wire       [18:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44;
-  wire       [15:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45;
-  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56;
-  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66;
-  wire       [12:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67;
-  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96;
-  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109;
-  wire       [9:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119;
-  wire       [7:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127;
-  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_1;
+  wire                _zz__zz_decode_CfuPlugin_CFU_ENABLE_2;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_3;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_4;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_5;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_6;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_7;
+  wire       [26:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_8;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_9;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_10;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_11;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_12;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_13;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_14;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_15;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_16;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_17;
+  wire                _zz__zz_decode_CfuPlugin_CFU_ENABLE_18;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_19;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_20;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_21;
+  wire                _zz__zz_decode_CfuPlugin_CFU_ENABLE_22;
+  wire       [21:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_23;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_24;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_25;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_26;
+  wire                _zz__zz_decode_CfuPlugin_CFU_ENABLE_27;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_28;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_29;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_30;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_31;
+  wire       [18:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_32;
+  wire                _zz__zz_decode_CfuPlugin_CFU_ENABLE_33;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_34;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_35;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_36;
+  wire                _zz__zz_decode_CfuPlugin_CFU_ENABLE_37;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_38;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_39;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_40;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_41;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_42;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_43;
+  wire       [14:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_44;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_45;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_46;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_47;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_48;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_49;
+  wire                _zz__zz_decode_CfuPlugin_CFU_ENABLE_50;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_51;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_52;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_53;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_54;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_55;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_56;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_57;
+  wire                _zz__zz_decode_CfuPlugin_CFU_ENABLE_58;
+  wire                _zz__zz_decode_CfuPlugin_CFU_ENABLE_59;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_60;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_61;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_62;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_63;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_64;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_65;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_66;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_67;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_68;
+  wire                _zz__zz_decode_CfuPlugin_CFU_ENABLE_69;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_70;
+  wire                _zz__zz_decode_CfuPlugin_CFU_ENABLE_71;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_72;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_73;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_74;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_75;
+  wire                _zz__zz_decode_CfuPlugin_CFU_ENABLE_76;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_77;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_78;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_79;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_80;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_81;
+  wire                _zz__zz_decode_CfuPlugin_CFU_ENABLE_82;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_83;
+  wire                _zz__zz_decode_CfuPlugin_CFU_ENABLE_84;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_85;
+  wire       [10:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_86;
+  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_87;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_88;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_89;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_90;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_91;
+  wire                _zz__zz_decode_CfuPlugin_CFU_ENABLE_92;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_93;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_94;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_95;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_96;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_97;
+  wire                _zz__zz_decode_CfuPlugin_CFU_ENABLE_98;
+  wire                _zz__zz_decode_CfuPlugin_CFU_ENABLE_99;
+  wire                _zz__zz_decode_CfuPlugin_CFU_ENABLE_100;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_101;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_102;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_103;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_104;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_105;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_106;
+  wire                _zz__zz_decode_CfuPlugin_CFU_ENABLE_107;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_108;
+  wire       [7:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_109;
+  wire                _zz__zz_decode_CfuPlugin_CFU_ENABLE_110;
+  wire                _zz__zz_decode_CfuPlugin_CFU_ENABLE_111;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_112;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_113;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_114;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_115;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_116;
+  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_117;
+  wire                _zz__zz_decode_CfuPlugin_CFU_ENABLE_118;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_119;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_120;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_121;
+  wire                _zz__zz_decode_CfuPlugin_CFU_ENABLE_122;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_123;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_124;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_125;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_126;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_127;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_128;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_129;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_130;
+  wire                _zz__zz_decode_CfuPlugin_CFU_ENABLE_131;
+  wire                _zz__zz_decode_CfuPlugin_CFU_ENABLE_132;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_133;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_134;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_135;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_136;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_137;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_138;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_139;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_140;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_141;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_142;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_143;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_144;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_ENABLE_145;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_ENABLE_146;
   wire                _zz_RegFilePlugin_regFile_port;
   wire                _zz_decode_RegFilePlugin_rs1Data;
   wire                _zz_RegFilePlugin_regFile_port_1;
@@ -366,14 +354,12 @@ module VexRiscv (
   wire       [0:0]    _zz__zz_execute_REGFILE_WRITE_DATA;
   wire       [2:0]    _zz__zz_execute_SRC1;
   wire       [4:0]    _zz__zz_execute_SRC1_1;
-  wire       [11:0]   _zz__zz_execute_SRC2_3;
+  wire       [11:0]   _zz__zz_execute_SRC2_2;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_1;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_2;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_3;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_4;
-  wire       [31:0]   _zz_execute_SrcPlugin_addSub_5;
-  wire       [31:0]   _zz_execute_SrcPlugin_addSub_6;
   wire       [19:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_2;
   wire       [11:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_4;
   wire       [31:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_6;
@@ -411,7 +397,7 @@ module VexRiscv (
   wire       [31:0]   _zz_memory_DivPlugin_rs2_1;
   wire       [0:0]    _zz_memory_DivPlugin_rs2_2;
   wire       [9:0]    _zz_execute_CfuPlugin_functionsIds_0;
-  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_25;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_24;
   wire       [26:0]   _zz_iBusWishbone_ADR_1;
   wire       [51:0]   memory_MUL_LOW;
   wire                writeBack_CfuPlugin_CFU_IN_FLIGHT;
@@ -494,9 +480,10 @@ module VexRiscv (
   wire                memory_CfuPlugin_CFU_IN_FLIGHT;
   wire       [0:0]    execute_CfuPlugin_CFU_INPUT_2_KIND;
   wire       [0:0]    _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
-  wire                execute_CfuPlugin_CFU_ENABLE;
   wire                writeBack_HAS_SIDE_EFFECT;
   wire                memory_HAS_SIDE_EFFECT;
+  wire                execute_LEGAL_INSTRUCTION;
+  reg                 execute_CfuPlugin_CFU_ENABLE;
   wire                execute_DO_EBREAK;
   wire                decode_IS_EBREAK;
   wire                execute_IS_RS1_SIGNED;
@@ -545,7 +532,7 @@ module VexRiscv (
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_execute_SRC2;
+  wire       [31:0]   _zz_execute_to_memory_PC;
   wire       [1:0]    execute_SRC2_CTRL;
   wire       [1:0]    _zz_execute_SRC2_CTRL;
   wire       [1:0]    execute_SRC1_CTRL;
@@ -713,7 +700,7 @@ module VexRiscv (
   reg                 DBusCachedPlugin_exceptionBus_valid;
   reg        [3:0]    DBusCachedPlugin_exceptionBus_payload_code;
   wire       [31:0]   DBusCachedPlugin_exceptionBus_payload_badAddr;
-  reg                 _zz_when_DBusCachedPlugin_l393;
+  reg                 _zz_when_DBusCachedPlugin_l472;
   wire                decodeExceptionPort_valid;
   wire       [3:0]    decodeExceptionPort_payload_code;
   wire       [31:0]   decodeExceptionPort_payload_badAddr;
@@ -726,8 +713,9 @@ module VexRiscv (
   wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
   wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
   wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
-  wire                CsrPlugin_csrMapping_allowCsrSignal;
+  reg                 CsrPlugin_csrMapping_allowCsrSignal;
   wire                CsrPlugin_csrMapping_hazardFree;
+  wire                CsrPlugin_csrMapping_doForceFailCsr;
   reg                 CsrPlugin_inWfi /* verilator public */ ;
   reg                 CsrPlugin_thirdPartyWake;
   reg                 CsrPlugin_jumpInterface_valid;
@@ -746,9 +734,10 @@ module VexRiscv (
   reg                 CsrPlugin_allowInterrupts;
   reg                 CsrPlugin_allowException;
   reg                 CsrPlugin_allowEbreakException;
-  reg                 IBusCachedPlugin_injectionPort_valid;
-  reg                 IBusCachedPlugin_injectionPort_ready;
-  wire       [31:0]   IBusCachedPlugin_injectionPort_payload;
+  wire                CsrPlugin_xretAwayFromMachine;
+  reg                 DebugPlugin_injectionPort_valid;
+  reg                 DebugPlugin_injectionPort_ready;
+  wire       [31:0]   DebugPlugin_injectionPort_payload;
   wire                IBusCachedPlugin_externalFlush;
   wire                IBusCachedPlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
@@ -768,14 +757,13 @@ module VexRiscv (
   reg                 IBusCachedPlugin_fetchPc_pcRegPropagate;
   reg                 IBusCachedPlugin_fetchPc_booted;
   reg                 IBusCachedPlugin_fetchPc_inc;
-  wire                when_Fetcher_l134;
-  wire                IBusCachedPlugin_fetchPc_output_fire_1;
-  wire                when_Fetcher_l134_1;
+  wire                when_Fetcher_l133;
+  wire                when_Fetcher_l133_1;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pc;
   wire                IBusCachedPlugin_fetchPc_redo_valid;
   wire       [31:0]   IBusCachedPlugin_fetchPc_redo_payload;
   reg                 IBusCachedPlugin_fetchPc_flushed;
-  wire                when_Fetcher_l161;
+  wire                when_Fetcher_l160;
   reg                 IBusCachedPlugin_iBusRsp_redoFetch;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_ready;
@@ -803,8 +791,8 @@ module VexRiscv (
   wire                _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready;
   wire                IBusCachedPlugin_iBusRsp_flush;
   wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
-  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
-  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid;
+  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1;
   wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
@@ -817,18 +805,18 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_output_payload_rsp_error;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   wire                IBusCachedPlugin_iBusRsp_output_payload_isRvc;
-  wire                when_Fetcher_l243;
-  wire                when_Fetcher_l323;
+  wire                when_Fetcher_l242;
+  wire                when_Fetcher_l322;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
-  wire                when_Fetcher_l332;
+  wire                when_Fetcher_l331;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
-  wire                when_Fetcher_l332_1;
+  wire                when_Fetcher_l331_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
-  wire                when_Fetcher_l332_2;
+  wire                when_Fetcher_l331_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
-  wire                when_Fetcher_l332_3;
+  wire                when_Fetcher_l331_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                when_Fetcher_l332_4;
+  wire                when_Fetcher_l331_4;
   wire                _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   reg        [18:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1;
   wire                _zz_2;
@@ -854,76 +842,77 @@ module VexRiscv (
   wire                IBusCachedPlugin_rsp_iBusRspOutputHalt;
   wire                IBusCachedPlugin_rsp_issueDetected;
   reg                 IBusCachedPlugin_rsp_redoFetch;
-  wire                when_IBusCachedPlugin_l239;
-  wire                when_IBusCachedPlugin_l244;
+  wire                when_IBusCachedPlugin_l245;
   wire                when_IBusCachedPlugin_l250;
   wire                when_IBusCachedPlugin_l256;
-  wire                when_IBusCachedPlugin_l267;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_valid;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_ready;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_address;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_data;
-  wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_size;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_last;
-  reg                 dataCache_1_io_mem_cmd_rValid;
-  reg                 dataCache_1_io_mem_cmd_rData_wr;
-  reg                 dataCache_1_io_mem_cmd_rData_uncached;
-  reg        [31:0]   dataCache_1_io_mem_cmd_rData_address;
-  reg        [31:0]   dataCache_1_io_mem_cmd_rData_data;
-  reg        [3:0]    dataCache_1_io_mem_cmd_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_rData_size;
-  reg                 dataCache_1_io_mem_cmd_rData_last;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
-  wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data;
-  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
-  wire                when_Stream_l368;
+  wire                when_IBusCachedPlugin_l262;
+  wire                when_IBusCachedPlugin_l273;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_valid;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+  wire       [3:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+  wire       [2:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_size;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rValidN;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rData_wr;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rData_uncached;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_rData_address;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_rData_data;
+  reg        [3:0]    toplevel_dataCache_1_io_mem_cmd_rData_mask;
+  reg        [2:0]    toplevel_dataCache_1_io_mem_cmd_rData_size;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rData_last;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
+  wire       [3:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
+  wire       [2:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_address;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_data;
+  reg        [3:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
+  reg        [2:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_size;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  wire                when_Stream_l369;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
-  wire                when_DBusCachedPlugin_l308;
+  wire                when_DBusCachedPlugin_l352;
   wire       [1:0]    execute_DBusCachedPlugin_size;
   reg        [31:0]   _zz_execute_MEMORY_STORE_DATA_RF;
-  wire                dataCache_1_io_cpu_flush_isStall;
-  wire                when_DBusCachedPlugin_l350;
-  wire                when_DBusCachedPlugin_l366;
-  wire                when_DBusCachedPlugin_l393;
-  wire                when_DBusCachedPlugin_l446;
-  wire                when_DBusCachedPlugin_l466;
+  wire                toplevel_dataCache_1_io_cpu_flush_isStall;
+  wire                when_DBusCachedPlugin_l394;
+  wire                when_DBusCachedPlugin_l410;
+  wire                when_DBusCachedPlugin_l472;
+  wire                when_DBusCachedPlugin_l533;
+  wire                when_DBusCachedPlugin_l553;
+  wire       [31:0]   writeBack_DBusCachedPlugin_rspData;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_0;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_1;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_2;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
   wire       [31:0]   writeBack_DBusCachedPlugin_rspRf;
-  wire       [1:0]    switch_Misc_l210;
+  wire       [1:0]    switch_Misc_l232;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_1;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated_2;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
-  wire                when_DBusCachedPlugin_l492;
-  wire       [34:0]   _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2;
-  wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3;
-  wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
-  wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5;
-  wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6;
-  wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7;
-  wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8;
+  wire                when_DBusCachedPlugin_l580;
+  wire       [34:0]   _zz_decode_CfuPlugin_CFU_ENABLE;
+  wire                _zz_decode_CfuPlugin_CFU_ENABLE_1;
+  wire                _zz_decode_CfuPlugin_CFU_ENABLE_2;
+  wire                _zz_decode_CfuPlugin_CFU_ENABLE_3;
+  wire                _zz_decode_CfuPlugin_CFU_ENABLE_4;
+  wire                _zz_decode_CfuPlugin_CFU_ENABLE_5;
+  wire                _zz_decode_CfuPlugin_CFU_ENABLE_6;
   wire       [1:0]    _zz_decode_SRC1_CTRL_2;
   wire       [1:0]    _zz_decode_ALU_CTRL_2;
   wire       [1:0]    _zz_decode_SRC2_CTRL_2;
@@ -931,7 +920,7 @@ module VexRiscv (
   wire       [1:0]    _zz_decode_SHIFT_CTRL_2;
   wire       [1:0]    _zz_decode_BRANCH_CTRL_2;
   wire       [1:0]    _zz_decode_ENV_CTRL_2;
-  wire       [0:0]    _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9;
+  wire       [0:0]    _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2;
   wire                when_RegFilePlugin_l63;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
@@ -940,15 +929,15 @@ module VexRiscv (
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
   reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
   reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_7;
+  reg                 _zz_10;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
   reg        [31:0]   _zz_execute_REGFILE_WRITE_DATA;
   reg        [31:0]   _zz_execute_SRC1;
-  wire                _zz_execute_SRC2_1;
-  reg        [19:0]   _zz_execute_SRC2_2;
-  wire                _zz_execute_SRC2_3;
-  reg        [19:0]   _zz_execute_SRC2_4;
-  reg        [31:0]   _zz_execute_SRC2_5;
+  wire                _zz_execute_SRC2;
+  reg        [19:0]   _zz_execute_SRC2_1;
+  wire                _zz_execute_SRC2_2;
+  reg        [19:0]   _zz_execute_SRC2_3;
+  reg        [31:0]   _zz_execute_SRC2_4;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   wire       [4:0]    execute_FullBarrelShifterPlugin_amplitude;
@@ -985,7 +974,7 @@ module VexRiscv (
   wire                when_HazardSimplePlugin_l108;
   wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    switch_Misc_l210_1;
+  wire       [2:0]    switch_Misc_l232_1;
   reg                 _zz_execute_BRANCH_COND_RESULT;
   reg                 _zz_execute_BRANCH_COND_RESULT_1;
   wire                _zz_execute_BranchPlugin_missAlignedTarget;
@@ -1005,9 +994,9 @@ module VexRiscv (
   wire                _zz_execute_BranchPlugin_branch_src2_4;
   reg        [18:0]   _zz_execute_BranchPlugin_branch_src2_5;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
-  wire                when_BranchPlugin_l302;
-  reg        [1:0]    CsrPlugin_misa_base;
-  reg        [25:0]   CsrPlugin_misa_extensions;
+  wire                when_BranchPlugin_l304;
+  wire       [1:0]    CsrPlugin_misa_base;
+  wire       [25:0]   CsrPlugin_misa_extensions;
   reg        [1:0]    CsrPlugin_mtvec_mode;
   reg        [29:0]   CsrPlugin_mtvec_base;
   reg        [31:0]   CsrPlugin_mepc;
@@ -1026,9 +1015,9 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_mtval;
   reg        [63:0]   CsrPlugin_mcycle;
   reg        [63:0]   CsrPlugin_minstret;
-  wire                _zz_when_CsrPlugin_l965;
-  wire                _zz_when_CsrPlugin_l965_1;
-  wire                _zz_when_CsrPlugin_l965_2;
+  wire                _zz_when_CsrPlugin_l1302;
+  wire                _zz_when_CsrPlugin_l1302_1;
+  wire                _zz_when_CsrPlugin_l1302_2;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -1045,59 +1034,62 @@ module VexRiscv (
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
   wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_2;
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3;
-  wire                when_CsrPlugin_l922;
-  wire                when_CsrPlugin_l922_1;
-  wire                when_CsrPlugin_l922_2;
-  wire                when_CsrPlugin_l922_3;
-  wire                when_CsrPlugin_l935;
+  wire                when_CsrPlugin_l1259;
+  wire                when_CsrPlugin_l1259_1;
+  wire                when_CsrPlugin_l1259_2;
+  wire                when_CsrPlugin_l1259_3;
+  wire                when_CsrPlugin_l1272;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
-  wire                when_CsrPlugin_l959;
-  wire                when_CsrPlugin_l965;
-  wire                when_CsrPlugin_l965_1;
-  wire                when_CsrPlugin_l965_2;
+  wire                when_CsrPlugin_l1296;
+  wire                when_CsrPlugin_l1302;
+  wire                when_CsrPlugin_l1302_1;
+  wire                when_CsrPlugin_l1302_2;
   wire                CsrPlugin_exception;
   reg                 CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
-  wire                when_CsrPlugin_l993;
-  wire                when_CsrPlugin_l993_1;
-  wire                when_CsrPlugin_l993_2;
-  wire                when_CsrPlugin_l998;
+  wire                when_CsrPlugin_l1335;
+  wire                when_CsrPlugin_l1335_1;
+  wire                when_CsrPlugin_l1335_2;
+  wire                when_CsrPlugin_l1340;
   reg                 CsrPlugin_pipelineLiberator_done;
-  wire                when_CsrPlugin_l1004;
+  wire                when_CsrPlugin_l1346;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
+  wire                CsrPlugin_trapCauseEbreakDebug;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
-  wire                when_CsrPlugin_l1032;
-  wire                when_CsrPlugin_l1077;
-  wire       [1:0]    switch_CsrPlugin_l1081;
+  wire                CsrPlugin_trapEnterDebug;
+  wire                when_CsrPlugin_l1390;
+  wire                when_CsrPlugin_l1398;
+  wire                when_CsrPlugin_l1456;
+  wire       [1:0]    switch_CsrPlugin_l1460;
   reg                 execute_CsrPlugin_wfiWake;
-  wire                when_CsrPlugin_l1121;
-  wire                when_CsrPlugin_l1123;
-  wire                when_CsrPlugin_l1129;
+  wire                when_CsrPlugin_l1519;
+  wire                when_CsrPlugin_l1521;
+  wire                when_CsrPlugin_l1527;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire                when_CsrPlugin_l1142;
-  wire                when_CsrPlugin_l1149;
-  wire                when_CsrPlugin_l1150;
-  wire                when_CsrPlugin_l1157;
+  wire                when_CsrPlugin_l1540;
+  wire                when_CsrPlugin_l1547;
+  wire                when_CsrPlugin_l1548;
+  wire                when_CsrPlugin_l1555;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   wire       [31:0]   execute_CsrPlugin_readToWriteData;
-  wire                switch_Misc_l210_2;
+  wire                switch_Misc_l232_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
-  wire                when_CsrPlugin_l1189;
-  wire                when_CsrPlugin_l1193;
+  wire                when_CsrPlugin_l1587;
+  wire                when_CsrPlugin_l1591;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg                 execute_MulPlugin_aSigned;
   reg                 execute_MulPlugin_bSigned;
@@ -1144,7 +1136,7 @@ module VexRiscv (
   reg        [32:0]   _zz_memory_DivPlugin_rs1_1;
   reg        [31:0]   externalInterruptArray_regNext;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit;
-  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
+  wire       [31:0]   _zz_externalInterrupt;
   reg                 DebugPlugin_firstCycle;
   reg                 DebugPlugin_secondCycle;
   reg                 DebugPlugin_resetIt;
@@ -1152,7 +1144,7 @@ module VexRiscv (
   reg                 DebugPlugin_stepIt;
   reg                 DebugPlugin_isPipBusy;
   reg                 DebugPlugin_godmode;
-  wire                when_DebugPlugin_l225;
+  wire                when_DebugPlugin_l238;
   reg                 DebugPlugin_haltedByBreak;
   reg                 DebugPlugin_debugUsed /* verilator public */ ;
   reg                 DebugPlugin_disableEbreak;
@@ -1162,31 +1154,32 @@ module VexRiscv (
   reg                 DebugPlugin_hardwareBreakpoints_1_valid;
   reg        [30:0]   DebugPlugin_hardwareBreakpoints_1_pc;
   reg        [31:0]   DebugPlugin_busReadDataReg;
-  reg                 _zz_when_DebugPlugin_l244;
-  wire                when_DebugPlugin_l244;
-  wire       [5:0]    switch_DebugPlugin_l267;
-  wire                when_DebugPlugin_l271;
-  wire                when_DebugPlugin_l271_1;
-  wire                when_DebugPlugin_l272;
-  wire                when_DebugPlugin_l272_1;
-  wire                when_DebugPlugin_l273;
-  wire                when_DebugPlugin_l274;
-  wire                when_DebugPlugin_l275;
-  wire                when_DebugPlugin_l275_1;
-  wire                when_DebugPlugin_l295;
-  wire                when_DebugPlugin_l298;
+  reg                 _zz_when_DebugPlugin_l257;
+  wire                when_DebugPlugin_l257;
+  wire       [5:0]    switch_DebugPlugin_l280;
+  wire                when_DebugPlugin_l284;
+  wire                when_DebugPlugin_l284_1;
+  wire                when_DebugPlugin_l285;
+  wire                when_DebugPlugin_l285_1;
+  wire                when_DebugPlugin_l286;
+  wire                when_DebugPlugin_l287;
+  wire                when_DebugPlugin_l288;
+  wire                when_DebugPlugin_l288_1;
+  wire                when_DebugPlugin_l308;
   wire                when_DebugPlugin_l311;
+  wire                when_DebugPlugin_l324;
   reg                 DebugPlugin_resetIt_regNext;
-  wire                when_DebugPlugin_l331;
+  wire                when_DebugPlugin_l344;
+  wire                when_CfuPlugin_l192;
   wire                execute_CfuPlugin_hazard;
   wire                execute_CfuPlugin_scheduleWish;
   wire                execute_CfuPlugin_schedule;
-  wire                when_CfuPlugin_l194;
+  wire                when_CfuPlugin_l196;
   reg                 execute_CfuPlugin_hold;
   reg                 execute_CfuPlugin_fired;
   wire                CfuPlugin_bus_cmd_fire;
-  wire                when_CfuPlugin_l197;
-  wire                when_CfuPlugin_l201;
+  wire                when_CfuPlugin_l199;
+  wire                when_CfuPlugin_l203;
   wire       [9:0]    execute_CfuPlugin_functionsIds_0;
   wire                _zz_CfuPlugin_bus_cmd_payload_inputs_1;
   reg        [23:0]   _zz_CfuPlugin_bus_cmd_payload_inputs_1_1;
@@ -1194,9 +1187,9 @@ module VexRiscv (
   wire                memory_CfuPlugin_rsp_valid;
   reg                 memory_CfuPlugin_rsp_ready;
   wire       [31:0]   memory_CfuPlugin_rsp_payload_outputs_0;
-  reg                 CfuPlugin_bus_rsp_rValid;
+  reg                 CfuPlugin_bus_rsp_rValidN;
   reg        [31:0]   CfuPlugin_bus_rsp_rData_outputs_0;
-  wire                when_CfuPlugin_l237;
+  wire                when_CfuPlugin_l239;
   wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
   wire                when_Pipeline_l124_1;
@@ -1218,120 +1211,122 @@ module VexRiscv (
   wire                when_Pipeline_l124_9;
   reg                 decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
   wire                when_Pipeline_l124_10;
-  reg        [1:0]    decode_to_execute_SRC1_CTRL;
+  reg                 decode_to_execute_LEGAL_INSTRUCTION;
   wire                when_Pipeline_l124_11;
-  reg                 decode_to_execute_SRC_USE_SUB_LESS;
+  reg        [1:0]    decode_to_execute_SRC1_CTRL;
   wire                when_Pipeline_l124_12;
-  reg                 decode_to_execute_MEMORY_ENABLE;
+  reg                 decode_to_execute_SRC_USE_SUB_LESS;
   wire                when_Pipeline_l124_13;
-  reg                 execute_to_memory_MEMORY_ENABLE;
+  reg                 decode_to_execute_MEMORY_ENABLE;
   wire                when_Pipeline_l124_14;
-  reg                 memory_to_writeBack_MEMORY_ENABLE;
+  reg                 execute_to_memory_MEMORY_ENABLE;
   wire                when_Pipeline_l124_15;
-  reg        [1:0]    decode_to_execute_ALU_CTRL;
+  reg                 memory_to_writeBack_MEMORY_ENABLE;
   wire                when_Pipeline_l124_16;
-  reg        [1:0]    decode_to_execute_SRC2_CTRL;
+  reg        [1:0]    decode_to_execute_ALU_CTRL;
   wire                when_Pipeline_l124_17;
-  reg                 decode_to_execute_REGFILE_WRITE_VALID;
+  reg        [1:0]    decode_to_execute_SRC2_CTRL;
   wire                when_Pipeline_l124_18;
-  reg                 execute_to_memory_REGFILE_WRITE_VALID;
+  reg                 decode_to_execute_REGFILE_WRITE_VALID;
   wire                when_Pipeline_l124_19;
-  reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
+  reg                 execute_to_memory_REGFILE_WRITE_VALID;
   wire                when_Pipeline_l124_20;
-  reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
+  reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
   wire                when_Pipeline_l124_21;
-  reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
   wire                when_Pipeline_l124_22;
-  reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
+  reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
   wire                when_Pipeline_l124_23;
-  reg                 decode_to_execute_MEMORY_WR;
+  reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
   wire                when_Pipeline_l124_24;
-  reg                 execute_to_memory_MEMORY_WR;
+  reg                 decode_to_execute_MEMORY_WR;
   wire                when_Pipeline_l124_25;
-  reg                 memory_to_writeBack_MEMORY_WR;
+  reg                 execute_to_memory_MEMORY_WR;
   wire                when_Pipeline_l124_26;
-  reg                 decode_to_execute_HAS_SIDE_EFFECT;
+  reg                 memory_to_writeBack_MEMORY_WR;
   wire                when_Pipeline_l124_27;
-  reg                 execute_to_memory_HAS_SIDE_EFFECT;
+  reg                 decode_to_execute_HAS_SIDE_EFFECT;
   wire                when_Pipeline_l124_28;
-  reg                 memory_to_writeBack_HAS_SIDE_EFFECT;
+  reg                 execute_to_memory_HAS_SIDE_EFFECT;
   wire                when_Pipeline_l124_29;
-  reg                 decode_to_execute_MEMORY_MANAGMENT;
+  reg                 memory_to_writeBack_HAS_SIDE_EFFECT;
   wire                when_Pipeline_l124_30;
-  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
+  reg                 decode_to_execute_MEMORY_MANAGMENT;
   wire                when_Pipeline_l124_31;
-  reg        [1:0]    decode_to_execute_ALU_BITWISE_CTRL;
+  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
   wire                when_Pipeline_l124_32;
-  reg        [1:0]    decode_to_execute_SHIFT_CTRL;
+  reg        [1:0]    decode_to_execute_ALU_BITWISE_CTRL;
   wire                when_Pipeline_l124_33;
-  reg        [1:0]    execute_to_memory_SHIFT_CTRL;
+  reg        [1:0]    decode_to_execute_SHIFT_CTRL;
   wire                when_Pipeline_l124_34;
-  reg        [1:0]    decode_to_execute_BRANCH_CTRL;
+  reg        [1:0]    execute_to_memory_SHIFT_CTRL;
   wire                when_Pipeline_l124_35;
-  reg                 decode_to_execute_IS_CSR;
+  reg        [1:0]    decode_to_execute_BRANCH_CTRL;
   wire                when_Pipeline_l124_36;
-  reg        [1:0]    decode_to_execute_ENV_CTRL;
+  reg                 decode_to_execute_IS_CSR;
   wire                when_Pipeline_l124_37;
-  reg        [1:0]    execute_to_memory_ENV_CTRL;
+  reg        [1:0]    decode_to_execute_ENV_CTRL;
   wire                when_Pipeline_l124_38;
-  reg        [1:0]    memory_to_writeBack_ENV_CTRL;
+  reg        [1:0]    execute_to_memory_ENV_CTRL;
   wire                when_Pipeline_l124_39;
-  reg                 decode_to_execute_IS_MUL;
+  reg        [1:0]    memory_to_writeBack_ENV_CTRL;
   wire                when_Pipeline_l124_40;
-  reg                 execute_to_memory_IS_MUL;
+  reg                 decode_to_execute_IS_MUL;
   wire                when_Pipeline_l124_41;
-  reg                 memory_to_writeBack_IS_MUL;
+  reg                 execute_to_memory_IS_MUL;
   wire                when_Pipeline_l124_42;
-  reg                 decode_to_execute_IS_DIV;
+  reg                 memory_to_writeBack_IS_MUL;
   wire                when_Pipeline_l124_43;
-  reg                 execute_to_memory_IS_DIV;
+  reg                 decode_to_execute_IS_DIV;
   wire                when_Pipeline_l124_44;
-  reg                 decode_to_execute_IS_RS1_SIGNED;
+  reg                 execute_to_memory_IS_DIV;
   wire                when_Pipeline_l124_45;
-  reg                 decode_to_execute_IS_RS2_SIGNED;
+  reg                 decode_to_execute_IS_RS1_SIGNED;
   wire                when_Pipeline_l124_46;
-  reg                 decode_to_execute_CfuPlugin_CFU_ENABLE;
+  reg                 decode_to_execute_IS_RS2_SIGNED;
   wire                when_Pipeline_l124_47;
-  reg        [0:0]    decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  reg                 decode_to_execute_CfuPlugin_CFU_ENABLE;
   wire                when_Pipeline_l124_48;
-  reg        [31:0]   decode_to_execute_RS1;
+  reg        [0:0]    decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   wire                when_Pipeline_l124_49;
-  reg        [31:0]   decode_to_execute_RS2;
+  reg        [31:0]   decode_to_execute_RS1;
   wire                when_Pipeline_l124_50;
-  reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  reg        [31:0]   decode_to_execute_RS2;
   wire                when_Pipeline_l124_51;
-  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
+  reg                 decode_to_execute_SRC2_FORCE_ZERO;
   wire                when_Pipeline_l124_52;
-  reg                 decode_to_execute_CSR_WRITE_OPCODE;
+  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
   wire                when_Pipeline_l124_53;
-  reg                 decode_to_execute_CSR_READ_OPCODE;
+  reg                 decode_to_execute_CSR_WRITE_OPCODE;
   wire                when_Pipeline_l124_54;
-  reg                 decode_to_execute_DO_EBREAK;
+  reg                 decode_to_execute_CSR_READ_OPCODE;
   wire                when_Pipeline_l124_55;
-  reg        [31:0]   execute_to_memory_MEMORY_STORE_DATA_RF;
+  reg                 decode_to_execute_DO_EBREAK;
   wire                when_Pipeline_l124_56;
-  reg        [31:0]   memory_to_writeBack_MEMORY_STORE_DATA_RF;
+  reg        [31:0]   execute_to_memory_MEMORY_STORE_DATA_RF;
   wire                when_Pipeline_l124_57;
-  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
+  reg        [31:0]   memory_to_writeBack_MEMORY_STORE_DATA_RF;
   wire                when_Pipeline_l124_58;
-  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
   wire                when_Pipeline_l124_59;
-  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
+  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
   wire                when_Pipeline_l124_60;
-  reg        [31:0]   execute_to_memory_MUL_LL;
+  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
   wire                when_Pipeline_l124_61;
-  reg        [33:0]   execute_to_memory_MUL_LH;
+  reg        [31:0]   execute_to_memory_MUL_LL;
   wire                when_Pipeline_l124_62;
-  reg        [33:0]   execute_to_memory_MUL_HL;
+  reg        [33:0]   execute_to_memory_MUL_LH;
   wire                when_Pipeline_l124_63;
-  reg        [33:0]   execute_to_memory_MUL_HH;
+  reg        [33:0]   execute_to_memory_MUL_HL;
   wire                when_Pipeline_l124_64;
-  reg        [33:0]   memory_to_writeBack_MUL_HH;
+  reg        [33:0]   execute_to_memory_MUL_HH;
   wire                when_Pipeline_l124_65;
-  reg                 execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
+  reg        [33:0]   memory_to_writeBack_MUL_HH;
   wire                when_Pipeline_l124_66;
-  reg                 memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+  reg                 execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
   wire                when_Pipeline_l124_67;
+  reg                 memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+  wire                when_Pipeline_l124_68;
   reg        [51:0]   memory_to_writeBack_MUL_LOW;
   wire                when_Pipeline_l151;
   wire                when_Pipeline_l154;
@@ -1339,62 +1334,63 @@ module VexRiscv (
   wire                when_Pipeline_l154_1;
   wire                when_Pipeline_l151_2;
   wire                when_Pipeline_l154_2;
-  reg        [2:0]    switch_Fetcher_l365;
-  wire                when_Fetcher_l381;
-  wire                when_CsrPlugin_l1277;
+  reg        [2:0]    IBusCachedPlugin_injector_port_state;
+  wire                when_Fetcher_l391;
+  wire                when_CsrPlugin_l1669;
   reg                 execute_CsrPlugin_csr_3264;
-  wire                when_CsrPlugin_l1277_1;
+  wire                when_CsrPlugin_l1669_1;
   reg                 execute_CsrPlugin_csr_3857;
-  wire                when_CsrPlugin_l1277_2;
+  wire                when_CsrPlugin_l1669_2;
   reg                 execute_CsrPlugin_csr_3858;
-  wire                when_CsrPlugin_l1277_3;
+  wire                when_CsrPlugin_l1669_3;
   reg                 execute_CsrPlugin_csr_3859;
-  wire                when_CsrPlugin_l1277_4;
+  wire                when_CsrPlugin_l1669_4;
   reg                 execute_CsrPlugin_csr_3860;
-  wire                when_CsrPlugin_l1277_5;
+  wire                when_CsrPlugin_l1669_5;
   reg                 execute_CsrPlugin_csr_769;
-  wire                when_CsrPlugin_l1277_6;
+  wire                when_CsrPlugin_l1669_6;
   reg                 execute_CsrPlugin_csr_768;
-  wire                when_CsrPlugin_l1277_7;
+  wire                when_CsrPlugin_l1669_7;
   reg                 execute_CsrPlugin_csr_836;
-  wire                when_CsrPlugin_l1277_8;
+  wire                when_CsrPlugin_l1669_8;
   reg                 execute_CsrPlugin_csr_772;
-  wire                when_CsrPlugin_l1277_9;
+  wire                when_CsrPlugin_l1669_9;
   reg                 execute_CsrPlugin_csr_773;
-  wire                when_CsrPlugin_l1277_10;
+  wire                when_CsrPlugin_l1669_10;
   reg                 execute_CsrPlugin_csr_833;
-  wire                when_CsrPlugin_l1277_11;
+  wire                when_CsrPlugin_l1669_11;
   reg                 execute_CsrPlugin_csr_832;
-  wire                when_CsrPlugin_l1277_12;
+  wire                when_CsrPlugin_l1669_12;
   reg                 execute_CsrPlugin_csr_834;
-  wire                when_CsrPlugin_l1277_13;
+  wire                when_CsrPlugin_l1669_13;
   reg                 execute_CsrPlugin_csr_835;
-  wire                when_CsrPlugin_l1277_14;
+  wire                when_CsrPlugin_l1669_14;
   reg                 execute_CsrPlugin_csr_2816;
-  wire                when_CsrPlugin_l1277_15;
+  wire                when_CsrPlugin_l1669_15;
   reg                 execute_CsrPlugin_csr_2944;
-  wire                when_CsrPlugin_l1277_16;
+  wire                when_CsrPlugin_l1669_16;
   reg                 execute_CsrPlugin_csr_2818;
-  wire                when_CsrPlugin_l1277_17;
+  wire                when_CsrPlugin_l1669_17;
   reg                 execute_CsrPlugin_csr_2946;
-  wire                when_CsrPlugin_l1277_18;
+  wire                when_CsrPlugin_l1669_18;
   reg                 execute_CsrPlugin_csr_3072;
-  wire                when_CsrPlugin_l1277_19;
+  wire                when_CsrPlugin_l1669_19;
   reg                 execute_CsrPlugin_csr_3200;
-  wire                when_CsrPlugin_l1277_20;
+  wire                when_CsrPlugin_l1669_20;
   reg                 execute_CsrPlugin_csr_3074;
-  wire                when_CsrPlugin_l1277_21;
+  wire                when_CsrPlugin_l1669_21;
   reg                 execute_CsrPlugin_csr_3202;
-  wire                when_CsrPlugin_l1277_22;
+  wire                when_CsrPlugin_l1669_22;
   reg                 execute_CsrPlugin_csr_3008;
-  wire                when_CsrPlugin_l1277_23;
+  wire                when_CsrPlugin_l1669_23;
   reg                 execute_CsrPlugin_csr_4032;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_5;
+  wire       [1:0]    switch_CsrPlugin_l1031;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_6;
-  wire       [1:0]    switch_CsrPlugin_l723;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_8;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
@@ -1412,19 +1408,22 @@ module VexRiscv (
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_21;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_22;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_23;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_24;
-  wire                when_CsrPlugin_l1310;
-  wire                when_CsrPlugin_l1315;
+  wire                when_CsrPlugin_l1702;
+  wire       [11:0]   _zz_when_CsrPlugin_l1709;
+  wire                when_CsrPlugin_l1709;
+  reg                 when_CsrPlugin_l1719;
+  wire                when_CsrPlugin_l1717;
+  wire                when_CsrPlugin_l1725;
   reg        [2:0]    _zz_iBusWishbone_ADR;
   wire                when_InstructionCache_l239;
   reg                 _zz_iBus_rsp_valid;
   reg        [31:0]   iBusWishbone_DAT_MISO_regNext;
-  reg        [2:0]    _zz_dBus_cmd_ready;
+  reg        [2:0]    _zz_dBusWishbone_ADR;
+  wire                _zz_dBusWishbone_CYC;
+  wire                _zz_dBus_cmd_ready;
   wire                _zz_dBus_cmd_ready_1;
   wire                _zz_dBus_cmd_ready_2;
-  wire                _zz_dBus_cmd_ready_3;
-  wire                _zz_dBus_cmd_ready_4;
-  wire                _zz_dBus_cmd_ready_5;
+  wire                _zz_dBusWishbone_ADR_1;
   reg                 _zz_dBus_rsp_valid;
   reg        [31:0]   dBusWishbone_DAT_MISO_regNext;
   `ifndef SYNTHESIS
@@ -1503,7 +1502,7 @@ module VexRiscv (
   reg [71:0] _zz_decode_SHIFT_CTRL_2_string;
   reg [31:0] _zz_decode_BRANCH_CTRL_2_string;
   reg [39:0] _zz_decode_ENV_CTRL_2_string;
-  reg [39:0] _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string;
+  reg [39:0] _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_string;
   reg [95:0] decode_to_execute_SRC1_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
   reg [23:0] decode_to_execute_SRC2_CTRL_string;
@@ -1521,20 +1520,19 @@ module VexRiscv (
 
   assign _zz_when = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
   assign _zz_when_1 = ({CsrPlugin_selfException_valid,BranchPlugin_branchExceptionPort_valid} != 2'b00);
-  assign _zz_memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW_1) + $signed(_zz_memory_MUL_LOW_5));
-  assign _zz_memory_MUL_LOW_1 = ($signed(_zz_memory_MUL_LOW_2) + $signed(_zz_memory_MUL_LOW_3));
-  assign _zz_memory_MUL_LOW_2 = 52'h0;
-  assign _zz_memory_MUL_LOW_4 = {1'b0,memory_MUL_LL};
-  assign _zz_memory_MUL_LOW_3 = {{19{_zz_memory_MUL_LOW_4[32]}}, _zz_memory_MUL_LOW_4};
-  assign _zz_memory_MUL_LOW_6 = ({16'd0,memory_MUL_LH} <<< 16);
-  assign _zz_memory_MUL_LOW_5 = {{2{_zz_memory_MUL_LOW_6[49]}}, _zz_memory_MUL_LOW_6};
-  assign _zz_memory_MUL_LOW_8 = ({16'd0,memory_MUL_HL} <<< 16);
-  assign _zz_memory_MUL_LOW_7 = {{2{_zz_memory_MUL_LOW_8[49]}}, _zz_memory_MUL_LOW_8};
+  assign _zz_memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW_1) + $signed(_zz_memory_MUL_LOW_4));
+  assign _zz_memory_MUL_LOW_1 = ($signed(52'h0000000000000) + $signed(_zz_memory_MUL_LOW_2));
+  assign _zz_memory_MUL_LOW_3 = {1'b0,memory_MUL_LL};
+  assign _zz_memory_MUL_LOW_2 = {{19{_zz_memory_MUL_LOW_3[32]}}, _zz_memory_MUL_LOW_3};
+  assign _zz_memory_MUL_LOW_5 = ({16'd0,memory_MUL_LH} <<< 5'd16);
+  assign _zz_memory_MUL_LOW_4 = {{2{_zz_memory_MUL_LOW_5[49]}}, _zz_memory_MUL_LOW_5};
+  assign _zz_memory_MUL_LOW_7 = ({16'd0,memory_MUL_HL} <<< 5'd16);
+  assign _zz_memory_MUL_LOW_6 = {{2{_zz_memory_MUL_LOW_7[49]}}, _zz_memory_MUL_LOW_7};
   assign _zz_execute_SHIFT_RIGHT_1 = ($signed(_zz_execute_SHIFT_RIGHT_2) >>> execute_FullBarrelShifterPlugin_amplitude);
   assign _zz_execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT_1[31 : 0];
   assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == ShiftCtrlEnum_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
-  assign _zz_decode_DO_EBREAK = (decode_PC >>> 1);
-  assign _zz_decode_DO_EBREAK_1 = (decode_PC >>> 1);
+  assign _zz_decode_DO_EBREAK = (decode_PC >>> 1'd1);
+  assign _zz_decode_DO_EBREAK_1 = (decode_PC >>> 1'd1);
   assign _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload - 4'b0001);
   assign _zz_IBusCachedPlugin_fetchPc_pc_1 = {IBusCachedPlugin_fetchPc_inc,2'b00};
   assign _zz_IBusCachedPlugin_fetchPc_pc = {29'd0, _zz_IBusCachedPlugin_fetchPc_pc_1};
@@ -1547,20 +1545,18 @@ module VexRiscv (
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
   assign _zz_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId_1;
-  assign _zz_io_cpu_flush_payload_lineId_1 = (execute_RS1 >>> 5);
+  assign _zz_io_cpu_flush_payload_lineId_1 = (execute_RS1 >>> 3'd5);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code_1 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
   assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
   assign _zz__zz_execute_SRC1 = 3'b100;
   assign _zz__zz_execute_SRC1_1 = execute_INSTRUCTION[19 : 15];
-  assign _zz__zz_execute_SRC2_3 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz__zz_execute_SRC2_2 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
   assign _zz_execute_SrcPlugin_addSub = ($signed(_zz_execute_SrcPlugin_addSub_1) + $signed(_zz_execute_SrcPlugin_addSub_4));
   assign _zz_execute_SrcPlugin_addSub_1 = ($signed(_zz_execute_SrcPlugin_addSub_2) + $signed(_zz_execute_SrcPlugin_addSub_3));
   assign _zz_execute_SrcPlugin_addSub_2 = execute_SRC1;
   assign _zz_execute_SrcPlugin_addSub_3 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? _zz_execute_SrcPlugin_addSub_5 : _zz_execute_SrcPlugin_addSub_6);
-  assign _zz_execute_SrcPlugin_addSub_5 = 32'h00000001;
-  assign _zz_execute_SrcPlugin_addSub_6 = 32'h0;
+  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? 32'h00000001 : 32'h00000000);
   assign _zz__zz_execute_BranchPlugin_missAlignedTarget_2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
   assign _zz__zz_execute_BranchPlugin_missAlignedTarget_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
   assign _zz__zz_execute_BranchPlugin_missAlignedTarget_6 = {_zz_execute_BranchPlugin_missAlignedTarget_1,execute_INSTRUCTION[31 : 20]};
@@ -1574,7 +1570,7 @@ module VexRiscv (
   assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_2 & (~ _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3_1));
   assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_2 - 2'b01);
   assign _zz_writeBack_MulPlugin_result = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
-  assign _zz_writeBack_MulPlugin_result_1 = ({32'd0,writeBack_MUL_HH} <<< 32);
+  assign _zz_writeBack_MulPlugin_result_1 = ({32'd0,writeBack_MUL_HH} <<< 6'd32);
   assign _zz__zz_decode_RS2_2 = writeBack_MUL_LOW[31 : 0];
   assign _zz__zz_decode_RS2_2_1 = writeBack_MulPlugin_result[63 : 32];
   assign _zz_memory_DivPlugin_div_counter_valueNext_1 = memory_DivPlugin_div_counter_willIncrement;
@@ -1593,195 +1589,184 @@ module VexRiscv (
   assign _zz_memory_DivPlugin_rs2_2 = _zz_memory_DivPlugin_rs2;
   assign _zz_memory_DivPlugin_rs2_1 = {31'd0, _zz_memory_DivPlugin_rs2_2};
   assign _zz_execute_CfuPlugin_functionsIds_0 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[14 : 12]};
-  assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 5);
+  assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 3'd5);
   assign _zz_decode_RegFilePlugin_rs1Data = 1'b1;
   assign _zz_decode_RegFilePlugin_rs2Data = 1'b1;
   assign _zz_IBusCachedPlugin_jump_pcLoad_payload_6 = {_zz_IBusCachedPlugin_jump_pcLoad_payload_4,_zz_IBusCachedPlugin_jump_pcLoad_payload_3};
   assign _zz_writeBack_DBusCachedPlugin_rspShifted_1 = dataCache_1_io_cpu_writeBack_address[1 : 0];
   assign _zz_writeBack_DBusCachedPlugin_rspShifted_3 = dataCache_1_io_cpu_writeBack_address[1 : 1];
-  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000106f;
-  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000107f);
-  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00001073;
-  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002073);
-  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_decode_LEGAL_INSTRUCTION_5 = {((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013),{((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_6) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_7 == _zz_decode_LEGAL_INSTRUCTION_8),{_zz_decode_LEGAL_INSTRUCTION_9,{_zz_decode_LEGAL_INSTRUCTION_10,_zz_decode_LEGAL_INSTRUCTION_11}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000107f;
+  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000207f);
+  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00002073;
+  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
+  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION_5 = {((decode_INSTRUCTION & 32'h0000107f) == 32'h00000013),{((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_6) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_7 == _zz_decode_LEGAL_INSTRUCTION_8),{_zz_decode_LEGAL_INSTRUCTION_9,{_zz_decode_LEGAL_INSTRUCTION_10,_zz_decode_LEGAL_INSTRUCTION_11}}}}}};
   assign _zz_decode_LEGAL_INSTRUCTION_6 = 32'h0000207f;
   assign _zz_decode_LEGAL_INSTRUCTION_7 = (decode_INSTRUCTION & 32'h0000505f);
   assign _zz_decode_LEGAL_INSTRUCTION_8 = 32'h00000003;
   assign _zz_decode_LEGAL_INSTRUCTION_9 = ((decode_INSTRUCTION & 32'h0000707b) == 32'h00000063);
   assign _zz_decode_LEGAL_INSTRUCTION_10 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
   assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033),{((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h00005013),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,{_zz_decode_LEGAL_INSTRUCTION_16,_zz_decode_LEGAL_INSTRUCTION_17}}}}}};
-  assign _zz_decode_LEGAL_INSTRUCTION_12 = 32'hbc00707f;
-  assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'hfc00307f);
+  assign _zz_decode_LEGAL_INSTRUCTION_12 = 32'hbe00705f;
+  assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'hfe00305f);
   assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h00001013;
-  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00005033);
-  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
-  assign _zz_decode_LEGAL_INSTRUCTION_17 = {((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073),{((decode_INSTRUCTION & 32'hffefffff) == 32'h00000073),((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073)}};
+  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
+  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
+  assign _zz_decode_LEGAL_INSTRUCTION_17 = {((decode_INSTRUCTION & 32'hffefffff) == 32'h00000073),((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073)};
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_4 = decode_INSTRUCTION[31];
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_5 = decode_INSTRUCTION[31];
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_6 = decode_INSTRUCTION[7];
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = 32'h10103050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1 = ((decode_INSTRUCTION & 32'h02004064) == 32'h02004020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2 = (|((decode_INSTRUCTION & 32'h02004074) == 32'h02000030));
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3 = (|{(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7)});
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8 = {(|(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10)),{(|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13}),{(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26}}}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4 = (decode_INSTRUCTION & 32'h10203050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5 = 32'h10000050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6 = (decode_INSTRUCTION & 32'h10103050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7 = 32'h00000050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9 = (decode_INSTRUCTION & 32'h00103050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10 = 32'h00000050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12) == 32'h00001050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14) == 32'h00002050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6,(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17)};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18 = (|(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20));
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24});
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12 = 32'h00001050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14 = 32'h00002050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16 = (decode_INSTRUCTION & 32'h0000001c);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17 = 32'h00000004;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19 = (decode_INSTRUCTION & 32'h00000058);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20 = 32'h00000040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23) == 32'h00005010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25) == 32'h00005020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32 = (|(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34));
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23 = 32'h00007034;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25 = 32'h02007064;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28 = (decode_INSTRUCTION & 32'h40003054);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29 = 32'h40001010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31 = ((decode_INSTRUCTION & 32'h02007054) == 32'h00001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33 = (decode_INSTRUCTION & 32'h00000064);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34 = 32'h00000024;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36 = ((decode_INSTRUCTION & 32'h00001000) == 32'h00001000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39) == 32'h00002000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42});
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39 = 32'h00003000;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00001000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44 = ((decode_INSTRUCTION & 32'h00004054) == 32'h00004004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57}});
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53) == 32'h00002040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85});
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48 = 32'h00000034;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50 = 32'h00000064;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53 = 32'h00002040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55 = (decode_INSTRUCTION & 32'h00001040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56 = 32'h00001040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59) == 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66 = 32'h00000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70) == 32'h00000008);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113});
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59 = 32'h00100040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62 = 32'h00000040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70 = 32'h00000008;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72 = (decode_INSTRUCTION & 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73 = 32'h00000040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87) == 32'h00002010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76 = (decode_INSTRUCTION & 32'h00004020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77 = 32'h00004020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80) == 32'h00000010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87 = 32'h00002030;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89 = (decode_INSTRUCTION & 32'h00001030);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90 = 32'h00000010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93) == 32'h00002020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99 = (decode_INSTRUCTION & 32'h00001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100 = 32'h00001010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103) == 32'h00002010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114 = (decode_INSTRUCTION & 32'h00000070);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115 = 32'h00000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123) == 32'h00004010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132});
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80 = 32'h00000030;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82 = 32'h02000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93 = 32'h02002060;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95 = 32'h02003020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103 = 32'h00002010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106 = 32'h00000010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109 = ((decode_INSTRUCTION & 32'h00000024) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119 = 32'h00000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123 = 32'h00004014;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126 = (decode_INSTRUCTION & 32'h00006014);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127 = 32'h00002010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146}});
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151});
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153),(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156)};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131 = 32'h00000044;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135) == 32'h00001000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137) == 32'h00004000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140 = 32'h00000058;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145) == 32'h00002010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147) == 32'h40000030);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150) == 32'h00000004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155),_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157) == 32'h00001004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135 = 32'h00005004;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137 = 32'h00004050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145 = 32'h00002014;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147 = 32'h40000034;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150 = 32'h00000014;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155 = 32'h00000004;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157 = 32'h00005054;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE = 32'h10103050;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_1 = ((decode_INSTRUCTION & 32'h02004064) == 32'h02004020);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_2 = (|((decode_INSTRUCTION & 32'h02004074) == 32'h02000030));
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_3 = (|{(_zz__zz_decode_CfuPlugin_CFU_ENABLE_4 == _zz__zz_decode_CfuPlugin_CFU_ENABLE_5),(_zz__zz_decode_CfuPlugin_CFU_ENABLE_6 == _zz__zz_decode_CfuPlugin_CFU_ENABLE_7)});
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_8 = {(|(_zz__zz_decode_CfuPlugin_CFU_ENABLE_9 == _zz__zz_decode_CfuPlugin_CFU_ENABLE_10)),{(|{_zz__zz_decode_CfuPlugin_CFU_ENABLE_11,_zz__zz_decode_CfuPlugin_CFU_ENABLE_13}),{(|_zz__zz_decode_CfuPlugin_CFU_ENABLE_15),{_zz__zz_decode_CfuPlugin_CFU_ENABLE_18,{_zz__zz_decode_CfuPlugin_CFU_ENABLE_21,_zz__zz_decode_CfuPlugin_CFU_ENABLE_23}}}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_4 = (decode_INSTRUCTION & 32'h10203050);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_5 = 32'h10000050;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_6 = (decode_INSTRUCTION & 32'h10103050);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_7 = 32'h00000050;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_9 = (decode_INSTRUCTION & 32'h00103050);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_10 = 32'h00000050;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_11 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_12) == 32'h00001050);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_13 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_14) == 32'h00002050);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_15 = {_zz_decode_CfuPlugin_CFU_ENABLE_4,(_zz__zz_decode_CfuPlugin_CFU_ENABLE_16 == _zz__zz_decode_CfuPlugin_CFU_ENABLE_17)};
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_18 = (|(_zz__zz_decode_CfuPlugin_CFU_ENABLE_19 == _zz__zz_decode_CfuPlugin_CFU_ENABLE_20));
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_21 = (|_zz__zz_decode_CfuPlugin_CFU_ENABLE_22);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_23 = {(|_zz__zz_decode_CfuPlugin_CFU_ENABLE_24),{_zz__zz_decode_CfuPlugin_CFU_ENABLE_27,{_zz__zz_decode_CfuPlugin_CFU_ENABLE_29,_zz__zz_decode_CfuPlugin_CFU_ENABLE_32}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_12 = 32'h00001050;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_14 = 32'h00002050;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_16 = (decode_INSTRUCTION & 32'h0000001c);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_17 = 32'h00000004;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_19 = (decode_INSTRUCTION & 32'h00000058);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_20 = 32'h00000040;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_22 = ((decode_INSTRUCTION & 32'h02007054) == 32'h00005010);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_24 = {((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_25) == 32'h40001010),((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_26) == 32'h00001010)};
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_27 = (|((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_28) == 32'h00000024));
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_29 = (|(_zz__zz_decode_CfuPlugin_CFU_ENABLE_30 == _zz__zz_decode_CfuPlugin_CFU_ENABLE_31));
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_32 = {(|_zz__zz_decode_CfuPlugin_CFU_ENABLE_33),{(|_zz__zz_decode_CfuPlugin_CFU_ENABLE_34),{_zz__zz_decode_CfuPlugin_CFU_ENABLE_37,{_zz__zz_decode_CfuPlugin_CFU_ENABLE_39,_zz__zz_decode_CfuPlugin_CFU_ENABLE_44}}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_25 = 32'h40003054;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_26 = 32'h02007054;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_28 = 32'h00000064;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_30 = (decode_INSTRUCTION & 32'h00001000);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_31 = 32'h00001000;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_33 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_34 = {((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_35) == 32'h00002000),((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_36) == 32'h00001000)};
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_37 = (|((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_38) == 32'h00004004));
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_39 = (|{_zz_decode_CfuPlugin_CFU_ENABLE_5,{_zz__zz_decode_CfuPlugin_CFU_ENABLE_40,_zz__zz_decode_CfuPlugin_CFU_ENABLE_42}});
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_44 = {(|{_zz__zz_decode_CfuPlugin_CFU_ENABLE_45,_zz__zz_decode_CfuPlugin_CFU_ENABLE_47}),{(|_zz__zz_decode_CfuPlugin_CFU_ENABLE_56),{_zz__zz_decode_CfuPlugin_CFU_ENABLE_58,{_zz__zz_decode_CfuPlugin_CFU_ENABLE_73,_zz__zz_decode_CfuPlugin_CFU_ENABLE_86}}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_35 = 32'h00002010;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_36 = 32'h00005000;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_38 = 32'h00004054;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_40 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_41) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_42 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_43) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_45 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_46) == 32'h00002040);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_47 = {(_zz__zz_decode_CfuPlugin_CFU_ENABLE_48 == _zz__zz_decode_CfuPlugin_CFU_ENABLE_49),{_zz__zz_decode_CfuPlugin_CFU_ENABLE_50,{_zz__zz_decode_CfuPlugin_CFU_ENABLE_52,_zz__zz_decode_CfuPlugin_CFU_ENABLE_55}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_56 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_57) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_58 = (|{_zz__zz_decode_CfuPlugin_CFU_ENABLE_59,{_zz__zz_decode_CfuPlugin_CFU_ENABLE_61,_zz__zz_decode_CfuPlugin_CFU_ENABLE_64}});
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_73 = (|{_zz__zz_decode_CfuPlugin_CFU_ENABLE_74,_zz__zz_decode_CfuPlugin_CFU_ENABLE_75});
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_86 = {(|_zz__zz_decode_CfuPlugin_CFU_ENABLE_87),{_zz__zz_decode_CfuPlugin_CFU_ENABLE_100,{_zz__zz_decode_CfuPlugin_CFU_ENABLE_105,_zz__zz_decode_CfuPlugin_CFU_ENABLE_109}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_41 = 32'h00000034;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_43 = 32'h00000064;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_46 = 32'h00002040;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_48 = (decode_INSTRUCTION & 32'h00001040);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_49 = 32'h00001040;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_50 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_51) == 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_52 = (_zz__zz_decode_CfuPlugin_CFU_ENABLE_53 == _zz__zz_decode_CfuPlugin_CFU_ENABLE_54);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_55 = _zz_decode_CfuPlugin_CFU_ENABLE_2;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_57 = 32'h00000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_59 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_60) == 32'h00000008);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_61 = (_zz__zz_decode_CfuPlugin_CFU_ENABLE_62 == _zz__zz_decode_CfuPlugin_CFU_ENABLE_63);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_64 = {_zz_decode_CfuPlugin_CFU_ENABLE_3,{_zz__zz_decode_CfuPlugin_CFU_ENABLE_65,_zz__zz_decode_CfuPlugin_CFU_ENABLE_68}};
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_74 = _zz_decode_CfuPlugin_CFU_ENABLE_3;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_75 = {_zz__zz_decode_CfuPlugin_CFU_ENABLE_76,{_zz__zz_decode_CfuPlugin_CFU_ENABLE_78,_zz__zz_decode_CfuPlugin_CFU_ENABLE_81}};
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_87 = {_zz_decode_CfuPlugin_CFU_ENABLE_4,{_zz__zz_decode_CfuPlugin_CFU_ENABLE_88,_zz__zz_decode_CfuPlugin_CFU_ENABLE_91}};
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_100 = (|{_zz__zz_decode_CfuPlugin_CFU_ENABLE_101,_zz__zz_decode_CfuPlugin_CFU_ENABLE_102});
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_105 = (|_zz__zz_decode_CfuPlugin_CFU_ENABLE_106);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_109 = {_zz__zz_decode_CfuPlugin_CFU_ENABLE_110,{_zz__zz_decode_CfuPlugin_CFU_ENABLE_113,_zz__zz_decode_CfuPlugin_CFU_ENABLE_117}};
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_51 = 32'h00100040;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_53 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_54 = 32'h00000040;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_60 = 32'h00000008;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_62 = (decode_INSTRUCTION & 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_63 = 32'h00000040;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_65 = (_zz__zz_decode_CfuPlugin_CFU_ENABLE_66 == _zz__zz_decode_CfuPlugin_CFU_ENABLE_67);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_68 = {_zz__zz_decode_CfuPlugin_CFU_ENABLE_69,_zz__zz_decode_CfuPlugin_CFU_ENABLE_71};
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_76 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_77) == 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_78 = (_zz__zz_decode_CfuPlugin_CFU_ENABLE_79 == _zz__zz_decode_CfuPlugin_CFU_ENABLE_80);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_81 = {_zz__zz_decode_CfuPlugin_CFU_ENABLE_82,_zz__zz_decode_CfuPlugin_CFU_ENABLE_84};
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_88 = (_zz__zz_decode_CfuPlugin_CFU_ENABLE_89 == _zz__zz_decode_CfuPlugin_CFU_ENABLE_90);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_91 = {_zz__zz_decode_CfuPlugin_CFU_ENABLE_92,{_zz__zz_decode_CfuPlugin_CFU_ENABLE_94,_zz__zz_decode_CfuPlugin_CFU_ENABLE_97}};
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_101 = _zz_decode_CfuPlugin_CFU_ENABLE_3;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_102 = (_zz__zz_decode_CfuPlugin_CFU_ENABLE_103 == _zz__zz_decode_CfuPlugin_CFU_ENABLE_104);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_106 = {_zz_decode_CfuPlugin_CFU_ENABLE_3,_zz__zz_decode_CfuPlugin_CFU_ENABLE_107};
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_110 = (|_zz__zz_decode_CfuPlugin_CFU_ENABLE_111);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_113 = (|_zz__zz_decode_CfuPlugin_CFU_ENABLE_114);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_117 = {_zz__zz_decode_CfuPlugin_CFU_ENABLE_118,{_zz__zz_decode_CfuPlugin_CFU_ENABLE_127,_zz__zz_decode_CfuPlugin_CFU_ENABLE_130}};
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_66 = (decode_INSTRUCTION & 32'h00004020);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_67 = 32'h00004020;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_69 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_70) == 32'h00000010);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_71 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_72) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_77 = 32'h00002030;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_79 = (decode_INSTRUCTION & 32'h00001030);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_80 = 32'h00000010;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_82 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_83) == 32'h00002020);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_84 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_85) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_89 = (decode_INSTRUCTION & 32'h00001010);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_90 = 32'h00001010;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_92 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_93) == 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_94 = (_zz__zz_decode_CfuPlugin_CFU_ENABLE_95 == _zz__zz_decode_CfuPlugin_CFU_ENABLE_96);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_97 = {_zz__zz_decode_CfuPlugin_CFU_ENABLE_98,_zz__zz_decode_CfuPlugin_CFU_ENABLE_99};
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_103 = (decode_INSTRUCTION & 32'h00000070);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_104 = 32'h00000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_107 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_108) == 32'h00000000);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_111 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_112) == 32'h00004010);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_114 = (_zz__zz_decode_CfuPlugin_CFU_ENABLE_115 == _zz__zz_decode_CfuPlugin_CFU_ENABLE_116);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_118 = (|{_zz__zz_decode_CfuPlugin_CFU_ENABLE_119,_zz__zz_decode_CfuPlugin_CFU_ENABLE_121});
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_127 = (|_zz__zz_decode_CfuPlugin_CFU_ENABLE_128);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_130 = {_zz__zz_decode_CfuPlugin_CFU_ENABLE_131,{_zz__zz_decode_CfuPlugin_CFU_ENABLE_137,_zz__zz_decode_CfuPlugin_CFU_ENABLE_141}};
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_70 = 32'h00000030;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_72 = 32'h02000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_83 = 32'h02002060;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_85 = 32'h02003020;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_93 = 32'h00002010;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_95 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_96 = 32'h00000010;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_98 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_99 = ((decode_INSTRUCTION & 32'h00000024) == 32'h00000000);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_108 = 32'h00000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_112 = 32'h00004014;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_115 = (decode_INSTRUCTION & 32'h00006014);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_116 = 32'h00002010;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_119 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_120) == 32'h00000000);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_121 = {_zz_decode_CfuPlugin_CFU_ENABLE_2,{_zz__zz_decode_CfuPlugin_CFU_ENABLE_122,{_zz__zz_decode_CfuPlugin_CFU_ENABLE_123,_zz__zz_decode_CfuPlugin_CFU_ENABLE_125}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_128 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_129) == 32'h00000000);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_131 = (|{_zz__zz_decode_CfuPlugin_CFU_ENABLE_132,{_zz__zz_decode_CfuPlugin_CFU_ENABLE_133,_zz__zz_decode_CfuPlugin_CFU_ENABLE_135}});
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_137 = (|{_zz__zz_decode_CfuPlugin_CFU_ENABLE_138,_zz__zz_decode_CfuPlugin_CFU_ENABLE_140});
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_141 = {(|_zz__zz_decode_CfuPlugin_CFU_ENABLE_142),(|_zz__zz_decode_CfuPlugin_CFU_ENABLE_145)};
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_120 = 32'h00000044;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_122 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_123 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_124) == 32'h00001000);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_125 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_126) == 32'h00004000);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_129 = 32'h00000058;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_132 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_133 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_134) == 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_135 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_136) == 32'h40000030);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_138 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_139) == 32'h00000004);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_140 = _zz_decode_CfuPlugin_CFU_ENABLE_1;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_142 = {(_zz__zz_decode_CfuPlugin_CFU_ENABLE_143 == _zz__zz_decode_CfuPlugin_CFU_ENABLE_144),_zz_decode_CfuPlugin_CFU_ENABLE_1};
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_145 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE_146) == 32'h00001004);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_124 = 32'h00005004;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_126 = 32'h00004050;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_134 = 32'h00002014;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_136 = 32'h40000034;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_139 = 32'h00000014;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_143 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_144 = 32'h00000004;
+  assign _zz__zz_decode_CfuPlugin_CFU_ENABLE_146 = 32'h00005054;
   assign _zz_execute_BranchPlugin_branch_src2_6 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_7 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_8 = execute_INSTRUCTION[7];
-  assign _zz_CsrPlugin_csrMapping_readDataInit_25 = 32'h0;
+  assign _zz_CsrPlugin_csrMapping_readDataInit_24 = 32'h00000000;
   always @(posedge clk) begin
     if(_zz_decode_RegFilePlugin_rs1Data) begin
       _zz_RegFilePlugin_regFile_port0 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
@@ -1839,8 +1824,8 @@ module VexRiscv (
     .io_mem_rsp_valid                      (iBus_rsp_valid                                            ), //i
     .io_mem_rsp_payload_data               (iBus_rsp_payload_data[31:0]                               ), //i
     .io_mem_rsp_payload_error              (iBus_rsp_payload_error                                    ), //i
-    ._zz_when_Fetcher_l401                 (switch_Fetcher_l365[2:0]                                  ), //i
-    ._zz_io_cpu_fetch_data_regNextWhen     (IBusCachedPlugin_injectionPort_payload[31:0]              ), //i
+    ._zz_when_Fetcher_l411                 (IBusCachedPlugin_injector_port_state[2:0]                 ), //i
+    ._zz_io_cpu_fetch_data_regNextWhen     (DebugPlugin_injectionPort_payload[31:0]                   ), //i
     .clk                                   (clk                                                       ), //i
     .reset                                 (reset                                                     )  //i
   );
@@ -1893,8 +1878,9 @@ module VexRiscv (
     .io_cpu_flush_ready                     (dataCache_1_io_cpu_flush_ready                   ), //o
     .io_cpu_flush_payload_singleLine        (dataCache_1_io_cpu_flush_payload_singleLine      ), //i
     .io_cpu_flush_payload_lineId            (dataCache_1_io_cpu_flush_payload_lineId[6:0]     ), //i
+    .io_cpu_writesPending                   (dataCache_1_io_cpu_writesPending                 ), //o
     .io_mem_cmd_valid                       (dataCache_1_io_mem_cmd_valid                     ), //o
-    .io_mem_cmd_ready                       (dataCache_1_io_mem_cmd_ready                     ), //i
+    .io_mem_cmd_ready                       (toplevel_dataCache_1_io_mem_cmd_rValidN          ), //i
     .io_mem_cmd_payload_wr                  (dataCache_1_io_mem_cmd_payload_wr                ), //o
     .io_mem_cmd_payload_uncached            (dataCache_1_io_mem_cmd_payload_uncached          ), //o
     .io_mem_cmd_payload_address             (dataCache_1_io_mem_cmd_payload_address[31:0]     ), //o
@@ -2581,10 +2567,10 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9)
-      Input2Kind_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string = "RS   ";
-      Input2Kind_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string = "IMM_I";
-      default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string = "?????";
+    case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2)
+      Input2Kind_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_string = "IMM_I";
+      default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2684,7 +2670,7 @@ module VexRiscv (
   end
   `endif
 
-  assign memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW) + $signed(_zz_memory_MUL_LOW_7));
+  assign memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW) + $signed(_zz_memory_MUL_LOW_6));
   assign writeBack_CfuPlugin_CFU_IN_FLIGHT = memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
   assign execute_CfuPlugin_CFU_IN_FLIGHT = ((execute_CfuPlugin_schedule || execute_CfuPlugin_hold) || execute_CfuPlugin_fired);
   assign memory_MUL_HH = execute_to_memory_MUL_HH;
@@ -2698,38 +2684,38 @@ module VexRiscv (
   assign execute_MEMORY_STORE_DATA_RF = _zz_execute_MEMORY_STORE_DATA_RF;
   assign decode_DO_EBREAK = (((! DebugPlugin_haltIt) && (decode_IS_EBREAK || ((1'b0 || (DebugPlugin_hardwareBreakpoints_0_valid && (DebugPlugin_hardwareBreakpoints_0_pc == _zz_decode_DO_EBREAK))) || (DebugPlugin_hardwareBreakpoints_1_valid && (DebugPlugin_hardwareBreakpoints_1_pc == _zz_decode_DO_EBREAK_1))))) && DebugPlugin_allowEBreak);
   assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
-  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
+  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h00)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h00))));
   assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
   assign decode_CfuPlugin_CFU_INPUT_2_KIND = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND;
   assign _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND = _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1;
-  assign decode_CfuPlugin_CFU_ENABLE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[33];
-  assign decode_IS_RS2_SIGNED = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[31];
-  assign decode_IS_RS1_SIGNED = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[30];
-  assign decode_IS_DIV = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[29];
+  assign decode_CfuPlugin_CFU_ENABLE = _zz_decode_CfuPlugin_CFU_ENABLE[33];
+  assign decode_IS_RS2_SIGNED = _zz_decode_CfuPlugin_CFU_ENABLE[31];
+  assign decode_IS_RS1_SIGNED = _zz_decode_CfuPlugin_CFU_ENABLE[30];
+  assign decode_IS_DIV = _zz_decode_CfuPlugin_CFU_ENABLE[29];
   assign memory_IS_MUL = execute_to_memory_IS_MUL;
   assign execute_IS_MUL = decode_to_execute_IS_MUL;
-  assign decode_IS_MUL = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[28];
+  assign decode_IS_MUL = _zz_decode_CfuPlugin_CFU_ENABLE[28];
   assign _zz_memory_to_writeBack_ENV_CTRL = _zz_memory_to_writeBack_ENV_CTRL_1;
   assign _zz_execute_to_memory_ENV_CTRL = _zz_execute_to_memory_ENV_CTRL_1;
   assign decode_ENV_CTRL = _zz_decode_ENV_CTRL;
   assign _zz_decode_to_execute_ENV_CTRL = _zz_decode_to_execute_ENV_CTRL_1;
-  assign decode_IS_CSR = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[25];
+  assign decode_IS_CSR = _zz_decode_CfuPlugin_CFU_ENABLE[25];
   assign _zz_decode_to_execute_BRANCH_CTRL = _zz_decode_to_execute_BRANCH_CTRL_1;
   assign _zz_execute_to_memory_SHIFT_CTRL = _zz_execute_to_memory_SHIFT_CTRL_1;
   assign decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL;
   assign _zz_decode_to_execute_SHIFT_CTRL = _zz_decode_to_execute_SHIFT_CTRL_1;
   assign decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL;
   assign _zz_decode_to_execute_ALU_BITWISE_CTRL = _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
-  assign decode_SRC_LESS_UNSIGNED = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[17];
-  assign decode_MEMORY_MANAGMENT = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[16];
+  assign decode_SRC_LESS_UNSIGNED = _zz_decode_CfuPlugin_CFU_ENABLE[17];
+  assign decode_MEMORY_MANAGMENT = _zz_decode_CfuPlugin_CFU_ENABLE[16];
   assign execute_HAS_SIDE_EFFECT = decode_to_execute_HAS_SIDE_EFFECT;
-  assign decode_HAS_SIDE_EFFECT = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[14];
+  assign decode_HAS_SIDE_EFFECT = _zz_decode_CfuPlugin_CFU_ENABLE[14];
   assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
-  assign decode_MEMORY_WR = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[13];
+  assign decode_MEMORY_WR = _zz_decode_CfuPlugin_CFU_ENABLE[13];
   assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[12];
-  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[11];
+  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_decode_CfuPlugin_CFU_ENABLE[12];
+  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_decode_CfuPlugin_CFU_ENABLE[11];
   assign decode_SRC2_CTRL = _zz_decode_SRC2_CTRL;
   assign _zz_decode_to_execute_SRC2_CTRL = _zz_decode_to_execute_SRC2_CTRL_1;
   assign decode_ALU_CTRL = _zz_decode_ALU_CTRL;
@@ -2758,11 +2744,18 @@ module VexRiscv (
 
   assign memory_CfuPlugin_CFU_IN_FLIGHT = execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
   assign execute_CfuPlugin_CFU_INPUT_2_KIND = _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
-  assign execute_CfuPlugin_CFU_ENABLE = decode_to_execute_CfuPlugin_CFU_ENABLE;
   assign writeBack_HAS_SIDE_EFFECT = memory_to_writeBack_HAS_SIDE_EFFECT;
   assign memory_HAS_SIDE_EFFECT = execute_to_memory_HAS_SIDE_EFFECT;
+  assign execute_LEGAL_INSTRUCTION = decode_to_execute_LEGAL_INSTRUCTION;
+  always @(*) begin
+    execute_CfuPlugin_CFU_ENABLE = decode_to_execute_CfuPlugin_CFU_ENABLE;
+    if(when_CfuPlugin_l192) begin
+      execute_CfuPlugin_CFU_ENABLE = 1'b0;
+    end
+  end
+
   assign execute_DO_EBREAK = decode_to_execute_DO_EBREAK;
-  assign decode_IS_EBREAK = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[32];
+  assign decode_IS_EBREAK = _zz_decode_CfuPlugin_CFU_ENABLE[32];
   assign execute_IS_RS1_SIGNED = decode_to_execute_IS_RS1_SIGNED;
   assign execute_IS_DIV = decode_to_execute_IS_DIV;
   assign execute_IS_RS2_SIGNED = decode_to_execute_IS_RS2_SIGNED;
@@ -2785,11 +2778,11 @@ module VexRiscv (
   assign execute_PREDICTION_HAD_BRANCHED2 = decode_to_execute_PREDICTION_HAD_BRANCHED2;
   assign execute_BRANCH_COND_RESULT = _zz_execute_BRANCH_COND_RESULT_1;
   assign execute_BRANCH_CTRL = _zz_execute_BRANCH_CTRL;
-  assign decode_RS2_USE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[15];
-  assign decode_RS1_USE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[5];
+  assign decode_RS2_USE = _zz_decode_CfuPlugin_CFU_ENABLE[15];
+  assign decode_RS1_USE = _zz_decode_CfuPlugin_CFU_ENABLE[5];
   always @(*) begin
     _zz_decode_RS2 = execute_REGFILE_WRITE_DATA;
-    if(when_CsrPlugin_l1189) begin
+    if(when_CsrPlugin_l1587) begin
       _zz_decode_RS2 = CsrPlugin_csrMapping_readDataSignal;
     end
   end
@@ -2888,15 +2881,15 @@ module VexRiscv (
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_execute_SRC2 = execute_PC;
+  assign _zz_execute_to_memory_PC = execute_PC;
   assign execute_SRC2_CTRL = _zz_execute_SRC2_CTRL;
   assign execute_SRC1_CTRL = _zz_execute_SRC1_CTRL;
-  assign decode_SRC_USE_SUB_LESS = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[3];
-  assign decode_SRC_ADD_ZERO = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[20];
+  assign decode_SRC_USE_SUB_LESS = _zz_decode_CfuPlugin_CFU_ENABLE[3];
+  assign decode_SRC_ADD_ZERO = _zz_decode_CfuPlugin_CFU_ENABLE[20];
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
   assign execute_ALU_CTRL = _zz_execute_ALU_CTRL;
-  assign execute_SRC2 = _zz_execute_SRC2_5;
+  assign execute_SRC2 = _zz_execute_SRC2_4;
   assign execute_SRC1 = _zz_execute_SRC1;
   assign execute_ALU_BITWISE_CTRL = _zz_execute_ALU_BITWISE_CTRL;
   assign _zz_lastStageRegFileWrite_payload_address = writeBack_INSTRUCTION;
@@ -2910,16 +2903,16 @@ module VexRiscv (
 
   assign decode_INSTRUCTION_ANTICIPATED = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusCachedPlugin_cache_io_cpu_fetch_data);
   always @(*) begin
-    decode_REGFILE_WRITE_VALID = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[10];
+    decode_REGFILE_WRITE_VALID = _zz_decode_CfuPlugin_CFU_ENABLE[10];
     if(when_RegFilePlugin_l63) begin
       decode_REGFILE_WRITE_VALID = 1'b0;
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000000b),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
+  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000000b),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00001073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
   always @(*) begin
     _zz_decode_RS2_2 = writeBack_REGFILE_WRITE_DATA;
-    if(when_DBusCachedPlugin_l492) begin
+    if(when_DBusCachedPlugin_l580) begin
       _zz_decode_RS2_2 = writeBack_DBusCachedPlugin_rspFormated;
     end
     if(when_MulPlugin_l147) begin
@@ -2948,32 +2941,32 @@ module VexRiscv (
   assign execute_SRC_ADD = execute_SrcPlugin_addSub;
   assign execute_MEMORY_ENABLE = decode_to_execute_MEMORY_ENABLE;
   assign execute_INSTRUCTION = decode_to_execute_INSTRUCTION;
-  assign decode_MEMORY_ENABLE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[4];
-  assign decode_FLUSH_ALL = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[0];
+  assign decode_MEMORY_ENABLE = _zz_decode_CfuPlugin_CFU_ENABLE[4];
+  assign decode_FLUSH_ALL = _zz_decode_CfuPlugin_CFU_ENABLE[0];
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_4 = IBusCachedPlugin_rsp_issueDetected_3;
-    if(when_IBusCachedPlugin_l256) begin
+    if(when_IBusCachedPlugin_l262) begin
       IBusCachedPlugin_rsp_issueDetected_4 = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_3 = IBusCachedPlugin_rsp_issueDetected_2;
-    if(when_IBusCachedPlugin_l250) begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_rsp_issueDetected_3 = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
-    if(when_IBusCachedPlugin_l244) begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
-    if(when_IBusCachedPlugin_l239) begin
+    if(when_IBusCachedPlugin_l245) begin
       IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
@@ -2999,10 +2992,10 @@ module VexRiscv (
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
   always @(*) begin
     decode_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l308) begin
+    if(when_DBusCachedPlugin_l352) begin
       decode_arbitration_haltItself = 1'b1;
     end
-    case(switch_Fetcher_l365)
+    case(IBusCachedPlugin_injector_port_state)
       3'b010 : begin
         decode_arbitration_haltItself = 1'b1;
       end
@@ -3019,7 +3012,7 @@ module VexRiscv (
     if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(when_CsrPlugin_l1129) begin
+    if(when_CsrPlugin_l1527) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
@@ -3047,33 +3040,33 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l350) begin
+    if(when_DBusCachedPlugin_l394) begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(when_CsrPlugin_l1121) begin
-      if(when_CsrPlugin_l1123) begin
+    if(when_CsrPlugin_l1519) begin
+      if(when_CsrPlugin_l1521) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(when_CsrPlugin_l1193) begin
+    if(when_CsrPlugin_l1591) begin
       if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(when_CfuPlugin_l194) begin
+    if(when_CfuPlugin_l196) begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(when_CfuPlugin_l201) begin
+    if(when_CfuPlugin_l203) begin
       execute_arbitration_haltItself = 1'b1;
     end
   end
 
   always @(*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if(when_DBusCachedPlugin_l366) begin
+    if(when_DBusCachedPlugin_l410) begin
       execute_arbitration_haltByOther = 1'b1;
     end
-    if(when_DebugPlugin_l295) begin
+    if(when_DebugPlugin_l308) begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
@@ -3090,8 +3083,8 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_flushIt = 1'b0;
-    if(when_DebugPlugin_l295) begin
-      if(when_DebugPlugin_l298) begin
+    if(when_DebugPlugin_l308) begin
+      if(when_DebugPlugin_l311) begin
         execute_arbitration_flushIt = 1'b1;
       end
     end
@@ -3105,8 +3098,8 @@ module VexRiscv (
     if(_zz_when_1) begin
       execute_arbitration_flushNext = 1'b1;
     end
-    if(when_DebugPlugin_l295) begin
-      if(when_DebugPlugin_l298) begin
+    if(when_DebugPlugin_l308) begin
+      if(when_DebugPlugin_l311) begin
         execute_arbitration_flushNext = 1'b1;
       end
     end
@@ -3120,7 +3113,7 @@ module VexRiscv (
       end
     end
     if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
-      if(when_CfuPlugin_l237) begin
+      if(when_CfuPlugin_l239) begin
         memory_arbitration_haltItself = 1'b1;
       end
     end
@@ -3138,7 +3131,7 @@ module VexRiscv (
   assign memory_arbitration_flushNext = 1'b0;
   always @(*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l466) begin
+    if(when_DBusCachedPlugin_l553) begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
@@ -3169,10 +3162,10 @@ module VexRiscv (
     if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -3183,24 +3176,24 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @(*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(when_CsrPlugin_l935) begin
+    if(when_CsrPlugin_l1272) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_DebugPlugin_l295) begin
-      if(when_DebugPlugin_l298) begin
+    if(when_DebugPlugin_l308) begin
+      if(when_DebugPlugin_l311) begin
         IBusCachedPlugin_fetcherHalt = 1'b1;
       end
     end
     if(DebugPlugin_haltIt) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_DebugPlugin_l311) begin
+    if(when_DebugPlugin_l324) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
@@ -3208,15 +3201,15 @@ module VexRiscv (
   assign IBusCachedPlugin_forceNoDecodeCond = 1'b0;
   always @(*) begin
     IBusCachedPlugin_incomingInstruction = 1'b0;
-    if(when_Fetcher_l243) begin
+    if(when_Fetcher_l242) begin
       IBusCachedPlugin_incomingInstruction = 1'b1;
     end
   end
 
   always @(*) begin
-    _zz_when_DBusCachedPlugin_l393 = 1'b0;
+    _zz_when_DBusCachedPlugin_l472 = 1'b0;
     if(DebugPlugin_godmode) begin
-      _zz_when_DBusCachedPlugin_l393 = 1'b1;
+      _zz_when_DBusCachedPlugin_l472 = 1'b1;
     end
   end
 
@@ -3227,11 +3220,21 @@ module VexRiscv (
     end
   end
 
-  assign CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+  always @(*) begin
+    CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+    if(when_CsrPlugin_l1702) begin
+      CsrPlugin_csrMapping_allowCsrSignal = 1'b1;
+    end
+    if(when_CsrPlugin_l1709) begin
+      CsrPlugin_csrMapping_allowCsrSignal = 1'b1;
+    end
+  end
+
+  assign CsrPlugin_csrMapping_doForceFailCsr = 1'b0;
   assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
   always @(*) begin
     CsrPlugin_inWfi = 1'b0;
-    if(when_CsrPlugin_l1121) begin
+    if(when_CsrPlugin_l1519) begin
       CsrPlugin_inWfi = 1'b1;
     end
   end
@@ -3245,21 +3248,21 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(when_CsrPlugin_l1077) begin
-      case(switch_CsrPlugin_l1081)
+    if(when_CsrPlugin_l1456) begin
+      case(switch_CsrPlugin_l1460)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -3278,7 +3281,7 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_allowInterrupts = 1'b1;
-    if(when_DebugPlugin_l331) begin
+    if(when_DebugPlugin_l344) begin
       CsrPlugin_allowInterrupts = 1'b0;
     end
   end
@@ -3297,6 +3300,7 @@ module VexRiscv (
     end
   end
 
+  assign CsrPlugin_xretAwayFromMachine = 1'b0;
   assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
   assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusCachedPlugin_redoBranch_valid,IBusCachedPlugin_predictionJumpInterface_valid}}} != 4'b0000);
   assign _zz_IBusCachedPlugin_jump_pcLoad_payload = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
@@ -3324,9 +3328,8 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l134 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
-  assign IBusCachedPlugin_fetchPc_output_fire_1 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
-  assign when_Fetcher_l134_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
+  assign when_Fetcher_l133 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l133_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
   always @(*) begin
     IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_IBusCachedPlugin_fetchPc_pc);
     if(IBusCachedPlugin_fetchPc_redo_valid) begin
@@ -3349,7 +3352,7 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l161 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
+  assign when_Fetcher_l160 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
   assign IBusCachedPlugin_fetchPc_output_valid = ((! IBusCachedPlugin_fetcherHalt) && IBusCachedPlugin_fetchPc_booted);
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
   always @(*) begin
@@ -3386,7 +3389,7 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_1_output_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b0;
-    if(when_IBusCachedPlugin_l267) begin
+    if(when_IBusCachedPlugin_l273) begin
       IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b1;
     end
   end
@@ -3399,9 +3402,9 @@ module VexRiscv (
   assign IBusCachedPlugin_fetchPc_redo_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_iBusRsp_flush = ((decode_arbitration_removeIt || (decode_arbitration_flushNext && (! decode_arbitration_isStuck))) || IBusCachedPlugin_iBusRsp_redoFetch);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
-  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1 = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
   assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid)) || IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready);
   assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
@@ -3411,18 +3414,18 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
   always @(*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
-    if(when_Fetcher_l323) begin
+    if(when_Fetcher_l322) begin
       IBusCachedPlugin_iBusRsp_readyForError = 1'b0;
     end
   end
 
-  assign when_Fetcher_l243 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
-  assign when_Fetcher_l323 = (! IBusCachedPlugin_pcValids_0);
-  assign when_Fetcher_l332 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
-  assign when_Fetcher_l332_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
-  assign when_Fetcher_l332_2 = (! execute_arbitration_isStuck);
-  assign when_Fetcher_l332_3 = (! memory_arbitration_isStuck);
-  assign when_Fetcher_l332_4 = (! writeBack_arbitration_isStuck);
+  assign when_Fetcher_l242 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
+  assign when_Fetcher_l322 = (! IBusCachedPlugin_pcValids_0);
+  assign when_Fetcher_l331 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l331_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
+  assign when_Fetcher_l331_2 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l331_3 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l331_4 = (! writeBack_arbitration_isStuck);
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
@@ -3430,7 +3433,7 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
   always @(*) begin
     decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
-    case(switch_Fetcher_l365)
+    case(IBusCachedPlugin_injector_port_state)
       3'b010 : begin
         decode_arbitration_isValid = 1'b1;
       end
@@ -3587,87 +3590,86 @@ module VexRiscv (
   assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
   always @(*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(when_IBusCachedPlugin_l239) begin
+    if(when_IBusCachedPlugin_l245) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(when_IBusCachedPlugin_l250) begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_cache_io_cpu_fill_valid = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
-    if(when_IBusCachedPlugin_l250) begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_cache_io_cpu_fill_valid = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_valid = 1'b0;
-    if(when_IBusCachedPlugin_l244) begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
-    if(when_IBusCachedPlugin_l256) begin
+    if(when_IBusCachedPlugin_l262) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_payload_code = 4'bxxxx;
-    if(when_IBusCachedPlugin_l244) begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b1100;
     end
-    if(when_IBusCachedPlugin_l256) begin
+    if(when_IBusCachedPlugin_l262) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b0001;
     end
   end
 
   assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_2_input_payload[31 : 2],2'b00};
-  assign when_IBusCachedPlugin_l239 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign when_IBusCachedPlugin_l244 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
-  assign when_IBusCachedPlugin_l250 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
-  assign when_IBusCachedPlugin_l256 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
-  assign when_IBusCachedPlugin_l267 = (IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt);
+  assign when_IBusCachedPlugin_l245 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign when_IBusCachedPlugin_l250 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign when_IBusCachedPlugin_l256 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
+  assign when_IBusCachedPlugin_l262 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
+  assign when_IBusCachedPlugin_l273 = (IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt);
   assign IBusCachedPlugin_iBusRsp_output_valid = IBusCachedPlugin_iBusRsp_stages_2_output_valid;
   assign IBusCachedPlugin_iBusRsp_stages_2_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
   assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_decode_data;
   assign IBusCachedPlugin_iBusRsp_output_payload_pc = IBusCachedPlugin_iBusRsp_stages_2_output_payload;
   assign IBusCachedPlugin_cache_io_flush = (decode_arbitration_isValid && decode_FLUSH_ALL);
-  assign dataCache_1_io_mem_cmd_ready = (! dataCache_1_io_mem_cmd_rValid);
-  assign dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || dataCache_1_io_mem_cmd_rValid);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_wr : dataCache_1_io_mem_cmd_payload_wr);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_uncached : dataCache_1_io_mem_cmd_payload_uncached);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_address = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_address : dataCache_1_io_mem_cmd_payload_address);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_data = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_data : dataCache_1_io_mem_cmd_payload_data);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_mask : dataCache_1_io_mem_cmd_payload_mask);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_size = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_size : dataCache_1_io_mem_cmd_payload_size);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_last : dataCache_1_io_mem_cmd_payload_last);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || (! toplevel_dataCache_1_io_mem_cmd_rValidN));
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_wr : toplevel_dataCache_1_io_mem_cmd_rData_wr);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_uncached : toplevel_dataCache_1_io_mem_cmd_rData_uncached);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_address = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_address : toplevel_dataCache_1_io_mem_cmd_rData_address);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_data = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_data : toplevel_dataCache_1_io_mem_cmd_rData_data);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_mask : toplevel_dataCache_1_io_mem_cmd_rData_mask);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_size = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_size : toplevel_dataCache_1_io_mem_cmd_rData_size);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_last = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_last : toplevel_dataCache_1_io_mem_cmd_rData_last);
   always @(*) begin
-    dataCache_1_io_mem_cmd_s2mPipe_ready = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
-    if(when_Stream_l368) begin
-      dataCache_1_io_mem_cmd_s2mPipe_ready = 1'b1;
+    toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
+    if(when_Stream_l369) begin
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l368 = (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_rValid;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_rData_address;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_rData_data;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size = dataCache_1_io_mem_cmd_s2mPipe_rData_size;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_rData_last;
-  assign dBus_cmd_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
-  assign dBus_cmd_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
-  assign dBus_cmd_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
-  assign dBus_cmd_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
-  assign dBus_cmd_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
-  assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  assign dBus_cmd_payload_size = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
-  assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  assign when_DBusCachedPlugin_l308 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
+  assign when_Stream_l369 = (! toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_address;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_data;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_size;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  assign dBus_cmd_valid = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
+  assign dBus_cmd_payload_wr = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
+  assign dBus_cmd_payload_uncached = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
+  assign dBus_cmd_payload_address = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
+  assign dBus_cmd_payload_data = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
+  assign dBus_cmd_payload_mask = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
+  assign dBus_cmd_payload_size = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
+  assign dBus_cmd_payload_last = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  assign when_DBusCachedPlugin_l352 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
   assign dataCache_1_io_cpu_execute_isValid = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
   assign dataCache_1_io_cpu_execute_address = execute_SRC_ADD;
@@ -3686,11 +3688,11 @@ module VexRiscv (
   end
 
   assign dataCache_1_io_cpu_flush_valid = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
-  assign dataCache_1_io_cpu_flush_payload_singleLine = (execute_INSTRUCTION[19 : 15] != 5'h0);
+  assign dataCache_1_io_cpu_flush_payload_singleLine = (execute_INSTRUCTION[19 : 15] != 5'h00);
   assign dataCache_1_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId[6:0];
-  assign dataCache_1_io_cpu_flush_isStall = (dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready));
-  assign when_DBusCachedPlugin_l350 = (dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
-  assign when_DBusCachedPlugin_l366 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
+  assign toplevel_dataCache_1_io_cpu_flush_isStall = (dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready));
+  assign when_DBusCachedPlugin_l394 = (toplevel_dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
+  assign when_DBusCachedPlugin_l410 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
   assign dataCache_1_io_cpu_memory_isValid = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
   assign dataCache_1_io_cpu_memory_address = memory_REGFILE_WRITE_DATA;
   assign DBusCachedPlugin_mmuBus_cmd_0_isValid = dataCache_1_io_cpu_memory_isValid;
@@ -3700,12 +3702,12 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
   always @(*) begin
     dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if(when_DBusCachedPlugin_l393) begin
+    if(when_DBusCachedPlugin_l472) begin
       dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = 1'b1;
     end
   end
 
-  assign when_DBusCachedPlugin_l393 = (_zz_when_DBusCachedPlugin_l393 && (! dataCache_1_io_cpu_memory_isWrite));
+  assign when_DBusCachedPlugin_l472 = (_zz_when_DBusCachedPlugin_l472 && (! dataCache_1_io_cpu_memory_isWrite));
   always @(*) begin
     dataCache_1_io_cpu_writeBack_isValid = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
     if(writeBack_arbitration_haltByOther) begin
@@ -3718,7 +3720,7 @@ module VexRiscv (
   assign dataCache_1_io_cpu_writeBack_storeData[31 : 0] = writeBack_MEMORY_STORE_DATA_RF;
   always @(*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(when_DBusCachedPlugin_l446) begin
+    if(when_DBusCachedPlugin_l533) begin
       if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
@@ -3728,7 +3730,7 @@ module VexRiscv (
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(when_DBusCachedPlugin_l446) begin
+    if(when_DBusCachedPlugin_l533) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
@@ -3747,7 +3749,7 @@ module VexRiscv (
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
-    if(when_DBusCachedPlugin_l446) begin
+    if(when_DBusCachedPlugin_l533) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code};
       end
@@ -3760,12 +3762,13 @@ module VexRiscv (
     end
   end
 
-  assign when_DBusCachedPlugin_l446 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign when_DBusCachedPlugin_l466 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
-  assign writeBack_DBusCachedPlugin_rspSplits_0 = dataCache_1_io_cpu_writeBack_data[7 : 0];
-  assign writeBack_DBusCachedPlugin_rspSplits_1 = dataCache_1_io_cpu_writeBack_data[15 : 8];
-  assign writeBack_DBusCachedPlugin_rspSplits_2 = dataCache_1_io_cpu_writeBack_data[23 : 16];
-  assign writeBack_DBusCachedPlugin_rspSplits_3 = dataCache_1_io_cpu_writeBack_data[31 : 24];
+  assign when_DBusCachedPlugin_l533 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l553 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
+  assign writeBack_DBusCachedPlugin_rspData = dataCache_1_io_cpu_writeBack_data;
+  assign writeBack_DBusCachedPlugin_rspSplits_0 = writeBack_DBusCachedPlugin_rspData[7 : 0];
+  assign writeBack_DBusCachedPlugin_rspSplits_1 = writeBack_DBusCachedPlugin_rspData[15 : 8];
+  assign writeBack_DBusCachedPlugin_rspSplits_2 = writeBack_DBusCachedPlugin_rspData[23 : 16];
+  assign writeBack_DBusCachedPlugin_rspSplits_3 = writeBack_DBusCachedPlugin_rspData[31 : 24];
   always @(*) begin
     writeBack_DBusCachedPlugin_rspShifted[7 : 0] = _zz_writeBack_DBusCachedPlugin_rspShifted;
     writeBack_DBusCachedPlugin_rspShifted[15 : 8] = _zz_writeBack_DBusCachedPlugin_rspShifted_2;
@@ -3774,7 +3777,7 @@ module VexRiscv (
   end
 
   assign writeBack_DBusCachedPlugin_rspRf = writeBack_DBusCachedPlugin_rspShifted[31 : 0];
-  assign switch_Misc_l210 = writeBack_INSTRUCTION[13 : 12];
+  assign switch_Misc_l232 = writeBack_INSTRUCTION[13 : 12];
   assign _zz_writeBack_DBusCachedPlugin_rspFormated = (writeBack_DBusCachedPlugin_rspRf[7] && (! writeBack_INSTRUCTION[14]));
   always @(*) begin
     _zz_writeBack_DBusCachedPlugin_rspFormated_1[31] = _zz_writeBack_DBusCachedPlugin_rspFormated;
@@ -3826,7 +3829,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    case(switch_Misc_l210)
+    case(switch_Misc_l232)
       2'b00 : begin
         writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_1;
       end
@@ -3839,7 +3842,7 @@ module VexRiscv (
     endcase
   end
 
-  assign when_DBusCachedPlugin_l492 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l580 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
   assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
@@ -3858,55 +3861,55 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
   assign DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign DBusCachedPlugin_mmuBus_busy = 1'b0;
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4 = ((decode_INSTRUCTION & 32'h00000018) == 32'h0);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000008);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = {1'b0,{(|_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7),{(|((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2) == 32'h00100050)),{(|_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8),{(|_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8),{(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8}}}}}}}};
-  assign _zz_decode_SRC1_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[2 : 1];
+  assign _zz_decode_CfuPlugin_CFU_ENABLE_1 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
+  assign _zz_decode_CfuPlugin_CFU_ENABLE_2 = ((decode_INSTRUCTION & 32'h00000018) == 32'h00000000);
+  assign _zz_decode_CfuPlugin_CFU_ENABLE_3 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_decode_CfuPlugin_CFU_ENABLE_4 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_decode_CfuPlugin_CFU_ENABLE_5 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000008);
+  assign _zz_decode_CfuPlugin_CFU_ENABLE_6 = ((decode_INSTRUCTION & 32'h00001000) == 32'h00000000);
+  assign _zz_decode_CfuPlugin_CFU_ENABLE = {1'b0,{(|_zz_decode_CfuPlugin_CFU_ENABLE_5),{(|((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_ENABLE) == 32'h00100050)),{(|_zz_decode_CfuPlugin_CFU_ENABLE_6),{(|_zz_decode_CfuPlugin_CFU_ENABLE_6),{(|_zz__zz_decode_CfuPlugin_CFU_ENABLE_1),{_zz__zz_decode_CfuPlugin_CFU_ENABLE_2,{_zz__zz_decode_CfuPlugin_CFU_ENABLE_3,_zz__zz_decode_CfuPlugin_CFU_ENABLE_8}}}}}}}};
+  assign _zz_decode_SRC1_CTRL_2 = _zz_decode_CfuPlugin_CFU_ENABLE[2 : 1];
   assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
-  assign _zz_decode_ALU_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[7 : 6];
+  assign _zz_decode_ALU_CTRL_2 = _zz_decode_CfuPlugin_CFU_ENABLE[7 : 6];
   assign _zz_decode_ALU_CTRL_1 = _zz_decode_ALU_CTRL_2;
-  assign _zz_decode_SRC2_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[9 : 8];
+  assign _zz_decode_SRC2_CTRL_2 = _zz_decode_CfuPlugin_CFU_ENABLE[9 : 8];
   assign _zz_decode_SRC2_CTRL_1 = _zz_decode_SRC2_CTRL_2;
-  assign _zz_decode_ALU_BITWISE_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[19 : 18];
+  assign _zz_decode_ALU_BITWISE_CTRL_2 = _zz_decode_CfuPlugin_CFU_ENABLE[19 : 18];
   assign _zz_decode_ALU_BITWISE_CTRL_1 = _zz_decode_ALU_BITWISE_CTRL_2;
-  assign _zz_decode_SHIFT_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[22 : 21];
+  assign _zz_decode_SHIFT_CTRL_2 = _zz_decode_CfuPlugin_CFU_ENABLE[22 : 21];
   assign _zz_decode_SHIFT_CTRL_1 = _zz_decode_SHIFT_CTRL_2;
-  assign _zz_decode_BRANCH_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[24 : 23];
+  assign _zz_decode_BRANCH_CTRL_2 = _zz_decode_CfuPlugin_CFU_ENABLE[24 : 23];
   assign _zz_decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_2;
-  assign _zz_decode_ENV_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[27 : 26];
+  assign _zz_decode_ENV_CTRL_2 = _zz_decode_CfuPlugin_CFU_ENABLE[27 : 26];
   assign _zz_decode_ENV_CTRL_1 = _zz_decode_ENV_CTRL_2;
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[34 : 34];
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9;
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = _zz_decode_CfuPlugin_CFU_ENABLE[34 : 34];
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
-  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h0);
+  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h00);
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
   assign decode_RegFilePlugin_rs1Data = _zz_RegFilePlugin_regFile_port0;
   assign decode_RegFilePlugin_rs2Data = _zz_RegFilePlugin_regFile_port1;
   always @(*) begin
     lastStageRegFileWrite_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
-    if(_zz_7) begin
+    if(_zz_10) begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
   always @(*) begin
     lastStageRegFileWrite_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
-    if(_zz_7) begin
-      lastStageRegFileWrite_payload_address = 5'h0;
+    if(_zz_10) begin
+      lastStageRegFileWrite_payload_address = 5'h00;
     end
   end
 
   always @(*) begin
     lastStageRegFileWrite_payload_data = _zz_decode_RS2_2;
-    if(_zz_7) begin
-      lastStageRegFileWrite_payload_data = 32'h0;
+    if(_zz_10) begin
+      lastStageRegFileWrite_payload_data = 32'h00000000;
     end
   end
 
@@ -3947,7 +3950,7 @@ module VexRiscv (
         _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
       Src1CtrlEnum_IMU : begin
-        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h000};
       end
       default : begin
         _zz_execute_SRC1 = {27'd0, _zz__zz_execute_SRC1_1};
@@ -3955,67 +3958,67 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_execute_SRC2_1 = execute_INSTRUCTION[31];
+  assign _zz_execute_SRC2 = execute_INSTRUCTION[31];
   always @(*) begin
-    _zz_execute_SRC2_2[19] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[18] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[17] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[16] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[15] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[14] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[13] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[12] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[11] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[10] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[9] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[8] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[7] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[6] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[5] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[4] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[3] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[2] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[1] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[0] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_1[19] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[18] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[17] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[16] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[15] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[14] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[13] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[12] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[11] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[10] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[9] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[8] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[7] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[6] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[5] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[4] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[3] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[2] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[1] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[0] = _zz_execute_SRC2;
   end
 
-  assign _zz_execute_SRC2_3 = _zz__zz_execute_SRC2_3[11];
+  assign _zz_execute_SRC2_2 = _zz__zz_execute_SRC2_2[11];
   always @(*) begin
-    _zz_execute_SRC2_4[19] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[18] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[17] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[16] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[15] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[14] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[13] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[12] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[11] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[10] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[9] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[8] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[7] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[6] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[5] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[4] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[3] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[2] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[1] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[0] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_3[19] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[18] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[17] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[16] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[15] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[14] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[13] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[12] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[11] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[10] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[9] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[8] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[7] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[6] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[5] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[4] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[3] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[2] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[1] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[0] = _zz_execute_SRC2_2;
   end
 
   always @(*) begin
     case(execute_SRC2_CTRL)
       Src2CtrlEnum_RS : begin
-        _zz_execute_SRC2_5 = execute_RS2;
+        _zz_execute_SRC2_4 = execute_RS2;
       end
       Src2CtrlEnum_IMI : begin
-        _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
+        _zz_execute_SRC2_4 = {_zz_execute_SRC2_1,execute_INSTRUCTION[31 : 20]};
       end
       Src2CtrlEnum_IMS : begin
-        _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_execute_SRC2_4 = {_zz_execute_SRC2_3,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_execute_SRC2_5 = _zz_execute_SRC2;
+        _zz_execute_SRC2_4 = _zz_execute_to_memory_PC;
       end
     endcase
   end
@@ -4181,16 +4184,19 @@ module VexRiscv (
   assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
   assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign switch_Misc_l210_1 = execute_INSTRUCTION[14 : 12];
+  assign switch_Misc_l232_1 = execute_INSTRUCTION[14 : 12];
   always @(*) begin
-    casez(switch_Misc_l210_1)
+    case(switch_Misc_l232_1)
       3'b000 : begin
         _zz_execute_BRANCH_COND_RESULT = execute_BranchPlugin_eq;
       end
       3'b001 : begin
         _zz_execute_BRANCH_COND_RESULT = (! execute_BranchPlugin_eq);
       end
-      3'b1?1 : begin
+      3'b101 : begin
+        _zz_execute_BRANCH_COND_RESULT = (! execute_SRC_LESS);
+      end
+      3'b111 : begin
         _zz_execute_BRANCH_COND_RESULT = (! execute_SRC_LESS);
       end
       default : begin
@@ -4385,14 +4391,14 @@ module VexRiscv (
   assign BranchPlugin_jumpInterface_payload = execute_BRANCH_CALC;
   always @(*) begin
     BranchPlugin_branchExceptionPort_valid = (execute_arbitration_isValid && (execute_BRANCH_DO && execute_BRANCH_CALC[1]));
-    if(when_BranchPlugin_l302) begin
+    if(when_BranchPlugin_l304) begin
       BranchPlugin_branchExceptionPort_valid = 1'b0;
     end
   end
 
   assign BranchPlugin_branchExceptionPort_payload_code = 4'b0000;
   assign BranchPlugin_branchExceptionPort_payload_badAddr = execute_BRANCH_CALC;
-  assign when_BranchPlugin_l302 = 1'b0;
+  assign when_BranchPlugin_l304 = 1'b0;
   assign IBusCachedPlugin_decodePrediction_rsp_wasWrong = BranchPlugin_jumpInterface_valid;
   always @(*) begin
     CsrPlugin_privilege = 2'b11;
@@ -4401,9 +4407,11 @@ module VexRiscv (
     end
   end
 
-  assign _zz_when_CsrPlugin_l965 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_when_CsrPlugin_l965_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_when_CsrPlugin_l965_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign CsrPlugin_misa_base = 2'b01;
+  assign CsrPlugin_misa_extensions = 26'h0000042;
+  assign _zz_when_CsrPlugin_l1302 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l1302_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l1302_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
   assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
@@ -4447,28 +4455,28 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l922 = (! decode_arbitration_isStuck);
-  assign when_CsrPlugin_l922_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l922_2 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l922_3 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l935 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
+  assign when_CsrPlugin_l1259 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l1272 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-  assign when_CsrPlugin_l959 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign when_CsrPlugin_l965 = ((_zz_when_CsrPlugin_l965 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l965_1 = ((_zz_when_CsrPlugin_l965_1 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l965_2 = ((_zz_when_CsrPlugin_l965_2 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1296 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l1302 = ((_zz_when_CsrPlugin_l1302 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1302_1 = ((_zz_when_CsrPlugin_l1302_1 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1302_2 = ((_zz_when_CsrPlugin_l1302_2 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  assign when_CsrPlugin_l993 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l993_1 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l993_2 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l998 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  assign when_CsrPlugin_l1335 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1335_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l1335_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l1340 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
   always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(when_CsrPlugin_l1004) begin
+    if(when_CsrPlugin_l1346) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException) begin
@@ -4476,7 +4484,7 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l1004 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
+  assign when_CsrPlugin_l1346 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
   always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
@@ -4492,6 +4500,7 @@ module VexRiscv (
     end
   end
 
+  assign CsrPlugin_trapCauseEbreakDebug = 1'b0;
   always @(*) begin
     CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
@@ -4514,13 +4523,15 @@ module VexRiscv (
     endcase
   end
 
-  assign when_CsrPlugin_l1032 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign when_CsrPlugin_l1077 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
-  assign switch_CsrPlugin_l1081 = writeBack_INSTRUCTION[29 : 28];
+  assign CsrPlugin_trapEnterDebug = 1'b0;
+  assign when_CsrPlugin_l1390 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1398 = (! CsrPlugin_trapEnterDebug);
+  assign when_CsrPlugin_l1456 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign switch_CsrPlugin_l1460 = writeBack_INSTRUCTION[29 : 28];
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign when_CsrPlugin_l1121 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_WFI));
-  assign when_CsrPlugin_l1123 = (! execute_CsrPlugin_wfiWake);
-  assign when_CsrPlugin_l1129 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
+  assign when_CsrPlugin_l1519 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_WFI));
+  assign when_CsrPlugin_l1521 = (! execute_CsrPlugin_wfiWake);
+  assign when_CsrPlugin_l1527 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
   assign execute_CsrPlugin_blockedBySideEffects = ((|{writeBack_arbitration_isValid,memory_arbitration_isValid}) || 1'b0);
   always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
@@ -4619,18 +4630,18 @@ module VexRiscv (
     if(CsrPlugin_csrMapping_allowCsrSignal) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(when_CsrPlugin_l1315) begin
+    if(when_CsrPlugin_l1725) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if(when_CsrPlugin_l1149) begin
-      if(when_CsrPlugin_l1150) begin
+    if(when_CsrPlugin_l1547) begin
+      if(when_CsrPlugin_l1548) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
@@ -4638,20 +4649,20 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(when_CsrPlugin_l1142) begin
+    if(when_CsrPlugin_l1540) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1157) begin
+    if(when_CsrPlugin_l1555) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(when_CsrPlugin_l1142) begin
+    if(when_CsrPlugin_l1540) begin
       CsrPlugin_selfException_payload_code = 4'b0010;
     end
-    if(when_CsrPlugin_l1157) begin
+    if(when_CsrPlugin_l1555) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -4664,20 +4675,20 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  assign when_CsrPlugin_l1142 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
-  assign when_CsrPlugin_l1149 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
-  assign when_CsrPlugin_l1150 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
-  assign when_CsrPlugin_l1157 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
+  assign when_CsrPlugin_l1540 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
+  assign when_CsrPlugin_l1547 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign when_CsrPlugin_l1548 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1555 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
   always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -4686,9 +4697,9 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
   assign execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
-  assign switch_Misc_l210_2 = execute_INSTRUCTION[13];
+  assign switch_Misc_l232_2 = execute_INSTRUCTION[13];
   always @(*) begin
-    case(switch_Misc_l210_2)
+    case(switch_Misc_l232_2)
       1'b0 : begin
         _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
@@ -4699,8 +4710,8 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
-  assign when_CsrPlugin_l1189 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign when_CsrPlugin_l1193 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
+  assign when_CsrPlugin_l1587 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1591 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
@@ -4763,12 +4774,12 @@ module VexRiscv (
   assign memory_DivPlugin_div_counter_willOverflow = (memory_DivPlugin_div_counter_willOverflowIfInc && memory_DivPlugin_div_counter_willIncrement);
   always @(*) begin
     if(memory_DivPlugin_div_counter_willOverflow) begin
-      memory_DivPlugin_div_counter_valueNext = 6'h0;
+      memory_DivPlugin_div_counter_valueNext = 6'h00;
     end else begin
       memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_memory_DivPlugin_div_counter_valueNext);
     end
     if(memory_DivPlugin_div_counter_willClear) begin
-      memory_DivPlugin_div_counter_valueNext = 6'h0;
+      memory_DivPlugin_div_counter_valueNext = 6'h00;
     end
   end
 
@@ -4792,17 +4803,17 @@ module VexRiscv (
     _zz_memory_DivPlugin_rs1_1[31 : 0] = execute_RS1;
   end
 
-  assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
-  assign externalInterrupt = (|_zz_CsrPlugin_csrMapping_readDataInit_1);
-  assign when_DebugPlugin_l225 = (DebugPlugin_haltIt && (! DebugPlugin_isPipBusy));
+  assign _zz_externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
+  assign externalInterrupt = (|_zz_externalInterrupt);
+  assign when_DebugPlugin_l238 = (DebugPlugin_haltIt && (! DebugPlugin_isPipBusy));
   assign DebugPlugin_allowEBreak = (DebugPlugin_debugUsed && (! DebugPlugin_disableEbreak));
   always @(*) begin
     debug_bus_cmd_ready = 1'b1;
     if(debug_bus_cmd_valid) begin
-      case(switch_DebugPlugin_l267)
+      case(switch_DebugPlugin_l280)
         6'h01 : begin
           if(debug_bus_cmd_payload_wr) begin
-            debug_bus_cmd_ready = IBusCachedPlugin_injectionPort_ready;
+            debug_bus_cmd_ready = DebugPlugin_injectionPort_ready;
           end
         end
         default : begin
@@ -4813,7 +4824,7 @@ module VexRiscv (
 
   always @(*) begin
     debug_bus_rsp_data = DebugPlugin_busReadDataReg;
-    if(when_DebugPlugin_l244) begin
+    if(when_DebugPlugin_l257) begin
       debug_bus_rsp_data[0] = DebugPlugin_resetIt;
       debug_bus_rsp_data[1] = DebugPlugin_haltIt;
       debug_bus_rsp_data[2] = DebugPlugin_isPipBusy;
@@ -4822,14 +4833,14 @@ module VexRiscv (
     end
   end
 
-  assign when_DebugPlugin_l244 = (! _zz_when_DebugPlugin_l244);
+  assign when_DebugPlugin_l257 = (! _zz_when_DebugPlugin_l257);
   always @(*) begin
-    IBusCachedPlugin_injectionPort_valid = 1'b0;
+    DebugPlugin_injectionPort_valid = 1'b0;
     if(debug_bus_cmd_valid) begin
-      case(switch_DebugPlugin_l267)
+      case(switch_DebugPlugin_l280)
         6'h01 : begin
           if(debug_bus_cmd_payload_wr) begin
-            IBusCachedPlugin_injectionPort_valid = 1'b1;
+            DebugPlugin_injectionPort_valid = 1'b1;
           end
         end
         default : begin
@@ -4838,29 +4849,30 @@ module VexRiscv (
     end
   end
 
-  assign IBusCachedPlugin_injectionPort_payload = debug_bus_cmd_payload_data;
-  assign switch_DebugPlugin_l267 = debug_bus_cmd_payload_address[7 : 2];
-  assign when_DebugPlugin_l271 = debug_bus_cmd_payload_data[16];
-  assign when_DebugPlugin_l271_1 = debug_bus_cmd_payload_data[24];
-  assign when_DebugPlugin_l272 = debug_bus_cmd_payload_data[17];
-  assign when_DebugPlugin_l272_1 = debug_bus_cmd_payload_data[25];
-  assign when_DebugPlugin_l273 = debug_bus_cmd_payload_data[25];
-  assign when_DebugPlugin_l274 = debug_bus_cmd_payload_data[25];
-  assign when_DebugPlugin_l275 = debug_bus_cmd_payload_data[18];
-  assign when_DebugPlugin_l275_1 = debug_bus_cmd_payload_data[26];
-  assign when_DebugPlugin_l295 = (execute_arbitration_isValid && execute_DO_EBREAK);
-  assign when_DebugPlugin_l298 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
-  assign when_DebugPlugin_l311 = (DebugPlugin_stepIt && IBusCachedPlugin_incomingInstruction);
+  assign DebugPlugin_injectionPort_payload = debug_bus_cmd_payload_data;
+  assign switch_DebugPlugin_l280 = debug_bus_cmd_payload_address[7 : 2];
+  assign when_DebugPlugin_l284 = debug_bus_cmd_payload_data[16];
+  assign when_DebugPlugin_l284_1 = debug_bus_cmd_payload_data[24];
+  assign when_DebugPlugin_l285 = debug_bus_cmd_payload_data[17];
+  assign when_DebugPlugin_l285_1 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l286 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l287 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l288 = debug_bus_cmd_payload_data[18];
+  assign when_DebugPlugin_l288_1 = debug_bus_cmd_payload_data[26];
+  assign when_DebugPlugin_l308 = (execute_arbitration_isValid && execute_DO_EBREAK);
+  assign when_DebugPlugin_l311 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
+  assign when_DebugPlugin_l324 = (DebugPlugin_stepIt && IBusCachedPlugin_incomingInstruction);
   assign debug_resetOut = DebugPlugin_resetIt_regNext;
-  assign when_DebugPlugin_l331 = (DebugPlugin_haltIt || DebugPlugin_stepIt);
+  assign when_DebugPlugin_l344 = (DebugPlugin_haltIt || DebugPlugin_stepIt);
+  assign when_CfuPlugin_l192 = (! execute_LEGAL_INSTRUCTION);
   assign execute_CfuPlugin_hazard = ({(writeBack_arbitration_isValid && writeBack_HAS_SIDE_EFFECT),(memory_arbitration_isValid && memory_HAS_SIDE_EFFECT)} != 2'b00);
   assign execute_CfuPlugin_scheduleWish = (execute_arbitration_isValid && execute_CfuPlugin_CFU_ENABLE);
   assign execute_CfuPlugin_schedule = (execute_CfuPlugin_scheduleWish && (! execute_CfuPlugin_hazard));
-  assign when_CfuPlugin_l194 = (execute_CfuPlugin_scheduleWish && execute_CfuPlugin_hazard);
+  assign when_CfuPlugin_l196 = (execute_CfuPlugin_scheduleWish && execute_CfuPlugin_hazard);
   assign CfuPlugin_bus_cmd_fire = (CfuPlugin_bus_cmd_valid && CfuPlugin_bus_cmd_ready);
-  assign when_CfuPlugin_l197 = (! execute_arbitration_isStuck);
+  assign when_CfuPlugin_l199 = (! execute_arbitration_isStuck);
   assign CfuPlugin_bus_cmd_valid = ((execute_CfuPlugin_schedule || execute_CfuPlugin_hold) && (! execute_CfuPlugin_fired));
-  assign when_CfuPlugin_l201 = (CfuPlugin_bus_cmd_valid && (! CfuPlugin_bus_cmd_ready));
+  assign when_CfuPlugin_l203 = (CfuPlugin_bus_cmd_valid && (! CfuPlugin_bus_cmd_ready));
   assign execute_CfuPlugin_functionsIds_0 = _zz_execute_CfuPlugin_functionsIds_0;
   assign CfuPlugin_bus_cmd_payload_function_id = execute_CfuPlugin_functionsIds_0;
   assign CfuPlugin_bus_cmd_payload_inputs_0 = execute_RS1;
@@ -4904,9 +4916,9 @@ module VexRiscv (
   end
 
   assign CfuPlugin_bus_cmd_payload_inputs_1 = _zz_CfuPlugin_bus_cmd_payload_inputs_1_2;
-  assign CfuPlugin_bus_rsp_ready = (! CfuPlugin_bus_rsp_rValid);
-  assign memory_CfuPlugin_rsp_valid = (CfuPlugin_bus_rsp_valid || CfuPlugin_bus_rsp_rValid);
-  assign memory_CfuPlugin_rsp_payload_outputs_0 = (CfuPlugin_bus_rsp_rValid ? CfuPlugin_bus_rsp_rData_outputs_0 : CfuPlugin_bus_rsp_payload_outputs_0);
+  assign CfuPlugin_bus_rsp_ready = CfuPlugin_bus_rsp_rValidN;
+  assign memory_CfuPlugin_rsp_valid = (CfuPlugin_bus_rsp_valid || (! CfuPlugin_bus_rsp_rValidN));
+  assign memory_CfuPlugin_rsp_payload_outputs_0 = (CfuPlugin_bus_rsp_rValidN ? CfuPlugin_bus_rsp_payload_outputs_0 : CfuPlugin_bus_rsp_rData_outputs_0);
   always @(*) begin
     memory_CfuPlugin_rsp_ready = 1'b0;
     if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
@@ -4914,7 +4926,7 @@ module VexRiscv (
     end
   end
 
-  assign when_CfuPlugin_l237 = (! memory_CfuPlugin_rsp_valid);
+  assign when_CfuPlugin_l239 = (! memory_CfuPlugin_rsp_valid);
   assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
@@ -4925,94 +4937,95 @@ module VexRiscv (
   assign when_Pipeline_l124_7 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_8 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_9 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_10 = (! execute_arbitration_isStuck);
   assign _zz_decode_to_execute_SRC1_CTRL_1 = decode_SRC1_CTRL;
   assign _zz_decode_SRC1_CTRL = _zz_decode_SRC1_CTRL_1;
-  assign when_Pipeline_l124_10 = (! execute_arbitration_isStuck);
-  assign _zz_execute_SRC1_CTRL = decode_to_execute_SRC1_CTRL;
   assign when_Pipeline_l124_11 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SRC1_CTRL = decode_to_execute_SRC1_CTRL;
   assign when_Pipeline_l124_12 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_13 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_14 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_13 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_14 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_15 = (! writeBack_arbitration_isStuck);
   assign _zz_decode_to_execute_ALU_CTRL_1 = decode_ALU_CTRL;
   assign _zz_decode_ALU_CTRL = _zz_decode_ALU_CTRL_1;
-  assign when_Pipeline_l124_15 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_16 = (! execute_arbitration_isStuck);
   assign _zz_execute_ALU_CTRL = decode_to_execute_ALU_CTRL;
   assign _zz_decode_to_execute_SRC2_CTRL_1 = decode_SRC2_CTRL;
   assign _zz_decode_SRC2_CTRL = _zz_decode_SRC2_CTRL_1;
-  assign when_Pipeline_l124_16 = (! execute_arbitration_isStuck);
-  assign _zz_execute_SRC2_CTRL = decode_to_execute_SRC2_CTRL;
   assign when_Pipeline_l124_17 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_18 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_19 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_20 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SRC2_CTRL = decode_to_execute_SRC2_CTRL;
+  assign when_Pipeline_l124_18 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_19 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_20 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_21 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_22 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_23 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_24 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_25 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_26 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_27 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_28 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_22 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_23 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_24 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_25 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_26 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_27 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_28 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_29 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_30 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_31 = (! execute_arbitration_isStuck);
   assign _zz_decode_to_execute_ALU_BITWISE_CTRL_1 = decode_ALU_BITWISE_CTRL;
   assign _zz_decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL_1;
-  assign when_Pipeline_l124_31 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_32 = (! execute_arbitration_isStuck);
   assign _zz_execute_ALU_BITWISE_CTRL = decode_to_execute_ALU_BITWISE_CTRL;
   assign _zz_decode_to_execute_SHIFT_CTRL_1 = decode_SHIFT_CTRL;
   assign _zz_execute_to_memory_SHIFT_CTRL_1 = execute_SHIFT_CTRL;
   assign _zz_decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL_1;
-  assign when_Pipeline_l124_32 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_33 = (! execute_arbitration_isStuck);
   assign _zz_execute_SHIFT_CTRL = decode_to_execute_SHIFT_CTRL;
-  assign when_Pipeline_l124_33 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_34 = (! memory_arbitration_isStuck);
   assign _zz_memory_SHIFT_CTRL = execute_to_memory_SHIFT_CTRL;
   assign _zz_decode_to_execute_BRANCH_CTRL_1 = decode_BRANCH_CTRL;
   assign _zz_decode_BRANCH_CTRL_1 = _zz_decode_BRANCH_CTRL;
-  assign when_Pipeline_l124_34 = (! execute_arbitration_isStuck);
-  assign _zz_execute_BRANCH_CTRL = decode_to_execute_BRANCH_CTRL;
   assign when_Pipeline_l124_35 = (! execute_arbitration_isStuck);
+  assign _zz_execute_BRANCH_CTRL = decode_to_execute_BRANCH_CTRL;
+  assign when_Pipeline_l124_36 = (! execute_arbitration_isStuck);
   assign _zz_decode_to_execute_ENV_CTRL_1 = decode_ENV_CTRL;
   assign _zz_execute_to_memory_ENV_CTRL_1 = execute_ENV_CTRL;
   assign _zz_memory_to_writeBack_ENV_CTRL_1 = memory_ENV_CTRL;
   assign _zz_decode_ENV_CTRL = _zz_decode_ENV_CTRL_1;
-  assign when_Pipeline_l124_36 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_37 = (! execute_arbitration_isStuck);
   assign _zz_execute_ENV_CTRL = decode_to_execute_ENV_CTRL;
-  assign when_Pipeline_l124_37 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_38 = (! memory_arbitration_isStuck);
   assign _zz_memory_ENV_CTRL = execute_to_memory_ENV_CTRL;
-  assign when_Pipeline_l124_38 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_39 = (! writeBack_arbitration_isStuck);
   assign _zz_writeBack_ENV_CTRL = memory_to_writeBack_ENV_CTRL;
-  assign when_Pipeline_l124_39 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_40 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_41 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_42 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_43 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_44 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_40 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_41 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_42 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_43 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_44 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_45 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_46 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_47 = (! execute_arbitration_isStuck);
   assign _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1 = decode_CfuPlugin_CFU_INPUT_2_KIND;
   assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
-  assign when_Pipeline_l124_47 = (! execute_arbitration_isStuck);
-  assign _zz_execute_CfuPlugin_CFU_INPUT_2_KIND = decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   assign when_Pipeline_l124_48 = (! execute_arbitration_isStuck);
+  assign _zz_execute_CfuPlugin_CFU_INPUT_2_KIND = decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   assign when_Pipeline_l124_49 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_50 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_51 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_52 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_53 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_54 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_55 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_56 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_57 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_58 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_59 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_55 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_56 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_57 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_58 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_59 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_60 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_61 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_62 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_63 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_64 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_65 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_66 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_64 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_65 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_66 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_67 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_68 = (! writeBack_arbitration_isStuck);
   assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
   assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
   assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
@@ -5040,216 +5053,225 @@ module VexRiscv (
   assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
   assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
   always @(*) begin
-    IBusCachedPlugin_injectionPort_ready = 1'b0;
-    case(switch_Fetcher_l365)
+    DebugPlugin_injectionPort_ready = 1'b0;
+    case(IBusCachedPlugin_injector_port_state)
       3'b100 : begin
-        IBusCachedPlugin_injectionPort_ready = 1'b1;
+        DebugPlugin_injectionPort_ready = 1'b1;
       end
       default : begin
       end
     endcase
   end
 
-  assign when_Fetcher_l381 = (! decode_arbitration_isStuck);
-  assign when_CsrPlugin_l1277 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_2 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_3 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_4 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_5 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_6 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_7 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_8 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_9 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_10 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_11 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_12 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_13 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_14 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_15 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_16 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_17 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_18 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_19 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_20 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_21 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_22 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_23 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l391 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l1669 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_8 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_9 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_10 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_11 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_12 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_13 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_14 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_15 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_16 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_17 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_18 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_19 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_20 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_21 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_22 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_23 = (! execute_arbitration_isStuck);
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_1 = 32'h00000000;
     if(execute_CsrPlugin_csr_3264) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_2[12 : 0] = 13'h1000;
-      _zz_CsrPlugin_csrMapping_readDataInit_2[25 : 20] = 6'h20;
+      _zz_CsrPlugin_csrMapping_readDataInit_1[12 : 0] = 13'h1000;
+      _zz_CsrPlugin_csrMapping_readDataInit_1[25 : 20] = 6'h20;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h00000000;
     if(execute_CsrPlugin_csr_3857) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_3[3 : 0] = 4'b1011;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[3 : 0] = 4'b1011;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h00000000;
     if(execute_CsrPlugin_csr_3858) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_4[4 : 0] = 5'h16;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[4 : 0] = 5'h16;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h00000000;
     if(execute_CsrPlugin_csr_3859) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_5[5 : 0] = 6'h21;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[5 : 0] = 6'h21;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h00000000;
     if(execute_CsrPlugin_csr_769) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_6[31 : 30] = CsrPlugin_misa_base;
-      _zz_CsrPlugin_csrMapping_readDataInit_6[25 : 0] = CsrPlugin_misa_extensions;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[31 : 30] = CsrPlugin_misa_base;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[25 : 0] = CsrPlugin_misa_extensions;
     end
   end
 
-  assign switch_CsrPlugin_l723 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
+  assign switch_CsrPlugin_l1031 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h00000000;
     if(execute_CsrPlugin_csr_768) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_7[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_7[3 : 3] = CsrPlugin_mstatus_MIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_7[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[12 : 11] = CsrPlugin_mstatus_MPP;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h00000000;
     if(execute_CsrPlugin_csr_836) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_8[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_8[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_8[3 : 3] = CsrPlugin_mip_MSIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[3 : 3] = CsrPlugin_mip_MSIP;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h00000000;
     if(execute_CsrPlugin_csr_772) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_9[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_9[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_9[3 : 3] = CsrPlugin_mie_MSIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_8[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_8[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_8[3 : 3] = CsrPlugin_mie_MSIE;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_10 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h00000000;
     if(execute_CsrPlugin_csr_773) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_10[31 : 2] = CsrPlugin_mtvec_base;
-      _zz_CsrPlugin_csrMapping_readDataInit_10[1 : 0] = CsrPlugin_mtvec_mode;
+      _zz_CsrPlugin_csrMapping_readDataInit_9[31 : 2] = CsrPlugin_mtvec_base;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_11 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_10 = 32'h00000000;
     if(execute_CsrPlugin_csr_833) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_11[31 : 0] = CsrPlugin_mepc;
+      _zz_CsrPlugin_csrMapping_readDataInit_10[31 : 0] = CsrPlugin_mepc;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_12 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_11 = 32'h00000000;
     if(execute_CsrPlugin_csr_832) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_12[31 : 0] = CsrPlugin_mscratch;
+      _zz_CsrPlugin_csrMapping_readDataInit_11[31 : 0] = CsrPlugin_mscratch;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_13 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_12 = 32'h00000000;
     if(execute_CsrPlugin_csr_834) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_13[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_CsrPlugin_csrMapping_readDataInit_13[3 : 0] = CsrPlugin_mcause_exceptionCode;
+      _zz_CsrPlugin_csrMapping_readDataInit_12[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_CsrPlugin_csrMapping_readDataInit_12[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_14 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_13 = 32'h00000000;
     if(execute_CsrPlugin_csr_835) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_14[31 : 0] = CsrPlugin_mtval;
+      _zz_CsrPlugin_csrMapping_readDataInit_13[31 : 0] = CsrPlugin_mtval;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_15 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_14 = 32'h00000000;
     if(execute_CsrPlugin_csr_2816) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_15[31 : 0] = CsrPlugin_mcycle[31 : 0];
+      _zz_CsrPlugin_csrMapping_readDataInit_14[31 : 0] = CsrPlugin_mcycle[31 : 0];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_16 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_15 = 32'h00000000;
     if(execute_CsrPlugin_csr_2944) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_16[31 : 0] = CsrPlugin_mcycle[63 : 32];
+      _zz_CsrPlugin_csrMapping_readDataInit_15[31 : 0] = CsrPlugin_mcycle[63 : 32];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_17 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_16 = 32'h00000000;
     if(execute_CsrPlugin_csr_2818) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_17[31 : 0] = CsrPlugin_minstret[31 : 0];
+      _zz_CsrPlugin_csrMapping_readDataInit_16[31 : 0] = CsrPlugin_minstret[31 : 0];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_18 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_17 = 32'h00000000;
     if(execute_CsrPlugin_csr_2946) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_18[31 : 0] = CsrPlugin_minstret[63 : 32];
+      _zz_CsrPlugin_csrMapping_readDataInit_17[31 : 0] = CsrPlugin_minstret[63 : 32];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_19 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_18 = 32'h00000000;
     if(execute_CsrPlugin_csr_3072) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_19[31 : 0] = CsrPlugin_mcycle[31 : 0];
+      _zz_CsrPlugin_csrMapping_readDataInit_18[31 : 0] = CsrPlugin_mcycle[31 : 0];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_20 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_19 = 32'h00000000;
     if(execute_CsrPlugin_csr_3200) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_20[31 : 0] = CsrPlugin_mcycle[63 : 32];
+      _zz_CsrPlugin_csrMapping_readDataInit_19[31 : 0] = CsrPlugin_mcycle[63 : 32];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_21 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_20 = 32'h00000000;
     if(execute_CsrPlugin_csr_3074) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_21[31 : 0] = CsrPlugin_minstret[31 : 0];
+      _zz_CsrPlugin_csrMapping_readDataInit_20[31 : 0] = CsrPlugin_minstret[31 : 0];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_22 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_21 = 32'h00000000;
     if(execute_CsrPlugin_csr_3202) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_22[31 : 0] = CsrPlugin_minstret[63 : 32];
+      _zz_CsrPlugin_csrMapping_readDataInit_21[31 : 0] = CsrPlugin_minstret[63 : 32];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_23 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_22 = 32'h00000000;
     if(execute_CsrPlugin_csr_3008) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_23[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
+      _zz_CsrPlugin_csrMapping_readDataInit_22[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_24 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_23 = 32'h00000000;
     if(execute_CsrPlugin_csr_4032) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_24[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_1;
+      _zz_CsrPlugin_csrMapping_readDataInit_23[31 : 0] = _zz_externalInterrupt;
     end
   end
 
-  assign CsrPlugin_csrMapping_readDataInit = (((((_zz_CsrPlugin_csrMapping_readDataInit_2 | _zz_CsrPlugin_csrMapping_readDataInit_3) | (_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5)) | ((_zz_CsrPlugin_csrMapping_readDataInit_25 | _zz_CsrPlugin_csrMapping_readDataInit_6) | (_zz_CsrPlugin_csrMapping_readDataInit_7 | _zz_CsrPlugin_csrMapping_readDataInit_8))) | (((_zz_CsrPlugin_csrMapping_readDataInit_9 | _zz_CsrPlugin_csrMapping_readDataInit_10) | (_zz_CsrPlugin_csrMapping_readDataInit_11 | _zz_CsrPlugin_csrMapping_readDataInit_12)) | ((_zz_CsrPlugin_csrMapping_readDataInit_13 | _zz_CsrPlugin_csrMapping_readDataInit_14) | (_zz_CsrPlugin_csrMapping_readDataInit_15 | _zz_CsrPlugin_csrMapping_readDataInit_16)))) | (((_zz_CsrPlugin_csrMapping_readDataInit_17 | _zz_CsrPlugin_csrMapping_readDataInit_18) | (_zz_CsrPlugin_csrMapping_readDataInit_19 | _zz_CsrPlugin_csrMapping_readDataInit_20)) | ((_zz_CsrPlugin_csrMapping_readDataInit_21 | _zz_CsrPlugin_csrMapping_readDataInit_22) | (_zz_CsrPlugin_csrMapping_readDataInit_23 | _zz_CsrPlugin_csrMapping_readDataInit_24))));
-  assign when_CsrPlugin_l1310 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign when_CsrPlugin_l1315 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign CsrPlugin_csrMapping_readDataInit = (((((_zz_CsrPlugin_csrMapping_readDataInit_1 | _zz_CsrPlugin_csrMapping_readDataInit_2) | (_zz_CsrPlugin_csrMapping_readDataInit_3 | _zz_CsrPlugin_csrMapping_readDataInit_4)) | ((_zz_CsrPlugin_csrMapping_readDataInit_24 | _zz_CsrPlugin_csrMapping_readDataInit_5) | (_zz_CsrPlugin_csrMapping_readDataInit_6 | _zz_CsrPlugin_csrMapping_readDataInit_7))) | (((_zz_CsrPlugin_csrMapping_readDataInit_8 | _zz_CsrPlugin_csrMapping_readDataInit_9) | (_zz_CsrPlugin_csrMapping_readDataInit_10 | _zz_CsrPlugin_csrMapping_readDataInit_11)) | ((_zz_CsrPlugin_csrMapping_readDataInit_12 | _zz_CsrPlugin_csrMapping_readDataInit_13) | (_zz_CsrPlugin_csrMapping_readDataInit_14 | _zz_CsrPlugin_csrMapping_readDataInit_15)))) | (((_zz_CsrPlugin_csrMapping_readDataInit_16 | _zz_CsrPlugin_csrMapping_readDataInit_17) | (_zz_CsrPlugin_csrMapping_readDataInit_18 | _zz_CsrPlugin_csrMapping_readDataInit_19)) | ((_zz_CsrPlugin_csrMapping_readDataInit_20 | _zz_CsrPlugin_csrMapping_readDataInit_21) | (_zz_CsrPlugin_csrMapping_readDataInit_22 | _zz_CsrPlugin_csrMapping_readDataInit_23))));
+  assign when_CsrPlugin_l1702 = ((execute_arbitration_isValid && execute_IS_CSR) && (({execute_CsrPlugin_csrAddress[11 : 2],2'b00} == 12'h3a0) || ({execute_CsrPlugin_csrAddress[11 : 4],4'b0000} == 12'h3b0)));
+  assign _zz_when_CsrPlugin_l1709 = (execute_CsrPlugin_csrAddress & 12'hf60);
+  assign when_CsrPlugin_l1709 = (((execute_arbitration_isValid && execute_IS_CSR) && (5'h03 <= execute_CsrPlugin_csrAddress[4 : 0])) && (((_zz_when_CsrPlugin_l1709 == 12'hb00) || (((_zz_when_CsrPlugin_l1709 == 12'hc00) && (! execute_CsrPlugin_writeInstruction)) && (CsrPlugin_privilege == 2'b11))) || ((execute_CsrPlugin_csrAddress & 12'hfe0) == 12'h320)));
+  always @(*) begin
+    when_CsrPlugin_l1719 = CsrPlugin_csrMapping_doForceFailCsr;
+    if(when_CsrPlugin_l1717) begin
+      when_CsrPlugin_l1719 = 1'b1;
+    end
+  end
+
+  assign when_CsrPlugin_l1717 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1725 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
   assign iBusWishbone_ADR = {_zz_iBusWishbone_ADR_1,_zz_iBusWishbone_ADR};
   assign iBusWishbone_CTI = ((_zz_iBusWishbone_ADR == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
@@ -5275,20 +5297,20 @@ module VexRiscv (
   assign iBus_rsp_valid = _zz_iBus_rsp_valid;
   assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
   assign iBus_rsp_payload_error = 1'b0;
-  assign _zz_dBus_cmd_ready_5 = (dBus_cmd_payload_size == 3'b101);
-  assign _zz_dBus_cmd_ready_1 = dBus_cmd_valid;
-  assign _zz_dBus_cmd_ready_3 = dBus_cmd_payload_wr;
-  assign _zz_dBus_cmd_ready_4 = ((! _zz_dBus_cmd_ready_5) || (_zz_dBus_cmd_ready == 3'b111));
-  assign dBus_cmd_ready = (_zz_dBus_cmd_ready_2 && (_zz_dBus_cmd_ready_3 || _zz_dBus_cmd_ready_4));
-  assign dBusWishbone_ADR = ((_zz_dBus_cmd_ready_5 ? {{dBus_cmd_payload_address[31 : 5],_zz_dBus_cmd_ready},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
-  assign dBusWishbone_CTI = (_zz_dBus_cmd_ready_5 ? (_zz_dBus_cmd_ready_4 ? 3'b111 : 3'b010) : 3'b000);
+  assign _zz_dBusWishbone_ADR_1 = (dBus_cmd_payload_size == 3'b101);
+  assign _zz_dBusWishbone_CYC = dBus_cmd_valid;
+  assign _zz_dBus_cmd_ready_1 = dBus_cmd_payload_wr;
+  assign _zz_dBus_cmd_ready_2 = ((! _zz_dBusWishbone_ADR_1) || (_zz_dBusWishbone_ADR == 3'b111));
+  assign dBus_cmd_ready = (_zz_dBus_cmd_ready && (_zz_dBus_cmd_ready_1 || _zz_dBus_cmd_ready_2));
+  assign dBusWishbone_ADR = ((_zz_dBusWishbone_ADR_1 ? {{dBus_cmd_payload_address[31 : 5],_zz_dBusWishbone_ADR},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2'd2);
+  assign dBusWishbone_CTI = (_zz_dBusWishbone_ADR_1 ? (_zz_dBus_cmd_ready_2 ? 3'b111 : 3'b010) : 3'b000);
   assign dBusWishbone_BTE = 2'b00;
-  assign dBusWishbone_SEL = (_zz_dBus_cmd_ready_3 ? dBus_cmd_payload_mask : 4'b1111);
-  assign dBusWishbone_WE = _zz_dBus_cmd_ready_3;
+  assign dBusWishbone_SEL = (_zz_dBus_cmd_ready_1 ? dBus_cmd_payload_mask : 4'b1111);
+  assign dBusWishbone_WE = _zz_dBus_cmd_ready_1;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_payload_data;
-  assign _zz_dBus_cmd_ready_2 = (_zz_dBus_cmd_ready_1 && dBusWishbone_ACK);
-  assign dBusWishbone_CYC = _zz_dBus_cmd_ready_1;
-  assign dBusWishbone_STB = _zz_dBus_cmd_ready_1;
+  assign _zz_dBus_cmd_ready = (_zz_dBusWishbone_CYC && dBusWishbone_ACK);
+  assign dBusWishbone_CYC = _zz_dBusWishbone_CYC;
+  assign dBusWishbone_STB = _zz_dBusWishbone_CYC;
   assign dBus_rsp_valid = _zz_dBus_rsp_valid;
   assign dBus_rsp_payload_data = dBusWishbone_DAT_MISO_regNext;
   assign dBus_rsp_payload_error = 1'b0;
@@ -5298,29 +5320,27 @@ module VexRiscv (
       IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
-      _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+      _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= 1'b0;
       _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= 32'h0;
-      dataCache_1_io_mem_cmd_rValid <= 1'b0;
-      dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= 32'h0;
-      _zz_7 <= 1'b1;
+      IBusCachedPlugin_rspCounter <= 32'h00000000;
+      toplevel_dataCache_1_io_mem_cmd_rValidN <= 1'b1;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
+      DBusCachedPlugin_rspCounter <= 32'h00000000;
+      _zz_10 <= 1'b1;
       HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
-      CsrPlugin_misa_base <= 2'b01;
-      CsrPlugin_misa_extensions <= 26'h0000042;
       CsrPlugin_mstatus_MIE <= 1'b0;
       CsrPlugin_mstatus_MPIE <= 1'b0;
       CsrPlugin_mstatus_MPP <= 2'b11;
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
-      CsrPlugin_mcycle <= 64'h0;
-      CsrPlugin_minstret <= 64'h0;
+      CsrPlugin_mcycle <= 64'h0000000000000000;
+      CsrPlugin_minstret <= 64'h0000000000000000;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= 1'b0;
@@ -5332,19 +5352,19 @@ module VexRiscv (
       CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
-      memory_DivPlugin_div_counter_value <= 6'h0;
-      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h0;
+      memory_DivPlugin_div_counter_value <= 6'h00;
+      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h00000000;
       execute_CfuPlugin_hold <= 1'b0;
       execute_CfuPlugin_fired <= 1'b0;
-      CfuPlugin_bus_rsp_rValid <= 1'b0;
+      CfuPlugin_bus_rsp_rValidN <= 1'b1;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
-      switch_Fetcher_l365 <= 3'b000;
+      IBusCachedPlugin_injector_port_state <= 3'b000;
       execute_to_memory_CfuPlugin_CFU_IN_FLIGHT <= 1'b0;
       _zz_iBusWishbone_ADR <= 3'b000;
       _zz_iBus_rsp_valid <= 1'b0;
-      _zz_dBus_cmd_ready <= 3'b000;
+      _zz_dBusWishbone_ADR <= 3'b000;
       _zz_dBus_rsp_valid <= 1'b0;
     end else begin
       if(IBusCachedPlugin_fetchPc_correction) begin
@@ -5354,23 +5374,23 @@ module VexRiscv (
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusCachedPlugin_fetchPc_booted <= 1'b1;
-      if(when_Fetcher_l134) begin
+      if(when_Fetcher_l133) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_output_fire_1) begin
+      if(IBusCachedPlugin_fetchPc_output_fire) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b1;
       end
-      if(when_Fetcher_l134_1) begin
+      if(when_Fetcher_l133_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(when_Fetcher_l161) begin
+      if(when_Fetcher_l160) begin
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
       if(IBusCachedPlugin_iBusRsp_flush) begin
-        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= 1'b0;
       end
       if(_zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready) begin
-        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
       if(IBusCachedPlugin_iBusRsp_flush) begin
         _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
@@ -5381,13 +5401,13 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if(when_Fetcher_l332) begin
+      if(when_Fetcher_l331) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(when_Fetcher_l332_1) begin
+      if(when_Fetcher_l331_1) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= IBusCachedPlugin_injector_nextPcCalc_valids_0;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5396,7 +5416,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(when_Fetcher_l332_2) begin
+      if(when_Fetcher_l331_2) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= IBusCachedPlugin_injector_nextPcCalc_valids_1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5405,7 +5425,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(when_Fetcher_l332_3) begin
+      if(when_Fetcher_l331_3) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5414,7 +5434,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if(when_Fetcher_l332_4) begin
+      if(when_Fetcher_l331_4) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= IBusCachedPlugin_injector_nextPcCalc_valids_3;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5424,68 +5444,68 @@ module VexRiscv (
         IBusCachedPlugin_rspCounter <= (IBusCachedPlugin_rspCounter + 32'h00000001);
       end
       if(dataCache_1_io_mem_cmd_valid) begin
-        dataCache_1_io_mem_cmd_rValid <= 1'b1;
+        toplevel_dataCache_1_io_mem_cmd_rValidN <= 1'b0;
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
-        dataCache_1_io_mem_cmd_rValid <= 1'b0;
+      if(toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+        toplevel_dataCache_1_io_mem_cmd_rValidN <= 1'b1;
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
-        dataCache_1_io_mem_cmd_s2mPipe_rValid <= dataCache_1_io_mem_cmd_s2mPipe_valid;
+      if(toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+        toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_valid;
       end
       if(dBus_rsp_valid) begin
         DBusCachedPlugin_rspCounter <= (DBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      _zz_7 <= 1'b0;
+      _zz_10 <= 1'b0;
       HazardSimplePlugin_writeBackBuffer_valid <= HazardSimplePlugin_writeBackWrites_valid;
       CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
       if(writeBack_arbitration_isFiring) begin
         CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
       end
-      if(when_CsrPlugin_l922) begin
+      if(when_CsrPlugin_l1259) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if(when_CsrPlugin_l922_1) begin
+      if(when_CsrPlugin_l1259_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if(when_CsrPlugin_l922_2) begin
+      if(when_CsrPlugin_l1259_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if(when_CsrPlugin_l922_3) begin
+      if(when_CsrPlugin_l1259_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(when_CsrPlugin_l959) begin
-        if(when_CsrPlugin_l965) begin
+      if(when_CsrPlugin_l1296) begin
+        if(when_CsrPlugin_l1302) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_1) begin
+        if(when_CsrPlugin_l1302_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_2) begin
+        if(when_CsrPlugin_l1302_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
       CsrPlugin_lastStageWasWfi <= (writeBack_arbitration_isFiring && (writeBack_ENV_CTRL == EnvCtrlEnum_WFI));
       if(CsrPlugin_pipelineLiberator_active) begin
-        if(when_CsrPlugin_l993) begin
+        if(when_CsrPlugin_l1335) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if(when_CsrPlugin_l993_1) begin
+        if(when_CsrPlugin_l1335_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if(when_CsrPlugin_l993_2) begin
+        if(when_CsrPlugin_l1335_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(when_CsrPlugin_l998) begin
+      if(when_CsrPlugin_l1340) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
@@ -5494,19 +5514,21 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(when_CsrPlugin_l1032) begin
-        case(CsrPlugin_targetPrivilege)
-          2'b11 : begin
-            CsrPlugin_mstatus_MIE <= 1'b0;
-            CsrPlugin_mstatus_MPIE <= CsrPlugin_mstatus_MIE;
-            CsrPlugin_mstatus_MPP <= CsrPlugin_privilege;
-          end
-          default : begin
-          end
-        endcase
+      if(when_CsrPlugin_l1390) begin
+        if(when_CsrPlugin_l1398) begin
+          case(CsrPlugin_targetPrivilege)
+            2'b11 : begin
+              CsrPlugin_mstatus_MIE <= 1'b0;
+              CsrPlugin_mstatus_MPIE <= CsrPlugin_mstatus_MIE;
+              CsrPlugin_mstatus_MPP <= CsrPlugin_privilege;
+            end
+            default : begin
+            end
+          endcase
+        end
       end
-      if(when_CsrPlugin_l1077) begin
-        case(switch_CsrPlugin_l1081)
+      if(when_CsrPlugin_l1456) begin
+        case(switch_CsrPlugin_l1460)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -5516,7 +5538,7 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l965_2,{_zz_when_CsrPlugin_l965_1,_zz_when_CsrPlugin_l965}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l1302_2,{_zz_when_CsrPlugin_l1302_1,_zz_when_CsrPlugin_l1302}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
       if(execute_CfuPlugin_schedule) begin
         execute_CfuPlugin_hold <= 1'b1;
@@ -5527,16 +5549,16 @@ module VexRiscv (
       if(CfuPlugin_bus_cmd_fire) begin
         execute_CfuPlugin_fired <= 1'b1;
       end
-      if(when_CfuPlugin_l197) begin
+      if(when_CfuPlugin_l199) begin
         execute_CfuPlugin_fired <= 1'b0;
       end
       if(CfuPlugin_bus_rsp_valid) begin
-        CfuPlugin_bus_rsp_rValid <= 1'b1;
+        CfuPlugin_bus_rsp_rValidN <= 1'b0;
       end
       if(memory_CfuPlugin_rsp_ready) begin
-        CfuPlugin_bus_rsp_rValid <= 1'b0;
+        CfuPlugin_bus_rsp_rValidN <= 1'b1;
       end
-      if(when_Pipeline_l124_65) begin
+      if(when_Pipeline_l124_66) begin
         execute_to_memory_CfuPlugin_CFU_IN_FLIGHT <= _zz_execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
       end
       if(when_Pipeline_l151) begin
@@ -5557,40 +5579,34 @@ module VexRiscv (
       if(when_Pipeline_l154_2) begin
         writeBack_arbitration_isValid <= memory_arbitration_isValid;
       end
-      case(switch_Fetcher_l365)
+      case(IBusCachedPlugin_injector_port_state)
         3'b000 : begin
-          if(IBusCachedPlugin_injectionPort_valid) begin
-            switch_Fetcher_l365 <= 3'b001;
+          if(DebugPlugin_injectionPort_valid) begin
+            IBusCachedPlugin_injector_port_state <= 3'b001;
           end
         end
         3'b001 : begin
-          switch_Fetcher_l365 <= 3'b010;
+          IBusCachedPlugin_injector_port_state <= 3'b010;
         end
         3'b010 : begin
-          switch_Fetcher_l365 <= 3'b011;
+          IBusCachedPlugin_injector_port_state <= 3'b011;
         end
         3'b011 : begin
-          if(when_Fetcher_l381) begin
-            switch_Fetcher_l365 <= 3'b100;
+          if(when_Fetcher_l391) begin
+            IBusCachedPlugin_injector_port_state <= 3'b100;
           end
         end
         3'b100 : begin
-          switch_Fetcher_l365 <= 3'b000;
+          IBusCachedPlugin_injector_port_state <= 3'b000;
         end
         default : begin
         end
       endcase
-      if(execute_CsrPlugin_csr_769) begin
-        if(execute_CsrPlugin_writeEnable) begin
-          CsrPlugin_misa_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 30];
-          CsrPlugin_misa_extensions <= CsrPlugin_csrMapping_writeDataSignal[25 : 0];
-        end
-      end
       if(execute_CsrPlugin_csr_768) begin
         if(execute_CsrPlugin_writeEnable) begin
           CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
           CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
-          case(switch_CsrPlugin_l723)
+          case(switch_CsrPlugin_l1031)
             2'b11 : begin
               CsrPlugin_mstatus_MPP <= 2'b11;
             end
@@ -5637,13 +5653,13 @@ module VexRiscv (
         end
       end
       _zz_iBus_rsp_valid <= (iBusWishbone_CYC && iBusWishbone_ACK);
-      if((_zz_dBus_cmd_ready_1 && _zz_dBus_cmd_ready_2)) begin
-        _zz_dBus_cmd_ready <= (_zz_dBus_cmd_ready + 3'b001);
-        if(_zz_dBus_cmd_ready_4) begin
-          _zz_dBus_cmd_ready <= 3'b000;
+      if((_zz_dBusWishbone_CYC && _zz_dBus_cmd_ready)) begin
+        _zz_dBusWishbone_ADR <= (_zz_dBusWishbone_ADR + 3'b001);
+        if(_zz_dBus_cmd_ready_2) begin
+          _zz_dBusWishbone_ADR <= 3'b000;
         end
       end
-      _zz_dBus_rsp_valid <= ((_zz_dBus_cmd_ready_1 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
+      _zz_dBus_rsp_valid <= ((_zz_dBusWishbone_CYC && (! dBusWishbone_WE)) && dBusWishbone_ACK);
     end
   end
 
@@ -5657,23 +5673,23 @@ module VexRiscv (
     if(IBusCachedPlugin_iBusRsp_stages_2_input_ready) begin
       IBusCachedPlugin_s2_tightlyCoupledHit <= IBusCachedPlugin_s1_tightlyCoupledHit;
     end
-    if(dataCache_1_io_mem_cmd_ready) begin
-      dataCache_1_io_mem_cmd_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
-      dataCache_1_io_mem_cmd_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
-      dataCache_1_io_mem_cmd_rData_address <= dataCache_1_io_mem_cmd_payload_address;
-      dataCache_1_io_mem_cmd_rData_data <= dataCache_1_io_mem_cmd_payload_data;
-      dataCache_1_io_mem_cmd_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
-      dataCache_1_io_mem_cmd_rData_size <= dataCache_1_io_mem_cmd_payload_size;
-      dataCache_1_io_mem_cmd_rData_last <= dataCache_1_io_mem_cmd_payload_last;
+    if(toplevel_dataCache_1_io_mem_cmd_rValidN) begin
+      toplevel_dataCache_1_io_mem_cmd_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
+      toplevel_dataCache_1_io_mem_cmd_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
+      toplevel_dataCache_1_io_mem_cmd_rData_address <= dataCache_1_io_mem_cmd_payload_address;
+      toplevel_dataCache_1_io_mem_cmd_rData_data <= dataCache_1_io_mem_cmd_payload_data;
+      toplevel_dataCache_1_io_mem_cmd_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
+      toplevel_dataCache_1_io_mem_cmd_rData_size <= dataCache_1_io_mem_cmd_payload_size;
+      toplevel_dataCache_1_io_mem_cmd_rData_last <= dataCache_1_io_mem_cmd_payload_last;
     end
-    if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
-      dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_address <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_data <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_size <= dataCache_1_io_mem_cmd_s2mPipe_payload_size;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_last <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+    if(toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_address <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_data <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_size <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_size;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_last <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_last;
     end
     HazardSimplePlugin_writeBackBuffer_payload_address <= HazardSimplePlugin_writeBackWrites_payload_address;
     HazardSimplePlugin_writeBackBuffer_payload_data <= HazardSimplePlugin_writeBackWrites_payload_data;
@@ -5692,33 +5708,35 @@ module VexRiscv (
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(when_CsrPlugin_l959) begin
-      if(when_CsrPlugin_l965) begin
+    if(when_CsrPlugin_l1296) begin
+      if(when_CsrPlugin_l1302) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l965_1) begin
+      if(when_CsrPlugin_l1302_1) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l965_2) begin
+      if(when_CsrPlugin_l1302_2) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(when_CsrPlugin_l1032) begin
-      case(CsrPlugin_targetPrivilege)
-        2'b11 : begin
-          CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
-          CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
-          CsrPlugin_mepc <= writeBack_PC;
-          if(CsrPlugin_hadException) begin
-            CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
+    if(when_CsrPlugin_l1390) begin
+      if(when_CsrPlugin_l1398) begin
+        case(CsrPlugin_targetPrivilege)
+          2'b11 : begin
+            CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
+            CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
+            CsrPlugin_mepc <= writeBack_PC;
+            if(CsrPlugin_hadException) begin
+              CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
+            end
           end
-        end
-        default : begin
-        end
-      endcase
+          default : begin
+          end
+        endcase
+      end
     end
     if(when_MulDivIterativePlugin_l126) begin
       memory_DivPlugin_div_done <= 1'b1;
@@ -5736,10 +5754,10 @@ module VexRiscv (
       end
     end
     if(when_MulDivIterativePlugin_l162) begin
-      memory_DivPlugin_accumulator <= 65'h0;
+      memory_DivPlugin_accumulator <= 65'h00000000000000000;
       memory_DivPlugin_rs1 <= ((_zz_memory_DivPlugin_rs1 ? (~ _zz_memory_DivPlugin_rs1_1) : _zz_memory_DivPlugin_rs1_1) + _zz_memory_DivPlugin_rs1_2);
       memory_DivPlugin_rs2 <= ((_zz_memory_DivPlugin_rs2 ? (~ execute_RS2) : execute_RS2) + _zz_memory_DivPlugin_rs2_1);
-      memory_DivPlugin_div_needRevert <= ((_zz_memory_DivPlugin_rs1 ^ (_zz_memory_DivPlugin_rs2 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
+      memory_DivPlugin_div_needRevert <= ((_zz_memory_DivPlugin_rs1 ^ (_zz_memory_DivPlugin_rs2 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h00000000) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
     end
     externalInterruptArray_regNext <= externalInterruptArray;
     if(CfuPlugin_bus_rsp_ready) begin
@@ -5749,7 +5767,7 @@ module VexRiscv (
       decode_to_execute_PC <= decode_PC;
     end
     if(when_Pipeline_l124_1) begin
-      execute_to_memory_PC <= _zz_execute_SRC2;
+      execute_to_memory_PC <= _zz_execute_to_memory_PC;
     end
     if(when_Pipeline_l124_2) begin
       memory_to_writeBack_PC <= memory_PC;
@@ -5776,246 +5794,249 @@ module VexRiscv (
       decode_to_execute_MEMORY_FORCE_CONSTISTENCY <= decode_MEMORY_FORCE_CONSTISTENCY;
     end
     if(when_Pipeline_l124_10) begin
-      decode_to_execute_SRC1_CTRL <= _zz_decode_to_execute_SRC1_CTRL;
+      decode_to_execute_LEGAL_INSTRUCTION <= decode_LEGAL_INSTRUCTION;
     end
     if(when_Pipeline_l124_11) begin
-      decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
+      decode_to_execute_SRC1_CTRL <= _zz_decode_to_execute_SRC1_CTRL;
     end
     if(when_Pipeline_l124_12) begin
-      decode_to_execute_MEMORY_ENABLE <= decode_MEMORY_ENABLE;
+      decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
     end
     if(when_Pipeline_l124_13) begin
-      execute_to_memory_MEMORY_ENABLE <= execute_MEMORY_ENABLE;
+      decode_to_execute_MEMORY_ENABLE <= decode_MEMORY_ENABLE;
     end
     if(when_Pipeline_l124_14) begin
-      memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
+      execute_to_memory_MEMORY_ENABLE <= execute_MEMORY_ENABLE;
     end
     if(when_Pipeline_l124_15) begin
-      decode_to_execute_ALU_CTRL <= _zz_decode_to_execute_ALU_CTRL;
+      memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
     end
     if(when_Pipeline_l124_16) begin
-      decode_to_execute_SRC2_CTRL <= _zz_decode_to_execute_SRC2_CTRL;
+      decode_to_execute_ALU_CTRL <= _zz_decode_to_execute_ALU_CTRL;
     end
     if(when_Pipeline_l124_17) begin
-      decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
+      decode_to_execute_SRC2_CTRL <= _zz_decode_to_execute_SRC2_CTRL;
     end
     if(when_Pipeline_l124_18) begin
-      execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
+      decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
     end
     if(when_Pipeline_l124_19) begin
-      memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
+      execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
     end
     if(when_Pipeline_l124_20) begin
-      decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
+      memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
     end
     if(when_Pipeline_l124_21) begin
-      decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
+      decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
     end
     if(when_Pipeline_l124_22) begin
-      execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
+      decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
     end
     if(when_Pipeline_l124_23) begin
-      decode_to_execute_MEMORY_WR <= decode_MEMORY_WR;
+      execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
     end
     if(when_Pipeline_l124_24) begin
-      execute_to_memory_MEMORY_WR <= execute_MEMORY_WR;
+      decode_to_execute_MEMORY_WR <= decode_MEMORY_WR;
     end
     if(when_Pipeline_l124_25) begin
-      memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
+      execute_to_memory_MEMORY_WR <= execute_MEMORY_WR;
     end
     if(when_Pipeline_l124_26) begin
-      decode_to_execute_HAS_SIDE_EFFECT <= decode_HAS_SIDE_EFFECT;
+      memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
     end
     if(when_Pipeline_l124_27) begin
-      execute_to_memory_HAS_SIDE_EFFECT <= execute_HAS_SIDE_EFFECT;
+      decode_to_execute_HAS_SIDE_EFFECT <= decode_HAS_SIDE_EFFECT;
     end
     if(when_Pipeline_l124_28) begin
-      memory_to_writeBack_HAS_SIDE_EFFECT <= memory_HAS_SIDE_EFFECT;
+      execute_to_memory_HAS_SIDE_EFFECT <= execute_HAS_SIDE_EFFECT;
     end
     if(when_Pipeline_l124_29) begin
-      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
+      memory_to_writeBack_HAS_SIDE_EFFECT <= memory_HAS_SIDE_EFFECT;
     end
     if(when_Pipeline_l124_30) begin
-      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
+      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
     end
     if(when_Pipeline_l124_31) begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
+      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
     end
     if(when_Pipeline_l124_32) begin
-      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
     end
     if(when_Pipeline_l124_33) begin
-      execute_to_memory_SHIFT_CTRL <= _zz_execute_to_memory_SHIFT_CTRL;
+      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
     end
     if(when_Pipeline_l124_34) begin
-      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
+      execute_to_memory_SHIFT_CTRL <= _zz_execute_to_memory_SHIFT_CTRL;
     end
     if(when_Pipeline_l124_35) begin
-      decode_to_execute_IS_CSR <= decode_IS_CSR;
+      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
     end
     if(when_Pipeline_l124_36) begin
-      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
+      decode_to_execute_IS_CSR <= decode_IS_CSR;
     end
     if(when_Pipeline_l124_37) begin
-      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
+      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
     end
     if(when_Pipeline_l124_38) begin
-      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
+      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
     end
     if(when_Pipeline_l124_39) begin
-      decode_to_execute_IS_MUL <= decode_IS_MUL;
+      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
     end
     if(when_Pipeline_l124_40) begin
-      execute_to_memory_IS_MUL <= execute_IS_MUL;
+      decode_to_execute_IS_MUL <= decode_IS_MUL;
     end
     if(when_Pipeline_l124_41) begin
-      memory_to_writeBack_IS_MUL <= memory_IS_MUL;
+      execute_to_memory_IS_MUL <= execute_IS_MUL;
     end
     if(when_Pipeline_l124_42) begin
-      decode_to_execute_IS_DIV <= decode_IS_DIV;
+      memory_to_writeBack_IS_MUL <= memory_IS_MUL;
     end
     if(when_Pipeline_l124_43) begin
-      execute_to_memory_IS_DIV <= execute_IS_DIV;
+      decode_to_execute_IS_DIV <= decode_IS_DIV;
     end
     if(when_Pipeline_l124_44) begin
-      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
+      execute_to_memory_IS_DIV <= execute_IS_DIV;
     end
     if(when_Pipeline_l124_45) begin
-      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
+      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
     end
     if(when_Pipeline_l124_46) begin
-      decode_to_execute_CfuPlugin_CFU_ENABLE <= decode_CfuPlugin_CFU_ENABLE;
+      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
     end
     if(when_Pipeline_l124_47) begin
-      decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND <= _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+      decode_to_execute_CfuPlugin_CFU_ENABLE <= decode_CfuPlugin_CFU_ENABLE;
     end
     if(when_Pipeline_l124_48) begin
-      decode_to_execute_RS1 <= decode_RS1;
+      decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND <= _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
     end
     if(when_Pipeline_l124_49) begin
-      decode_to_execute_RS2 <= decode_RS2;
+      decode_to_execute_RS1 <= decode_RS1;
     end
     if(when_Pipeline_l124_50) begin
-      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
+      decode_to_execute_RS2 <= decode_RS2;
     end
     if(when_Pipeline_l124_51) begin
-      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
+      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
     end
     if(when_Pipeline_l124_52) begin
-      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
+      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
     end
     if(when_Pipeline_l124_53) begin
-      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
+      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
     end
     if(when_Pipeline_l124_54) begin
-      decode_to_execute_DO_EBREAK <= decode_DO_EBREAK;
+      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
     end
     if(when_Pipeline_l124_55) begin
-      execute_to_memory_MEMORY_STORE_DATA_RF <= execute_MEMORY_STORE_DATA_RF;
+      decode_to_execute_DO_EBREAK <= decode_DO_EBREAK;
     end
     if(when_Pipeline_l124_56) begin
-      memory_to_writeBack_MEMORY_STORE_DATA_RF <= memory_MEMORY_STORE_DATA_RF;
+      execute_to_memory_MEMORY_STORE_DATA_RF <= execute_MEMORY_STORE_DATA_RF;
     end
     if(when_Pipeline_l124_57) begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_decode_RS2;
+      memory_to_writeBack_MEMORY_STORE_DATA_RF <= memory_MEMORY_STORE_DATA_RF;
     end
     if(when_Pipeline_l124_58) begin
-      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_decode_RS2_1;
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_decode_RS2;
     end
     if(when_Pipeline_l124_59) begin
-      execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_decode_RS2_1;
     end
     if(when_Pipeline_l124_60) begin
-      execute_to_memory_MUL_LL <= execute_MUL_LL;
+      execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
     end
     if(when_Pipeline_l124_61) begin
-      execute_to_memory_MUL_LH <= execute_MUL_LH;
+      execute_to_memory_MUL_LL <= execute_MUL_LL;
     end
     if(when_Pipeline_l124_62) begin
-      execute_to_memory_MUL_HL <= execute_MUL_HL;
+      execute_to_memory_MUL_LH <= execute_MUL_LH;
     end
     if(when_Pipeline_l124_63) begin
-      execute_to_memory_MUL_HH <= execute_MUL_HH;
+      execute_to_memory_MUL_HL <= execute_MUL_HL;
     end
     if(when_Pipeline_l124_64) begin
+      execute_to_memory_MUL_HH <= execute_MUL_HH;
+    end
+    if(when_Pipeline_l124_65) begin
       memory_to_writeBack_MUL_HH <= memory_MUL_HH;
     end
-    if(when_Pipeline_l124_66) begin
+    if(when_Pipeline_l124_67) begin
       memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT <= _zz_memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
     end
-    if(when_Pipeline_l124_67) begin
+    if(when_Pipeline_l124_68) begin
       memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
     end
-    if(when_CsrPlugin_l1277) begin
+    if(when_CsrPlugin_l1669) begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
     end
-    if(when_CsrPlugin_l1277_1) begin
+    if(when_CsrPlugin_l1669_1) begin
       execute_CsrPlugin_csr_3857 <= (decode_INSTRUCTION[31 : 20] == 12'hf11);
     end
-    if(when_CsrPlugin_l1277_2) begin
+    if(when_CsrPlugin_l1669_2) begin
       execute_CsrPlugin_csr_3858 <= (decode_INSTRUCTION[31 : 20] == 12'hf12);
     end
-    if(when_CsrPlugin_l1277_3) begin
+    if(when_CsrPlugin_l1669_3) begin
       execute_CsrPlugin_csr_3859 <= (decode_INSTRUCTION[31 : 20] == 12'hf13);
     end
-    if(when_CsrPlugin_l1277_4) begin
+    if(when_CsrPlugin_l1669_4) begin
       execute_CsrPlugin_csr_3860 <= (decode_INSTRUCTION[31 : 20] == 12'hf14);
     end
-    if(when_CsrPlugin_l1277_5) begin
+    if(when_CsrPlugin_l1669_5) begin
       execute_CsrPlugin_csr_769 <= (decode_INSTRUCTION[31 : 20] == 12'h301);
     end
-    if(when_CsrPlugin_l1277_6) begin
+    if(when_CsrPlugin_l1669_6) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if(when_CsrPlugin_l1277_7) begin
+    if(when_CsrPlugin_l1669_7) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if(when_CsrPlugin_l1277_8) begin
+    if(when_CsrPlugin_l1669_8) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if(when_CsrPlugin_l1277_9) begin
+    if(when_CsrPlugin_l1669_9) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if(when_CsrPlugin_l1277_10) begin
+    if(when_CsrPlugin_l1669_10) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if(when_CsrPlugin_l1277_11) begin
+    if(when_CsrPlugin_l1669_11) begin
       execute_CsrPlugin_csr_832 <= (decode_INSTRUCTION[31 : 20] == 12'h340);
     end
-    if(when_CsrPlugin_l1277_12) begin
+    if(when_CsrPlugin_l1669_12) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if(when_CsrPlugin_l1277_13) begin
+    if(when_CsrPlugin_l1669_13) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if(when_CsrPlugin_l1277_14) begin
+    if(when_CsrPlugin_l1669_14) begin
       execute_CsrPlugin_csr_2816 <= (decode_INSTRUCTION[31 : 20] == 12'hb00);
     end
-    if(when_CsrPlugin_l1277_15) begin
+    if(when_CsrPlugin_l1669_15) begin
       execute_CsrPlugin_csr_2944 <= (decode_INSTRUCTION[31 : 20] == 12'hb80);
     end
-    if(when_CsrPlugin_l1277_16) begin
+    if(when_CsrPlugin_l1669_16) begin
       execute_CsrPlugin_csr_2818 <= (decode_INSTRUCTION[31 : 20] == 12'hb02);
     end
-    if(when_CsrPlugin_l1277_17) begin
+    if(when_CsrPlugin_l1669_17) begin
       execute_CsrPlugin_csr_2946 <= (decode_INSTRUCTION[31 : 20] == 12'hb82);
     end
-    if(when_CsrPlugin_l1277_18) begin
+    if(when_CsrPlugin_l1669_18) begin
       execute_CsrPlugin_csr_3072 <= (decode_INSTRUCTION[31 : 20] == 12'hc00);
     end
-    if(when_CsrPlugin_l1277_19) begin
+    if(when_CsrPlugin_l1669_19) begin
       execute_CsrPlugin_csr_3200 <= (decode_INSTRUCTION[31 : 20] == 12'hc80);
     end
-    if(when_CsrPlugin_l1277_20) begin
+    if(when_CsrPlugin_l1669_20) begin
       execute_CsrPlugin_csr_3074 <= (decode_INSTRUCTION[31 : 20] == 12'hc02);
     end
-    if(when_CsrPlugin_l1277_21) begin
+    if(when_CsrPlugin_l1669_21) begin
       execute_CsrPlugin_csr_3202 <= (decode_INSTRUCTION[31 : 20] == 12'hc82);
     end
-    if(when_CsrPlugin_l1277_22) begin
+    if(when_CsrPlugin_l1669_22) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if(when_CsrPlugin_l1277_23) begin
+    if(when_CsrPlugin_l1669_23) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
     if(execute_CsrPlugin_csr_836) begin
@@ -6026,7 +6047,6 @@ module VexRiscv (
     if(execute_CsrPlugin_csr_773) begin
       if(execute_CsrPlugin_writeEnable) begin
         CsrPlugin_mtvec_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 2];
-        CsrPlugin_mtvec_mode <= CsrPlugin_csrMapping_writeDataSignal[1 : 0];
       end
     end
     if(execute_CsrPlugin_csr_833) begin
@@ -6064,9 +6084,9 @@ module VexRiscv (
     if(writeBack_arbitration_isValid) begin
       DebugPlugin_busReadDataReg <= _zz_decode_RS2_2;
     end
-    _zz_when_DebugPlugin_l244 <= debug_bus_cmd_payload_address[2];
+    _zz_when_DebugPlugin_l257 <= debug_bus_cmd_payload_address[2];
     if(debug_bus_cmd_valid) begin
-      case(switch_DebugPlugin_l267)
+      case(switch_DebugPlugin_l280)
         6'h10 : begin
           if(debug_bus_cmd_payload_wr) begin
             DebugPlugin_hardwareBreakpoints_0_pc <= debug_bus_cmd_payload_data[31 : 1];
@@ -6081,7 +6101,7 @@ module VexRiscv (
         end
       endcase
     end
-    if(when_DebugPlugin_l295) begin
+    if(when_DebugPlugin_l308) begin
       DebugPlugin_busReadDataReg <= execute_PC;
     end
     DebugPlugin_resetIt_regNext <= DebugPlugin_resetIt;
@@ -6099,39 +6119,39 @@ module VexRiscv (
       DebugPlugin_hardwareBreakpoints_0_valid <= 1'b0;
       DebugPlugin_hardwareBreakpoints_1_valid <= 1'b0;
     end else begin
-      if(when_DebugPlugin_l225) begin
+      if(when_DebugPlugin_l238) begin
         DebugPlugin_godmode <= 1'b1;
       end
       if(debug_bus_cmd_valid) begin
         DebugPlugin_debugUsed <= 1'b1;
       end
       if(debug_bus_cmd_valid) begin
-        case(switch_DebugPlugin_l267)
-          6'h0 : begin
+        case(switch_DebugPlugin_l280)
+          6'h00 : begin
             if(debug_bus_cmd_payload_wr) begin
               DebugPlugin_stepIt <= debug_bus_cmd_payload_data[4];
-              if(when_DebugPlugin_l271) begin
+              if(when_DebugPlugin_l284) begin
                 DebugPlugin_resetIt <= 1'b1;
               end
-              if(when_DebugPlugin_l271_1) begin
+              if(when_DebugPlugin_l284_1) begin
                 DebugPlugin_resetIt <= 1'b0;
               end
-              if(when_DebugPlugin_l272) begin
+              if(when_DebugPlugin_l285) begin
                 DebugPlugin_haltIt <= 1'b1;
               end
-              if(when_DebugPlugin_l272_1) begin
+              if(when_DebugPlugin_l285_1) begin
                 DebugPlugin_haltIt <= 1'b0;
               end
-              if(when_DebugPlugin_l273) begin
+              if(when_DebugPlugin_l286) begin
                 DebugPlugin_haltedByBreak <= 1'b0;
               end
-              if(when_DebugPlugin_l274) begin
+              if(when_DebugPlugin_l287) begin
                 DebugPlugin_godmode <= 1'b0;
               end
-              if(when_DebugPlugin_l275) begin
+              if(when_DebugPlugin_l288) begin
                 DebugPlugin_disableEbreak <= 1'b1;
               end
-              if(when_DebugPlugin_l275_1) begin
+              if(when_DebugPlugin_l288_1) begin
                 DebugPlugin_disableEbreak <= 1'b0;
               end
             end
@@ -6150,13 +6170,13 @@ module VexRiscv (
           end
         endcase
       end
-      if(when_DebugPlugin_l295) begin
-        if(when_DebugPlugin_l298) begin
+      if(when_DebugPlugin_l308) begin
+        if(when_DebugPlugin_l311) begin
           DebugPlugin_haltIt <= 1'b1;
           DebugPlugin_haltedByBreak <= 1'b1;
         end
       end
-      if(when_DebugPlugin_l311) begin
+      if(when_DebugPlugin_l324) begin
         if(decode_arbitration_isValid) begin
           DebugPlugin_haltIt <= 1'b1;
         end
@@ -6168,76 +6188,75 @@ module VexRiscv (
 endmodule
 
 module DataCache (
-  input               io_cpu_execute_isValid,
-  input      [31:0]   io_cpu_execute_address,
-  output reg          io_cpu_execute_haltIt,
-  input               io_cpu_execute_args_wr,
-  input      [1:0]    io_cpu_execute_args_size,
-  input               io_cpu_execute_args_totalyConsistent,
-  output              io_cpu_execute_refilling,
-  input               io_cpu_memory_isValid,
-  input               io_cpu_memory_isStuck,
-  output              io_cpu_memory_isWrite,
-  input      [31:0]   io_cpu_memory_address,
-  input      [31:0]   io_cpu_memory_mmuRsp_physicalAddress,
-  input               io_cpu_memory_mmuRsp_isIoAccess,
-  input               io_cpu_memory_mmuRsp_isPaging,
-  input               io_cpu_memory_mmuRsp_allowRead,
-  input               io_cpu_memory_mmuRsp_allowWrite,
-  input               io_cpu_memory_mmuRsp_allowExecute,
-  input               io_cpu_memory_mmuRsp_exception,
-  input               io_cpu_memory_mmuRsp_refilling,
-  input               io_cpu_memory_mmuRsp_bypassTranslation,
-  input               io_cpu_writeBack_isValid,
-  input               io_cpu_writeBack_isStuck,
-  input               io_cpu_writeBack_isFiring,
-  input               io_cpu_writeBack_isUser,
-  output reg          io_cpu_writeBack_haltIt,
-  output              io_cpu_writeBack_isWrite,
-  input      [31:0]   io_cpu_writeBack_storeData,
-  output reg [31:0]   io_cpu_writeBack_data,
-  input      [31:0]   io_cpu_writeBack_address,
-  output              io_cpu_writeBack_mmuException,
-  output              io_cpu_writeBack_unalignedAccess,
-  output reg          io_cpu_writeBack_accessError,
-  output              io_cpu_writeBack_keepMemRspData,
-  input               io_cpu_writeBack_fence_SW,
-  input               io_cpu_writeBack_fence_SR,
-  input               io_cpu_writeBack_fence_SO,
-  input               io_cpu_writeBack_fence_SI,
-  input               io_cpu_writeBack_fence_PW,
-  input               io_cpu_writeBack_fence_PR,
-  input               io_cpu_writeBack_fence_PO,
-  input               io_cpu_writeBack_fence_PI,
-  input      [3:0]    io_cpu_writeBack_fence_FM,
-  output              io_cpu_writeBack_exclusiveOk,
-  output reg          io_cpu_redo,
-  input               io_cpu_flush_valid,
-  output              io_cpu_flush_ready,
-  input               io_cpu_flush_payload_singleLine,
-  input      [6:0]    io_cpu_flush_payload_lineId,
-  output reg          io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output reg          io_mem_cmd_payload_wr,
-  output              io_mem_cmd_payload_uncached,
-  output reg [31:0]   io_mem_cmd_payload_address,
-  output     [31:0]   io_mem_cmd_payload_data,
-  output     [3:0]    io_mem_cmd_payload_mask,
-  output reg [2:0]    io_mem_cmd_payload_size,
-  output              io_mem_cmd_payload_last,
-  input               io_mem_rsp_valid,
-  input               io_mem_rsp_payload_last,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input               clk,
-  input               reset
+  input  wire          io_cpu_execute_isValid,
+  input  wire [31:0]   io_cpu_execute_address,
+  output reg           io_cpu_execute_haltIt,
+  input  wire          io_cpu_execute_args_wr,
+  input  wire [1:0]    io_cpu_execute_args_size,
+  input  wire          io_cpu_execute_args_totalyConsistent,
+  output wire          io_cpu_execute_refilling,
+  input  wire          io_cpu_memory_isValid,
+  input  wire          io_cpu_memory_isStuck,
+  output wire          io_cpu_memory_isWrite,
+  input  wire [31:0]   io_cpu_memory_address,
+  input  wire [31:0]   io_cpu_memory_mmuRsp_physicalAddress,
+  input  wire          io_cpu_memory_mmuRsp_isIoAccess,
+  input  wire          io_cpu_memory_mmuRsp_isPaging,
+  input  wire          io_cpu_memory_mmuRsp_allowRead,
+  input  wire          io_cpu_memory_mmuRsp_allowWrite,
+  input  wire          io_cpu_memory_mmuRsp_allowExecute,
+  input  wire          io_cpu_memory_mmuRsp_exception,
+  input  wire          io_cpu_memory_mmuRsp_refilling,
+  input  wire          io_cpu_memory_mmuRsp_bypassTranslation,
+  input  wire          io_cpu_writeBack_isValid,
+  input  wire          io_cpu_writeBack_isStuck,
+  input  wire          io_cpu_writeBack_isFiring,
+  input  wire          io_cpu_writeBack_isUser,
+  output reg           io_cpu_writeBack_haltIt,
+  output wire          io_cpu_writeBack_isWrite,
+  input  wire [31:0]   io_cpu_writeBack_storeData,
+  output reg  [31:0]   io_cpu_writeBack_data,
+  input  wire [31:0]   io_cpu_writeBack_address,
+  output wire          io_cpu_writeBack_mmuException,
+  output wire          io_cpu_writeBack_unalignedAccess,
+  output reg           io_cpu_writeBack_accessError,
+  output wire          io_cpu_writeBack_keepMemRspData,
+  input  wire          io_cpu_writeBack_fence_SW,
+  input  wire          io_cpu_writeBack_fence_SR,
+  input  wire          io_cpu_writeBack_fence_SO,
+  input  wire          io_cpu_writeBack_fence_SI,
+  input  wire          io_cpu_writeBack_fence_PW,
+  input  wire          io_cpu_writeBack_fence_PR,
+  input  wire          io_cpu_writeBack_fence_PO,
+  input  wire          io_cpu_writeBack_fence_PI,
+  input  wire [3:0]    io_cpu_writeBack_fence_FM,
+  output wire          io_cpu_writeBack_exclusiveOk,
+  output reg           io_cpu_redo,
+  input  wire          io_cpu_flush_valid,
+  output wire          io_cpu_flush_ready,
+  input  wire          io_cpu_flush_payload_singleLine,
+  input  wire [6:0]    io_cpu_flush_payload_lineId,
+  output wire          io_cpu_writesPending,
+  output reg           io_mem_cmd_valid,
+  input  wire          io_mem_cmd_ready,
+  output reg           io_mem_cmd_payload_wr,
+  output wire          io_mem_cmd_payload_uncached,
+  output reg  [31:0]   io_mem_cmd_payload_address,
+  output wire [31:0]   io_mem_cmd_payload_data,
+  output wire [3:0]    io_mem_cmd_payload_mask,
+  output reg  [2:0]    io_mem_cmd_payload_size,
+  output wire          io_mem_cmd_payload_last,
+  input  wire          io_mem_rsp_valid,
+  input  wire          io_mem_rsp_payload_last,
+  input  wire [31:0]   io_mem_rsp_payload_data,
+  input  wire          io_mem_rsp_payload_error,
+  input  wire          clk,
+  input  wire          reset
 );
 
   reg        [21:0]   _zz_ways_0_tags_port0;
   reg        [31:0]   _zz_ways_0_data_port0;
   wire       [21:0]   _zz_ways_0_tags_port;
-  wire       [9:0]    _zz_stage0_dataColisions;
-  wire       [9:0]    _zz__zz_stageA_dataColisions;
   wire       [0:0]    _zz_when;
   wire       [2:0]    _zz_loader_counter_valueNext;
   wire       [0:0]    _zz_loader_counter_valueNext_1;
@@ -6274,40 +6293,40 @@ module DataCache (
   wire                _zz_ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRsp;
-  wire                when_DataCache_l642;
   wire                when_DataCache_l645;
-  wire                when_DataCache_l664;
+  wire                when_DataCache_l648;
+  wire                when_DataCache_l667;
   wire                rspSync;
   wire                rspLast;
   reg                 memCmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_DataCache_l686;
+  wire                when_DataCache_l689;
   reg        [3:0]    _zz_stage0_mask;
   wire       [3:0]    stage0_mask;
   wire       [0:0]    stage0_dataColisions;
   wire       [0:0]    stage0_wayInvalidate;
   wire                stage0_isAmo;
-  wire                when_DataCache_l771;
+  wire                when_DataCache_l776;
   reg                 stageA_request_wr;
   reg        [1:0]    stageA_request_size;
   reg                 stageA_request_totalyConsistent;
-  wire                when_DataCache_l771_1;
+  wire                when_DataCache_l776_1;
   reg        [3:0]    stageA_mask;
   wire                stageA_isAmo;
   wire                stageA_isLrsc;
   wire       [0:0]    stageA_wayHits;
-  wire                when_DataCache_l771_2;
+  wire                when_DataCache_l776_2;
   reg        [0:0]    stageA_wayInvalidate;
-  wire                when_DataCache_l771_3;
+  wire                when_DataCache_l776_3;
   reg        [0:0]    stage0_dataColisions_regNextWhen;
   wire       [0:0]    _zz_stageA_dataColisions;
   wire       [0:0]    stageA_dataColisions;
-  wire                when_DataCache_l822;
+  wire                when_DataCache_l827;
   reg                 stageB_request_wr;
   reg        [1:0]    stageB_request_size;
   reg                 stageB_request_totalyConsistent;
   reg                 stageB_mmuRspFreeze;
-  wire                when_DataCache_l824;
+  wire                when_DataCache_l829;
   reg        [31:0]   stageB_mmuRsp_physicalAddress;
   reg                 stageB_mmuRsp_isIoAccess;
   reg                 stageB_mmuRsp_isPaging;
@@ -6317,52 +6336,54 @@ module DataCache (
   reg                 stageB_mmuRsp_exception;
   reg                 stageB_mmuRsp_refilling;
   reg                 stageB_mmuRsp_bypassTranslation;
-  wire                when_DataCache_l821;
+  wire                when_DataCache_l826;
   reg                 stageB_tagsReadRsp_0_valid;
   reg                 stageB_tagsReadRsp_0_error;
   reg        [19:0]   stageB_tagsReadRsp_0_address;
-  wire                when_DataCache_l821_1;
+  wire                when_DataCache_l826_1;
   reg        [31:0]   stageB_dataReadRsp_0;
-  wire                when_DataCache_l820;
+  wire                when_DataCache_l825;
   reg        [0:0]    stageB_wayInvalidate;
   wire                stageB_consistancyHazard;
-  wire                when_DataCache_l820_1;
+  wire                when_DataCache_l825_1;
   reg        [0:0]    stageB_dataColisions;
-  wire                when_DataCache_l820_2;
+  wire                when_DataCache_l825_2;
   reg                 stageB_unaligned;
-  wire                when_DataCache_l820_3;
+  wire                when_DataCache_l825_3;
   reg        [0:0]    stageB_waysHitsBeforeInvalidate;
   wire       [0:0]    stageB_waysHits;
   wire                stageB_waysHit;
   wire       [31:0]   stageB_dataMux;
-  wire                when_DataCache_l820_4;
+  wire                when_DataCache_l825_4;
   reg        [3:0]    stageB_mask;
   reg                 stageB_loaderValid;
   wire       [31:0]   stageB_ioMemRspMuxed;
   reg                 stageB_flusher_waitDone;
   wire                stageB_flusher_hold;
   reg        [7:0]    stageB_flusher_counter;
-  wire                when_DataCache_l850;
-  wire                when_DataCache_l856;
+  wire                when_DataCache_l855;
+  wire                when_DataCache_l861;
+  wire                when_DataCache_l863;
   reg                 stageB_flusher_start;
+  wire                when_DataCache_l877;
   wire                stageB_isAmo;
   wire                stageB_isAmoCached;
   wire                stageB_isExternalLsrc;
   wire                stageB_isExternalAmo;
   wire       [31:0]   stageB_requestDataBypass;
   reg                 stageB_cpuWriteToCache;
-  wire                when_DataCache_l926;
+  wire                when_DataCache_l931;
   wire                stageB_badPermissions;
   wire                stageB_loadStoreFault;
   wire                stageB_bypassCache;
-  wire                when_DataCache_l995;
-  wire                when_DataCache_l1004;
+  wire                when_DataCache_l1000;
   wire                when_DataCache_l1009;
-  wire                when_DataCache_l1020;
-  wire                when_DataCache_l1032;
-  wire                when_DataCache_l991;
-  wire                when_DataCache_l1066;
-  wire                when_DataCache_l1075;
+  wire                when_DataCache_l1014;
+  wire                when_DataCache_l1025;
+  wire                when_DataCache_l1037;
+  wire                when_DataCache_l996;
+  wire                when_DataCache_l1072;
+  wire                when_DataCache_l1081;
   reg                 loader_valid;
   reg                 loader_counter_willIncrement;
   wire                loader_counter_willClear;
@@ -6374,12 +6395,12 @@ module DataCache (
   reg                 loader_error;
   wire                loader_kill;
   reg                 loader_killReg;
-  wire                when_DataCache_l1090;
+  wire                when_DataCache_l1097;
   wire                loader_done;
-  wire                when_DataCache_l1118;
-  reg                 loader_valid_regNext;
-  wire                when_DataCache_l1122;
   wire                when_DataCache_l1125;
+  reg                 loader_valid_regNext;
+  wire                when_DataCache_l1129;
+  wire                when_DataCache_l1132;
   (* no_rw_check , ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
   (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
   (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
@@ -6390,8 +6411,6 @@ module DataCache (
   reg [7:0] _zz_ways_0_datasymbol_read_2;
   reg [7:0] _zz_ways_0_datasymbol_read_3;
 
-  assign _zz_stage0_dataColisions = (io_cpu_execute_address[11 : 2] >>> 0);
-  assign _zz__zz_stageA_dataColisions = (io_cpu_memory_address[11 : 2] >>> 0);
   assign _zz_when = 1'b1;
   assign _zz_loader_counter_valueNext_1 = loader_counter_willIncrement;
   assign _zz_loader_counter_valueNext = {2'd0, _zz_loader_counter_valueNext_1};
@@ -6438,14 +6457,14 @@ module DataCache (
 
   always @(*) begin
     _zz_1 = 1'b0;
-    if(when_DataCache_l645) begin
+    if(when_DataCache_l648) begin
       _zz_1 = 1'b1;
     end
   end
 
   always @(*) begin
     _zz_2 = 1'b0;
-    if(when_DataCache_l642) begin
+    if(when_DataCache_l645) begin
       _zz_2 = 1'b1;
     end
   end
@@ -6459,43 +6478,45 @@ module DataCache (
   assign _zz_ways_0_dataReadRspMem = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
   assign ways_0_dataReadRspMem = _zz_ways_0_data_port0;
   assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
-  assign when_DataCache_l642 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
-  assign when_DataCache_l645 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
+  assign when_DataCache_l645 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
+  assign when_DataCache_l648 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
   always @(*) begin
     tagsReadCmd_valid = 1'b0;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       tagsReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     tagsReadCmd_payload = 7'bxxxxxxx;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
     end
   end
 
   always @(*) begin
     dataReadCmd_valid = 1'b0;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       dataReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     dataReadCmd_payload = 10'bxxxxxxxxxx;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       dataReadCmd_payload = io_cpu_execute_address[11 : 2];
     end
   end
 
   always @(*) begin
     tagsWriteCmd_valid = 1'b0;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_valid = 1'b1;
     end
-    if(when_DataCache_l1066) begin
-      tagsWriteCmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        tagsWriteCmd_valid = 1'b0;
+      end
     end
     if(loader_done) begin
       tagsWriteCmd_valid = 1'b1;
@@ -6504,7 +6525,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_way = 1'bx;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_payload_way = 1'b1;
     end
     if(loader_done) begin
@@ -6514,7 +6535,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_address = 7'bxxxxxxx;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_payload_address = stageB_flusher_counter[6:0];
     end
     if(loader_done) begin
@@ -6524,7 +6545,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_data_valid = 1'bx;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_payload_data_valid = 1'b0;
     end
     if(loader_done) begin
@@ -6549,14 +6570,16 @@ module DataCache (
   always @(*) begin
     dataWriteCmd_valid = 1'b0;
     if(stageB_cpuWriteToCache) begin
-      if(when_DataCache_l926) begin
+      if(when_DataCache_l931) begin
         dataWriteCmd_valid = 1'b1;
       end
     end
-    if(when_DataCache_l1066) begin
-      dataWriteCmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        dataWriteCmd_valid = 1'b0;
+      end
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_valid = 1'b1;
     end
   end
@@ -6566,7 +6589,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_way = stageB_waysHits;
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_way = loader_waysAllocator;
     end
   end
@@ -6576,7 +6599,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
     end
   end
@@ -6586,7 +6609,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_data = io_mem_rsp_payload_data;
     end
   end
@@ -6599,15 +6622,15 @@ module DataCache (
         dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
       end
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_mask = 4'b1111;
     end
   end
 
-  assign when_DataCache_l664 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  assign when_DataCache_l667 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
   always @(*) begin
     io_cpu_execute_haltIt = 1'b0;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       io_cpu_execute_haltIt = 1'b1;
     end
   end
@@ -6615,7 +6638,7 @@ module DataCache (
   assign rspSync = 1'b1;
   assign rspLast = 1'b1;
   assign io_mem_cmd_fire = (io_mem_cmd_valid && io_mem_cmd_ready);
-  assign when_DataCache_l686 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l689 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     _zz_stage0_mask = 4'bxxxx;
     case(io_cpu_execute_args_size)
@@ -6634,45 +6657,45 @@ module DataCache (
   end
 
   assign stage0_mask = (_zz_stage0_mask <<< io_cpu_execute_address[1 : 0]);
-  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_stage0_dataColisions)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_execute_address[11 : 2])) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stage0_wayInvalidate = 1'b0;
   assign stage0_isAmo = 1'b0;
-  assign when_DataCache_l771 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l771_1 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l776 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l776_1 = (! io_cpu_memory_isStuck);
   assign io_cpu_memory_isWrite = stageA_request_wr;
   assign stageA_isAmo = 1'b0;
   assign stageA_isLrsc = 1'b0;
   assign stageA_wayHits = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign when_DataCache_l771_2 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l771_3 = (! io_cpu_memory_isStuck);
-  assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz__zz_stageA_dataColisions)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign when_DataCache_l776_2 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l776_3 = (! io_cpu_memory_isStuck);
+  assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_memory_address[11 : 2])) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_stageA_dataColisions);
-  assign when_DataCache_l822 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l827 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_mmuRspFreeze = 1'b0;
-    if(when_DataCache_l1125) begin
+    if(when_DataCache_l1132) begin
       stageB_mmuRspFreeze = 1'b1;
     end
   end
 
-  assign when_DataCache_l824 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
-  assign when_DataCache_l821 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l821_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l820 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l829 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
+  assign when_DataCache_l826 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l826_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825 = (! io_cpu_writeBack_isStuck);
   assign stageB_consistancyHazard = 1'b0;
-  assign when_DataCache_l820_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l820_2 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l820_3 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_2 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_3 = (! io_cpu_writeBack_isStuck);
   assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
   assign stageB_waysHit = (|stageB_waysHits);
   assign stageB_dataMux = stageB_dataReadRsp_0;
-  assign when_DataCache_l820_4 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_4 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_loaderValid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
             if(io_mem_cmd_ready) begin
               stageB_loaderValid = 1'b1;
             end
@@ -6680,8 +6703,10 @@ module DataCache (
         end
       end
     end
-    if(when_DataCache_l1066) begin
-      stageB_loaderValid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        stageB_loaderValid = 1'b0;
+      end
     end
   end
 
@@ -6690,28 +6715,32 @@ module DataCache (
     io_cpu_writeBack_haltIt = 1'b1;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l991) begin
-          if(when_DataCache_l995) begin
+        if(when_DataCache_l996) begin
+          if(when_DataCache_l1000) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
         end else begin
-          if(when_DataCache_l1004) begin
-            if(when_DataCache_l1009) begin
+          if(when_DataCache_l1009) begin
+            if(when_DataCache_l1014) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1066) begin
-      io_cpu_writeBack_haltIt = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        io_cpu_writeBack_haltIt = 1'b0;
+      end
     end
   end
 
   assign stageB_flusher_hold = 1'b0;
-  assign when_DataCache_l850 = (! stageB_flusher_counter[7]);
-  assign when_DataCache_l856 = (! stageB_flusher_hold);
+  assign when_DataCache_l855 = (! stageB_flusher_counter[7]);
+  assign when_DataCache_l861 = (! stageB_flusher_hold);
+  assign when_DataCache_l863 = (io_cpu_flush_valid && io_cpu_flush_payload_singleLine);
   assign io_cpu_flush_ready = (stageB_flusher_waitDone && stageB_flusher_counter[7]);
+  assign when_DataCache_l877 = (io_cpu_flush_valid && io_cpu_flush_payload_singleLine);
   assign stageB_isAmo = 1'b0;
   assign stageB_isAmoCached = 1'b0;
   assign stageB_isExternalLsrc = 1'b0;
@@ -6721,8 +6750,8 @@ module DataCache (
     stageB_cpuWriteToCache = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(when_DataCache_l1009) begin
             stageB_cpuWriteToCache = 1'b1;
           end
         end
@@ -6730,26 +6759,28 @@ module DataCache (
     end
   end
 
-  assign when_DataCache_l926 = (stageB_request_wr && stageB_waysHit);
+  assign when_DataCache_l931 = (stageB_request_wr && stageB_waysHit);
   assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_isAmo)));
   assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
   always @(*) begin
     io_cpu_redo = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(when_DataCache_l1004) begin
-            if(when_DataCache_l1020) begin
+        if(!when_DataCache_l996) begin
+          if(when_DataCache_l1009) begin
+            if(when_DataCache_l1025) begin
               io_cpu_redo = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1075) begin
-      io_cpu_redo = 1'b1;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1081) begin
+        io_cpu_redo = 1'b1;
+      end
     end
-    if(when_DataCache_l1122) begin
+    if(when_DataCache_l1129) begin
       io_cpu_redo = 1'b1;
     end
   end
@@ -6770,23 +6801,25 @@ module DataCache (
     io_mem_cmd_valid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l991) begin
+        if(when_DataCache_l996) begin
           io_mem_cmd_valid = (! memCmdSent);
         end else begin
-          if(when_DataCache_l1004) begin
+          if(when_DataCache_l1009) begin
             if(stageB_request_wr) begin
               io_mem_cmd_valid = 1'b1;
             end
           end else begin
-            if(when_DataCache_l1032) begin
+            if(when_DataCache_l1037) begin
               io_mem_cmd_valid = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1066) begin
-      io_mem_cmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        io_mem_cmd_valid = 1'b0;
+      end
     end
   end
 
@@ -6794,9 +6827,9 @@ module DataCache (
     io_mem_cmd_payload_address = stageB_mmuRsp_physicalAddress;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
-            io_mem_cmd_payload_address[4 : 0] = 5'h0;
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
+            io_mem_cmd_payload_address[4 : 0] = 5'h00;
           end
         end
       end
@@ -6808,8 +6841,8 @@ module DataCache (
     io_mem_cmd_payload_wr = stageB_request_wr;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
             io_mem_cmd_payload_wr = 1'b0;
           end
         end
@@ -6824,8 +6857,8 @@ module DataCache (
     io_mem_cmd_payload_size = {1'd0, stageB_request_size};
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
             io_mem_cmd_payload_size = 3'b101;
           end
         end
@@ -6835,12 +6868,12 @@ module DataCache (
 
   assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
   assign io_cpu_writeBack_keepMemRspData = 1'b0;
-  assign when_DataCache_l995 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
-  assign when_DataCache_l1004 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
-  assign when_DataCache_l1009 = ((! stageB_request_wr) || io_mem_cmd_ready);
-  assign when_DataCache_l1020 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
-  assign when_DataCache_l1032 = (! memCmdSent);
-  assign when_DataCache_l991 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  assign when_DataCache_l1000 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
+  assign when_DataCache_l1009 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
+  assign when_DataCache_l1014 = ((! stageB_request_wr) || io_mem_cmd_ready);
+  assign when_DataCache_l1025 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
+  assign when_DataCache_l1037 = (! memCmdSent);
+  assign when_DataCache_l996 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
   always @(*) begin
     if(stageB_bypassCache) begin
       io_cpu_writeBack_data = stageB_ioMemRspMuxed;
@@ -6849,11 +6882,11 @@ module DataCache (
     end
   end
 
-  assign when_DataCache_l1066 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign when_DataCache_l1075 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
+  assign when_DataCache_l1072 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign when_DataCache_l1081 = (stageB_mmuRsp_refilling || stageB_consistancyHazard);
   always @(*) begin
     loader_counter_willIncrement = 1'b0;
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       loader_counter_willIncrement = 1'b1;
     end
   end
@@ -6869,12 +6902,12 @@ module DataCache (
   end
 
   assign loader_kill = 1'b0;
-  assign when_DataCache_l1090 = ((loader_valid && io_mem_rsp_valid) && rspLast);
+  assign when_DataCache_l1097 = ((loader_valid && io_mem_rsp_valid) && rspLast);
   assign loader_done = loader_counter_willOverflow;
-  assign when_DataCache_l1118 = (! loader_valid);
-  assign when_DataCache_l1122 = (loader_valid && (! loader_valid_regNext));
+  assign when_DataCache_l1125 = (! loader_valid);
+  assign when_DataCache_l1129 = (loader_valid && (! loader_valid_regNext));
   assign io_cpu_execute_refilling = loader_valid;
-  assign when_DataCache_l1125 = (stageB_loaderValid || loader_valid);
+  assign when_DataCache_l1132 = (stageB_loaderValid || loader_valid);
   always @(posedge clk) begin
     tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
     tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
@@ -6882,26 +6915,26 @@ module DataCache (
     tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
     tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
     tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if(when_DataCache_l771) begin
+    if(when_DataCache_l776) begin
       stageA_request_wr <= io_cpu_execute_args_wr;
       stageA_request_size <= io_cpu_execute_args_size;
       stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
     end
-    if(when_DataCache_l771_1) begin
+    if(when_DataCache_l776_1) begin
       stageA_mask <= stage0_mask;
     end
-    if(when_DataCache_l771_2) begin
+    if(when_DataCache_l776_2) begin
       stageA_wayInvalidate <= stage0_wayInvalidate;
     end
-    if(when_DataCache_l771_3) begin
+    if(when_DataCache_l776_3) begin
       stage0_dataColisions_regNextWhen <= stage0_dataColisions;
     end
-    if(when_DataCache_l822) begin
+    if(when_DataCache_l827) begin
       stageB_request_wr <= stageA_request_wr;
       stageB_request_size <= stageA_request_size;
       stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
     end
-    if(when_DataCache_l824) begin
+    if(when_DataCache_l829) begin
       stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
       stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
       stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
@@ -6912,27 +6945,27 @@ module DataCache (
       stageB_mmuRsp_refilling <= io_cpu_memory_mmuRsp_refilling;
       stageB_mmuRsp_bypassTranslation <= io_cpu_memory_mmuRsp_bypassTranslation;
     end
-    if(when_DataCache_l821) begin
+    if(when_DataCache_l826) begin
       stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
       stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
       stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
     end
-    if(when_DataCache_l821_1) begin
+    if(when_DataCache_l826_1) begin
       stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
     end
-    if(when_DataCache_l820) begin
+    if(when_DataCache_l825) begin
       stageB_wayInvalidate <= stageA_wayInvalidate;
     end
-    if(when_DataCache_l820_1) begin
+    if(when_DataCache_l825_1) begin
       stageB_dataColisions <= stageA_dataColisions;
     end
-    if(when_DataCache_l820_2) begin
+    if(when_DataCache_l825_2) begin
       stageB_unaligned <= ({((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)),((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0))} != 2'b00);
     end
-    if(when_DataCache_l820_3) begin
+    if(when_DataCache_l825_3) begin
       stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
     end
-    if(when_DataCache_l820_4) begin
+    if(when_DataCache_l825_4) begin
       stageB_mask <= stageA_mask;
     end
     loader_valid_regNext <= loader_valid;
@@ -6942,7 +6975,7 @@ module DataCache (
     if(reset) begin
       memCmdSent <= 1'b0;
       stageB_flusher_waitDone <= 1'b0;
-      stageB_flusher_counter <= 8'h0;
+      stageB_flusher_counter <= 8'h00;
       stageB_flusher_start <= 1'b1;
       loader_valid <= 1'b0;
       loader_counter_value <= 3'b000;
@@ -6953,16 +6986,16 @@ module DataCache (
       if(io_mem_cmd_fire) begin
         memCmdSent <= 1'b1;
       end
-      if(when_DataCache_l686) begin
+      if(when_DataCache_l689) begin
         memCmdSent <= 1'b0;
       end
       if(io_cpu_flush_ready) begin
         stageB_flusher_waitDone <= 1'b0;
       end
-      if(when_DataCache_l850) begin
-        if(when_DataCache_l856) begin
+      if(when_DataCache_l855) begin
+        if(when_DataCache_l861) begin
           stageB_flusher_counter <= (stageB_flusher_counter + 8'h01);
-          if(io_cpu_flush_payload_singleLine) begin
+          if(when_DataCache_l863) begin
             stageB_flusher_counter[7] <= 1'b1;
           end
         end
@@ -6970,17 +7003,17 @@ module DataCache (
       stageB_flusher_start <= (((((((! stageB_flusher_waitDone) && (! stageB_flusher_start)) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
       if(stageB_flusher_start) begin
         stageB_flusher_waitDone <= 1'b1;
-        stageB_flusher_counter <= 8'h0;
-        if(io_cpu_flush_payload_singleLine) begin
+        stageB_flusher_counter <= 8'h00;
+        if(when_DataCache_l877) begin
           stageB_flusher_counter <= {1'b0,io_cpu_flush_payload_lineId};
         end
       end
       `ifndef SYNTHESIS
         `ifdef FORMAL
-          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))); // DataCache.scala:L1077
+          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))); // DataCache.scala:L1084
         `else
           if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-            $display("ERROR writeBack stuck by another plugin is not allowed"); // DataCache.scala:L1077
+            $display("ERROR writeBack stuck by another plugin is not allowed"); // DataCache.scala:L1084
           end
         `endif
       `endif
@@ -6991,7 +7024,7 @@ module DataCache (
       if(loader_kill) begin
         loader_killReg <= 1'b1;
       end
-      if(when_DataCache_l1090) begin
+      if(when_DataCache_l1097) begin
         loader_error <= (loader_error || io_mem_rsp_payload_error);
       end
       if(loader_done) begin
@@ -6999,7 +7032,7 @@ module DataCache (
         loader_error <= 1'b0;
         loader_killReg <= 1'b0;
       end
-      if(when_DataCache_l1118) begin
+      if(when_DataCache_l1125) begin
         loader_waysAllocator <= _zz_loader_waysAllocator[0:0];
       end
     end
@@ -7009,48 +7042,48 @@ module DataCache (
 endmodule
 
 module InstructionCache (
-  input               io_flush,
-  input               io_cpu_prefetch_isValid,
-  output reg          io_cpu_prefetch_haltIt,
-  input      [31:0]   io_cpu_prefetch_pc,
-  input               io_cpu_fetch_isValid,
-  input               io_cpu_fetch_isStuck,
-  input               io_cpu_fetch_isRemoved,
-  input      [31:0]   io_cpu_fetch_pc,
-  output     [31:0]   io_cpu_fetch_data,
-  input      [31:0]   io_cpu_fetch_mmuRsp_physicalAddress,
-  input               io_cpu_fetch_mmuRsp_isIoAccess,
-  input               io_cpu_fetch_mmuRsp_isPaging,
-  input               io_cpu_fetch_mmuRsp_allowRead,
-  input               io_cpu_fetch_mmuRsp_allowWrite,
-  input               io_cpu_fetch_mmuRsp_allowExecute,
-  input               io_cpu_fetch_mmuRsp_exception,
-  input               io_cpu_fetch_mmuRsp_refilling,
-  input               io_cpu_fetch_mmuRsp_bypassTranslation,
-  output     [31:0]   io_cpu_fetch_physicalAddress,
-  input               io_cpu_decode_isValid,
-  input               io_cpu_decode_isStuck,
-  input      [31:0]   io_cpu_decode_pc,
-  output     [31:0]   io_cpu_decode_physicalAddress,
-  output     [31:0]   io_cpu_decode_data,
-  output              io_cpu_decode_cacheMiss,
-  output              io_cpu_decode_error,
-  output              io_cpu_decode_mmuRefilling,
-  output              io_cpu_decode_mmuException,
-  input               io_cpu_decode_isUser,
-  input               io_cpu_fill_valid,
-  input      [31:0]   io_cpu_fill_payload,
-  output              io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output     [31:0]   io_mem_cmd_payload_address,
-  output     [2:0]    io_mem_cmd_payload_size,
-  input               io_mem_rsp_valid,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input      [2:0]    _zz_when_Fetcher_l401,
-  input      [31:0]   _zz_io_cpu_fetch_data_regNextWhen,
-  input               clk,
-  input               reset
+  input  wire          io_flush,
+  input  wire          io_cpu_prefetch_isValid,
+  output reg           io_cpu_prefetch_haltIt,
+  input  wire [31:0]   io_cpu_prefetch_pc,
+  input  wire          io_cpu_fetch_isValid,
+  input  wire          io_cpu_fetch_isStuck,
+  input  wire          io_cpu_fetch_isRemoved,
+  input  wire [31:0]   io_cpu_fetch_pc,
+  output wire [31:0]   io_cpu_fetch_data,
+  input  wire [31:0]   io_cpu_fetch_mmuRsp_physicalAddress,
+  input  wire          io_cpu_fetch_mmuRsp_isIoAccess,
+  input  wire          io_cpu_fetch_mmuRsp_isPaging,
+  input  wire          io_cpu_fetch_mmuRsp_allowRead,
+  input  wire          io_cpu_fetch_mmuRsp_allowWrite,
+  input  wire          io_cpu_fetch_mmuRsp_allowExecute,
+  input  wire          io_cpu_fetch_mmuRsp_exception,
+  input  wire          io_cpu_fetch_mmuRsp_refilling,
+  input  wire          io_cpu_fetch_mmuRsp_bypassTranslation,
+  output wire [31:0]   io_cpu_fetch_physicalAddress,
+  input  wire          io_cpu_decode_isValid,
+  input  wire          io_cpu_decode_isStuck,
+  input  wire [31:0]   io_cpu_decode_pc,
+  output wire [31:0]   io_cpu_decode_physicalAddress,
+  output wire [31:0]   io_cpu_decode_data,
+  output wire          io_cpu_decode_cacheMiss,
+  output wire          io_cpu_decode_error,
+  output wire          io_cpu_decode_mmuRefilling,
+  output wire          io_cpu_decode_mmuException,
+  input  wire          io_cpu_decode_isUser,
+  input  wire          io_cpu_fill_valid,
+  input  wire [31:0]   io_cpu_fill_payload,
+  output wire          io_mem_cmd_valid,
+  input  wire          io_mem_cmd_ready,
+  output wire [31:0]   io_mem_cmd_payload_address,
+  output wire [2:0]    io_mem_cmd_payload_size,
+  input  wire          io_mem_rsp_valid,
+  input  wire [31:0]   io_mem_rsp_payload_data,
+  input  wire          io_mem_rsp_payload_error,
+  input  wire [2:0]    _zz_when_Fetcher_l411,
+  input  wire [31:0]   _zz_io_cpu_fetch_data_regNextWhen,
+  input  wire          clk,
+  input  wire          reset
 );
 
   reg        [31:0]   _zz_banks_0_port1;
@@ -7070,7 +7103,7 @@ module InstructionCache (
   wire                when_InstructionCache_l351;
   reg                 lineLoader_cmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_Utils_l515;
+  wire                when_Utils_l560;
   reg                 lineLoader_wayToAllocate_willIncrement;
   wire                lineLoader_wayToAllocate_willClear;
   wire                lineLoader_wayToAllocate_willOverflowIfInc;
@@ -7116,7 +7149,7 @@ module InstructionCache (
   reg                 decodeStage_hit_valid;
   wire                when_InstructionCache_l459_2;
   reg                 decodeStage_hit_error;
-  wire                when_Fetcher_l401;
+  wire                when_Fetcher_l411;
   (* no_rw_check , ram_style = "block" *) reg [31:0] banks_0 [0:1023];
   (* no_rw_check , ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
 
@@ -7186,12 +7219,12 @@ module InstructionCache (
   assign when_InstructionCache_l351 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
   assign io_mem_cmd_fire = (io_mem_cmd_valid && io_mem_cmd_ready);
   assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
-  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
+  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h00};
   assign io_mem_cmd_payload_size = 3'b101;
-  assign when_Utils_l515 = (! lineLoader_valid);
+  assign when_Utils_l560 = (! lineLoader_valid);
   always @(*) begin
     lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if(when_Utils_l515) begin
+    if(when_Utils_l560) begin
       lineLoader_wayToAllocate_willIncrement = 1'b1;
     end
   end
@@ -7235,7 +7268,7 @@ module InstructionCache (
   assign io_cpu_decode_mmuRefilling = decodeStage_mmuRsp_refilling;
   assign io_cpu_decode_mmuException = (((! decodeStage_mmuRsp_refilling) && decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute)));
   assign io_cpu_decode_physicalAddress = decodeStage_mmuRsp_physicalAddress;
-  assign when_Fetcher_l401 = (_zz_when_Fetcher_l401 != 3'b000);
+  assign when_Fetcher_l411 = (_zz_when_Fetcher_l411 != 3'b000);
   always @(posedge clk) begin
     if(reset) begin
       lineLoader_valid <= 1'b0;
@@ -7283,7 +7316,7 @@ module InstructionCache (
     end
     _zz_when_InstructionCache_l342 <= lineLoader_flushCounter[7];
     if(when_InstructionCache_l351) begin
-      lineLoader_flushCounter <= 8'h0;
+      lineLoader_flushCounter <= 8'h00;
     end
     if(when_InstructionCache_l435) begin
       io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;
@@ -7305,7 +7338,7 @@ module InstructionCache (
     if(when_InstructionCache_l459_2) begin
       decodeStage_hit_error <= fetchStage_hit_error;
     end
-    if(when_Fetcher_l401) begin
+    if(when_Fetcher_l411) begin
       io_cpu_fetch_data_regNextWhen <= _zz_io_cpu_fetch_data_regNextWhen;
     end
   end

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_FullDebug.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_FullDebug.v
@@ -1,46 +1,46 @@
-// Generator : SpinalHDL v1.7.1    git head : 0444bb76ab1d6e19f0ec46bc03c4769776deb7d5
+// Generator : SpinalHDL v1.9.4    git head : 270018552577f3bb8e5339ee2583c9c22d324215
 // Component : VexRiscv
-// Git hash  : 581fcb065adf7ea8b626f939ff51679d4c95872f
+// Git hash  : 63430af99f84cc1d11d58b556debe1cc3f238c67
 
 `timescale 1ns/1ps
 
 module VexRiscv (
-  input      [31:0]   externalResetVector,
-  input               timerInterrupt,
-  input               softwareInterrupt,
-  input      [31:0]   externalInterruptArray,
-  input               debug_bus_cmd_valid,
-  output reg          debug_bus_cmd_ready,
-  input               debug_bus_cmd_payload_wr,
-  input      [7:0]    debug_bus_cmd_payload_address,
-  input      [31:0]   debug_bus_cmd_payload_data,
-  output reg [31:0]   debug_bus_rsp_data,
-  output              debug_resetOut,
-  output reg          iBusWishbone_CYC,
-  output reg          iBusWishbone_STB,
-  input               iBusWishbone_ACK,
-  output              iBusWishbone_WE,
-  output     [29:0]   iBusWishbone_ADR,
-  input      [31:0]   iBusWishbone_DAT_MISO,
-  output     [31:0]   iBusWishbone_DAT_MOSI,
-  output     [3:0]    iBusWishbone_SEL,
-  input               iBusWishbone_ERR,
-  output     [2:0]    iBusWishbone_CTI,
-  output     [1:0]    iBusWishbone_BTE,
-  output              dBusWishbone_CYC,
-  output              dBusWishbone_STB,
-  input               dBusWishbone_ACK,
-  output              dBusWishbone_WE,
-  output     [29:0]   dBusWishbone_ADR,
-  input      [31:0]   dBusWishbone_DAT_MISO,
-  output     [31:0]   dBusWishbone_DAT_MOSI,
-  output     [3:0]    dBusWishbone_SEL,
-  input               dBusWishbone_ERR,
-  output     [2:0]    dBusWishbone_CTI,
-  output     [1:0]    dBusWishbone_BTE,
-  input               clk,
-  input               reset,
-  input               debugReset
+  input  wire [31:0]   externalResetVector,
+  input  wire          timerInterrupt,
+  input  wire          softwareInterrupt,
+  input  wire [31:0]   externalInterruptArray,
+  input  wire          debug_bus_cmd_valid,
+  output reg           debug_bus_cmd_ready,
+  input  wire          debug_bus_cmd_payload_wr,
+  input  wire [7:0]    debug_bus_cmd_payload_address,
+  input  wire [31:0]   debug_bus_cmd_payload_data,
+  output reg  [31:0]   debug_bus_rsp_data,
+  output wire          debug_resetOut,
+  output reg           iBusWishbone_CYC,
+  output reg           iBusWishbone_STB,
+  input  wire          iBusWishbone_ACK,
+  output wire          iBusWishbone_WE,
+  output wire [29:0]   iBusWishbone_ADR,
+  input  wire [31:0]   iBusWishbone_DAT_MISO,
+  output wire [31:0]   iBusWishbone_DAT_MOSI,
+  output wire [3:0]    iBusWishbone_SEL,
+  input  wire          iBusWishbone_ERR,
+  output wire [2:0]    iBusWishbone_CTI,
+  output wire [1:0]    iBusWishbone_BTE,
+  output wire          dBusWishbone_CYC,
+  output wire          dBusWishbone_STB,
+  input  wire          dBusWishbone_ACK,
+  output wire          dBusWishbone_WE,
+  output wire [29:0]   dBusWishbone_ADR,
+  input  wire [31:0]   dBusWishbone_DAT_MISO,
+  output wire [31:0]   dBusWishbone_DAT_MOSI,
+  output wire [3:0]    dBusWishbone_SEL,
+  input  wire          dBusWishbone_ERR,
+  output wire [2:0]    dBusWishbone_CTI,
+  output wire [1:0]    dBusWishbone_BTE,
+  input  wire          clk,
+  input  wire          reset,
+  input  wire          debugReset
 );
   localparam ShiftCtrlEnum_DISABLE_1 = 2'd0;
   localparam ShiftCtrlEnum_SLL_1 = 2'd1;
@@ -99,7 +99,6 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_flush_valid;
   wire                dataCache_1_io_cpu_flush_payload_singleLine;
   wire       [6:0]    dataCache_1_io_cpu_flush_payload_lineId;
-  wire                dataCache_1_io_mem_cmd_ready;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
@@ -127,6 +126,7 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_writeBack_exclusiveOk;
   wire                dataCache_1_io_cpu_flush_ready;
   wire                dataCache_1_io_cpu_redo;
+  wire                dataCache_1_io_cpu_writesPending;
   wire                dataCache_1_io_mem_cmd_valid;
   wire                dataCache_1_io_mem_cmd_payload_wr;
   wire                dataCache_1_io_mem_cmd_payload_uncached;
@@ -138,12 +138,11 @@ module VexRiscv (
   wire       [51:0]   _zz_memory_MUL_LOW;
   wire       [51:0]   _zz_memory_MUL_LOW_1;
   wire       [51:0]   _zz_memory_MUL_LOW_2;
-  wire       [51:0]   _zz_memory_MUL_LOW_3;
-  wire       [32:0]   _zz_memory_MUL_LOW_4;
-  wire       [51:0]   _zz_memory_MUL_LOW_5;
-  wire       [49:0]   _zz_memory_MUL_LOW_6;
-  wire       [51:0]   _zz_memory_MUL_LOW_7;
-  wire       [49:0]   _zz_memory_MUL_LOW_8;
+  wire       [32:0]   _zz_memory_MUL_LOW_3;
+  wire       [51:0]   _zz_memory_MUL_LOW_4;
+  wire       [49:0]   _zz_memory_MUL_LOW_5;
+  wire       [51:0]   _zz_memory_MUL_LOW_6;
+  wire       [49:0]   _zz_memory_MUL_LOW_7;
   wire       [31:0]   _zz_execute_SHIFT_RIGHT;
   wire       [32:0]   _zz_execute_SHIFT_RIGHT_1;
   wire       [32:0]   _zz_execute_SHIFT_RIGHT_2;
@@ -154,19 +153,19 @@ module VexRiscv (
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_2;
   wire                _zz_decode_LEGAL_INSTRUCTION_3;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_4;
-  wire       [13:0]   _zz_decode_LEGAL_INSTRUCTION_5;
+  wire       [12:0]   _zz_decode_LEGAL_INSTRUCTION_5;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_6;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_7;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_8;
   wire                _zz_decode_LEGAL_INSTRUCTION_9;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_10;
-  wire       [7:0]    _zz_decode_LEGAL_INSTRUCTION_11;
+  wire       [6:0]    _zz_decode_LEGAL_INSTRUCTION_11;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_12;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_13;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_14;
   wire                _zz_decode_LEGAL_INSTRUCTION_15;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_16;
-  wire       [1:0]    _zz_decode_LEGAL_INSTRUCTION_17;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_17;
   wire       [3:0]    _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1;
   reg        [31:0]   _zz_IBusCachedPlugin_jump_pcLoad_payload_5;
   wire       [1:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_6;
@@ -213,133 +212,127 @@ module VexRiscv (
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_19;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_20;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_21;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_22;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_23;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_24;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_22;
+  wire       [21:0]   _zz__zz_decode_IS_RS2_SIGNED_23;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_24;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_25;
-  wire       [21:0]   _zz__zz_decode_IS_RS2_SIGNED_26;
-  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_27;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_26;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_27;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_28;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_29;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_30;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_31;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_32;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_33;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_34;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_35;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_36;
-  wire       [18:0]   _zz__zz_decode_IS_RS2_SIGNED_37;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_38;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_39;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_29;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_30;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_31;
+  wire       [18:0]   _zz__zz_decode_IS_RS2_SIGNED_32;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_33;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_34;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_35;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_36;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_37;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_38;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_39;
   wire                _zz__zz_decode_IS_RS2_SIGNED_40;
   wire                _zz__zz_decode_IS_RS2_SIGNED_41;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_42;
+  wire       [14:0]   _zz__zz_decode_IS_RS2_SIGNED_42;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_43;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_44;
-  wire       [15:0]   _zz__zz_decode_IS_RS2_SIGNED_45;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_46;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_44;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_45;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_46;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_47;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_48;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_48;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_49;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_50;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_51;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_52;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_50;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_51;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_52;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_53;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_54;
-  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_55;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_56;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_57;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_58;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_59;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_60;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_54;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_55;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_56;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_57;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_58;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_59;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_60;
   wire                _zz__zz_decode_IS_RS2_SIGNED_61;
-  wire       [12:0]   _zz__zz_decode_IS_RS2_SIGNED_62;
-  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_63;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_62;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_63;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_64;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_65;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_66;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_67;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_68;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_69;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_70;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_71;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_69;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_70;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_71;
   wire                _zz__zz_decode_IS_RS2_SIGNED_72;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_73;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_74;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_75;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_74;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_75;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_76;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_77;
-  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_78;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_79;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_80;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_81;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_82;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_83;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_77;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_78;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_79;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_80;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_81;
+  wire       [10:0]   _zz__zz_decode_IS_RS2_SIGNED_82;
+  wire       [5:0]    _zz__zz_decode_IS_RS2_SIGNED_83;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_84;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_85;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_86;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_87;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_88;
-  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_89;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_90;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_87;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_88;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_89;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_90;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_91;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_92;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_93;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_94;
-  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_95;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_92;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_93;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_94;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_95;
   wire                _zz__zz_decode_IS_RS2_SIGNED_96;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_97;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_98;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_99;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_98;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_99;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_100;
-  wire       [9:0]    _zz__zz_decode_IS_RS2_SIGNED_101;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_101;
   wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_102;
   wire                _zz__zz_decode_IS_RS2_SIGNED_103;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_104;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_105;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_106;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_107;
+  wire       [7:0]    _zz__zz_decode_IS_RS2_SIGNED_105;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_106;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_107;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_108;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_109;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_109;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_110;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_111;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_111;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_112;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_113;
-  wire       [6:0]    _zz__zz_decode_IS_RS2_SIGNED_114;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_115;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_116;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_117;
-  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_118;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_119;
+  wire       [5:0]    _zz__zz_decode_IS_RS2_SIGNED_113;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_114;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_115;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_116;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_117;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_118;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_119;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_120;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_121;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_122;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_123;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_124;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_123;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_124;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_125;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_126;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_127;
-  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_128;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_129;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_126;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_127;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_128;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_129;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_130;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_131;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_132;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_131;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_132;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_133;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_134;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_135;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_136;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_137;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_138;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_134;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_135;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_136;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_137;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_138;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_139;
-  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_140;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_141;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_140;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_141;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_142;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_143;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_144;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_145;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_146;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_147;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_148;
   wire                _zz_RegFilePlugin_regFile_port;
   wire                _zz_decode_RegFilePlugin_rs1Data;
   wire                _zz_RegFilePlugin_regFile_port_1;
@@ -347,14 +340,12 @@ module VexRiscv (
   wire       [0:0]    _zz__zz_execute_REGFILE_WRITE_DATA;
   wire       [2:0]    _zz__zz_execute_SRC1;
   wire       [4:0]    _zz__zz_execute_SRC1_1;
-  wire       [11:0]   _zz__zz_execute_SRC2_3;
+  wire       [11:0]   _zz__zz_execute_SRC2_2;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_1;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_2;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_3;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_4;
-  wire       [31:0]   _zz_execute_SrcPlugin_addSub_5;
-  wire       [31:0]   _zz_execute_SrcPlugin_addSub_6;
   wire       [19:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_2;
   wire       [11:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_4;
   wire       [31:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_6;
@@ -388,7 +379,7 @@ module VexRiscv (
   wire       [0:0]    _zz_memory_DivPlugin_rs1_3;
   wire       [31:0]   _zz_memory_DivPlugin_rs2_1;
   wire       [0:0]    _zz_memory_DivPlugin_rs2_2;
-  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_25;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_24;
   wire       [26:0]   _zz_iBusWishbone_ADR_1;
   wire       [51:0]   memory_MUL_LOW;
   wire       [33:0]   memory_MUL_HH;
@@ -507,7 +498,7 @@ module VexRiscv (
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_execute_SRC2;
+  wire       [31:0]   _zz_execute_to_memory_PC;
   wire       [1:0]    execute_SRC2_CTRL;
   wire       [1:0]    _zz_execute_SRC2_CTRL;
   wire       [1:0]    execute_SRC1_CTRL;
@@ -674,7 +665,7 @@ module VexRiscv (
   reg                 DBusCachedPlugin_exceptionBus_valid;
   reg        [3:0]    DBusCachedPlugin_exceptionBus_payload_code;
   wire       [31:0]   DBusCachedPlugin_exceptionBus_payload_badAddr;
-  reg                 _zz_when_DBusCachedPlugin_l393;
+  reg                 _zz_when_DBusCachedPlugin_l472;
   wire                decodeExceptionPort_valid;
   wire       [3:0]    decodeExceptionPort_payload_code;
   wire       [31:0]   decodeExceptionPort_payload_badAddr;
@@ -687,8 +678,9 @@ module VexRiscv (
   wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
   wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
   wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
-  wire                CsrPlugin_csrMapping_allowCsrSignal;
+  reg                 CsrPlugin_csrMapping_allowCsrSignal;
   wire                CsrPlugin_csrMapping_hazardFree;
+  wire                CsrPlugin_csrMapping_doForceFailCsr;
   reg                 CsrPlugin_inWfi /* verilator public */ ;
   reg                 CsrPlugin_thirdPartyWake;
   reg                 CsrPlugin_jumpInterface_valid;
@@ -707,9 +699,10 @@ module VexRiscv (
   reg                 CsrPlugin_allowInterrupts;
   reg                 CsrPlugin_allowException;
   reg                 CsrPlugin_allowEbreakException;
-  reg                 IBusCachedPlugin_injectionPort_valid;
-  reg                 IBusCachedPlugin_injectionPort_ready;
-  wire       [31:0]   IBusCachedPlugin_injectionPort_payload;
+  wire                CsrPlugin_xretAwayFromMachine;
+  reg                 DebugPlugin_injectionPort_valid;
+  reg                 DebugPlugin_injectionPort_ready;
+  wire       [31:0]   DebugPlugin_injectionPort_payload;
   wire                IBusCachedPlugin_externalFlush;
   wire                IBusCachedPlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
@@ -729,14 +722,13 @@ module VexRiscv (
   reg                 IBusCachedPlugin_fetchPc_pcRegPropagate;
   reg                 IBusCachedPlugin_fetchPc_booted;
   reg                 IBusCachedPlugin_fetchPc_inc;
-  wire                when_Fetcher_l134;
-  wire                IBusCachedPlugin_fetchPc_output_fire_1;
-  wire                when_Fetcher_l134_1;
+  wire                when_Fetcher_l133;
+  wire                when_Fetcher_l133_1;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pc;
   wire                IBusCachedPlugin_fetchPc_redo_valid;
   wire       [31:0]   IBusCachedPlugin_fetchPc_redo_payload;
   reg                 IBusCachedPlugin_fetchPc_flushed;
-  wire                when_Fetcher_l161;
+  wire                when_Fetcher_l160;
   reg                 IBusCachedPlugin_iBusRsp_redoFetch;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_ready;
@@ -764,8 +756,8 @@ module VexRiscv (
   wire                _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready;
   wire                IBusCachedPlugin_iBusRsp_flush;
   wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
-  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
-  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid;
+  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1;
   wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
@@ -778,18 +770,18 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_output_payload_rsp_error;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   wire                IBusCachedPlugin_iBusRsp_output_payload_isRvc;
-  wire                when_Fetcher_l243;
-  wire                when_Fetcher_l323;
+  wire                when_Fetcher_l242;
+  wire                when_Fetcher_l322;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
-  wire                when_Fetcher_l332;
+  wire                when_Fetcher_l331;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
-  wire                when_Fetcher_l332_1;
+  wire                when_Fetcher_l331_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
-  wire                when_Fetcher_l332_2;
+  wire                when_Fetcher_l331_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
-  wire                when_Fetcher_l332_3;
+  wire                when_Fetcher_l331_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                when_Fetcher_l332_4;
+  wire                when_Fetcher_l331_4;
   wire                _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   reg        [18:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1;
   wire                _zz_2;
@@ -815,69 +807,70 @@ module VexRiscv (
   wire                IBusCachedPlugin_rsp_iBusRspOutputHalt;
   wire                IBusCachedPlugin_rsp_issueDetected;
   reg                 IBusCachedPlugin_rsp_redoFetch;
-  wire                when_IBusCachedPlugin_l239;
-  wire                when_IBusCachedPlugin_l244;
+  wire                when_IBusCachedPlugin_l245;
   wire                when_IBusCachedPlugin_l250;
   wire                when_IBusCachedPlugin_l256;
-  wire                when_IBusCachedPlugin_l267;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_valid;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_ready;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_address;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_data;
-  wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_size;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_last;
-  reg                 dataCache_1_io_mem_cmd_rValid;
-  reg                 dataCache_1_io_mem_cmd_rData_wr;
-  reg                 dataCache_1_io_mem_cmd_rData_uncached;
-  reg        [31:0]   dataCache_1_io_mem_cmd_rData_address;
-  reg        [31:0]   dataCache_1_io_mem_cmd_rData_data;
-  reg        [3:0]    dataCache_1_io_mem_cmd_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_rData_size;
-  reg                 dataCache_1_io_mem_cmd_rData_last;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
-  wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data;
-  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
-  wire                when_Stream_l368;
+  wire                when_IBusCachedPlugin_l262;
+  wire                when_IBusCachedPlugin_l273;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_valid;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+  wire       [3:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+  wire       [2:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_size;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rValidN;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rData_wr;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rData_uncached;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_rData_address;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_rData_data;
+  reg        [3:0]    toplevel_dataCache_1_io_mem_cmd_rData_mask;
+  reg        [2:0]    toplevel_dataCache_1_io_mem_cmd_rData_size;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rData_last;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
+  wire       [3:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
+  wire       [2:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_address;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_data;
+  reg        [3:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
+  reg        [2:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_size;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  wire                when_Stream_l369;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
-  wire                when_DBusCachedPlugin_l308;
+  wire                when_DBusCachedPlugin_l352;
   wire       [1:0]    execute_DBusCachedPlugin_size;
   reg        [31:0]   _zz_execute_MEMORY_STORE_DATA_RF;
-  wire                dataCache_1_io_cpu_flush_isStall;
-  wire                when_DBusCachedPlugin_l350;
-  wire                when_DBusCachedPlugin_l366;
-  wire                when_DBusCachedPlugin_l393;
-  wire                when_DBusCachedPlugin_l446;
-  wire                when_DBusCachedPlugin_l466;
+  wire                toplevel_dataCache_1_io_cpu_flush_isStall;
+  wire                when_DBusCachedPlugin_l394;
+  wire                when_DBusCachedPlugin_l410;
+  wire                when_DBusCachedPlugin_l472;
+  wire                when_DBusCachedPlugin_l533;
+  wire                when_DBusCachedPlugin_l553;
+  wire       [31:0]   writeBack_DBusCachedPlugin_rspData;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_0;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_1;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_2;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
   wire       [31:0]   writeBack_DBusCachedPlugin_rspRf;
-  wire       [1:0]    switch_Misc_l210;
+  wire       [1:0]    switch_Misc_l232;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_1;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated_2;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
-  wire                when_DBusCachedPlugin_l492;
+  wire                when_DBusCachedPlugin_l580;
   wire       [32:0]   _zz_decode_IS_RS2_SIGNED;
   wire                _zz_decode_IS_RS2_SIGNED_1;
   wire                _zz_decode_IS_RS2_SIGNED_2;
@@ -899,15 +892,15 @@ module VexRiscv (
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
   reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
   reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_7;
+  reg                 _zz_10;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
   reg        [31:0]   _zz_execute_REGFILE_WRITE_DATA;
   reg        [31:0]   _zz_execute_SRC1;
-  wire                _zz_execute_SRC2_1;
-  reg        [19:0]   _zz_execute_SRC2_2;
-  wire                _zz_execute_SRC2_3;
-  reg        [19:0]   _zz_execute_SRC2_4;
-  reg        [31:0]   _zz_execute_SRC2_5;
+  wire                _zz_execute_SRC2;
+  reg        [19:0]   _zz_execute_SRC2_1;
+  wire                _zz_execute_SRC2_2;
+  reg        [19:0]   _zz_execute_SRC2_3;
+  reg        [31:0]   _zz_execute_SRC2_4;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   wire       [4:0]    execute_FullBarrelShifterPlugin_amplitude;
@@ -944,7 +937,7 @@ module VexRiscv (
   wire                when_HazardSimplePlugin_l108;
   wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    switch_Misc_l210_1;
+  wire       [2:0]    switch_Misc_l232_1;
   reg                 _zz_execute_BRANCH_COND_RESULT;
   reg                 _zz_execute_BRANCH_COND_RESULT_1;
   wire                _zz_execute_BranchPlugin_missAlignedTarget;
@@ -964,8 +957,8 @@ module VexRiscv (
   wire                _zz_execute_BranchPlugin_branch_src2_4;
   reg        [18:0]   _zz_execute_BranchPlugin_branch_src2_5;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
-  reg        [1:0]    CsrPlugin_misa_base;
-  reg        [25:0]   CsrPlugin_misa_extensions;
+  wire       [1:0]    CsrPlugin_misa_base;
+  wire       [25:0]   CsrPlugin_misa_extensions;
   reg        [1:0]    CsrPlugin_mtvec_mode;
   reg        [29:0]   CsrPlugin_mtvec_base;
   reg        [31:0]   CsrPlugin_mepc;
@@ -984,9 +977,9 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_mtval;
   reg        [63:0]   CsrPlugin_mcycle;
   reg        [63:0]   CsrPlugin_minstret;
-  wire                _zz_when_CsrPlugin_l965;
-  wire                _zz_when_CsrPlugin_l965_1;
-  wire                _zz_when_CsrPlugin_l965_2;
+  wire                _zz_when_CsrPlugin_l1302;
+  wire                _zz_when_CsrPlugin_l1302_1;
+  wire                _zz_when_CsrPlugin_l1302_2;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -1001,59 +994,62 @@ module VexRiscv (
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
   wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code;
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
-  wire                when_CsrPlugin_l922;
-  wire                when_CsrPlugin_l922_1;
-  wire                when_CsrPlugin_l922_2;
-  wire                when_CsrPlugin_l922_3;
-  wire                when_CsrPlugin_l935;
+  wire                when_CsrPlugin_l1259;
+  wire                when_CsrPlugin_l1259_1;
+  wire                when_CsrPlugin_l1259_2;
+  wire                when_CsrPlugin_l1259_3;
+  wire                when_CsrPlugin_l1272;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
-  wire                when_CsrPlugin_l959;
-  wire                when_CsrPlugin_l965;
-  wire                when_CsrPlugin_l965_1;
-  wire                when_CsrPlugin_l965_2;
+  wire                when_CsrPlugin_l1296;
+  wire                when_CsrPlugin_l1302;
+  wire                when_CsrPlugin_l1302_1;
+  wire                when_CsrPlugin_l1302_2;
   wire                CsrPlugin_exception;
   reg                 CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
-  wire                when_CsrPlugin_l993;
-  wire                when_CsrPlugin_l993_1;
-  wire                when_CsrPlugin_l993_2;
-  wire                when_CsrPlugin_l998;
+  wire                when_CsrPlugin_l1335;
+  wire                when_CsrPlugin_l1335_1;
+  wire                when_CsrPlugin_l1335_2;
+  wire                when_CsrPlugin_l1340;
   reg                 CsrPlugin_pipelineLiberator_done;
-  wire                when_CsrPlugin_l1004;
+  wire                when_CsrPlugin_l1346;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
+  wire                CsrPlugin_trapCauseEbreakDebug;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
-  wire                when_CsrPlugin_l1032;
-  wire                when_CsrPlugin_l1077;
-  wire       [1:0]    switch_CsrPlugin_l1081;
+  wire                CsrPlugin_trapEnterDebug;
+  wire                when_CsrPlugin_l1390;
+  wire                when_CsrPlugin_l1398;
+  wire                when_CsrPlugin_l1456;
+  wire       [1:0]    switch_CsrPlugin_l1460;
   reg                 execute_CsrPlugin_wfiWake;
-  wire                when_CsrPlugin_l1121;
-  wire                when_CsrPlugin_l1123;
-  wire                when_CsrPlugin_l1129;
+  wire                when_CsrPlugin_l1519;
+  wire                when_CsrPlugin_l1521;
+  wire                when_CsrPlugin_l1527;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire                when_CsrPlugin_l1142;
-  wire                when_CsrPlugin_l1149;
-  wire                when_CsrPlugin_l1150;
-  wire                when_CsrPlugin_l1157;
+  wire                when_CsrPlugin_l1540;
+  wire                when_CsrPlugin_l1547;
+  wire                when_CsrPlugin_l1548;
+  wire                when_CsrPlugin_l1555;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   wire       [31:0]   execute_CsrPlugin_readToWriteData;
-  wire                switch_Misc_l210_2;
+  wire                switch_Misc_l232_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
-  wire                when_CsrPlugin_l1189;
-  wire                when_CsrPlugin_l1193;
+  wire                when_CsrPlugin_l1587;
+  wire                when_CsrPlugin_l1591;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg                 execute_MulPlugin_aSigned;
   reg                 execute_MulPlugin_bSigned;
@@ -1100,7 +1096,7 @@ module VexRiscv (
   reg        [32:0]   _zz_memory_DivPlugin_rs1_1;
   reg        [31:0]   externalInterruptArray_regNext;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit;
-  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
+  wire       [31:0]   _zz_externalInterrupt;
   reg                 DebugPlugin_firstCycle;
   reg                 DebugPlugin_secondCycle;
   reg                 DebugPlugin_resetIt;
@@ -1108,7 +1104,7 @@ module VexRiscv (
   reg                 DebugPlugin_stepIt;
   reg                 DebugPlugin_isPipBusy;
   reg                 DebugPlugin_godmode;
-  wire                when_DebugPlugin_l225;
+  wire                when_DebugPlugin_l238;
   reg                 DebugPlugin_haltedByBreak;
   reg                 DebugPlugin_debugUsed /* verilator public */ ;
   reg                 DebugPlugin_disableEbreak;
@@ -1118,22 +1114,22 @@ module VexRiscv (
   reg                 DebugPlugin_hardwareBreakpoints_1_valid;
   reg        [30:0]   DebugPlugin_hardwareBreakpoints_1_pc;
   reg        [31:0]   DebugPlugin_busReadDataReg;
-  reg                 _zz_when_DebugPlugin_l244;
-  wire                when_DebugPlugin_l244;
-  wire       [5:0]    switch_DebugPlugin_l267;
-  wire                when_DebugPlugin_l271;
-  wire                when_DebugPlugin_l271_1;
-  wire                when_DebugPlugin_l272;
-  wire                when_DebugPlugin_l272_1;
-  wire                when_DebugPlugin_l273;
-  wire                when_DebugPlugin_l274;
-  wire                when_DebugPlugin_l275;
-  wire                when_DebugPlugin_l275_1;
-  wire                when_DebugPlugin_l295;
-  wire                when_DebugPlugin_l298;
+  reg                 _zz_when_DebugPlugin_l257;
+  wire                when_DebugPlugin_l257;
+  wire       [5:0]    switch_DebugPlugin_l280;
+  wire                when_DebugPlugin_l284;
+  wire                when_DebugPlugin_l284_1;
+  wire                when_DebugPlugin_l285;
+  wire                when_DebugPlugin_l285_1;
+  wire                when_DebugPlugin_l286;
+  wire                when_DebugPlugin_l287;
+  wire                when_DebugPlugin_l288;
+  wire                when_DebugPlugin_l288_1;
+  wire                when_DebugPlugin_l308;
   wire                when_DebugPlugin_l311;
+  wire                when_DebugPlugin_l324;
   reg                 DebugPlugin_resetIt_regNext;
-  wire                when_DebugPlugin_l331;
+  wire                when_DebugPlugin_l344;
   wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
   wire                when_Pipeline_l124_1;
@@ -1266,62 +1262,63 @@ module VexRiscv (
   wire                when_Pipeline_l154_1;
   wire                when_Pipeline_l151_2;
   wire                when_Pipeline_l154_2;
-  reg        [2:0]    switch_Fetcher_l365;
-  wire                when_Fetcher_l381;
-  wire                when_CsrPlugin_l1277;
+  reg        [2:0]    IBusCachedPlugin_injector_port_state;
+  wire                when_Fetcher_l391;
+  wire                when_CsrPlugin_l1669;
   reg                 execute_CsrPlugin_csr_3264;
-  wire                when_CsrPlugin_l1277_1;
+  wire                when_CsrPlugin_l1669_1;
   reg                 execute_CsrPlugin_csr_3857;
-  wire                when_CsrPlugin_l1277_2;
+  wire                when_CsrPlugin_l1669_2;
   reg                 execute_CsrPlugin_csr_3858;
-  wire                when_CsrPlugin_l1277_3;
+  wire                when_CsrPlugin_l1669_3;
   reg                 execute_CsrPlugin_csr_3859;
-  wire                when_CsrPlugin_l1277_4;
+  wire                when_CsrPlugin_l1669_4;
   reg                 execute_CsrPlugin_csr_3860;
-  wire                when_CsrPlugin_l1277_5;
+  wire                when_CsrPlugin_l1669_5;
   reg                 execute_CsrPlugin_csr_769;
-  wire                when_CsrPlugin_l1277_6;
+  wire                when_CsrPlugin_l1669_6;
   reg                 execute_CsrPlugin_csr_768;
-  wire                when_CsrPlugin_l1277_7;
+  wire                when_CsrPlugin_l1669_7;
   reg                 execute_CsrPlugin_csr_836;
-  wire                when_CsrPlugin_l1277_8;
+  wire                when_CsrPlugin_l1669_8;
   reg                 execute_CsrPlugin_csr_772;
-  wire                when_CsrPlugin_l1277_9;
+  wire                when_CsrPlugin_l1669_9;
   reg                 execute_CsrPlugin_csr_773;
-  wire                when_CsrPlugin_l1277_10;
+  wire                when_CsrPlugin_l1669_10;
   reg                 execute_CsrPlugin_csr_833;
-  wire                when_CsrPlugin_l1277_11;
+  wire                when_CsrPlugin_l1669_11;
   reg                 execute_CsrPlugin_csr_832;
-  wire                when_CsrPlugin_l1277_12;
+  wire                when_CsrPlugin_l1669_12;
   reg                 execute_CsrPlugin_csr_834;
-  wire                when_CsrPlugin_l1277_13;
+  wire                when_CsrPlugin_l1669_13;
   reg                 execute_CsrPlugin_csr_835;
-  wire                when_CsrPlugin_l1277_14;
+  wire                when_CsrPlugin_l1669_14;
   reg                 execute_CsrPlugin_csr_2816;
-  wire                when_CsrPlugin_l1277_15;
+  wire                when_CsrPlugin_l1669_15;
   reg                 execute_CsrPlugin_csr_2944;
-  wire                when_CsrPlugin_l1277_16;
+  wire                when_CsrPlugin_l1669_16;
   reg                 execute_CsrPlugin_csr_2818;
-  wire                when_CsrPlugin_l1277_17;
+  wire                when_CsrPlugin_l1669_17;
   reg                 execute_CsrPlugin_csr_2946;
-  wire                when_CsrPlugin_l1277_18;
+  wire                when_CsrPlugin_l1669_18;
   reg                 execute_CsrPlugin_csr_3072;
-  wire                when_CsrPlugin_l1277_19;
+  wire                when_CsrPlugin_l1669_19;
   reg                 execute_CsrPlugin_csr_3200;
-  wire                when_CsrPlugin_l1277_20;
+  wire                when_CsrPlugin_l1669_20;
   reg                 execute_CsrPlugin_csr_3074;
-  wire                when_CsrPlugin_l1277_21;
+  wire                when_CsrPlugin_l1669_21;
   reg                 execute_CsrPlugin_csr_3202;
-  wire                when_CsrPlugin_l1277_22;
+  wire                when_CsrPlugin_l1669_22;
   reg                 execute_CsrPlugin_csr_3008;
-  wire                when_CsrPlugin_l1277_23;
+  wire                when_CsrPlugin_l1669_23;
   reg                 execute_CsrPlugin_csr_4032;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_5;
+  wire       [1:0]    switch_CsrPlugin_l1031;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_6;
-  wire       [1:0]    switch_CsrPlugin_l723;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_8;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
@@ -1339,19 +1336,22 @@ module VexRiscv (
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_21;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_22;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_23;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_24;
-  wire                when_CsrPlugin_l1310;
-  wire                when_CsrPlugin_l1315;
+  wire                when_CsrPlugin_l1702;
+  wire       [11:0]   _zz_when_CsrPlugin_l1709;
+  wire                when_CsrPlugin_l1709;
+  reg                 when_CsrPlugin_l1719;
+  wire                when_CsrPlugin_l1717;
+  wire                when_CsrPlugin_l1725;
   reg        [2:0]    _zz_iBusWishbone_ADR;
   wire                when_InstructionCache_l239;
   reg                 _zz_iBus_rsp_valid;
   reg        [31:0]   iBusWishbone_DAT_MISO_regNext;
-  reg        [2:0]    _zz_dBus_cmd_ready;
+  reg        [2:0]    _zz_dBusWishbone_ADR;
+  wire                _zz_dBusWishbone_CYC;
+  wire                _zz_dBus_cmd_ready;
   wire                _zz_dBus_cmd_ready_1;
   wire                _zz_dBus_cmd_ready_2;
-  wire                _zz_dBus_cmd_ready_3;
-  wire                _zz_dBus_cmd_ready_4;
-  wire                _zz_dBus_cmd_ready_5;
+  wire                _zz_dBusWishbone_ADR_1;
   reg                 _zz_dBus_rsp_valid;
   reg        [31:0]   dBusWishbone_DAT_MISO_regNext;
   `ifndef SYNTHESIS
@@ -1438,20 +1438,19 @@ module VexRiscv (
   (* no_rw_check , ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
   assign _zz_when = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
-  assign _zz_memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW_1) + $signed(_zz_memory_MUL_LOW_5));
-  assign _zz_memory_MUL_LOW_1 = ($signed(_zz_memory_MUL_LOW_2) + $signed(_zz_memory_MUL_LOW_3));
-  assign _zz_memory_MUL_LOW_2 = 52'h0;
-  assign _zz_memory_MUL_LOW_4 = {1'b0,memory_MUL_LL};
-  assign _zz_memory_MUL_LOW_3 = {{19{_zz_memory_MUL_LOW_4[32]}}, _zz_memory_MUL_LOW_4};
-  assign _zz_memory_MUL_LOW_6 = ({16'd0,memory_MUL_LH} <<< 16);
-  assign _zz_memory_MUL_LOW_5 = {{2{_zz_memory_MUL_LOW_6[49]}}, _zz_memory_MUL_LOW_6};
-  assign _zz_memory_MUL_LOW_8 = ({16'd0,memory_MUL_HL} <<< 16);
-  assign _zz_memory_MUL_LOW_7 = {{2{_zz_memory_MUL_LOW_8[49]}}, _zz_memory_MUL_LOW_8};
+  assign _zz_memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW_1) + $signed(_zz_memory_MUL_LOW_4));
+  assign _zz_memory_MUL_LOW_1 = ($signed(52'h0000000000000) + $signed(_zz_memory_MUL_LOW_2));
+  assign _zz_memory_MUL_LOW_3 = {1'b0,memory_MUL_LL};
+  assign _zz_memory_MUL_LOW_2 = {{19{_zz_memory_MUL_LOW_3[32]}}, _zz_memory_MUL_LOW_3};
+  assign _zz_memory_MUL_LOW_5 = ({16'd0,memory_MUL_LH} <<< 5'd16);
+  assign _zz_memory_MUL_LOW_4 = {{2{_zz_memory_MUL_LOW_5[49]}}, _zz_memory_MUL_LOW_5};
+  assign _zz_memory_MUL_LOW_7 = ({16'd0,memory_MUL_HL} <<< 5'd16);
+  assign _zz_memory_MUL_LOW_6 = {{2{_zz_memory_MUL_LOW_7[49]}}, _zz_memory_MUL_LOW_7};
   assign _zz_execute_SHIFT_RIGHT_1 = ($signed(_zz_execute_SHIFT_RIGHT_2) >>> execute_FullBarrelShifterPlugin_amplitude);
   assign _zz_execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT_1[31 : 0];
   assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == ShiftCtrlEnum_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
-  assign _zz_decode_DO_EBREAK = (decode_PC >>> 1);
-  assign _zz_decode_DO_EBREAK_1 = (decode_PC >>> 1);
+  assign _zz_decode_DO_EBREAK = (decode_PC >>> 1'd1);
+  assign _zz_decode_DO_EBREAK_1 = (decode_PC >>> 1'd1);
   assign _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload - 4'b0001);
   assign _zz_IBusCachedPlugin_fetchPc_pc_1 = {IBusCachedPlugin_fetchPc_inc,2'b00};
   assign _zz_IBusCachedPlugin_fetchPc_pc = {29'd0, _zz_IBusCachedPlugin_fetchPc_pc_1};
@@ -1464,20 +1463,18 @@ module VexRiscv (
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
   assign _zz_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId_1;
-  assign _zz_io_cpu_flush_payload_lineId_1 = (execute_RS1 >>> 5);
+  assign _zz_io_cpu_flush_payload_lineId_1 = (execute_RS1 >>> 3'd5);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code_1 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
   assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
   assign _zz__zz_execute_SRC1 = 3'b100;
   assign _zz__zz_execute_SRC1_1 = execute_INSTRUCTION[19 : 15];
-  assign _zz__zz_execute_SRC2_3 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz__zz_execute_SRC2_2 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
   assign _zz_execute_SrcPlugin_addSub = ($signed(_zz_execute_SrcPlugin_addSub_1) + $signed(_zz_execute_SrcPlugin_addSub_4));
   assign _zz_execute_SrcPlugin_addSub_1 = ($signed(_zz_execute_SrcPlugin_addSub_2) + $signed(_zz_execute_SrcPlugin_addSub_3));
   assign _zz_execute_SrcPlugin_addSub_2 = execute_SRC1;
   assign _zz_execute_SrcPlugin_addSub_3 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? _zz_execute_SrcPlugin_addSub_5 : _zz_execute_SrcPlugin_addSub_6);
-  assign _zz_execute_SrcPlugin_addSub_5 = 32'h00000001;
-  assign _zz_execute_SrcPlugin_addSub_6 = 32'h0;
+  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? 32'h00000001 : 32'h00000000);
   assign _zz__zz_execute_BranchPlugin_missAlignedTarget_2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
   assign _zz__zz_execute_BranchPlugin_missAlignedTarget_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
   assign _zz__zz_execute_BranchPlugin_missAlignedTarget_6 = {_zz_execute_BranchPlugin_missAlignedTarget_1,execute_INSTRUCTION[31 : 20]};
@@ -1489,7 +1486,7 @@ module VexRiscv (
   assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code & (~ _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1));
   assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code - 2'b01);
   assign _zz_writeBack_MulPlugin_result = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
-  assign _zz_writeBack_MulPlugin_result_1 = ({32'd0,writeBack_MUL_HH} <<< 32);
+  assign _zz_writeBack_MulPlugin_result_1 = ({32'd0,writeBack_MUL_HH} <<< 6'd32);
   assign _zz__zz_decode_RS2_2 = writeBack_MUL_LOW[31 : 0];
   assign _zz__zz_decode_RS2_2_1 = writeBack_MulPlugin_result[63 : 32];
   assign _zz_memory_DivPlugin_div_counter_valueNext_1 = memory_DivPlugin_div_counter_willIncrement;
@@ -1507,30 +1504,30 @@ module VexRiscv (
   assign _zz_memory_DivPlugin_rs1_2 = {32'd0, _zz_memory_DivPlugin_rs1_3};
   assign _zz_memory_DivPlugin_rs2_2 = _zz_memory_DivPlugin_rs2;
   assign _zz_memory_DivPlugin_rs2_1 = {31'd0, _zz_memory_DivPlugin_rs2_2};
-  assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 5);
+  assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 3'd5);
   assign _zz_decode_RegFilePlugin_rs1Data = 1'b1;
   assign _zz_decode_RegFilePlugin_rs2Data = 1'b1;
   assign _zz_IBusCachedPlugin_jump_pcLoad_payload_6 = {_zz_IBusCachedPlugin_jump_pcLoad_payload_4,_zz_IBusCachedPlugin_jump_pcLoad_payload_3};
   assign _zz_writeBack_DBusCachedPlugin_rspShifted_1 = dataCache_1_io_cpu_writeBack_address[1 : 0];
   assign _zz_writeBack_DBusCachedPlugin_rspShifted_3 = dataCache_1_io_cpu_writeBack_address[1 : 1];
-  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000107f;
-  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00002073;
-  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000207f;
+  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000407f);
+  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00004063;
+  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000107f) == 32'h00000013);
   assign _zz_decode_LEGAL_INSTRUCTION_5 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_6) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_7 == _zz_decode_LEGAL_INSTRUCTION_8),{_zz_decode_LEGAL_INSTRUCTION_9,{_zz_decode_LEGAL_INSTRUCTION_10,_zz_decode_LEGAL_INSTRUCTION_11}}}}}};
   assign _zz_decode_LEGAL_INSTRUCTION_6 = 32'h0000505f;
   assign _zz_decode_LEGAL_INSTRUCTION_7 = (decode_INSTRUCTION & 32'h0000707b);
   assign _zz_decode_LEGAL_INSTRUCTION_8 = 32'h00000063;
   assign _zz_decode_LEGAL_INSTRUCTION_9 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
   assign _zz_decode_LEGAL_INSTRUCTION_10 = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
-  assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h00001013),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,{_zz_decode_LEGAL_INSTRUCTION_16,_zz_decode_LEGAL_INSTRUCTION_17}}}}}};
-  assign _zz_decode_LEGAL_INSTRUCTION_12 = 32'hfc00307f;
+  assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & 32'hbe00705f) == 32'h00005013),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h00001013),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,{_zz_decode_LEGAL_INSTRUCTION_16,_zz_decode_LEGAL_INSTRUCTION_17}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_12 = 32'hfe00305f;
   assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'hbe00707f);
-  assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h00005033;
-  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
-  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
-  assign _zz_decode_LEGAL_INSTRUCTION_17 = {((decode_INSTRUCTION & 32'hffefffff) == 32'h00000073),((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073)};
+  assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h00000033;
+  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
+  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hffefffff) == 32'h00000073);
+  assign _zz_decode_LEGAL_INSTRUCTION_17 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073);
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_4 = decode_INSTRUCTION[31];
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_5 = decode_INSTRUCTION[31];
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_6 = decode_INSTRUCTION[7];
@@ -1538,7 +1535,7 @@ module VexRiscv (
   assign _zz__zz_decode_IS_RS2_SIGNED_1 = ((decode_INSTRUCTION & 32'h02004074) == 32'h02000030);
   assign _zz__zz_decode_IS_RS2_SIGNED_2 = (|{(_zz__zz_decode_IS_RS2_SIGNED_3 == _zz__zz_decode_IS_RS2_SIGNED_4),(_zz__zz_decode_IS_RS2_SIGNED_5 == _zz__zz_decode_IS_RS2_SIGNED_6)});
   assign _zz__zz_decode_IS_RS2_SIGNED_7 = (|(_zz__zz_decode_IS_RS2_SIGNED_8 == _zz__zz_decode_IS_RS2_SIGNED_9));
-  assign _zz__zz_decode_IS_RS2_SIGNED_10 = {(|{_zz__zz_decode_IS_RS2_SIGNED_11,_zz__zz_decode_IS_RS2_SIGNED_13}),{(|_zz__zz_decode_IS_RS2_SIGNED_15),{_zz__zz_decode_IS_RS2_SIGNED_18,{_zz__zz_decode_IS_RS2_SIGNED_21,_zz__zz_decode_IS_RS2_SIGNED_26}}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_10 = {(|{_zz__zz_decode_IS_RS2_SIGNED_11,_zz__zz_decode_IS_RS2_SIGNED_13}),{(|_zz__zz_decode_IS_RS2_SIGNED_15),{_zz__zz_decode_IS_RS2_SIGNED_18,{_zz__zz_decode_IS_RS2_SIGNED_21,_zz__zz_decode_IS_RS2_SIGNED_23}}}};
   assign _zz__zz_decode_IS_RS2_SIGNED_3 = (decode_INSTRUCTION & 32'h10203050);
   assign _zz__zz_decode_IS_RS2_SIGNED_4 = 32'h10000050;
   assign _zz__zz_decode_IS_RS2_SIGNED_5 = (decode_INSTRUCTION & 32'h10103050);
@@ -1549,144 +1546,138 @@ module VexRiscv (
   assign _zz__zz_decode_IS_RS2_SIGNED_13 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_14) == 32'h00002050);
   assign _zz__zz_decode_IS_RS2_SIGNED_15 = {_zz_decode_IS_RS2_SIGNED_4,(_zz__zz_decode_IS_RS2_SIGNED_16 == _zz__zz_decode_IS_RS2_SIGNED_17)};
   assign _zz__zz_decode_IS_RS2_SIGNED_18 = (|(_zz__zz_decode_IS_RS2_SIGNED_19 == _zz__zz_decode_IS_RS2_SIGNED_20));
-  assign _zz__zz_decode_IS_RS2_SIGNED_21 = (|{_zz__zz_decode_IS_RS2_SIGNED_22,_zz__zz_decode_IS_RS2_SIGNED_24});
-  assign _zz__zz_decode_IS_RS2_SIGNED_26 = {(|_zz__zz_decode_IS_RS2_SIGNED_27),{_zz__zz_decode_IS_RS2_SIGNED_32,{_zz__zz_decode_IS_RS2_SIGNED_35,_zz__zz_decode_IS_RS2_SIGNED_37}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_21 = (|_zz__zz_decode_IS_RS2_SIGNED_22);
+  assign _zz__zz_decode_IS_RS2_SIGNED_23 = {(|_zz__zz_decode_IS_RS2_SIGNED_24),{_zz__zz_decode_IS_RS2_SIGNED_27,{_zz__zz_decode_IS_RS2_SIGNED_29,_zz__zz_decode_IS_RS2_SIGNED_32}}};
   assign _zz__zz_decode_IS_RS2_SIGNED_12 = 32'h00001050;
   assign _zz__zz_decode_IS_RS2_SIGNED_14 = 32'h00002050;
   assign _zz__zz_decode_IS_RS2_SIGNED_16 = (decode_INSTRUCTION & 32'h0000001c);
   assign _zz__zz_decode_IS_RS2_SIGNED_17 = 32'h00000004;
   assign _zz__zz_decode_IS_RS2_SIGNED_19 = (decode_INSTRUCTION & 32'h00000058);
   assign _zz__zz_decode_IS_RS2_SIGNED_20 = 32'h00000040;
-  assign _zz__zz_decode_IS_RS2_SIGNED_22 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_23) == 32'h00005010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_24 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_25) == 32'h00005020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_27 = {(_zz__zz_decode_IS_RS2_SIGNED_28 == _zz__zz_decode_IS_RS2_SIGNED_29),{_zz__zz_decode_IS_RS2_SIGNED_30,_zz__zz_decode_IS_RS2_SIGNED_31}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_32 = (|(_zz__zz_decode_IS_RS2_SIGNED_33 == _zz__zz_decode_IS_RS2_SIGNED_34));
-  assign _zz__zz_decode_IS_RS2_SIGNED_35 = (|_zz__zz_decode_IS_RS2_SIGNED_36);
-  assign _zz__zz_decode_IS_RS2_SIGNED_37 = {(|_zz__zz_decode_IS_RS2_SIGNED_38),{_zz__zz_decode_IS_RS2_SIGNED_40,{_zz__zz_decode_IS_RS2_SIGNED_43,_zz__zz_decode_IS_RS2_SIGNED_45}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_23 = 32'h00007034;
-  assign _zz__zz_decode_IS_RS2_SIGNED_25 = 32'h02007064;
-  assign _zz__zz_decode_IS_RS2_SIGNED_28 = (decode_INSTRUCTION & 32'h40003054);
-  assign _zz__zz_decode_IS_RS2_SIGNED_29 = 32'h40001010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_30 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00001010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_31 = ((decode_INSTRUCTION & 32'h02007054) == 32'h00001010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_33 = (decode_INSTRUCTION & 32'h00000064);
-  assign _zz__zz_decode_IS_RS2_SIGNED_34 = 32'h00000024;
-  assign _zz__zz_decode_IS_RS2_SIGNED_36 = ((decode_INSTRUCTION & 32'h00001000) == 32'h00001000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_38 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_39) == 32'h00002000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_40 = (|{_zz__zz_decode_IS_RS2_SIGNED_41,_zz__zz_decode_IS_RS2_SIGNED_42});
-  assign _zz__zz_decode_IS_RS2_SIGNED_43 = (|_zz__zz_decode_IS_RS2_SIGNED_44);
-  assign _zz__zz_decode_IS_RS2_SIGNED_45 = {(|_zz__zz_decode_IS_RS2_SIGNED_46),{_zz__zz_decode_IS_RS2_SIGNED_51,{_zz__zz_decode_IS_RS2_SIGNED_60,_zz__zz_decode_IS_RS2_SIGNED_62}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_39 = 32'h00003000;
-  assign _zz__zz_decode_IS_RS2_SIGNED_41 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_42 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00001000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_44 = ((decode_INSTRUCTION & 32'h00004048) == 32'h00004008);
-  assign _zz__zz_decode_IS_RS2_SIGNED_46 = {(_zz__zz_decode_IS_RS2_SIGNED_47 == _zz__zz_decode_IS_RS2_SIGNED_48),(_zz__zz_decode_IS_RS2_SIGNED_49 == _zz__zz_decode_IS_RS2_SIGNED_50)};
-  assign _zz__zz_decode_IS_RS2_SIGNED_51 = (|{_zz__zz_decode_IS_RS2_SIGNED_52,{_zz__zz_decode_IS_RS2_SIGNED_53,_zz__zz_decode_IS_RS2_SIGNED_55}});
-  assign _zz__zz_decode_IS_RS2_SIGNED_60 = (|_zz__zz_decode_IS_RS2_SIGNED_61);
-  assign _zz__zz_decode_IS_RS2_SIGNED_62 = {(|_zz__zz_decode_IS_RS2_SIGNED_63),{_zz__zz_decode_IS_RS2_SIGNED_74,{_zz__zz_decode_IS_RS2_SIGNED_87,_zz__zz_decode_IS_RS2_SIGNED_101}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_47 = (decode_INSTRUCTION & 32'h00000034);
-  assign _zz__zz_decode_IS_RS2_SIGNED_48 = 32'h00000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_49 = (decode_INSTRUCTION & 32'h00000064);
-  assign _zz__zz_decode_IS_RS2_SIGNED_50 = 32'h00000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_52 = ((decode_INSTRUCTION & 32'h00002040) == 32'h00002040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_53 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_54) == 32'h00001040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_55 = {(_zz__zz_decode_IS_RS2_SIGNED_56 == _zz__zz_decode_IS_RS2_SIGNED_57),{_zz__zz_decode_IS_RS2_SIGNED_58,_zz_decode_IS_RS2_SIGNED_2}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_61 = ((decode_INSTRUCTION & 32'h00000020) == 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_63 = {(_zz__zz_decode_IS_RS2_SIGNED_64 == _zz__zz_decode_IS_RS2_SIGNED_65),{_zz_decode_IS_RS2_SIGNED_3,{_zz__zz_decode_IS_RS2_SIGNED_66,_zz__zz_decode_IS_RS2_SIGNED_69}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_74 = (|{_zz_decode_IS_RS2_SIGNED_3,{_zz__zz_decode_IS_RS2_SIGNED_75,_zz__zz_decode_IS_RS2_SIGNED_78}});
-  assign _zz__zz_decode_IS_RS2_SIGNED_87 = (|{_zz__zz_decode_IS_RS2_SIGNED_88,_zz__zz_decode_IS_RS2_SIGNED_89});
-  assign _zz__zz_decode_IS_RS2_SIGNED_101 = {(|_zz__zz_decode_IS_RS2_SIGNED_102),{_zz__zz_decode_IS_RS2_SIGNED_105,{_zz__zz_decode_IS_RS2_SIGNED_110,_zz__zz_decode_IS_RS2_SIGNED_114}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_54 = 32'h00001040;
-  assign _zz__zz_decode_IS_RS2_SIGNED_56 = (decode_INSTRUCTION & 32'h00100040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_57 = 32'h00000040;
-  assign _zz__zz_decode_IS_RS2_SIGNED_58 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_59) == 32'h00000040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_64 = (decode_INSTRUCTION & 32'h00000040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_65 = 32'h00000040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_22 = ((decode_INSTRUCTION & 32'h02007054) == 32'h00005010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_24 = {((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_25) == 32'h40001010),((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_26) == 32'h00001010)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_27 = (|((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_28) == 32'h00000024));
+  assign _zz__zz_decode_IS_RS2_SIGNED_29 = (|(_zz__zz_decode_IS_RS2_SIGNED_30 == _zz__zz_decode_IS_RS2_SIGNED_31));
+  assign _zz__zz_decode_IS_RS2_SIGNED_32 = {(|_zz__zz_decode_IS_RS2_SIGNED_33),{(|_zz__zz_decode_IS_RS2_SIGNED_34),{_zz__zz_decode_IS_RS2_SIGNED_37,{_zz__zz_decode_IS_RS2_SIGNED_39,_zz__zz_decode_IS_RS2_SIGNED_42}}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_25 = 32'h40003054;
+  assign _zz__zz_decode_IS_RS2_SIGNED_26 = 32'h02007054;
+  assign _zz__zz_decode_IS_RS2_SIGNED_28 = 32'h00000064;
+  assign _zz__zz_decode_IS_RS2_SIGNED_30 = (decode_INSTRUCTION & 32'h00001000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_31 = 32'h00001000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_33 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_34 = {((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_35) == 32'h00002000),((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_36) == 32'h00001000)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_37 = (|((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_38) == 32'h00004008));
+  assign _zz__zz_decode_IS_RS2_SIGNED_39 = (|{_zz__zz_decode_IS_RS2_SIGNED_40,_zz__zz_decode_IS_RS2_SIGNED_41});
+  assign _zz__zz_decode_IS_RS2_SIGNED_42 = {(|{_zz__zz_decode_IS_RS2_SIGNED_43,_zz__zz_decode_IS_RS2_SIGNED_45}),{(|_zz__zz_decode_IS_RS2_SIGNED_54),{_zz__zz_decode_IS_RS2_SIGNED_56,{_zz__zz_decode_IS_RS2_SIGNED_69,_zz__zz_decode_IS_RS2_SIGNED_82}}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_35 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_36 = 32'h00005000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_38 = 32'h00004048;
+  assign _zz__zz_decode_IS_RS2_SIGNED_40 = ((decode_INSTRUCTION & 32'h00000034) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_41 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_43 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_44) == 32'h00002040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_45 = {(_zz__zz_decode_IS_RS2_SIGNED_46 == _zz__zz_decode_IS_RS2_SIGNED_47),{_zz__zz_decode_IS_RS2_SIGNED_48,{_zz__zz_decode_IS_RS2_SIGNED_50,_zz__zz_decode_IS_RS2_SIGNED_53}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_54 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_55) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_56 = (|{_zz__zz_decode_IS_RS2_SIGNED_57,{_zz__zz_decode_IS_RS2_SIGNED_59,_zz__zz_decode_IS_RS2_SIGNED_60}});
+  assign _zz__zz_decode_IS_RS2_SIGNED_69 = (|{_zz__zz_decode_IS_RS2_SIGNED_70,_zz__zz_decode_IS_RS2_SIGNED_71});
+  assign _zz__zz_decode_IS_RS2_SIGNED_82 = {(|_zz__zz_decode_IS_RS2_SIGNED_83),{_zz__zz_decode_IS_RS2_SIGNED_96,{_zz__zz_decode_IS_RS2_SIGNED_101,_zz__zz_decode_IS_RS2_SIGNED_105}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_44 = 32'h00002040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_46 = (decode_INSTRUCTION & 32'h00001040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_47 = 32'h00001040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_48 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_49) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_50 = (_zz__zz_decode_IS_RS2_SIGNED_51 == _zz__zz_decode_IS_RS2_SIGNED_52);
+  assign _zz__zz_decode_IS_RS2_SIGNED_53 = _zz_decode_IS_RS2_SIGNED_2;
+  assign _zz__zz_decode_IS_RS2_SIGNED_55 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_57 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_58) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_59 = _zz_decode_IS_RS2_SIGNED_3;
+  assign _zz__zz_decode_IS_RS2_SIGNED_60 = {_zz__zz_decode_IS_RS2_SIGNED_61,{_zz__zz_decode_IS_RS2_SIGNED_63,_zz__zz_decode_IS_RS2_SIGNED_66}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_70 = _zz_decode_IS_RS2_SIGNED_3;
+  assign _zz__zz_decode_IS_RS2_SIGNED_71 = {_zz__zz_decode_IS_RS2_SIGNED_72,{_zz__zz_decode_IS_RS2_SIGNED_74,_zz__zz_decode_IS_RS2_SIGNED_77}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_83 = {_zz_decode_IS_RS2_SIGNED_4,{_zz__zz_decode_IS_RS2_SIGNED_84,_zz__zz_decode_IS_RS2_SIGNED_87}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_96 = (|{_zz__zz_decode_IS_RS2_SIGNED_97,_zz__zz_decode_IS_RS2_SIGNED_98});
+  assign _zz__zz_decode_IS_RS2_SIGNED_101 = (|_zz__zz_decode_IS_RS2_SIGNED_102);
+  assign _zz__zz_decode_IS_RS2_SIGNED_105 = {_zz__zz_decode_IS_RS2_SIGNED_106,{_zz__zz_decode_IS_RS2_SIGNED_109,_zz__zz_decode_IS_RS2_SIGNED_113}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_49 = 32'h00100040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_51 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_52 = 32'h00000040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_58 = 32'h00000040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_61 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_62) == 32'h00004020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_63 = (_zz__zz_decode_IS_RS2_SIGNED_64 == _zz__zz_decode_IS_RS2_SIGNED_65);
   assign _zz__zz_decode_IS_RS2_SIGNED_66 = (_zz__zz_decode_IS_RS2_SIGNED_67 == _zz__zz_decode_IS_RS2_SIGNED_68);
-  assign _zz__zz_decode_IS_RS2_SIGNED_69 = {_zz__zz_decode_IS_RS2_SIGNED_70,_zz__zz_decode_IS_RS2_SIGNED_72};
-  assign _zz__zz_decode_IS_RS2_SIGNED_75 = (_zz__zz_decode_IS_RS2_SIGNED_76 == _zz__zz_decode_IS_RS2_SIGNED_77);
-  assign _zz__zz_decode_IS_RS2_SIGNED_78 = {_zz__zz_decode_IS_RS2_SIGNED_79,{_zz__zz_decode_IS_RS2_SIGNED_81,_zz__zz_decode_IS_RS2_SIGNED_84}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_88 = _zz_decode_IS_RS2_SIGNED_4;
-  assign _zz__zz_decode_IS_RS2_SIGNED_89 = {_zz__zz_decode_IS_RS2_SIGNED_90,{_zz__zz_decode_IS_RS2_SIGNED_92,_zz__zz_decode_IS_RS2_SIGNED_95}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_102 = {_zz_decode_IS_RS2_SIGNED_3,_zz__zz_decode_IS_RS2_SIGNED_103};
-  assign _zz__zz_decode_IS_RS2_SIGNED_105 = (|{_zz__zz_decode_IS_RS2_SIGNED_106,_zz__zz_decode_IS_RS2_SIGNED_107});
-  assign _zz__zz_decode_IS_RS2_SIGNED_110 = (|_zz__zz_decode_IS_RS2_SIGNED_111);
-  assign _zz__zz_decode_IS_RS2_SIGNED_114 = {_zz__zz_decode_IS_RS2_SIGNED_115,{_zz__zz_decode_IS_RS2_SIGNED_117,_zz__zz_decode_IS_RS2_SIGNED_128}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_59 = 32'h00000050;
-  assign _zz__zz_decode_IS_RS2_SIGNED_67 = (decode_INSTRUCTION & 32'h00004020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_68 = 32'h00004020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_70 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_71) == 32'h00000010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_72 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_73) == 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_76 = (decode_INSTRUCTION & 32'h00002030);
-  assign _zz__zz_decode_IS_RS2_SIGNED_77 = 32'h00002010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_79 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_80) == 32'h00000010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_81 = (_zz__zz_decode_IS_RS2_SIGNED_82 == _zz__zz_decode_IS_RS2_SIGNED_83);
+  assign _zz__zz_decode_IS_RS2_SIGNED_72 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_73) == 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_74 = (_zz__zz_decode_IS_RS2_SIGNED_75 == _zz__zz_decode_IS_RS2_SIGNED_76);
+  assign _zz__zz_decode_IS_RS2_SIGNED_77 = {_zz__zz_decode_IS_RS2_SIGNED_78,_zz__zz_decode_IS_RS2_SIGNED_80};
   assign _zz__zz_decode_IS_RS2_SIGNED_84 = (_zz__zz_decode_IS_RS2_SIGNED_85 == _zz__zz_decode_IS_RS2_SIGNED_86);
-  assign _zz__zz_decode_IS_RS2_SIGNED_90 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_91) == 32'h00001010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_92 = (_zz__zz_decode_IS_RS2_SIGNED_93 == _zz__zz_decode_IS_RS2_SIGNED_94);
-  assign _zz__zz_decode_IS_RS2_SIGNED_95 = {_zz__zz_decode_IS_RS2_SIGNED_96,{_zz__zz_decode_IS_RS2_SIGNED_97,_zz__zz_decode_IS_RS2_SIGNED_99}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_103 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_104) == 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_106 = _zz_decode_IS_RS2_SIGNED_3;
-  assign _zz__zz_decode_IS_RS2_SIGNED_107 = (_zz__zz_decode_IS_RS2_SIGNED_108 == _zz__zz_decode_IS_RS2_SIGNED_109);
-  assign _zz__zz_decode_IS_RS2_SIGNED_111 = (_zz__zz_decode_IS_RS2_SIGNED_112 == _zz__zz_decode_IS_RS2_SIGNED_113);
-  assign _zz__zz_decode_IS_RS2_SIGNED_115 = (|_zz__zz_decode_IS_RS2_SIGNED_116);
-  assign _zz__zz_decode_IS_RS2_SIGNED_117 = (|_zz__zz_decode_IS_RS2_SIGNED_118);
-  assign _zz__zz_decode_IS_RS2_SIGNED_128 = {_zz__zz_decode_IS_RS2_SIGNED_129,{_zz__zz_decode_IS_RS2_SIGNED_132,_zz__zz_decode_IS_RS2_SIGNED_140}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_71 = 32'h00000030;
-  assign _zz__zz_decode_IS_RS2_SIGNED_73 = 32'h02000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_80 = 32'h00001030;
-  assign _zz__zz_decode_IS_RS2_SIGNED_82 = (decode_INSTRUCTION & 32'h02002060);
-  assign _zz__zz_decode_IS_RS2_SIGNED_83 = 32'h00002020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_85 = (decode_INSTRUCTION & 32'h02003020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_86 = 32'h00000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_91 = 32'h00001010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_93 = (decode_INSTRUCTION & 32'h00002010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_94 = 32'h00002010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_96 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_97 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_98) == 32'h00000004);
-  assign _zz__zz_decode_IS_RS2_SIGNED_99 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_100) == 32'h0);
-  assign _zz__zz_decode_IS_RS2_SIGNED_104 = 32'h00000070;
-  assign _zz__zz_decode_IS_RS2_SIGNED_108 = (decode_INSTRUCTION & 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_109 = 32'h0;
-  assign _zz__zz_decode_IS_RS2_SIGNED_112 = (decode_INSTRUCTION & 32'h00004014);
-  assign _zz__zz_decode_IS_RS2_SIGNED_113 = 32'h00004010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_116 = ((decode_INSTRUCTION & 32'h00006014) == 32'h00002010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_118 = {(_zz__zz_decode_IS_RS2_SIGNED_119 == _zz__zz_decode_IS_RS2_SIGNED_120),{_zz_decode_IS_RS2_SIGNED_2,{_zz__zz_decode_IS_RS2_SIGNED_121,_zz__zz_decode_IS_RS2_SIGNED_123}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_129 = (|(_zz__zz_decode_IS_RS2_SIGNED_130 == _zz__zz_decode_IS_RS2_SIGNED_131));
-  assign _zz__zz_decode_IS_RS2_SIGNED_132 = (|{_zz__zz_decode_IS_RS2_SIGNED_133,_zz__zz_decode_IS_RS2_SIGNED_135});
-  assign _zz__zz_decode_IS_RS2_SIGNED_140 = {(|_zz__zz_decode_IS_RS2_SIGNED_141),{_zz__zz_decode_IS_RS2_SIGNED_144,_zz__zz_decode_IS_RS2_SIGNED_146}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_98 = 32'h0000000c;
-  assign _zz__zz_decode_IS_RS2_SIGNED_100 = 32'h00000028;
-  assign _zz__zz_decode_IS_RS2_SIGNED_119 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz__zz_decode_IS_RS2_SIGNED_120 = 32'h0;
-  assign _zz__zz_decode_IS_RS2_SIGNED_121 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_122) == 32'h00002000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_123 = {(_zz__zz_decode_IS_RS2_SIGNED_124 == _zz__zz_decode_IS_RS2_SIGNED_125),(_zz__zz_decode_IS_RS2_SIGNED_126 == _zz__zz_decode_IS_RS2_SIGNED_127)};
-  assign _zz__zz_decode_IS_RS2_SIGNED_130 = (decode_INSTRUCTION & 32'h00000058);
-  assign _zz__zz_decode_IS_RS2_SIGNED_131 = 32'h0;
-  assign _zz__zz_decode_IS_RS2_SIGNED_133 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_134) == 32'h00000040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_135 = {(_zz__zz_decode_IS_RS2_SIGNED_136 == _zz__zz_decode_IS_RS2_SIGNED_137),(_zz__zz_decode_IS_RS2_SIGNED_138 == _zz__zz_decode_IS_RS2_SIGNED_139)};
-  assign _zz__zz_decode_IS_RS2_SIGNED_141 = {(_zz__zz_decode_IS_RS2_SIGNED_142 == _zz__zz_decode_IS_RS2_SIGNED_143),_zz_decode_IS_RS2_SIGNED_1};
-  assign _zz__zz_decode_IS_RS2_SIGNED_144 = (|{_zz__zz_decode_IS_RS2_SIGNED_145,_zz_decode_IS_RS2_SIGNED_1});
-  assign _zz__zz_decode_IS_RS2_SIGNED_146 = (|(_zz__zz_decode_IS_RS2_SIGNED_147 == _zz__zz_decode_IS_RS2_SIGNED_148));
-  assign _zz__zz_decode_IS_RS2_SIGNED_122 = 32'h00006004;
-  assign _zz__zz_decode_IS_RS2_SIGNED_124 = (decode_INSTRUCTION & 32'h00005004);
-  assign _zz__zz_decode_IS_RS2_SIGNED_125 = 32'h00001000;
-  assign _zz__zz_decode_IS_RS2_SIGNED_126 = (decode_INSTRUCTION & 32'h00004050);
-  assign _zz__zz_decode_IS_RS2_SIGNED_127 = 32'h00004000;
-  assign _zz__zz_decode_IS_RS2_SIGNED_134 = 32'h00000044;
-  assign _zz__zz_decode_IS_RS2_SIGNED_136 = (decode_INSTRUCTION & 32'h00002014);
-  assign _zz__zz_decode_IS_RS2_SIGNED_137 = 32'h00002010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_138 = (decode_INSTRUCTION & 32'h40000034);
-  assign _zz__zz_decode_IS_RS2_SIGNED_139 = 32'h40000030;
-  assign _zz__zz_decode_IS_RS2_SIGNED_142 = (decode_INSTRUCTION & 32'h00000014);
-  assign _zz__zz_decode_IS_RS2_SIGNED_143 = 32'h00000004;
-  assign _zz__zz_decode_IS_RS2_SIGNED_145 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000004);
-  assign _zz__zz_decode_IS_RS2_SIGNED_147 = (decode_INSTRUCTION & 32'h00005048);
-  assign _zz__zz_decode_IS_RS2_SIGNED_148 = 32'h00001008;
+  assign _zz__zz_decode_IS_RS2_SIGNED_87 = {_zz__zz_decode_IS_RS2_SIGNED_88,{_zz__zz_decode_IS_RS2_SIGNED_90,_zz__zz_decode_IS_RS2_SIGNED_93}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_97 = _zz_decode_IS_RS2_SIGNED_3;
+  assign _zz__zz_decode_IS_RS2_SIGNED_98 = (_zz__zz_decode_IS_RS2_SIGNED_99 == _zz__zz_decode_IS_RS2_SIGNED_100);
+  assign _zz__zz_decode_IS_RS2_SIGNED_102 = {_zz_decode_IS_RS2_SIGNED_3,_zz__zz_decode_IS_RS2_SIGNED_103};
+  assign _zz__zz_decode_IS_RS2_SIGNED_106 = (|_zz__zz_decode_IS_RS2_SIGNED_107);
+  assign _zz__zz_decode_IS_RS2_SIGNED_109 = (|_zz__zz_decode_IS_RS2_SIGNED_110);
+  assign _zz__zz_decode_IS_RS2_SIGNED_113 = {_zz__zz_decode_IS_RS2_SIGNED_114,{_zz__zz_decode_IS_RS2_SIGNED_123,_zz__zz_decode_IS_RS2_SIGNED_126}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_62 = 32'h00004020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_64 = (decode_INSTRUCTION & 32'h00000030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_65 = 32'h00000010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_67 = (decode_INSTRUCTION & 32'h02000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_68 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_73 = 32'h00002030;
+  assign _zz__zz_decode_IS_RS2_SIGNED_75 = (decode_INSTRUCTION & 32'h00001030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_76 = 32'h00000010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_78 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_79) == 32'h00002020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_80 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_81) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_85 = (decode_INSTRUCTION & 32'h00001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_86 = 32'h00001010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_88 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_89) == 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_90 = (_zz__zz_decode_IS_RS2_SIGNED_91 == _zz__zz_decode_IS_RS2_SIGNED_92);
+  assign _zz__zz_decode_IS_RS2_SIGNED_93 = {_zz__zz_decode_IS_RS2_SIGNED_94,_zz__zz_decode_IS_RS2_SIGNED_95};
+  assign _zz__zz_decode_IS_RS2_SIGNED_99 = (decode_INSTRUCTION & 32'h00000070);
+  assign _zz__zz_decode_IS_RS2_SIGNED_100 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_103 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_104) == 32'h00000000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_107 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_108) == 32'h00004010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_110 = (_zz__zz_decode_IS_RS2_SIGNED_111 == _zz__zz_decode_IS_RS2_SIGNED_112);
+  assign _zz__zz_decode_IS_RS2_SIGNED_114 = (|{_zz__zz_decode_IS_RS2_SIGNED_115,_zz__zz_decode_IS_RS2_SIGNED_117});
+  assign _zz__zz_decode_IS_RS2_SIGNED_123 = (|_zz__zz_decode_IS_RS2_SIGNED_124);
+  assign _zz__zz_decode_IS_RS2_SIGNED_126 = {_zz__zz_decode_IS_RS2_SIGNED_127,{_zz__zz_decode_IS_RS2_SIGNED_133,_zz__zz_decode_IS_RS2_SIGNED_137}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_79 = 32'h02002060;
+  assign _zz__zz_decode_IS_RS2_SIGNED_81 = 32'h02003020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_89 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_91 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_92 = 32'h00000010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_94 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_95 = ((decode_INSTRUCTION & 32'h00000028) == 32'h00000000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_104 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_108 = 32'h00004014;
+  assign _zz__zz_decode_IS_RS2_SIGNED_111 = (decode_INSTRUCTION & 32'h00006014);
+  assign _zz__zz_decode_IS_RS2_SIGNED_112 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_115 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_116) == 32'h00000000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_117 = {_zz_decode_IS_RS2_SIGNED_2,{_zz__zz_decode_IS_RS2_SIGNED_118,{_zz__zz_decode_IS_RS2_SIGNED_119,_zz__zz_decode_IS_RS2_SIGNED_121}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_124 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_125) == 32'h00000000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_127 = (|{_zz__zz_decode_IS_RS2_SIGNED_128,{_zz__zz_decode_IS_RS2_SIGNED_129,_zz__zz_decode_IS_RS2_SIGNED_131}});
+  assign _zz__zz_decode_IS_RS2_SIGNED_133 = (|{_zz__zz_decode_IS_RS2_SIGNED_134,_zz__zz_decode_IS_RS2_SIGNED_136});
+  assign _zz__zz_decode_IS_RS2_SIGNED_137 = {(|_zz__zz_decode_IS_RS2_SIGNED_138),(|_zz__zz_decode_IS_RS2_SIGNED_141)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_116 = 32'h00000044;
+  assign _zz__zz_decode_IS_RS2_SIGNED_118 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_119 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_120) == 32'h00001000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_121 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_122) == 32'h00004000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_125 = 32'h00000058;
+  assign _zz__zz_decode_IS_RS2_SIGNED_128 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_129 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_130) == 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_131 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_132) == 32'h40000030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_134 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_135) == 32'h00000004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_136 = _zz_decode_IS_RS2_SIGNED_1;
+  assign _zz__zz_decode_IS_RS2_SIGNED_138 = {(_zz__zz_decode_IS_RS2_SIGNED_139 == _zz__zz_decode_IS_RS2_SIGNED_140),_zz_decode_IS_RS2_SIGNED_1};
+  assign _zz__zz_decode_IS_RS2_SIGNED_141 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_142) == 32'h00001008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_120 = 32'h00005004;
+  assign _zz__zz_decode_IS_RS2_SIGNED_122 = 32'h00004050;
+  assign _zz__zz_decode_IS_RS2_SIGNED_130 = 32'h00002014;
+  assign _zz__zz_decode_IS_RS2_SIGNED_132 = 32'h40000034;
+  assign _zz__zz_decode_IS_RS2_SIGNED_135 = 32'h00000014;
+  assign _zz__zz_decode_IS_RS2_SIGNED_139 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz__zz_decode_IS_RS2_SIGNED_140 = 32'h00000004;
+  assign _zz__zz_decode_IS_RS2_SIGNED_142 = 32'h00005048;
   assign _zz_execute_BranchPlugin_branch_src2_6 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_7 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_8 = execute_INSTRUCTION[7];
-  assign _zz_CsrPlugin_csrMapping_readDataInit_25 = 32'h0;
+  assign _zz_CsrPlugin_csrMapping_readDataInit_24 = 32'h00000000;
   always @(posedge clk) begin
     if(_zz_decode_RegFilePlugin_rs1Data) begin
       _zz_RegFilePlugin_regFile_port0 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
@@ -1744,8 +1735,8 @@ module VexRiscv (
     .io_mem_rsp_valid                      (iBus_rsp_valid                                            ), //i
     .io_mem_rsp_payload_data               (iBus_rsp_payload_data[31:0]                               ), //i
     .io_mem_rsp_payload_error              (iBus_rsp_payload_error                                    ), //i
-    ._zz_when_Fetcher_l401                 (switch_Fetcher_l365[2:0]                                  ), //i
-    ._zz_io_cpu_fetch_data_regNextWhen     (IBusCachedPlugin_injectionPort_payload[31:0]              ), //i
+    ._zz_when_Fetcher_l411                 (IBusCachedPlugin_injector_port_state[2:0]                 ), //i
+    ._zz_io_cpu_fetch_data_regNextWhen     (DebugPlugin_injectionPort_payload[31:0]                   ), //i
     .clk                                   (clk                                                       ), //i
     .reset                                 (reset                                                     )  //i
   );
@@ -1798,8 +1789,9 @@ module VexRiscv (
     .io_cpu_flush_ready                     (dataCache_1_io_cpu_flush_ready                   ), //o
     .io_cpu_flush_payload_singleLine        (dataCache_1_io_cpu_flush_payload_singleLine      ), //i
     .io_cpu_flush_payload_lineId            (dataCache_1_io_cpu_flush_payload_lineId[6:0]     ), //i
+    .io_cpu_writesPending                   (dataCache_1_io_cpu_writesPending                 ), //o
     .io_mem_cmd_valid                       (dataCache_1_io_mem_cmd_valid                     ), //o
-    .io_mem_cmd_ready                       (dataCache_1_io_mem_cmd_ready                     ), //i
+    .io_mem_cmd_ready                       (toplevel_dataCache_1_io_mem_cmd_rValidN          ), //i
     .io_mem_cmd_payload_wr                  (dataCache_1_io_mem_cmd_payload_wr                ), //o
     .io_mem_cmd_payload_uncached            (dataCache_1_io_mem_cmd_payload_uncached          ), //o
     .io_mem_cmd_payload_address             (dataCache_1_io_mem_cmd_payload_address[31:0]     ), //o
@@ -2526,7 +2518,7 @@ module VexRiscv (
   end
   `endif
 
-  assign memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW) + $signed(_zz_memory_MUL_LOW_7));
+  assign memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW) + $signed(_zz_memory_MUL_LOW_6));
   assign memory_MUL_HH = execute_to_memory_MUL_HH;
   assign execute_MUL_HH = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bHigh));
   assign execute_MUL_HL = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bSLow));
@@ -2540,7 +2532,7 @@ module VexRiscv (
   assign execute_MEMORY_STORE_DATA_RF = _zz_execute_MEMORY_STORE_DATA_RF;
   assign decode_DO_EBREAK = (((! DebugPlugin_haltIt) && (decode_IS_EBREAK || ((1'b0 || (DebugPlugin_hardwareBreakpoints_0_valid && (DebugPlugin_hardwareBreakpoints_0_pc == _zz_decode_DO_EBREAK))) || (DebugPlugin_hardwareBreakpoints_1_valid && (DebugPlugin_hardwareBreakpoints_1_pc == _zz_decode_DO_EBREAK_1))))) && DebugPlugin_allowEBreak);
   assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
-  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
+  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h00)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h00))));
   assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
   assign decode_IS_RS2_SIGNED = _zz_decode_IS_RS2_SIGNED[31];
@@ -2607,7 +2599,7 @@ module VexRiscv (
   assign decode_RS1_USE = _zz_decode_IS_RS2_SIGNED[5];
   always @(*) begin
     _zz_decode_RS2 = execute_REGFILE_WRITE_DATA;
-    if(when_CsrPlugin_l1189) begin
+    if(when_CsrPlugin_l1587) begin
       _zz_decode_RS2 = CsrPlugin_csrMapping_readDataSignal;
     end
   end
@@ -2703,7 +2695,7 @@ module VexRiscv (
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_execute_SRC2 = execute_PC;
+  assign _zz_execute_to_memory_PC = execute_PC;
   assign execute_SRC2_CTRL = _zz_execute_SRC2_CTRL;
   assign execute_SRC1_CTRL = _zz_execute_SRC1_CTRL;
   assign decode_SRC_USE_SUB_LESS = _zz_decode_IS_RS2_SIGNED[3];
@@ -2711,7 +2703,7 @@ module VexRiscv (
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
   assign execute_ALU_CTRL = _zz_execute_ALU_CTRL;
-  assign execute_SRC2 = _zz_execute_SRC2_5;
+  assign execute_SRC2 = _zz_execute_SRC2_4;
   assign execute_SRC1 = _zz_execute_SRC1;
   assign execute_ALU_BITWISE_CTRL = _zz_execute_ALU_BITWISE_CTRL;
   assign _zz_lastStageRegFileWrite_payload_address = writeBack_INSTRUCTION;
@@ -2731,10 +2723,10 @@ module VexRiscv (
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00001073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
+  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000107f) == 32'h00001073),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00002073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
   always @(*) begin
     _zz_decode_RS2_2 = writeBack_REGFILE_WRITE_DATA;
-    if(when_DBusCachedPlugin_l492) begin
+    if(when_DBusCachedPlugin_l580) begin
       _zz_decode_RS2_2 = writeBack_DBusCachedPlugin_rspFormated;
     end
     if(when_MulPlugin_l147) begin
@@ -2767,28 +2759,28 @@ module VexRiscv (
   assign decode_FLUSH_ALL = _zz_decode_IS_RS2_SIGNED[0];
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_4 = IBusCachedPlugin_rsp_issueDetected_3;
-    if(when_IBusCachedPlugin_l256) begin
+    if(when_IBusCachedPlugin_l262) begin
       IBusCachedPlugin_rsp_issueDetected_4 = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_3 = IBusCachedPlugin_rsp_issueDetected_2;
-    if(when_IBusCachedPlugin_l250) begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_rsp_issueDetected_3 = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
-    if(when_IBusCachedPlugin_l244) begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
-    if(when_IBusCachedPlugin_l239) begin
+    if(when_IBusCachedPlugin_l245) begin
       IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
@@ -2814,10 +2806,10 @@ module VexRiscv (
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
   always @(*) begin
     decode_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l308) begin
+    if(when_DBusCachedPlugin_l352) begin
       decode_arbitration_haltItself = 1'b1;
     end
-    case(switch_Fetcher_l365)
+    case(IBusCachedPlugin_injector_port_state)
       3'b010 : begin
         decode_arbitration_haltItself = 1'b1;
       end
@@ -2834,7 +2826,7 @@ module VexRiscv (
     if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(when_CsrPlugin_l1129) begin
+    if(when_CsrPlugin_l1527) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
@@ -2862,15 +2854,15 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l350) begin
+    if(when_DBusCachedPlugin_l394) begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(when_CsrPlugin_l1121) begin
-      if(when_CsrPlugin_l1123) begin
+    if(when_CsrPlugin_l1519) begin
+      if(when_CsrPlugin_l1521) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(when_CsrPlugin_l1193) begin
+    if(when_CsrPlugin_l1591) begin
       if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
@@ -2879,10 +2871,10 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if(when_DBusCachedPlugin_l366) begin
+    if(when_DBusCachedPlugin_l410) begin
       execute_arbitration_haltByOther = 1'b1;
     end
-    if(when_DebugPlugin_l295) begin
+    if(when_DebugPlugin_l308) begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
@@ -2899,8 +2891,8 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_flushIt = 1'b0;
-    if(when_DebugPlugin_l295) begin
-      if(when_DebugPlugin_l298) begin
+    if(when_DebugPlugin_l308) begin
+      if(when_DebugPlugin_l311) begin
         execute_arbitration_flushIt = 1'b1;
       end
     end
@@ -2911,8 +2903,8 @@ module VexRiscv (
     if(CsrPlugin_selfException_valid) begin
       execute_arbitration_flushNext = 1'b1;
     end
-    if(when_DebugPlugin_l295) begin
-      if(when_DebugPlugin_l298) begin
+    if(when_DebugPlugin_l308) begin
+      if(when_DebugPlugin_l311) begin
         execute_arbitration_flushNext = 1'b1;
       end
     end
@@ -2951,7 +2943,7 @@ module VexRiscv (
 
   always @(*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l466) begin
+    if(when_DBusCachedPlugin_l553) begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
@@ -2982,10 +2974,10 @@ module VexRiscv (
     if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -2996,24 +2988,24 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @(*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(when_CsrPlugin_l935) begin
+    if(when_CsrPlugin_l1272) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_DebugPlugin_l295) begin
-      if(when_DebugPlugin_l298) begin
+    if(when_DebugPlugin_l308) begin
+      if(when_DebugPlugin_l311) begin
         IBusCachedPlugin_fetcherHalt = 1'b1;
       end
     end
     if(DebugPlugin_haltIt) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_DebugPlugin_l311) begin
+    if(when_DebugPlugin_l324) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
@@ -3021,15 +3013,15 @@ module VexRiscv (
   assign IBusCachedPlugin_forceNoDecodeCond = 1'b0;
   always @(*) begin
     IBusCachedPlugin_incomingInstruction = 1'b0;
-    if(when_Fetcher_l243) begin
+    if(when_Fetcher_l242) begin
       IBusCachedPlugin_incomingInstruction = 1'b1;
     end
   end
 
   always @(*) begin
-    _zz_when_DBusCachedPlugin_l393 = 1'b0;
+    _zz_when_DBusCachedPlugin_l472 = 1'b0;
     if(DebugPlugin_godmode) begin
-      _zz_when_DBusCachedPlugin_l393 = 1'b1;
+      _zz_when_DBusCachedPlugin_l472 = 1'b1;
     end
   end
 
@@ -3040,11 +3032,21 @@ module VexRiscv (
     end
   end
 
-  assign CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+  always @(*) begin
+    CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+    if(when_CsrPlugin_l1702) begin
+      CsrPlugin_csrMapping_allowCsrSignal = 1'b1;
+    end
+    if(when_CsrPlugin_l1709) begin
+      CsrPlugin_csrMapping_allowCsrSignal = 1'b1;
+    end
+  end
+
+  assign CsrPlugin_csrMapping_doForceFailCsr = 1'b0;
   assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
   always @(*) begin
     CsrPlugin_inWfi = 1'b0;
-    if(when_CsrPlugin_l1121) begin
+    if(when_CsrPlugin_l1519) begin
       CsrPlugin_inWfi = 1'b1;
     end
   end
@@ -3058,21 +3060,21 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(when_CsrPlugin_l1077) begin
-      case(switch_CsrPlugin_l1081)
+    if(when_CsrPlugin_l1456) begin
+      case(switch_CsrPlugin_l1460)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -3091,7 +3093,7 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_allowInterrupts = 1'b1;
-    if(when_DebugPlugin_l331) begin
+    if(when_DebugPlugin_l344) begin
       CsrPlugin_allowInterrupts = 1'b0;
     end
   end
@@ -3110,6 +3112,7 @@ module VexRiscv (
     end
   end
 
+  assign CsrPlugin_xretAwayFromMachine = 1'b0;
   assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
   assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusCachedPlugin_redoBranch_valid,IBusCachedPlugin_predictionJumpInterface_valid}}} != 4'b0000);
   assign _zz_IBusCachedPlugin_jump_pcLoad_payload = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
@@ -3137,9 +3140,8 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l134 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
-  assign IBusCachedPlugin_fetchPc_output_fire_1 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
-  assign when_Fetcher_l134_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
+  assign when_Fetcher_l133 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l133_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
   always @(*) begin
     IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_IBusCachedPlugin_fetchPc_pc);
     if(IBusCachedPlugin_fetchPc_redo_valid) begin
@@ -3162,7 +3164,7 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l161 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
+  assign when_Fetcher_l160 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
   assign IBusCachedPlugin_fetchPc_output_valid = ((! IBusCachedPlugin_fetcherHalt) && IBusCachedPlugin_fetchPc_booted);
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
   always @(*) begin
@@ -3199,7 +3201,7 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_1_output_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b0;
-    if(when_IBusCachedPlugin_l267) begin
+    if(when_IBusCachedPlugin_l273) begin
       IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b1;
     end
   end
@@ -3212,9 +3214,9 @@ module VexRiscv (
   assign IBusCachedPlugin_fetchPc_redo_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_iBusRsp_flush = ((decode_arbitration_removeIt || (decode_arbitration_flushNext && (! decode_arbitration_isStuck))) || IBusCachedPlugin_iBusRsp_redoFetch);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
-  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1 = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
   assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid)) || IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready);
   assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
@@ -3224,18 +3226,18 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
   always @(*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
-    if(when_Fetcher_l323) begin
+    if(when_Fetcher_l322) begin
       IBusCachedPlugin_iBusRsp_readyForError = 1'b0;
     end
   end
 
-  assign when_Fetcher_l243 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
-  assign when_Fetcher_l323 = (! IBusCachedPlugin_pcValids_0);
-  assign when_Fetcher_l332 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
-  assign when_Fetcher_l332_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
-  assign when_Fetcher_l332_2 = (! execute_arbitration_isStuck);
-  assign when_Fetcher_l332_3 = (! memory_arbitration_isStuck);
-  assign when_Fetcher_l332_4 = (! writeBack_arbitration_isStuck);
+  assign when_Fetcher_l242 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
+  assign when_Fetcher_l322 = (! IBusCachedPlugin_pcValids_0);
+  assign when_Fetcher_l331 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l331_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
+  assign when_Fetcher_l331_2 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l331_3 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l331_4 = (! writeBack_arbitration_isStuck);
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
@@ -3243,7 +3245,7 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
   always @(*) begin
     decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
-    case(switch_Fetcher_l365)
+    case(IBusCachedPlugin_injector_port_state)
       3'b010 : begin
         decode_arbitration_isValid = 1'b1;
       end
@@ -3400,87 +3402,86 @@ module VexRiscv (
   assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
   always @(*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(when_IBusCachedPlugin_l239) begin
+    if(when_IBusCachedPlugin_l245) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(when_IBusCachedPlugin_l250) begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_cache_io_cpu_fill_valid = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
-    if(when_IBusCachedPlugin_l250) begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_cache_io_cpu_fill_valid = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_valid = 1'b0;
-    if(when_IBusCachedPlugin_l244) begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
-    if(when_IBusCachedPlugin_l256) begin
+    if(when_IBusCachedPlugin_l262) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_payload_code = 4'bxxxx;
-    if(when_IBusCachedPlugin_l244) begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b1100;
     end
-    if(when_IBusCachedPlugin_l256) begin
+    if(when_IBusCachedPlugin_l262) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b0001;
     end
   end
 
   assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_2_input_payload[31 : 2],2'b00};
-  assign when_IBusCachedPlugin_l239 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign when_IBusCachedPlugin_l244 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
-  assign when_IBusCachedPlugin_l250 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
-  assign when_IBusCachedPlugin_l256 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
-  assign when_IBusCachedPlugin_l267 = (IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt);
+  assign when_IBusCachedPlugin_l245 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign when_IBusCachedPlugin_l250 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign when_IBusCachedPlugin_l256 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
+  assign when_IBusCachedPlugin_l262 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
+  assign when_IBusCachedPlugin_l273 = (IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt);
   assign IBusCachedPlugin_iBusRsp_output_valid = IBusCachedPlugin_iBusRsp_stages_2_output_valid;
   assign IBusCachedPlugin_iBusRsp_stages_2_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
   assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_decode_data;
   assign IBusCachedPlugin_iBusRsp_output_payload_pc = IBusCachedPlugin_iBusRsp_stages_2_output_payload;
   assign IBusCachedPlugin_cache_io_flush = (decode_arbitration_isValid && decode_FLUSH_ALL);
-  assign dataCache_1_io_mem_cmd_ready = (! dataCache_1_io_mem_cmd_rValid);
-  assign dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || dataCache_1_io_mem_cmd_rValid);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_wr : dataCache_1_io_mem_cmd_payload_wr);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_uncached : dataCache_1_io_mem_cmd_payload_uncached);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_address = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_address : dataCache_1_io_mem_cmd_payload_address);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_data = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_data : dataCache_1_io_mem_cmd_payload_data);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_mask : dataCache_1_io_mem_cmd_payload_mask);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_size = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_size : dataCache_1_io_mem_cmd_payload_size);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_last : dataCache_1_io_mem_cmd_payload_last);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || (! toplevel_dataCache_1_io_mem_cmd_rValidN));
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_wr : toplevel_dataCache_1_io_mem_cmd_rData_wr);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_uncached : toplevel_dataCache_1_io_mem_cmd_rData_uncached);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_address = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_address : toplevel_dataCache_1_io_mem_cmd_rData_address);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_data = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_data : toplevel_dataCache_1_io_mem_cmd_rData_data);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_mask : toplevel_dataCache_1_io_mem_cmd_rData_mask);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_size = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_size : toplevel_dataCache_1_io_mem_cmd_rData_size);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_last = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_last : toplevel_dataCache_1_io_mem_cmd_rData_last);
   always @(*) begin
-    dataCache_1_io_mem_cmd_s2mPipe_ready = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
-    if(when_Stream_l368) begin
-      dataCache_1_io_mem_cmd_s2mPipe_ready = 1'b1;
+    toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
+    if(when_Stream_l369) begin
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l368 = (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_rValid;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_rData_address;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_rData_data;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size = dataCache_1_io_mem_cmd_s2mPipe_rData_size;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_rData_last;
-  assign dBus_cmd_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
-  assign dBus_cmd_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
-  assign dBus_cmd_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
-  assign dBus_cmd_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
-  assign dBus_cmd_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
-  assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  assign dBus_cmd_payload_size = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
-  assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  assign when_DBusCachedPlugin_l308 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
+  assign when_Stream_l369 = (! toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_address;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_data;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_size;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  assign dBus_cmd_valid = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
+  assign dBus_cmd_payload_wr = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
+  assign dBus_cmd_payload_uncached = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
+  assign dBus_cmd_payload_address = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
+  assign dBus_cmd_payload_data = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
+  assign dBus_cmd_payload_mask = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
+  assign dBus_cmd_payload_size = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
+  assign dBus_cmd_payload_last = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  assign when_DBusCachedPlugin_l352 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
   assign dataCache_1_io_cpu_execute_isValid = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
   assign dataCache_1_io_cpu_execute_address = execute_SRC_ADD;
@@ -3499,11 +3500,11 @@ module VexRiscv (
   end
 
   assign dataCache_1_io_cpu_flush_valid = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
-  assign dataCache_1_io_cpu_flush_payload_singleLine = (execute_INSTRUCTION[19 : 15] != 5'h0);
+  assign dataCache_1_io_cpu_flush_payload_singleLine = (execute_INSTRUCTION[19 : 15] != 5'h00);
   assign dataCache_1_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId[6:0];
-  assign dataCache_1_io_cpu_flush_isStall = (dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready));
-  assign when_DBusCachedPlugin_l350 = (dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
-  assign when_DBusCachedPlugin_l366 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
+  assign toplevel_dataCache_1_io_cpu_flush_isStall = (dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready));
+  assign when_DBusCachedPlugin_l394 = (toplevel_dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
+  assign when_DBusCachedPlugin_l410 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
   assign dataCache_1_io_cpu_memory_isValid = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
   assign dataCache_1_io_cpu_memory_address = memory_REGFILE_WRITE_DATA;
   assign DBusCachedPlugin_mmuBus_cmd_0_isValid = dataCache_1_io_cpu_memory_isValid;
@@ -3513,12 +3514,12 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
   always @(*) begin
     dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if(when_DBusCachedPlugin_l393) begin
+    if(when_DBusCachedPlugin_l472) begin
       dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = 1'b1;
     end
   end
 
-  assign when_DBusCachedPlugin_l393 = (_zz_when_DBusCachedPlugin_l393 && (! dataCache_1_io_cpu_memory_isWrite));
+  assign when_DBusCachedPlugin_l472 = (_zz_when_DBusCachedPlugin_l472 && (! dataCache_1_io_cpu_memory_isWrite));
   always @(*) begin
     dataCache_1_io_cpu_writeBack_isValid = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
     if(writeBack_arbitration_haltByOther) begin
@@ -3531,7 +3532,7 @@ module VexRiscv (
   assign dataCache_1_io_cpu_writeBack_storeData[31 : 0] = writeBack_MEMORY_STORE_DATA_RF;
   always @(*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(when_DBusCachedPlugin_l446) begin
+    if(when_DBusCachedPlugin_l533) begin
       if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
@@ -3541,7 +3542,7 @@ module VexRiscv (
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(when_DBusCachedPlugin_l446) begin
+    if(when_DBusCachedPlugin_l533) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
@@ -3560,7 +3561,7 @@ module VexRiscv (
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
-    if(when_DBusCachedPlugin_l446) begin
+    if(when_DBusCachedPlugin_l533) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code};
       end
@@ -3573,12 +3574,13 @@ module VexRiscv (
     end
   end
 
-  assign when_DBusCachedPlugin_l446 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign when_DBusCachedPlugin_l466 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
-  assign writeBack_DBusCachedPlugin_rspSplits_0 = dataCache_1_io_cpu_writeBack_data[7 : 0];
-  assign writeBack_DBusCachedPlugin_rspSplits_1 = dataCache_1_io_cpu_writeBack_data[15 : 8];
-  assign writeBack_DBusCachedPlugin_rspSplits_2 = dataCache_1_io_cpu_writeBack_data[23 : 16];
-  assign writeBack_DBusCachedPlugin_rspSplits_3 = dataCache_1_io_cpu_writeBack_data[31 : 24];
+  assign when_DBusCachedPlugin_l533 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l553 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
+  assign writeBack_DBusCachedPlugin_rspData = dataCache_1_io_cpu_writeBack_data;
+  assign writeBack_DBusCachedPlugin_rspSplits_0 = writeBack_DBusCachedPlugin_rspData[7 : 0];
+  assign writeBack_DBusCachedPlugin_rspSplits_1 = writeBack_DBusCachedPlugin_rspData[15 : 8];
+  assign writeBack_DBusCachedPlugin_rspSplits_2 = writeBack_DBusCachedPlugin_rspData[23 : 16];
+  assign writeBack_DBusCachedPlugin_rspSplits_3 = writeBack_DBusCachedPlugin_rspData[31 : 24];
   always @(*) begin
     writeBack_DBusCachedPlugin_rspShifted[7 : 0] = _zz_writeBack_DBusCachedPlugin_rspShifted;
     writeBack_DBusCachedPlugin_rspShifted[15 : 8] = _zz_writeBack_DBusCachedPlugin_rspShifted_2;
@@ -3587,7 +3589,7 @@ module VexRiscv (
   end
 
   assign writeBack_DBusCachedPlugin_rspRf = writeBack_DBusCachedPlugin_rspShifted[31 : 0];
-  assign switch_Misc_l210 = writeBack_INSTRUCTION[13 : 12];
+  assign switch_Misc_l232 = writeBack_INSTRUCTION[13 : 12];
   assign _zz_writeBack_DBusCachedPlugin_rspFormated = (writeBack_DBusCachedPlugin_rspRf[7] && (! writeBack_INSTRUCTION[14]));
   always @(*) begin
     _zz_writeBack_DBusCachedPlugin_rspFormated_1[31] = _zz_writeBack_DBusCachedPlugin_rspFormated;
@@ -3639,7 +3641,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    case(switch_Misc_l210)
+    case(switch_Misc_l232)
       2'b00 : begin
         writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_1;
       end
@@ -3652,7 +3654,7 @@ module VexRiscv (
     endcase
   end
 
-  assign when_DBusCachedPlugin_l492 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l580 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
   assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
@@ -3672,10 +3674,10 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign DBusCachedPlugin_mmuBus_busy = 1'b0;
   assign _zz_decode_IS_RS2_SIGNED_1 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_decode_IS_RS2_SIGNED_2 = ((decode_INSTRUCTION & 32'h00000018) == 32'h0);
+  assign _zz_decode_IS_RS2_SIGNED_2 = ((decode_INSTRUCTION & 32'h00000018) == 32'h00000000);
   assign _zz_decode_IS_RS2_SIGNED_3 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
   assign _zz_decode_IS_RS2_SIGNED_4 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_decode_IS_RS2_SIGNED_5 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
+  assign _zz_decode_IS_RS2_SIGNED_5 = ((decode_INSTRUCTION & 32'h00001000) == 32'h00000000);
   assign _zz_decode_IS_RS2_SIGNED = {(|((decode_INSTRUCTION & 32'h10103050) == 32'h00100050)),{(|_zz_decode_IS_RS2_SIGNED_5),{(|_zz_decode_IS_RS2_SIGNED_5),{(|_zz__zz_decode_IS_RS2_SIGNED),{(|_zz__zz_decode_IS_RS2_SIGNED_1),{_zz__zz_decode_IS_RS2_SIGNED_2,{_zz__zz_decode_IS_RS2_SIGNED_7,_zz__zz_decode_IS_RS2_SIGNED_10}}}}}}};
   assign _zz_decode_SRC1_CTRL_2 = _zz_decode_IS_RS2_SIGNED[2 : 1];
   assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
@@ -3694,29 +3696,29 @@ module VexRiscv (
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
-  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h0);
+  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h00);
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
   assign decode_RegFilePlugin_rs1Data = _zz_RegFilePlugin_regFile_port0;
   assign decode_RegFilePlugin_rs2Data = _zz_RegFilePlugin_regFile_port1;
   always @(*) begin
     lastStageRegFileWrite_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
-    if(_zz_7) begin
+    if(_zz_10) begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
   always @(*) begin
     lastStageRegFileWrite_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
-    if(_zz_7) begin
-      lastStageRegFileWrite_payload_address = 5'h0;
+    if(_zz_10) begin
+      lastStageRegFileWrite_payload_address = 5'h00;
     end
   end
 
   always @(*) begin
     lastStageRegFileWrite_payload_data = _zz_decode_RS2_2;
-    if(_zz_7) begin
-      lastStageRegFileWrite_payload_data = 32'h0;
+    if(_zz_10) begin
+      lastStageRegFileWrite_payload_data = 32'h00000000;
     end
   end
 
@@ -3757,7 +3759,7 @@ module VexRiscv (
         _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
       Src1CtrlEnum_IMU : begin
-        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h000};
       end
       default : begin
         _zz_execute_SRC1 = {27'd0, _zz__zz_execute_SRC1_1};
@@ -3765,67 +3767,67 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_execute_SRC2_1 = execute_INSTRUCTION[31];
+  assign _zz_execute_SRC2 = execute_INSTRUCTION[31];
   always @(*) begin
-    _zz_execute_SRC2_2[19] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[18] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[17] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[16] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[15] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[14] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[13] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[12] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[11] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[10] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[9] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[8] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[7] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[6] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[5] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[4] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[3] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[2] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[1] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[0] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_1[19] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[18] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[17] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[16] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[15] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[14] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[13] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[12] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[11] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[10] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[9] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[8] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[7] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[6] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[5] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[4] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[3] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[2] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[1] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[0] = _zz_execute_SRC2;
   end
 
-  assign _zz_execute_SRC2_3 = _zz__zz_execute_SRC2_3[11];
+  assign _zz_execute_SRC2_2 = _zz__zz_execute_SRC2_2[11];
   always @(*) begin
-    _zz_execute_SRC2_4[19] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[18] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[17] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[16] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[15] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[14] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[13] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[12] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[11] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[10] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[9] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[8] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[7] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[6] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[5] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[4] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[3] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[2] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[1] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[0] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_3[19] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[18] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[17] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[16] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[15] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[14] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[13] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[12] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[11] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[10] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[9] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[8] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[7] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[6] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[5] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[4] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[3] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[2] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[1] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[0] = _zz_execute_SRC2_2;
   end
 
   always @(*) begin
     case(execute_SRC2_CTRL)
       Src2CtrlEnum_RS : begin
-        _zz_execute_SRC2_5 = execute_RS2;
+        _zz_execute_SRC2_4 = execute_RS2;
       end
       Src2CtrlEnum_IMI : begin
-        _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
+        _zz_execute_SRC2_4 = {_zz_execute_SRC2_1,execute_INSTRUCTION[31 : 20]};
       end
       Src2CtrlEnum_IMS : begin
-        _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_execute_SRC2_4 = {_zz_execute_SRC2_3,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_execute_SRC2_5 = _zz_execute_SRC2;
+        _zz_execute_SRC2_4 = _zz_execute_to_memory_PC;
       end
     endcase
   end
@@ -3991,16 +3993,19 @@ module VexRiscv (
   assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
   assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign switch_Misc_l210_1 = execute_INSTRUCTION[14 : 12];
+  assign switch_Misc_l232_1 = execute_INSTRUCTION[14 : 12];
   always @(*) begin
-    casez(switch_Misc_l210_1)
+    case(switch_Misc_l232_1)
       3'b000 : begin
         _zz_execute_BRANCH_COND_RESULT = execute_BranchPlugin_eq;
       end
       3'b001 : begin
         _zz_execute_BRANCH_COND_RESULT = (! execute_BranchPlugin_eq);
       end
-      3'b1?1 : begin
+      3'b101 : begin
+        _zz_execute_BRANCH_COND_RESULT = (! execute_SRC_LESS);
+      end
+      3'b111 : begin
         _zz_execute_BRANCH_COND_RESULT = (! execute_SRC_LESS);
       end
       default : begin
@@ -4204,9 +4209,11 @@ module VexRiscv (
     end
   end
 
-  assign _zz_when_CsrPlugin_l965 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_when_CsrPlugin_l965_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_when_CsrPlugin_l965_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign CsrPlugin_misa_base = 2'b01;
+  assign CsrPlugin_misa_extensions = 26'h0000042;
+  assign _zz_when_CsrPlugin_l1302 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l1302_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l1302_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
   assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
@@ -4251,28 +4258,28 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l922 = (! decode_arbitration_isStuck);
-  assign when_CsrPlugin_l922_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l922_2 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l922_3 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l935 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
+  assign when_CsrPlugin_l1259 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l1272 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-  assign when_CsrPlugin_l959 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign when_CsrPlugin_l965 = ((_zz_when_CsrPlugin_l965 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l965_1 = ((_zz_when_CsrPlugin_l965_1 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l965_2 = ((_zz_when_CsrPlugin_l965_2 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1296 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l1302 = ((_zz_when_CsrPlugin_l1302 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1302_1 = ((_zz_when_CsrPlugin_l1302_1 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1302_2 = ((_zz_when_CsrPlugin_l1302_2 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  assign when_CsrPlugin_l993 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l993_1 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l993_2 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l998 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  assign when_CsrPlugin_l1335 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1335_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l1335_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l1340 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
   always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(when_CsrPlugin_l1004) begin
+    if(when_CsrPlugin_l1346) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException) begin
@@ -4280,7 +4287,7 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l1004 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
+  assign when_CsrPlugin_l1346 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
   always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
@@ -4296,6 +4303,7 @@ module VexRiscv (
     end
   end
 
+  assign CsrPlugin_trapCauseEbreakDebug = 1'b0;
   always @(*) begin
     CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
@@ -4318,13 +4326,15 @@ module VexRiscv (
     endcase
   end
 
-  assign when_CsrPlugin_l1032 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign when_CsrPlugin_l1077 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
-  assign switch_CsrPlugin_l1081 = writeBack_INSTRUCTION[29 : 28];
+  assign CsrPlugin_trapEnterDebug = 1'b0;
+  assign when_CsrPlugin_l1390 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1398 = (! CsrPlugin_trapEnterDebug);
+  assign when_CsrPlugin_l1456 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign switch_CsrPlugin_l1460 = writeBack_INSTRUCTION[29 : 28];
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign when_CsrPlugin_l1121 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_WFI));
-  assign when_CsrPlugin_l1123 = (! execute_CsrPlugin_wfiWake);
-  assign when_CsrPlugin_l1129 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
+  assign when_CsrPlugin_l1519 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_WFI));
+  assign when_CsrPlugin_l1521 = (! execute_CsrPlugin_wfiWake);
+  assign when_CsrPlugin_l1527 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
   assign execute_CsrPlugin_blockedBySideEffects = ((|{writeBack_arbitration_isValid,memory_arbitration_isValid}) || 1'b0);
   always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
@@ -4423,18 +4433,18 @@ module VexRiscv (
     if(CsrPlugin_csrMapping_allowCsrSignal) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(when_CsrPlugin_l1315) begin
+    if(when_CsrPlugin_l1725) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if(when_CsrPlugin_l1149) begin
-      if(when_CsrPlugin_l1150) begin
+    if(when_CsrPlugin_l1547) begin
+      if(when_CsrPlugin_l1548) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
@@ -4442,20 +4452,20 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(when_CsrPlugin_l1142) begin
+    if(when_CsrPlugin_l1540) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1157) begin
+    if(when_CsrPlugin_l1555) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(when_CsrPlugin_l1142) begin
+    if(when_CsrPlugin_l1540) begin
       CsrPlugin_selfException_payload_code = 4'b0010;
     end
-    if(when_CsrPlugin_l1157) begin
+    if(when_CsrPlugin_l1555) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -4468,20 +4478,20 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  assign when_CsrPlugin_l1142 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
-  assign when_CsrPlugin_l1149 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
-  assign when_CsrPlugin_l1150 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
-  assign when_CsrPlugin_l1157 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
+  assign when_CsrPlugin_l1540 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
+  assign when_CsrPlugin_l1547 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign when_CsrPlugin_l1548 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1555 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
   always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -4490,9 +4500,9 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
   assign execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
-  assign switch_Misc_l210_2 = execute_INSTRUCTION[13];
+  assign switch_Misc_l232_2 = execute_INSTRUCTION[13];
   always @(*) begin
-    case(switch_Misc_l210_2)
+    case(switch_Misc_l232_2)
       1'b0 : begin
         _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
@@ -4503,8 +4513,8 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
-  assign when_CsrPlugin_l1189 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign when_CsrPlugin_l1193 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
+  assign when_CsrPlugin_l1587 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1591 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
@@ -4567,12 +4577,12 @@ module VexRiscv (
   assign memory_DivPlugin_div_counter_willOverflow = (memory_DivPlugin_div_counter_willOverflowIfInc && memory_DivPlugin_div_counter_willIncrement);
   always @(*) begin
     if(memory_DivPlugin_div_counter_willOverflow) begin
-      memory_DivPlugin_div_counter_valueNext = 6'h0;
+      memory_DivPlugin_div_counter_valueNext = 6'h00;
     end else begin
       memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_memory_DivPlugin_div_counter_valueNext);
     end
     if(memory_DivPlugin_div_counter_willClear) begin
-      memory_DivPlugin_div_counter_valueNext = 6'h0;
+      memory_DivPlugin_div_counter_valueNext = 6'h00;
     end
   end
 
@@ -4596,17 +4606,17 @@ module VexRiscv (
     _zz_memory_DivPlugin_rs1_1[31 : 0] = execute_RS1;
   end
 
-  assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
-  assign externalInterrupt = (|_zz_CsrPlugin_csrMapping_readDataInit_1);
-  assign when_DebugPlugin_l225 = (DebugPlugin_haltIt && (! DebugPlugin_isPipBusy));
+  assign _zz_externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
+  assign externalInterrupt = (|_zz_externalInterrupt);
+  assign when_DebugPlugin_l238 = (DebugPlugin_haltIt && (! DebugPlugin_isPipBusy));
   assign DebugPlugin_allowEBreak = (DebugPlugin_debugUsed && (! DebugPlugin_disableEbreak));
   always @(*) begin
     debug_bus_cmd_ready = 1'b1;
     if(debug_bus_cmd_valid) begin
-      case(switch_DebugPlugin_l267)
+      case(switch_DebugPlugin_l280)
         6'h01 : begin
           if(debug_bus_cmd_payload_wr) begin
-            debug_bus_cmd_ready = IBusCachedPlugin_injectionPort_ready;
+            debug_bus_cmd_ready = DebugPlugin_injectionPort_ready;
           end
         end
         default : begin
@@ -4617,7 +4627,7 @@ module VexRiscv (
 
   always @(*) begin
     debug_bus_rsp_data = DebugPlugin_busReadDataReg;
-    if(when_DebugPlugin_l244) begin
+    if(when_DebugPlugin_l257) begin
       debug_bus_rsp_data[0] = DebugPlugin_resetIt;
       debug_bus_rsp_data[1] = DebugPlugin_haltIt;
       debug_bus_rsp_data[2] = DebugPlugin_isPipBusy;
@@ -4626,14 +4636,14 @@ module VexRiscv (
     end
   end
 
-  assign when_DebugPlugin_l244 = (! _zz_when_DebugPlugin_l244);
+  assign when_DebugPlugin_l257 = (! _zz_when_DebugPlugin_l257);
   always @(*) begin
-    IBusCachedPlugin_injectionPort_valid = 1'b0;
+    DebugPlugin_injectionPort_valid = 1'b0;
     if(debug_bus_cmd_valid) begin
-      case(switch_DebugPlugin_l267)
+      case(switch_DebugPlugin_l280)
         6'h01 : begin
           if(debug_bus_cmd_payload_wr) begin
-            IBusCachedPlugin_injectionPort_valid = 1'b1;
+            DebugPlugin_injectionPort_valid = 1'b1;
           end
         end
         default : begin
@@ -4642,21 +4652,21 @@ module VexRiscv (
     end
   end
 
-  assign IBusCachedPlugin_injectionPort_payload = debug_bus_cmd_payload_data;
-  assign switch_DebugPlugin_l267 = debug_bus_cmd_payload_address[7 : 2];
-  assign when_DebugPlugin_l271 = debug_bus_cmd_payload_data[16];
-  assign when_DebugPlugin_l271_1 = debug_bus_cmd_payload_data[24];
-  assign when_DebugPlugin_l272 = debug_bus_cmd_payload_data[17];
-  assign when_DebugPlugin_l272_1 = debug_bus_cmd_payload_data[25];
-  assign when_DebugPlugin_l273 = debug_bus_cmd_payload_data[25];
-  assign when_DebugPlugin_l274 = debug_bus_cmd_payload_data[25];
-  assign when_DebugPlugin_l275 = debug_bus_cmd_payload_data[18];
-  assign when_DebugPlugin_l275_1 = debug_bus_cmd_payload_data[26];
-  assign when_DebugPlugin_l295 = (execute_arbitration_isValid && execute_DO_EBREAK);
-  assign when_DebugPlugin_l298 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
-  assign when_DebugPlugin_l311 = (DebugPlugin_stepIt && IBusCachedPlugin_incomingInstruction);
+  assign DebugPlugin_injectionPort_payload = debug_bus_cmd_payload_data;
+  assign switch_DebugPlugin_l280 = debug_bus_cmd_payload_address[7 : 2];
+  assign when_DebugPlugin_l284 = debug_bus_cmd_payload_data[16];
+  assign when_DebugPlugin_l284_1 = debug_bus_cmd_payload_data[24];
+  assign when_DebugPlugin_l285 = debug_bus_cmd_payload_data[17];
+  assign when_DebugPlugin_l285_1 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l286 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l287 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l288 = debug_bus_cmd_payload_data[18];
+  assign when_DebugPlugin_l288_1 = debug_bus_cmd_payload_data[26];
+  assign when_DebugPlugin_l308 = (execute_arbitration_isValid && execute_DO_EBREAK);
+  assign when_DebugPlugin_l311 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
+  assign when_DebugPlugin_l324 = (DebugPlugin_stepIt && IBusCachedPlugin_incomingInstruction);
   assign debug_resetOut = DebugPlugin_resetIt_regNext;
-  assign when_DebugPlugin_l331 = (DebugPlugin_haltIt || DebugPlugin_stepIt);
+  assign when_DebugPlugin_l344 = (DebugPlugin_haltIt || DebugPlugin_stepIt);
   assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
@@ -4774,216 +4784,225 @@ module VexRiscv (
   assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
   assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
   always @(*) begin
-    IBusCachedPlugin_injectionPort_ready = 1'b0;
-    case(switch_Fetcher_l365)
+    DebugPlugin_injectionPort_ready = 1'b0;
+    case(IBusCachedPlugin_injector_port_state)
       3'b100 : begin
-        IBusCachedPlugin_injectionPort_ready = 1'b1;
+        DebugPlugin_injectionPort_ready = 1'b1;
       end
       default : begin
       end
     endcase
   end
 
-  assign when_Fetcher_l381 = (! decode_arbitration_isStuck);
-  assign when_CsrPlugin_l1277 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_2 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_3 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_4 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_5 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_6 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_7 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_8 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_9 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_10 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_11 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_12 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_13 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_14 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_15 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_16 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_17 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_18 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_19 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_20 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_21 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_22 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_23 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l391 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l1669 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_8 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_9 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_10 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_11 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_12 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_13 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_14 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_15 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_16 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_17 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_18 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_19 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_20 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_21 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_22 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_23 = (! execute_arbitration_isStuck);
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_1 = 32'h00000000;
     if(execute_CsrPlugin_csr_3264) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_2[12 : 0] = 13'h1000;
-      _zz_CsrPlugin_csrMapping_readDataInit_2[25 : 20] = 6'h20;
+      _zz_CsrPlugin_csrMapping_readDataInit_1[12 : 0] = 13'h1000;
+      _zz_CsrPlugin_csrMapping_readDataInit_1[25 : 20] = 6'h20;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h00000000;
     if(execute_CsrPlugin_csr_3857) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_3[3 : 0] = 4'b1011;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[3 : 0] = 4'b1011;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h00000000;
     if(execute_CsrPlugin_csr_3858) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_4[4 : 0] = 5'h16;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[4 : 0] = 5'h16;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h00000000;
     if(execute_CsrPlugin_csr_3859) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_5[5 : 0] = 6'h21;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[5 : 0] = 6'h21;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h00000000;
     if(execute_CsrPlugin_csr_769) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_6[31 : 30] = CsrPlugin_misa_base;
-      _zz_CsrPlugin_csrMapping_readDataInit_6[25 : 0] = CsrPlugin_misa_extensions;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[31 : 30] = CsrPlugin_misa_base;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[25 : 0] = CsrPlugin_misa_extensions;
     end
   end
 
-  assign switch_CsrPlugin_l723 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
+  assign switch_CsrPlugin_l1031 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h00000000;
     if(execute_CsrPlugin_csr_768) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_7[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_7[3 : 3] = CsrPlugin_mstatus_MIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_7[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[12 : 11] = CsrPlugin_mstatus_MPP;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h00000000;
     if(execute_CsrPlugin_csr_836) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_8[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_8[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_8[3 : 3] = CsrPlugin_mip_MSIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[3 : 3] = CsrPlugin_mip_MSIP;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h00000000;
     if(execute_CsrPlugin_csr_772) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_9[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_9[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_9[3 : 3] = CsrPlugin_mie_MSIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_8[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_8[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_8[3 : 3] = CsrPlugin_mie_MSIE;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_10 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h00000000;
     if(execute_CsrPlugin_csr_773) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_10[31 : 2] = CsrPlugin_mtvec_base;
-      _zz_CsrPlugin_csrMapping_readDataInit_10[1 : 0] = CsrPlugin_mtvec_mode;
+      _zz_CsrPlugin_csrMapping_readDataInit_9[31 : 2] = CsrPlugin_mtvec_base;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_11 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_10 = 32'h00000000;
     if(execute_CsrPlugin_csr_833) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_11[31 : 0] = CsrPlugin_mepc;
+      _zz_CsrPlugin_csrMapping_readDataInit_10[31 : 0] = CsrPlugin_mepc;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_12 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_11 = 32'h00000000;
     if(execute_CsrPlugin_csr_832) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_12[31 : 0] = CsrPlugin_mscratch;
+      _zz_CsrPlugin_csrMapping_readDataInit_11[31 : 0] = CsrPlugin_mscratch;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_13 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_12 = 32'h00000000;
     if(execute_CsrPlugin_csr_834) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_13[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_CsrPlugin_csrMapping_readDataInit_13[3 : 0] = CsrPlugin_mcause_exceptionCode;
+      _zz_CsrPlugin_csrMapping_readDataInit_12[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_CsrPlugin_csrMapping_readDataInit_12[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_14 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_13 = 32'h00000000;
     if(execute_CsrPlugin_csr_835) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_14[31 : 0] = CsrPlugin_mtval;
+      _zz_CsrPlugin_csrMapping_readDataInit_13[31 : 0] = CsrPlugin_mtval;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_15 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_14 = 32'h00000000;
     if(execute_CsrPlugin_csr_2816) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_15[31 : 0] = CsrPlugin_mcycle[31 : 0];
+      _zz_CsrPlugin_csrMapping_readDataInit_14[31 : 0] = CsrPlugin_mcycle[31 : 0];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_16 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_15 = 32'h00000000;
     if(execute_CsrPlugin_csr_2944) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_16[31 : 0] = CsrPlugin_mcycle[63 : 32];
+      _zz_CsrPlugin_csrMapping_readDataInit_15[31 : 0] = CsrPlugin_mcycle[63 : 32];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_17 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_16 = 32'h00000000;
     if(execute_CsrPlugin_csr_2818) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_17[31 : 0] = CsrPlugin_minstret[31 : 0];
+      _zz_CsrPlugin_csrMapping_readDataInit_16[31 : 0] = CsrPlugin_minstret[31 : 0];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_18 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_17 = 32'h00000000;
     if(execute_CsrPlugin_csr_2946) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_18[31 : 0] = CsrPlugin_minstret[63 : 32];
+      _zz_CsrPlugin_csrMapping_readDataInit_17[31 : 0] = CsrPlugin_minstret[63 : 32];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_19 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_18 = 32'h00000000;
     if(execute_CsrPlugin_csr_3072) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_19[31 : 0] = CsrPlugin_mcycle[31 : 0];
+      _zz_CsrPlugin_csrMapping_readDataInit_18[31 : 0] = CsrPlugin_mcycle[31 : 0];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_20 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_19 = 32'h00000000;
     if(execute_CsrPlugin_csr_3200) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_20[31 : 0] = CsrPlugin_mcycle[63 : 32];
+      _zz_CsrPlugin_csrMapping_readDataInit_19[31 : 0] = CsrPlugin_mcycle[63 : 32];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_21 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_20 = 32'h00000000;
     if(execute_CsrPlugin_csr_3074) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_21[31 : 0] = CsrPlugin_minstret[31 : 0];
+      _zz_CsrPlugin_csrMapping_readDataInit_20[31 : 0] = CsrPlugin_minstret[31 : 0];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_22 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_21 = 32'h00000000;
     if(execute_CsrPlugin_csr_3202) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_22[31 : 0] = CsrPlugin_minstret[63 : 32];
+      _zz_CsrPlugin_csrMapping_readDataInit_21[31 : 0] = CsrPlugin_minstret[63 : 32];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_23 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_22 = 32'h00000000;
     if(execute_CsrPlugin_csr_3008) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_23[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
+      _zz_CsrPlugin_csrMapping_readDataInit_22[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_24 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_23 = 32'h00000000;
     if(execute_CsrPlugin_csr_4032) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_24[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_1;
+      _zz_CsrPlugin_csrMapping_readDataInit_23[31 : 0] = _zz_externalInterrupt;
     end
   end
 
-  assign CsrPlugin_csrMapping_readDataInit = (((((_zz_CsrPlugin_csrMapping_readDataInit_2 | _zz_CsrPlugin_csrMapping_readDataInit_3) | (_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5)) | ((_zz_CsrPlugin_csrMapping_readDataInit_25 | _zz_CsrPlugin_csrMapping_readDataInit_6) | (_zz_CsrPlugin_csrMapping_readDataInit_7 | _zz_CsrPlugin_csrMapping_readDataInit_8))) | (((_zz_CsrPlugin_csrMapping_readDataInit_9 | _zz_CsrPlugin_csrMapping_readDataInit_10) | (_zz_CsrPlugin_csrMapping_readDataInit_11 | _zz_CsrPlugin_csrMapping_readDataInit_12)) | ((_zz_CsrPlugin_csrMapping_readDataInit_13 | _zz_CsrPlugin_csrMapping_readDataInit_14) | (_zz_CsrPlugin_csrMapping_readDataInit_15 | _zz_CsrPlugin_csrMapping_readDataInit_16)))) | (((_zz_CsrPlugin_csrMapping_readDataInit_17 | _zz_CsrPlugin_csrMapping_readDataInit_18) | (_zz_CsrPlugin_csrMapping_readDataInit_19 | _zz_CsrPlugin_csrMapping_readDataInit_20)) | ((_zz_CsrPlugin_csrMapping_readDataInit_21 | _zz_CsrPlugin_csrMapping_readDataInit_22) | (_zz_CsrPlugin_csrMapping_readDataInit_23 | _zz_CsrPlugin_csrMapping_readDataInit_24))));
-  assign when_CsrPlugin_l1310 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign when_CsrPlugin_l1315 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign CsrPlugin_csrMapping_readDataInit = (((((_zz_CsrPlugin_csrMapping_readDataInit_1 | _zz_CsrPlugin_csrMapping_readDataInit_2) | (_zz_CsrPlugin_csrMapping_readDataInit_3 | _zz_CsrPlugin_csrMapping_readDataInit_4)) | ((_zz_CsrPlugin_csrMapping_readDataInit_24 | _zz_CsrPlugin_csrMapping_readDataInit_5) | (_zz_CsrPlugin_csrMapping_readDataInit_6 | _zz_CsrPlugin_csrMapping_readDataInit_7))) | (((_zz_CsrPlugin_csrMapping_readDataInit_8 | _zz_CsrPlugin_csrMapping_readDataInit_9) | (_zz_CsrPlugin_csrMapping_readDataInit_10 | _zz_CsrPlugin_csrMapping_readDataInit_11)) | ((_zz_CsrPlugin_csrMapping_readDataInit_12 | _zz_CsrPlugin_csrMapping_readDataInit_13) | (_zz_CsrPlugin_csrMapping_readDataInit_14 | _zz_CsrPlugin_csrMapping_readDataInit_15)))) | (((_zz_CsrPlugin_csrMapping_readDataInit_16 | _zz_CsrPlugin_csrMapping_readDataInit_17) | (_zz_CsrPlugin_csrMapping_readDataInit_18 | _zz_CsrPlugin_csrMapping_readDataInit_19)) | ((_zz_CsrPlugin_csrMapping_readDataInit_20 | _zz_CsrPlugin_csrMapping_readDataInit_21) | (_zz_CsrPlugin_csrMapping_readDataInit_22 | _zz_CsrPlugin_csrMapping_readDataInit_23))));
+  assign when_CsrPlugin_l1702 = ((execute_arbitration_isValid && execute_IS_CSR) && (({execute_CsrPlugin_csrAddress[11 : 2],2'b00} == 12'h3a0) || ({execute_CsrPlugin_csrAddress[11 : 4],4'b0000} == 12'h3b0)));
+  assign _zz_when_CsrPlugin_l1709 = (execute_CsrPlugin_csrAddress & 12'hf60);
+  assign when_CsrPlugin_l1709 = (((execute_arbitration_isValid && execute_IS_CSR) && (5'h03 <= execute_CsrPlugin_csrAddress[4 : 0])) && (((_zz_when_CsrPlugin_l1709 == 12'hb00) || (((_zz_when_CsrPlugin_l1709 == 12'hc00) && (! execute_CsrPlugin_writeInstruction)) && (CsrPlugin_privilege == 2'b11))) || ((execute_CsrPlugin_csrAddress & 12'hfe0) == 12'h320)));
+  always @(*) begin
+    when_CsrPlugin_l1719 = CsrPlugin_csrMapping_doForceFailCsr;
+    if(when_CsrPlugin_l1717) begin
+      when_CsrPlugin_l1719 = 1'b1;
+    end
+  end
+
+  assign when_CsrPlugin_l1717 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1725 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
   assign iBusWishbone_ADR = {_zz_iBusWishbone_ADR_1,_zz_iBusWishbone_ADR};
   assign iBusWishbone_CTI = ((_zz_iBusWishbone_ADR == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
@@ -5009,20 +5028,20 @@ module VexRiscv (
   assign iBus_rsp_valid = _zz_iBus_rsp_valid;
   assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
   assign iBus_rsp_payload_error = 1'b0;
-  assign _zz_dBus_cmd_ready_5 = (dBus_cmd_payload_size == 3'b101);
-  assign _zz_dBus_cmd_ready_1 = dBus_cmd_valid;
-  assign _zz_dBus_cmd_ready_3 = dBus_cmd_payload_wr;
-  assign _zz_dBus_cmd_ready_4 = ((! _zz_dBus_cmd_ready_5) || (_zz_dBus_cmd_ready == 3'b111));
-  assign dBus_cmd_ready = (_zz_dBus_cmd_ready_2 && (_zz_dBus_cmd_ready_3 || _zz_dBus_cmd_ready_4));
-  assign dBusWishbone_ADR = ((_zz_dBus_cmd_ready_5 ? {{dBus_cmd_payload_address[31 : 5],_zz_dBus_cmd_ready},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
-  assign dBusWishbone_CTI = (_zz_dBus_cmd_ready_5 ? (_zz_dBus_cmd_ready_4 ? 3'b111 : 3'b010) : 3'b000);
+  assign _zz_dBusWishbone_ADR_1 = (dBus_cmd_payload_size == 3'b101);
+  assign _zz_dBusWishbone_CYC = dBus_cmd_valid;
+  assign _zz_dBus_cmd_ready_1 = dBus_cmd_payload_wr;
+  assign _zz_dBus_cmd_ready_2 = ((! _zz_dBusWishbone_ADR_1) || (_zz_dBusWishbone_ADR == 3'b111));
+  assign dBus_cmd_ready = (_zz_dBus_cmd_ready && (_zz_dBus_cmd_ready_1 || _zz_dBus_cmd_ready_2));
+  assign dBusWishbone_ADR = ((_zz_dBusWishbone_ADR_1 ? {{dBus_cmd_payload_address[31 : 5],_zz_dBusWishbone_ADR},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2'd2);
+  assign dBusWishbone_CTI = (_zz_dBusWishbone_ADR_1 ? (_zz_dBus_cmd_ready_2 ? 3'b111 : 3'b010) : 3'b000);
   assign dBusWishbone_BTE = 2'b00;
-  assign dBusWishbone_SEL = (_zz_dBus_cmd_ready_3 ? dBus_cmd_payload_mask : 4'b1111);
-  assign dBusWishbone_WE = _zz_dBus_cmd_ready_3;
+  assign dBusWishbone_SEL = (_zz_dBus_cmd_ready_1 ? dBus_cmd_payload_mask : 4'b1111);
+  assign dBusWishbone_WE = _zz_dBus_cmd_ready_1;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_payload_data;
-  assign _zz_dBus_cmd_ready_2 = (_zz_dBus_cmd_ready_1 && dBusWishbone_ACK);
-  assign dBusWishbone_CYC = _zz_dBus_cmd_ready_1;
-  assign dBusWishbone_STB = _zz_dBus_cmd_ready_1;
+  assign _zz_dBus_cmd_ready = (_zz_dBusWishbone_CYC && dBusWishbone_ACK);
+  assign dBusWishbone_CYC = _zz_dBusWishbone_CYC;
+  assign dBusWishbone_STB = _zz_dBusWishbone_CYC;
   assign dBus_rsp_valid = _zz_dBus_rsp_valid;
   assign dBus_rsp_payload_data = dBusWishbone_DAT_MISO_regNext;
   assign dBus_rsp_payload_error = 1'b0;
@@ -5032,29 +5051,27 @@ module VexRiscv (
       IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
-      _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+      _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= 1'b0;
       _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= 32'h0;
-      dataCache_1_io_mem_cmd_rValid <= 1'b0;
-      dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= 32'h0;
-      _zz_7 <= 1'b1;
+      IBusCachedPlugin_rspCounter <= 32'h00000000;
+      toplevel_dataCache_1_io_mem_cmd_rValidN <= 1'b1;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
+      DBusCachedPlugin_rspCounter <= 32'h00000000;
+      _zz_10 <= 1'b1;
       HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
-      CsrPlugin_misa_base <= 2'b01;
-      CsrPlugin_misa_extensions <= 26'h0000042;
       CsrPlugin_mstatus_MIE <= 1'b0;
       CsrPlugin_mstatus_MPIE <= 1'b0;
       CsrPlugin_mstatus_MPP <= 2'b11;
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
-      CsrPlugin_mcycle <= 64'h0;
-      CsrPlugin_minstret <= 64'h0;
+      CsrPlugin_mcycle <= 64'h0000000000000000;
+      CsrPlugin_minstret <= 64'h0000000000000000;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= 1'b0;
@@ -5066,15 +5083,15 @@ module VexRiscv (
       CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
-      memory_DivPlugin_div_counter_value <= 6'h0;
-      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h0;
+      memory_DivPlugin_div_counter_value <= 6'h00;
+      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h00000000;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
-      switch_Fetcher_l365 <= 3'b000;
+      IBusCachedPlugin_injector_port_state <= 3'b000;
       _zz_iBusWishbone_ADR <= 3'b000;
       _zz_iBus_rsp_valid <= 1'b0;
-      _zz_dBus_cmd_ready <= 3'b000;
+      _zz_dBusWishbone_ADR <= 3'b000;
       _zz_dBus_rsp_valid <= 1'b0;
     end else begin
       if(IBusCachedPlugin_fetchPc_correction) begin
@@ -5084,23 +5101,23 @@ module VexRiscv (
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusCachedPlugin_fetchPc_booted <= 1'b1;
-      if(when_Fetcher_l134) begin
+      if(when_Fetcher_l133) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_output_fire_1) begin
+      if(IBusCachedPlugin_fetchPc_output_fire) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b1;
       end
-      if(when_Fetcher_l134_1) begin
+      if(when_Fetcher_l133_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(when_Fetcher_l161) begin
+      if(when_Fetcher_l160) begin
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
       if(IBusCachedPlugin_iBusRsp_flush) begin
-        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= 1'b0;
       end
       if(_zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready) begin
-        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
       if(IBusCachedPlugin_iBusRsp_flush) begin
         _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
@@ -5111,13 +5128,13 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if(when_Fetcher_l332) begin
+      if(when_Fetcher_l331) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(when_Fetcher_l332_1) begin
+      if(when_Fetcher_l331_1) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= IBusCachedPlugin_injector_nextPcCalc_valids_0;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5126,7 +5143,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(when_Fetcher_l332_2) begin
+      if(when_Fetcher_l331_2) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= IBusCachedPlugin_injector_nextPcCalc_valids_1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5135,7 +5152,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(when_Fetcher_l332_3) begin
+      if(when_Fetcher_l331_3) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5144,7 +5161,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if(when_Fetcher_l332_4) begin
+      if(when_Fetcher_l331_4) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= IBusCachedPlugin_injector_nextPcCalc_valids_3;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5154,68 +5171,68 @@ module VexRiscv (
         IBusCachedPlugin_rspCounter <= (IBusCachedPlugin_rspCounter + 32'h00000001);
       end
       if(dataCache_1_io_mem_cmd_valid) begin
-        dataCache_1_io_mem_cmd_rValid <= 1'b1;
+        toplevel_dataCache_1_io_mem_cmd_rValidN <= 1'b0;
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
-        dataCache_1_io_mem_cmd_rValid <= 1'b0;
+      if(toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+        toplevel_dataCache_1_io_mem_cmd_rValidN <= 1'b1;
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
-        dataCache_1_io_mem_cmd_s2mPipe_rValid <= dataCache_1_io_mem_cmd_s2mPipe_valid;
+      if(toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+        toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_valid;
       end
       if(dBus_rsp_valid) begin
         DBusCachedPlugin_rspCounter <= (DBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      _zz_7 <= 1'b0;
+      _zz_10 <= 1'b0;
       HazardSimplePlugin_writeBackBuffer_valid <= HazardSimplePlugin_writeBackWrites_valid;
       CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
       if(writeBack_arbitration_isFiring) begin
         CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
       end
-      if(when_CsrPlugin_l922) begin
+      if(when_CsrPlugin_l1259) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if(when_CsrPlugin_l922_1) begin
+      if(when_CsrPlugin_l1259_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if(when_CsrPlugin_l922_2) begin
+      if(when_CsrPlugin_l1259_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if(when_CsrPlugin_l922_3) begin
+      if(when_CsrPlugin_l1259_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(when_CsrPlugin_l959) begin
-        if(when_CsrPlugin_l965) begin
+      if(when_CsrPlugin_l1296) begin
+        if(when_CsrPlugin_l1302) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_1) begin
+        if(when_CsrPlugin_l1302_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_2) begin
+        if(when_CsrPlugin_l1302_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
       CsrPlugin_lastStageWasWfi <= (writeBack_arbitration_isFiring && (writeBack_ENV_CTRL == EnvCtrlEnum_WFI));
       if(CsrPlugin_pipelineLiberator_active) begin
-        if(when_CsrPlugin_l993) begin
+        if(when_CsrPlugin_l1335) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if(when_CsrPlugin_l993_1) begin
+        if(when_CsrPlugin_l1335_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if(when_CsrPlugin_l993_2) begin
+        if(when_CsrPlugin_l1335_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(when_CsrPlugin_l998) begin
+      if(when_CsrPlugin_l1340) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
@@ -5224,19 +5241,21 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(when_CsrPlugin_l1032) begin
-        case(CsrPlugin_targetPrivilege)
-          2'b11 : begin
-            CsrPlugin_mstatus_MIE <= 1'b0;
-            CsrPlugin_mstatus_MPIE <= CsrPlugin_mstatus_MIE;
-            CsrPlugin_mstatus_MPP <= CsrPlugin_privilege;
-          end
-          default : begin
-          end
-        endcase
+      if(when_CsrPlugin_l1390) begin
+        if(when_CsrPlugin_l1398) begin
+          case(CsrPlugin_targetPrivilege)
+            2'b11 : begin
+              CsrPlugin_mstatus_MIE <= 1'b0;
+              CsrPlugin_mstatus_MPIE <= CsrPlugin_mstatus_MIE;
+              CsrPlugin_mstatus_MPP <= CsrPlugin_privilege;
+            end
+            default : begin
+            end
+          endcase
+        end
       end
-      if(when_CsrPlugin_l1077) begin
-        case(switch_CsrPlugin_l1081)
+      if(when_CsrPlugin_l1456) begin
+        case(switch_CsrPlugin_l1460)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -5246,7 +5265,7 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l965_2,{_zz_when_CsrPlugin_l965_1,_zz_when_CsrPlugin_l965}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l1302_2,{_zz_when_CsrPlugin_l1302_1,_zz_when_CsrPlugin_l1302}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
       if(when_Pipeline_l151) begin
         execute_arbitration_isValid <= 1'b0;
@@ -5266,40 +5285,34 @@ module VexRiscv (
       if(when_Pipeline_l154_2) begin
         writeBack_arbitration_isValid <= memory_arbitration_isValid;
       end
-      case(switch_Fetcher_l365)
+      case(IBusCachedPlugin_injector_port_state)
         3'b000 : begin
-          if(IBusCachedPlugin_injectionPort_valid) begin
-            switch_Fetcher_l365 <= 3'b001;
+          if(DebugPlugin_injectionPort_valid) begin
+            IBusCachedPlugin_injector_port_state <= 3'b001;
           end
         end
         3'b001 : begin
-          switch_Fetcher_l365 <= 3'b010;
+          IBusCachedPlugin_injector_port_state <= 3'b010;
         end
         3'b010 : begin
-          switch_Fetcher_l365 <= 3'b011;
+          IBusCachedPlugin_injector_port_state <= 3'b011;
         end
         3'b011 : begin
-          if(when_Fetcher_l381) begin
-            switch_Fetcher_l365 <= 3'b100;
+          if(when_Fetcher_l391) begin
+            IBusCachedPlugin_injector_port_state <= 3'b100;
           end
         end
         3'b100 : begin
-          switch_Fetcher_l365 <= 3'b000;
+          IBusCachedPlugin_injector_port_state <= 3'b000;
         end
         default : begin
         end
       endcase
-      if(execute_CsrPlugin_csr_769) begin
-        if(execute_CsrPlugin_writeEnable) begin
-          CsrPlugin_misa_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 30];
-          CsrPlugin_misa_extensions <= CsrPlugin_csrMapping_writeDataSignal[25 : 0];
-        end
-      end
       if(execute_CsrPlugin_csr_768) begin
         if(execute_CsrPlugin_writeEnable) begin
           CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
           CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
-          case(switch_CsrPlugin_l723)
+          case(switch_CsrPlugin_l1031)
             2'b11 : begin
               CsrPlugin_mstatus_MPP <= 2'b11;
             end
@@ -5346,13 +5359,13 @@ module VexRiscv (
         end
       end
       _zz_iBus_rsp_valid <= (iBusWishbone_CYC && iBusWishbone_ACK);
-      if((_zz_dBus_cmd_ready_1 && _zz_dBus_cmd_ready_2)) begin
-        _zz_dBus_cmd_ready <= (_zz_dBus_cmd_ready + 3'b001);
-        if(_zz_dBus_cmd_ready_4) begin
-          _zz_dBus_cmd_ready <= 3'b000;
+      if((_zz_dBusWishbone_CYC && _zz_dBus_cmd_ready)) begin
+        _zz_dBusWishbone_ADR <= (_zz_dBusWishbone_ADR + 3'b001);
+        if(_zz_dBus_cmd_ready_2) begin
+          _zz_dBusWishbone_ADR <= 3'b000;
         end
       end
-      _zz_dBus_rsp_valid <= ((_zz_dBus_cmd_ready_1 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
+      _zz_dBus_rsp_valid <= ((_zz_dBusWishbone_CYC && (! dBusWishbone_WE)) && dBusWishbone_ACK);
     end
   end
 
@@ -5366,23 +5379,23 @@ module VexRiscv (
     if(IBusCachedPlugin_iBusRsp_stages_2_input_ready) begin
       IBusCachedPlugin_s2_tightlyCoupledHit <= IBusCachedPlugin_s1_tightlyCoupledHit;
     end
-    if(dataCache_1_io_mem_cmd_ready) begin
-      dataCache_1_io_mem_cmd_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
-      dataCache_1_io_mem_cmd_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
-      dataCache_1_io_mem_cmd_rData_address <= dataCache_1_io_mem_cmd_payload_address;
-      dataCache_1_io_mem_cmd_rData_data <= dataCache_1_io_mem_cmd_payload_data;
-      dataCache_1_io_mem_cmd_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
-      dataCache_1_io_mem_cmd_rData_size <= dataCache_1_io_mem_cmd_payload_size;
-      dataCache_1_io_mem_cmd_rData_last <= dataCache_1_io_mem_cmd_payload_last;
+    if(toplevel_dataCache_1_io_mem_cmd_rValidN) begin
+      toplevel_dataCache_1_io_mem_cmd_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
+      toplevel_dataCache_1_io_mem_cmd_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
+      toplevel_dataCache_1_io_mem_cmd_rData_address <= dataCache_1_io_mem_cmd_payload_address;
+      toplevel_dataCache_1_io_mem_cmd_rData_data <= dataCache_1_io_mem_cmd_payload_data;
+      toplevel_dataCache_1_io_mem_cmd_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
+      toplevel_dataCache_1_io_mem_cmd_rData_size <= dataCache_1_io_mem_cmd_payload_size;
+      toplevel_dataCache_1_io_mem_cmd_rData_last <= dataCache_1_io_mem_cmd_payload_last;
     end
-    if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
-      dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_address <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_data <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_size <= dataCache_1_io_mem_cmd_s2mPipe_payload_size;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_last <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+    if(toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_address <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_data <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_size <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_size;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_last <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_last;
     end
     HazardSimplePlugin_writeBackBuffer_payload_address <= HazardSimplePlugin_writeBackWrites_payload_address;
     HazardSimplePlugin_writeBackBuffer_payload_data <= HazardSimplePlugin_writeBackWrites_payload_data;
@@ -5405,33 +5418,35 @@ module VexRiscv (
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(when_CsrPlugin_l959) begin
-      if(when_CsrPlugin_l965) begin
+    if(when_CsrPlugin_l1296) begin
+      if(when_CsrPlugin_l1302) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l965_1) begin
+      if(when_CsrPlugin_l1302_1) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l965_2) begin
+      if(when_CsrPlugin_l1302_2) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(when_CsrPlugin_l1032) begin
-      case(CsrPlugin_targetPrivilege)
-        2'b11 : begin
-          CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
-          CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
-          CsrPlugin_mepc <= writeBack_PC;
-          if(CsrPlugin_hadException) begin
-            CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
+    if(when_CsrPlugin_l1390) begin
+      if(when_CsrPlugin_l1398) begin
+        case(CsrPlugin_targetPrivilege)
+          2'b11 : begin
+            CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
+            CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
+            CsrPlugin_mepc <= writeBack_PC;
+            if(CsrPlugin_hadException) begin
+              CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
+            end
           end
-        end
-        default : begin
-        end
-      endcase
+          default : begin
+          end
+        endcase
+      end
     end
     if(when_MulDivIterativePlugin_l126) begin
       memory_DivPlugin_div_done <= 1'b1;
@@ -5449,17 +5464,17 @@ module VexRiscv (
       end
     end
     if(when_MulDivIterativePlugin_l162) begin
-      memory_DivPlugin_accumulator <= 65'h0;
+      memory_DivPlugin_accumulator <= 65'h00000000000000000;
       memory_DivPlugin_rs1 <= ((_zz_memory_DivPlugin_rs1 ? (~ _zz_memory_DivPlugin_rs1_1) : _zz_memory_DivPlugin_rs1_1) + _zz_memory_DivPlugin_rs1_2);
       memory_DivPlugin_rs2 <= ((_zz_memory_DivPlugin_rs2 ? (~ execute_RS2) : execute_RS2) + _zz_memory_DivPlugin_rs2_1);
-      memory_DivPlugin_div_needRevert <= ((_zz_memory_DivPlugin_rs1 ^ (_zz_memory_DivPlugin_rs2 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
+      memory_DivPlugin_div_needRevert <= ((_zz_memory_DivPlugin_rs1 ^ (_zz_memory_DivPlugin_rs2 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h00000000) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
     end
     externalInterruptArray_regNext <= externalInterruptArray;
     if(when_Pipeline_l124) begin
       decode_to_execute_PC <= decode_PC;
     end
     if(when_Pipeline_l124_1) begin
-      execute_to_memory_PC <= _zz_execute_SRC2;
+      execute_to_memory_PC <= _zz_execute_to_memory_PC;
     end
     if(when_Pipeline_l124_2) begin
       memory_to_writeBack_PC <= memory_PC;
@@ -5644,76 +5659,76 @@ module VexRiscv (
     if(when_Pipeline_l124_62) begin
       memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
     end
-    if(when_CsrPlugin_l1277) begin
+    if(when_CsrPlugin_l1669) begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
     end
-    if(when_CsrPlugin_l1277_1) begin
+    if(when_CsrPlugin_l1669_1) begin
       execute_CsrPlugin_csr_3857 <= (decode_INSTRUCTION[31 : 20] == 12'hf11);
     end
-    if(when_CsrPlugin_l1277_2) begin
+    if(when_CsrPlugin_l1669_2) begin
       execute_CsrPlugin_csr_3858 <= (decode_INSTRUCTION[31 : 20] == 12'hf12);
     end
-    if(when_CsrPlugin_l1277_3) begin
+    if(when_CsrPlugin_l1669_3) begin
       execute_CsrPlugin_csr_3859 <= (decode_INSTRUCTION[31 : 20] == 12'hf13);
     end
-    if(when_CsrPlugin_l1277_4) begin
+    if(when_CsrPlugin_l1669_4) begin
       execute_CsrPlugin_csr_3860 <= (decode_INSTRUCTION[31 : 20] == 12'hf14);
     end
-    if(when_CsrPlugin_l1277_5) begin
+    if(when_CsrPlugin_l1669_5) begin
       execute_CsrPlugin_csr_769 <= (decode_INSTRUCTION[31 : 20] == 12'h301);
     end
-    if(when_CsrPlugin_l1277_6) begin
+    if(when_CsrPlugin_l1669_6) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if(when_CsrPlugin_l1277_7) begin
+    if(when_CsrPlugin_l1669_7) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if(when_CsrPlugin_l1277_8) begin
+    if(when_CsrPlugin_l1669_8) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if(when_CsrPlugin_l1277_9) begin
+    if(when_CsrPlugin_l1669_9) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if(when_CsrPlugin_l1277_10) begin
+    if(when_CsrPlugin_l1669_10) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if(when_CsrPlugin_l1277_11) begin
+    if(when_CsrPlugin_l1669_11) begin
       execute_CsrPlugin_csr_832 <= (decode_INSTRUCTION[31 : 20] == 12'h340);
     end
-    if(when_CsrPlugin_l1277_12) begin
+    if(when_CsrPlugin_l1669_12) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if(when_CsrPlugin_l1277_13) begin
+    if(when_CsrPlugin_l1669_13) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if(when_CsrPlugin_l1277_14) begin
+    if(when_CsrPlugin_l1669_14) begin
       execute_CsrPlugin_csr_2816 <= (decode_INSTRUCTION[31 : 20] == 12'hb00);
     end
-    if(when_CsrPlugin_l1277_15) begin
+    if(when_CsrPlugin_l1669_15) begin
       execute_CsrPlugin_csr_2944 <= (decode_INSTRUCTION[31 : 20] == 12'hb80);
     end
-    if(when_CsrPlugin_l1277_16) begin
+    if(when_CsrPlugin_l1669_16) begin
       execute_CsrPlugin_csr_2818 <= (decode_INSTRUCTION[31 : 20] == 12'hb02);
     end
-    if(when_CsrPlugin_l1277_17) begin
+    if(when_CsrPlugin_l1669_17) begin
       execute_CsrPlugin_csr_2946 <= (decode_INSTRUCTION[31 : 20] == 12'hb82);
     end
-    if(when_CsrPlugin_l1277_18) begin
+    if(when_CsrPlugin_l1669_18) begin
       execute_CsrPlugin_csr_3072 <= (decode_INSTRUCTION[31 : 20] == 12'hc00);
     end
-    if(when_CsrPlugin_l1277_19) begin
+    if(when_CsrPlugin_l1669_19) begin
       execute_CsrPlugin_csr_3200 <= (decode_INSTRUCTION[31 : 20] == 12'hc80);
     end
-    if(when_CsrPlugin_l1277_20) begin
+    if(when_CsrPlugin_l1669_20) begin
       execute_CsrPlugin_csr_3074 <= (decode_INSTRUCTION[31 : 20] == 12'hc02);
     end
-    if(when_CsrPlugin_l1277_21) begin
+    if(when_CsrPlugin_l1669_21) begin
       execute_CsrPlugin_csr_3202 <= (decode_INSTRUCTION[31 : 20] == 12'hc82);
     end
-    if(when_CsrPlugin_l1277_22) begin
+    if(when_CsrPlugin_l1669_22) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if(when_CsrPlugin_l1277_23) begin
+    if(when_CsrPlugin_l1669_23) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
     if(execute_CsrPlugin_csr_836) begin
@@ -5724,7 +5739,6 @@ module VexRiscv (
     if(execute_CsrPlugin_csr_773) begin
       if(execute_CsrPlugin_writeEnable) begin
         CsrPlugin_mtvec_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 2];
-        CsrPlugin_mtvec_mode <= CsrPlugin_csrMapping_writeDataSignal[1 : 0];
       end
     end
     if(execute_CsrPlugin_csr_833) begin
@@ -5762,9 +5776,9 @@ module VexRiscv (
     if(writeBack_arbitration_isValid) begin
       DebugPlugin_busReadDataReg <= _zz_decode_RS2_2;
     end
-    _zz_when_DebugPlugin_l244 <= debug_bus_cmd_payload_address[2];
+    _zz_when_DebugPlugin_l257 <= debug_bus_cmd_payload_address[2];
     if(debug_bus_cmd_valid) begin
-      case(switch_DebugPlugin_l267)
+      case(switch_DebugPlugin_l280)
         6'h10 : begin
           if(debug_bus_cmd_payload_wr) begin
             DebugPlugin_hardwareBreakpoints_0_pc <= debug_bus_cmd_payload_data[31 : 1];
@@ -5779,7 +5793,7 @@ module VexRiscv (
         end
       endcase
     end
-    if(when_DebugPlugin_l295) begin
+    if(when_DebugPlugin_l308) begin
       DebugPlugin_busReadDataReg <= execute_PC;
     end
     DebugPlugin_resetIt_regNext <= DebugPlugin_resetIt;
@@ -5797,39 +5811,39 @@ module VexRiscv (
       DebugPlugin_hardwareBreakpoints_0_valid <= 1'b0;
       DebugPlugin_hardwareBreakpoints_1_valid <= 1'b0;
     end else begin
-      if(when_DebugPlugin_l225) begin
+      if(when_DebugPlugin_l238) begin
         DebugPlugin_godmode <= 1'b1;
       end
       if(debug_bus_cmd_valid) begin
         DebugPlugin_debugUsed <= 1'b1;
       end
       if(debug_bus_cmd_valid) begin
-        case(switch_DebugPlugin_l267)
-          6'h0 : begin
+        case(switch_DebugPlugin_l280)
+          6'h00 : begin
             if(debug_bus_cmd_payload_wr) begin
               DebugPlugin_stepIt <= debug_bus_cmd_payload_data[4];
-              if(when_DebugPlugin_l271) begin
+              if(when_DebugPlugin_l284) begin
                 DebugPlugin_resetIt <= 1'b1;
               end
-              if(when_DebugPlugin_l271_1) begin
+              if(when_DebugPlugin_l284_1) begin
                 DebugPlugin_resetIt <= 1'b0;
               end
-              if(when_DebugPlugin_l272) begin
+              if(when_DebugPlugin_l285) begin
                 DebugPlugin_haltIt <= 1'b1;
               end
-              if(when_DebugPlugin_l272_1) begin
+              if(when_DebugPlugin_l285_1) begin
                 DebugPlugin_haltIt <= 1'b0;
               end
-              if(when_DebugPlugin_l273) begin
+              if(when_DebugPlugin_l286) begin
                 DebugPlugin_haltedByBreak <= 1'b0;
               end
-              if(when_DebugPlugin_l274) begin
+              if(when_DebugPlugin_l287) begin
                 DebugPlugin_godmode <= 1'b0;
               end
-              if(when_DebugPlugin_l275) begin
+              if(when_DebugPlugin_l288) begin
                 DebugPlugin_disableEbreak <= 1'b1;
               end
-              if(when_DebugPlugin_l275_1) begin
+              if(when_DebugPlugin_l288_1) begin
                 DebugPlugin_disableEbreak <= 1'b0;
               end
             end
@@ -5848,13 +5862,13 @@ module VexRiscv (
           end
         endcase
       end
-      if(when_DebugPlugin_l295) begin
-        if(when_DebugPlugin_l298) begin
+      if(when_DebugPlugin_l308) begin
+        if(when_DebugPlugin_l311) begin
           DebugPlugin_haltIt <= 1'b1;
           DebugPlugin_haltedByBreak <= 1'b1;
         end
       end
-      if(when_DebugPlugin_l311) begin
+      if(when_DebugPlugin_l324) begin
         if(decode_arbitration_isValid) begin
           DebugPlugin_haltIt <= 1'b1;
         end
@@ -5866,76 +5880,75 @@ module VexRiscv (
 endmodule
 
 module DataCache (
-  input               io_cpu_execute_isValid,
-  input      [31:0]   io_cpu_execute_address,
-  output reg          io_cpu_execute_haltIt,
-  input               io_cpu_execute_args_wr,
-  input      [1:0]    io_cpu_execute_args_size,
-  input               io_cpu_execute_args_totalyConsistent,
-  output              io_cpu_execute_refilling,
-  input               io_cpu_memory_isValid,
-  input               io_cpu_memory_isStuck,
-  output              io_cpu_memory_isWrite,
-  input      [31:0]   io_cpu_memory_address,
-  input      [31:0]   io_cpu_memory_mmuRsp_physicalAddress,
-  input               io_cpu_memory_mmuRsp_isIoAccess,
-  input               io_cpu_memory_mmuRsp_isPaging,
-  input               io_cpu_memory_mmuRsp_allowRead,
-  input               io_cpu_memory_mmuRsp_allowWrite,
-  input               io_cpu_memory_mmuRsp_allowExecute,
-  input               io_cpu_memory_mmuRsp_exception,
-  input               io_cpu_memory_mmuRsp_refilling,
-  input               io_cpu_memory_mmuRsp_bypassTranslation,
-  input               io_cpu_writeBack_isValid,
-  input               io_cpu_writeBack_isStuck,
-  input               io_cpu_writeBack_isFiring,
-  input               io_cpu_writeBack_isUser,
-  output reg          io_cpu_writeBack_haltIt,
-  output              io_cpu_writeBack_isWrite,
-  input      [31:0]   io_cpu_writeBack_storeData,
-  output reg [31:0]   io_cpu_writeBack_data,
-  input      [31:0]   io_cpu_writeBack_address,
-  output              io_cpu_writeBack_mmuException,
-  output              io_cpu_writeBack_unalignedAccess,
-  output reg          io_cpu_writeBack_accessError,
-  output              io_cpu_writeBack_keepMemRspData,
-  input               io_cpu_writeBack_fence_SW,
-  input               io_cpu_writeBack_fence_SR,
-  input               io_cpu_writeBack_fence_SO,
-  input               io_cpu_writeBack_fence_SI,
-  input               io_cpu_writeBack_fence_PW,
-  input               io_cpu_writeBack_fence_PR,
-  input               io_cpu_writeBack_fence_PO,
-  input               io_cpu_writeBack_fence_PI,
-  input      [3:0]    io_cpu_writeBack_fence_FM,
-  output              io_cpu_writeBack_exclusiveOk,
-  output reg          io_cpu_redo,
-  input               io_cpu_flush_valid,
-  output              io_cpu_flush_ready,
-  input               io_cpu_flush_payload_singleLine,
-  input      [6:0]    io_cpu_flush_payload_lineId,
-  output reg          io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output reg          io_mem_cmd_payload_wr,
-  output              io_mem_cmd_payload_uncached,
-  output reg [31:0]   io_mem_cmd_payload_address,
-  output     [31:0]   io_mem_cmd_payload_data,
-  output     [3:0]    io_mem_cmd_payload_mask,
-  output reg [2:0]    io_mem_cmd_payload_size,
-  output              io_mem_cmd_payload_last,
-  input               io_mem_rsp_valid,
-  input               io_mem_rsp_payload_last,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input               clk,
-  input               reset
+  input  wire          io_cpu_execute_isValid,
+  input  wire [31:0]   io_cpu_execute_address,
+  output reg           io_cpu_execute_haltIt,
+  input  wire          io_cpu_execute_args_wr,
+  input  wire [1:0]    io_cpu_execute_args_size,
+  input  wire          io_cpu_execute_args_totalyConsistent,
+  output wire          io_cpu_execute_refilling,
+  input  wire          io_cpu_memory_isValid,
+  input  wire          io_cpu_memory_isStuck,
+  output wire          io_cpu_memory_isWrite,
+  input  wire [31:0]   io_cpu_memory_address,
+  input  wire [31:0]   io_cpu_memory_mmuRsp_physicalAddress,
+  input  wire          io_cpu_memory_mmuRsp_isIoAccess,
+  input  wire          io_cpu_memory_mmuRsp_isPaging,
+  input  wire          io_cpu_memory_mmuRsp_allowRead,
+  input  wire          io_cpu_memory_mmuRsp_allowWrite,
+  input  wire          io_cpu_memory_mmuRsp_allowExecute,
+  input  wire          io_cpu_memory_mmuRsp_exception,
+  input  wire          io_cpu_memory_mmuRsp_refilling,
+  input  wire          io_cpu_memory_mmuRsp_bypassTranslation,
+  input  wire          io_cpu_writeBack_isValid,
+  input  wire          io_cpu_writeBack_isStuck,
+  input  wire          io_cpu_writeBack_isFiring,
+  input  wire          io_cpu_writeBack_isUser,
+  output reg           io_cpu_writeBack_haltIt,
+  output wire          io_cpu_writeBack_isWrite,
+  input  wire [31:0]   io_cpu_writeBack_storeData,
+  output reg  [31:0]   io_cpu_writeBack_data,
+  input  wire [31:0]   io_cpu_writeBack_address,
+  output wire          io_cpu_writeBack_mmuException,
+  output wire          io_cpu_writeBack_unalignedAccess,
+  output reg           io_cpu_writeBack_accessError,
+  output wire          io_cpu_writeBack_keepMemRspData,
+  input  wire          io_cpu_writeBack_fence_SW,
+  input  wire          io_cpu_writeBack_fence_SR,
+  input  wire          io_cpu_writeBack_fence_SO,
+  input  wire          io_cpu_writeBack_fence_SI,
+  input  wire          io_cpu_writeBack_fence_PW,
+  input  wire          io_cpu_writeBack_fence_PR,
+  input  wire          io_cpu_writeBack_fence_PO,
+  input  wire          io_cpu_writeBack_fence_PI,
+  input  wire [3:0]    io_cpu_writeBack_fence_FM,
+  output wire          io_cpu_writeBack_exclusiveOk,
+  output reg           io_cpu_redo,
+  input  wire          io_cpu_flush_valid,
+  output wire          io_cpu_flush_ready,
+  input  wire          io_cpu_flush_payload_singleLine,
+  input  wire [6:0]    io_cpu_flush_payload_lineId,
+  output wire          io_cpu_writesPending,
+  output reg           io_mem_cmd_valid,
+  input  wire          io_mem_cmd_ready,
+  output reg           io_mem_cmd_payload_wr,
+  output wire          io_mem_cmd_payload_uncached,
+  output reg  [31:0]   io_mem_cmd_payload_address,
+  output wire [31:0]   io_mem_cmd_payload_data,
+  output wire [3:0]    io_mem_cmd_payload_mask,
+  output reg  [2:0]    io_mem_cmd_payload_size,
+  output wire          io_mem_cmd_payload_last,
+  input  wire          io_mem_rsp_valid,
+  input  wire          io_mem_rsp_payload_last,
+  input  wire [31:0]   io_mem_rsp_payload_data,
+  input  wire          io_mem_rsp_payload_error,
+  input  wire          clk,
+  input  wire          reset
 );
 
   reg        [21:0]   _zz_ways_0_tags_port0;
   reg        [31:0]   _zz_ways_0_data_port0;
   wire       [21:0]   _zz_ways_0_tags_port;
-  wire       [9:0]    _zz_stage0_dataColisions;
-  wire       [9:0]    _zz__zz_stageA_dataColisions;
   wire       [0:0]    _zz_when;
   wire       [2:0]    _zz_loader_counter_valueNext;
   wire       [0:0]    _zz_loader_counter_valueNext_1;
@@ -5972,40 +5985,40 @@ module DataCache (
   wire                _zz_ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRsp;
-  wire                when_DataCache_l642;
   wire                when_DataCache_l645;
-  wire                when_DataCache_l664;
+  wire                when_DataCache_l648;
+  wire                when_DataCache_l667;
   wire                rspSync;
   wire                rspLast;
   reg                 memCmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_DataCache_l686;
+  wire                when_DataCache_l689;
   reg        [3:0]    _zz_stage0_mask;
   wire       [3:0]    stage0_mask;
   wire       [0:0]    stage0_dataColisions;
   wire       [0:0]    stage0_wayInvalidate;
   wire                stage0_isAmo;
-  wire                when_DataCache_l771;
+  wire                when_DataCache_l776;
   reg                 stageA_request_wr;
   reg        [1:0]    stageA_request_size;
   reg                 stageA_request_totalyConsistent;
-  wire                when_DataCache_l771_1;
+  wire                when_DataCache_l776_1;
   reg        [3:0]    stageA_mask;
   wire                stageA_isAmo;
   wire                stageA_isLrsc;
   wire       [0:0]    stageA_wayHits;
-  wire                when_DataCache_l771_2;
+  wire                when_DataCache_l776_2;
   reg        [0:0]    stageA_wayInvalidate;
-  wire                when_DataCache_l771_3;
+  wire                when_DataCache_l776_3;
   reg        [0:0]    stage0_dataColisions_regNextWhen;
   wire       [0:0]    _zz_stageA_dataColisions;
   wire       [0:0]    stageA_dataColisions;
-  wire                when_DataCache_l822;
+  wire                when_DataCache_l827;
   reg                 stageB_request_wr;
   reg        [1:0]    stageB_request_size;
   reg                 stageB_request_totalyConsistent;
   reg                 stageB_mmuRspFreeze;
-  wire                when_DataCache_l824;
+  wire                when_DataCache_l829;
   reg        [31:0]   stageB_mmuRsp_physicalAddress;
   reg                 stageB_mmuRsp_isIoAccess;
   reg                 stageB_mmuRsp_isPaging;
@@ -6015,52 +6028,54 @@ module DataCache (
   reg                 stageB_mmuRsp_exception;
   reg                 stageB_mmuRsp_refilling;
   reg                 stageB_mmuRsp_bypassTranslation;
-  wire                when_DataCache_l821;
+  wire                when_DataCache_l826;
   reg                 stageB_tagsReadRsp_0_valid;
   reg                 stageB_tagsReadRsp_0_error;
   reg        [19:0]   stageB_tagsReadRsp_0_address;
-  wire                when_DataCache_l821_1;
+  wire                when_DataCache_l826_1;
   reg        [31:0]   stageB_dataReadRsp_0;
-  wire                when_DataCache_l820;
+  wire                when_DataCache_l825;
   reg        [0:0]    stageB_wayInvalidate;
   wire                stageB_consistancyHazard;
-  wire                when_DataCache_l820_1;
+  wire                when_DataCache_l825_1;
   reg        [0:0]    stageB_dataColisions;
-  wire                when_DataCache_l820_2;
+  wire                when_DataCache_l825_2;
   reg                 stageB_unaligned;
-  wire                when_DataCache_l820_3;
+  wire                when_DataCache_l825_3;
   reg        [0:0]    stageB_waysHitsBeforeInvalidate;
   wire       [0:0]    stageB_waysHits;
   wire                stageB_waysHit;
   wire       [31:0]   stageB_dataMux;
-  wire                when_DataCache_l820_4;
+  wire                when_DataCache_l825_4;
   reg        [3:0]    stageB_mask;
   reg                 stageB_loaderValid;
   wire       [31:0]   stageB_ioMemRspMuxed;
   reg                 stageB_flusher_waitDone;
   wire                stageB_flusher_hold;
   reg        [7:0]    stageB_flusher_counter;
-  wire                when_DataCache_l850;
-  wire                when_DataCache_l856;
+  wire                when_DataCache_l855;
+  wire                when_DataCache_l861;
+  wire                when_DataCache_l863;
   reg                 stageB_flusher_start;
+  wire                when_DataCache_l877;
   wire                stageB_isAmo;
   wire                stageB_isAmoCached;
   wire                stageB_isExternalLsrc;
   wire                stageB_isExternalAmo;
   wire       [31:0]   stageB_requestDataBypass;
   reg                 stageB_cpuWriteToCache;
-  wire                when_DataCache_l926;
+  wire                when_DataCache_l931;
   wire                stageB_badPermissions;
   wire                stageB_loadStoreFault;
   wire                stageB_bypassCache;
-  wire                when_DataCache_l995;
-  wire                when_DataCache_l1004;
+  wire                when_DataCache_l1000;
   wire                when_DataCache_l1009;
-  wire                when_DataCache_l1020;
-  wire                when_DataCache_l1032;
-  wire                when_DataCache_l991;
-  wire                when_DataCache_l1066;
-  wire                when_DataCache_l1075;
+  wire                when_DataCache_l1014;
+  wire                when_DataCache_l1025;
+  wire                when_DataCache_l1037;
+  wire                when_DataCache_l996;
+  wire                when_DataCache_l1072;
+  wire                when_DataCache_l1081;
   reg                 loader_valid;
   reg                 loader_counter_willIncrement;
   wire                loader_counter_willClear;
@@ -6072,12 +6087,12 @@ module DataCache (
   reg                 loader_error;
   wire                loader_kill;
   reg                 loader_killReg;
-  wire                when_DataCache_l1090;
+  wire                when_DataCache_l1097;
   wire                loader_done;
-  wire                when_DataCache_l1118;
-  reg                 loader_valid_regNext;
-  wire                when_DataCache_l1122;
   wire                when_DataCache_l1125;
+  reg                 loader_valid_regNext;
+  wire                when_DataCache_l1129;
+  wire                when_DataCache_l1132;
   (* no_rw_check , ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
   (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
   (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
@@ -6088,8 +6103,6 @@ module DataCache (
   reg [7:0] _zz_ways_0_datasymbol_read_2;
   reg [7:0] _zz_ways_0_datasymbol_read_3;
 
-  assign _zz_stage0_dataColisions = (io_cpu_execute_address[11 : 2] >>> 0);
-  assign _zz__zz_stageA_dataColisions = (io_cpu_memory_address[11 : 2] >>> 0);
   assign _zz_when = 1'b1;
   assign _zz_loader_counter_valueNext_1 = loader_counter_willIncrement;
   assign _zz_loader_counter_valueNext = {2'd0, _zz_loader_counter_valueNext_1};
@@ -6136,14 +6149,14 @@ module DataCache (
 
   always @(*) begin
     _zz_1 = 1'b0;
-    if(when_DataCache_l645) begin
+    if(when_DataCache_l648) begin
       _zz_1 = 1'b1;
     end
   end
 
   always @(*) begin
     _zz_2 = 1'b0;
-    if(when_DataCache_l642) begin
+    if(when_DataCache_l645) begin
       _zz_2 = 1'b1;
     end
   end
@@ -6157,43 +6170,45 @@ module DataCache (
   assign _zz_ways_0_dataReadRspMem = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
   assign ways_0_dataReadRspMem = _zz_ways_0_data_port0;
   assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
-  assign when_DataCache_l642 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
-  assign when_DataCache_l645 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
+  assign when_DataCache_l645 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
+  assign when_DataCache_l648 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
   always @(*) begin
     tagsReadCmd_valid = 1'b0;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       tagsReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     tagsReadCmd_payload = 7'bxxxxxxx;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
     end
   end
 
   always @(*) begin
     dataReadCmd_valid = 1'b0;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       dataReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     dataReadCmd_payload = 10'bxxxxxxxxxx;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       dataReadCmd_payload = io_cpu_execute_address[11 : 2];
     end
   end
 
   always @(*) begin
     tagsWriteCmd_valid = 1'b0;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_valid = 1'b1;
     end
-    if(when_DataCache_l1066) begin
-      tagsWriteCmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        tagsWriteCmd_valid = 1'b0;
+      end
     end
     if(loader_done) begin
       tagsWriteCmd_valid = 1'b1;
@@ -6202,7 +6217,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_way = 1'bx;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_payload_way = 1'b1;
     end
     if(loader_done) begin
@@ -6212,7 +6227,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_address = 7'bxxxxxxx;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_payload_address = stageB_flusher_counter[6:0];
     end
     if(loader_done) begin
@@ -6222,7 +6237,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_data_valid = 1'bx;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_payload_data_valid = 1'b0;
     end
     if(loader_done) begin
@@ -6247,14 +6262,16 @@ module DataCache (
   always @(*) begin
     dataWriteCmd_valid = 1'b0;
     if(stageB_cpuWriteToCache) begin
-      if(when_DataCache_l926) begin
+      if(when_DataCache_l931) begin
         dataWriteCmd_valid = 1'b1;
       end
     end
-    if(when_DataCache_l1066) begin
-      dataWriteCmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        dataWriteCmd_valid = 1'b0;
+      end
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_valid = 1'b1;
     end
   end
@@ -6264,7 +6281,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_way = stageB_waysHits;
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_way = loader_waysAllocator;
     end
   end
@@ -6274,7 +6291,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
     end
   end
@@ -6284,7 +6301,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_data = io_mem_rsp_payload_data;
     end
   end
@@ -6297,15 +6314,15 @@ module DataCache (
         dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
       end
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_mask = 4'b1111;
     end
   end
 
-  assign when_DataCache_l664 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  assign when_DataCache_l667 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
   always @(*) begin
     io_cpu_execute_haltIt = 1'b0;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       io_cpu_execute_haltIt = 1'b1;
     end
   end
@@ -6313,7 +6330,7 @@ module DataCache (
   assign rspSync = 1'b1;
   assign rspLast = 1'b1;
   assign io_mem_cmd_fire = (io_mem_cmd_valid && io_mem_cmd_ready);
-  assign when_DataCache_l686 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l689 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     _zz_stage0_mask = 4'bxxxx;
     case(io_cpu_execute_args_size)
@@ -6332,45 +6349,45 @@ module DataCache (
   end
 
   assign stage0_mask = (_zz_stage0_mask <<< io_cpu_execute_address[1 : 0]);
-  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_stage0_dataColisions)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_execute_address[11 : 2])) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stage0_wayInvalidate = 1'b0;
   assign stage0_isAmo = 1'b0;
-  assign when_DataCache_l771 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l771_1 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l776 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l776_1 = (! io_cpu_memory_isStuck);
   assign io_cpu_memory_isWrite = stageA_request_wr;
   assign stageA_isAmo = 1'b0;
   assign stageA_isLrsc = 1'b0;
   assign stageA_wayHits = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign when_DataCache_l771_2 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l771_3 = (! io_cpu_memory_isStuck);
-  assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz__zz_stageA_dataColisions)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign when_DataCache_l776_2 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l776_3 = (! io_cpu_memory_isStuck);
+  assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_memory_address[11 : 2])) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_stageA_dataColisions);
-  assign when_DataCache_l822 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l827 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_mmuRspFreeze = 1'b0;
-    if(when_DataCache_l1125) begin
+    if(when_DataCache_l1132) begin
       stageB_mmuRspFreeze = 1'b1;
     end
   end
 
-  assign when_DataCache_l824 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
-  assign when_DataCache_l821 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l821_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l820 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l829 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
+  assign when_DataCache_l826 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l826_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825 = (! io_cpu_writeBack_isStuck);
   assign stageB_consistancyHazard = 1'b0;
-  assign when_DataCache_l820_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l820_2 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l820_3 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_2 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_3 = (! io_cpu_writeBack_isStuck);
   assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
   assign stageB_waysHit = (|stageB_waysHits);
   assign stageB_dataMux = stageB_dataReadRsp_0;
-  assign when_DataCache_l820_4 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_4 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_loaderValid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
             if(io_mem_cmd_ready) begin
               stageB_loaderValid = 1'b1;
             end
@@ -6378,8 +6395,10 @@ module DataCache (
         end
       end
     end
-    if(when_DataCache_l1066) begin
-      stageB_loaderValid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        stageB_loaderValid = 1'b0;
+      end
     end
   end
 
@@ -6388,28 +6407,32 @@ module DataCache (
     io_cpu_writeBack_haltIt = 1'b1;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l991) begin
-          if(when_DataCache_l995) begin
+        if(when_DataCache_l996) begin
+          if(when_DataCache_l1000) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
         end else begin
-          if(when_DataCache_l1004) begin
-            if(when_DataCache_l1009) begin
+          if(when_DataCache_l1009) begin
+            if(when_DataCache_l1014) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1066) begin
-      io_cpu_writeBack_haltIt = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        io_cpu_writeBack_haltIt = 1'b0;
+      end
     end
   end
 
   assign stageB_flusher_hold = 1'b0;
-  assign when_DataCache_l850 = (! stageB_flusher_counter[7]);
-  assign when_DataCache_l856 = (! stageB_flusher_hold);
+  assign when_DataCache_l855 = (! stageB_flusher_counter[7]);
+  assign when_DataCache_l861 = (! stageB_flusher_hold);
+  assign when_DataCache_l863 = (io_cpu_flush_valid && io_cpu_flush_payload_singleLine);
   assign io_cpu_flush_ready = (stageB_flusher_waitDone && stageB_flusher_counter[7]);
+  assign when_DataCache_l877 = (io_cpu_flush_valid && io_cpu_flush_payload_singleLine);
   assign stageB_isAmo = 1'b0;
   assign stageB_isAmoCached = 1'b0;
   assign stageB_isExternalLsrc = 1'b0;
@@ -6419,8 +6442,8 @@ module DataCache (
     stageB_cpuWriteToCache = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(when_DataCache_l1009) begin
             stageB_cpuWriteToCache = 1'b1;
           end
         end
@@ -6428,26 +6451,28 @@ module DataCache (
     end
   end
 
-  assign when_DataCache_l926 = (stageB_request_wr && stageB_waysHit);
+  assign when_DataCache_l931 = (stageB_request_wr && stageB_waysHit);
   assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_isAmo)));
   assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
   always @(*) begin
     io_cpu_redo = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(when_DataCache_l1004) begin
-            if(when_DataCache_l1020) begin
+        if(!when_DataCache_l996) begin
+          if(when_DataCache_l1009) begin
+            if(when_DataCache_l1025) begin
               io_cpu_redo = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1075) begin
-      io_cpu_redo = 1'b1;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1081) begin
+        io_cpu_redo = 1'b1;
+      end
     end
-    if(when_DataCache_l1122) begin
+    if(when_DataCache_l1129) begin
       io_cpu_redo = 1'b1;
     end
   end
@@ -6468,23 +6493,25 @@ module DataCache (
     io_mem_cmd_valid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l991) begin
+        if(when_DataCache_l996) begin
           io_mem_cmd_valid = (! memCmdSent);
         end else begin
-          if(when_DataCache_l1004) begin
+          if(when_DataCache_l1009) begin
             if(stageB_request_wr) begin
               io_mem_cmd_valid = 1'b1;
             end
           end else begin
-            if(when_DataCache_l1032) begin
+            if(when_DataCache_l1037) begin
               io_mem_cmd_valid = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1066) begin
-      io_mem_cmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        io_mem_cmd_valid = 1'b0;
+      end
     end
   end
 
@@ -6492,9 +6519,9 @@ module DataCache (
     io_mem_cmd_payload_address = stageB_mmuRsp_physicalAddress;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
-            io_mem_cmd_payload_address[4 : 0] = 5'h0;
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
+            io_mem_cmd_payload_address[4 : 0] = 5'h00;
           end
         end
       end
@@ -6506,8 +6533,8 @@ module DataCache (
     io_mem_cmd_payload_wr = stageB_request_wr;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
             io_mem_cmd_payload_wr = 1'b0;
           end
         end
@@ -6522,8 +6549,8 @@ module DataCache (
     io_mem_cmd_payload_size = {1'd0, stageB_request_size};
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
             io_mem_cmd_payload_size = 3'b101;
           end
         end
@@ -6533,12 +6560,12 @@ module DataCache (
 
   assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
   assign io_cpu_writeBack_keepMemRspData = 1'b0;
-  assign when_DataCache_l995 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
-  assign when_DataCache_l1004 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
-  assign when_DataCache_l1009 = ((! stageB_request_wr) || io_mem_cmd_ready);
-  assign when_DataCache_l1020 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
-  assign when_DataCache_l1032 = (! memCmdSent);
-  assign when_DataCache_l991 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  assign when_DataCache_l1000 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
+  assign when_DataCache_l1009 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
+  assign when_DataCache_l1014 = ((! stageB_request_wr) || io_mem_cmd_ready);
+  assign when_DataCache_l1025 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
+  assign when_DataCache_l1037 = (! memCmdSent);
+  assign when_DataCache_l996 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
   always @(*) begin
     if(stageB_bypassCache) begin
       io_cpu_writeBack_data = stageB_ioMemRspMuxed;
@@ -6547,11 +6574,11 @@ module DataCache (
     end
   end
 
-  assign when_DataCache_l1066 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign when_DataCache_l1075 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
+  assign when_DataCache_l1072 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign when_DataCache_l1081 = (stageB_mmuRsp_refilling || stageB_consistancyHazard);
   always @(*) begin
     loader_counter_willIncrement = 1'b0;
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       loader_counter_willIncrement = 1'b1;
     end
   end
@@ -6567,12 +6594,12 @@ module DataCache (
   end
 
   assign loader_kill = 1'b0;
-  assign when_DataCache_l1090 = ((loader_valid && io_mem_rsp_valid) && rspLast);
+  assign when_DataCache_l1097 = ((loader_valid && io_mem_rsp_valid) && rspLast);
   assign loader_done = loader_counter_willOverflow;
-  assign when_DataCache_l1118 = (! loader_valid);
-  assign when_DataCache_l1122 = (loader_valid && (! loader_valid_regNext));
+  assign when_DataCache_l1125 = (! loader_valid);
+  assign when_DataCache_l1129 = (loader_valid && (! loader_valid_regNext));
   assign io_cpu_execute_refilling = loader_valid;
-  assign when_DataCache_l1125 = (stageB_loaderValid || loader_valid);
+  assign when_DataCache_l1132 = (stageB_loaderValid || loader_valid);
   always @(posedge clk) begin
     tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
     tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
@@ -6580,26 +6607,26 @@ module DataCache (
     tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
     tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
     tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if(when_DataCache_l771) begin
+    if(when_DataCache_l776) begin
       stageA_request_wr <= io_cpu_execute_args_wr;
       stageA_request_size <= io_cpu_execute_args_size;
       stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
     end
-    if(when_DataCache_l771_1) begin
+    if(when_DataCache_l776_1) begin
       stageA_mask <= stage0_mask;
     end
-    if(when_DataCache_l771_2) begin
+    if(when_DataCache_l776_2) begin
       stageA_wayInvalidate <= stage0_wayInvalidate;
     end
-    if(when_DataCache_l771_3) begin
+    if(when_DataCache_l776_3) begin
       stage0_dataColisions_regNextWhen <= stage0_dataColisions;
     end
-    if(when_DataCache_l822) begin
+    if(when_DataCache_l827) begin
       stageB_request_wr <= stageA_request_wr;
       stageB_request_size <= stageA_request_size;
       stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
     end
-    if(when_DataCache_l824) begin
+    if(when_DataCache_l829) begin
       stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
       stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
       stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
@@ -6610,27 +6637,27 @@ module DataCache (
       stageB_mmuRsp_refilling <= io_cpu_memory_mmuRsp_refilling;
       stageB_mmuRsp_bypassTranslation <= io_cpu_memory_mmuRsp_bypassTranslation;
     end
-    if(when_DataCache_l821) begin
+    if(when_DataCache_l826) begin
       stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
       stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
       stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
     end
-    if(when_DataCache_l821_1) begin
+    if(when_DataCache_l826_1) begin
       stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
     end
-    if(when_DataCache_l820) begin
+    if(when_DataCache_l825) begin
       stageB_wayInvalidate <= stageA_wayInvalidate;
     end
-    if(when_DataCache_l820_1) begin
+    if(when_DataCache_l825_1) begin
       stageB_dataColisions <= stageA_dataColisions;
     end
-    if(when_DataCache_l820_2) begin
+    if(when_DataCache_l825_2) begin
       stageB_unaligned <= ({((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)),((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0))} != 2'b00);
     end
-    if(when_DataCache_l820_3) begin
+    if(when_DataCache_l825_3) begin
       stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
     end
-    if(when_DataCache_l820_4) begin
+    if(when_DataCache_l825_4) begin
       stageB_mask <= stageA_mask;
     end
     loader_valid_regNext <= loader_valid;
@@ -6640,7 +6667,7 @@ module DataCache (
     if(reset) begin
       memCmdSent <= 1'b0;
       stageB_flusher_waitDone <= 1'b0;
-      stageB_flusher_counter <= 8'h0;
+      stageB_flusher_counter <= 8'h00;
       stageB_flusher_start <= 1'b1;
       loader_valid <= 1'b0;
       loader_counter_value <= 3'b000;
@@ -6651,16 +6678,16 @@ module DataCache (
       if(io_mem_cmd_fire) begin
         memCmdSent <= 1'b1;
       end
-      if(when_DataCache_l686) begin
+      if(when_DataCache_l689) begin
         memCmdSent <= 1'b0;
       end
       if(io_cpu_flush_ready) begin
         stageB_flusher_waitDone <= 1'b0;
       end
-      if(when_DataCache_l850) begin
-        if(when_DataCache_l856) begin
+      if(when_DataCache_l855) begin
+        if(when_DataCache_l861) begin
           stageB_flusher_counter <= (stageB_flusher_counter + 8'h01);
-          if(io_cpu_flush_payload_singleLine) begin
+          if(when_DataCache_l863) begin
             stageB_flusher_counter[7] <= 1'b1;
           end
         end
@@ -6668,17 +6695,17 @@ module DataCache (
       stageB_flusher_start <= (((((((! stageB_flusher_waitDone) && (! stageB_flusher_start)) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
       if(stageB_flusher_start) begin
         stageB_flusher_waitDone <= 1'b1;
-        stageB_flusher_counter <= 8'h0;
-        if(io_cpu_flush_payload_singleLine) begin
+        stageB_flusher_counter <= 8'h00;
+        if(when_DataCache_l877) begin
           stageB_flusher_counter <= {1'b0,io_cpu_flush_payload_lineId};
         end
       end
       `ifndef SYNTHESIS
         `ifdef FORMAL
-          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))); // DataCache.scala:L1077
+          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))); // DataCache.scala:L1084
         `else
           if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-            $display("ERROR writeBack stuck by another plugin is not allowed"); // DataCache.scala:L1077
+            $display("ERROR writeBack stuck by another plugin is not allowed"); // DataCache.scala:L1084
           end
         `endif
       `endif
@@ -6689,7 +6716,7 @@ module DataCache (
       if(loader_kill) begin
         loader_killReg <= 1'b1;
       end
-      if(when_DataCache_l1090) begin
+      if(when_DataCache_l1097) begin
         loader_error <= (loader_error || io_mem_rsp_payload_error);
       end
       if(loader_done) begin
@@ -6697,7 +6724,7 @@ module DataCache (
         loader_error <= 1'b0;
         loader_killReg <= 1'b0;
       end
-      if(when_DataCache_l1118) begin
+      if(when_DataCache_l1125) begin
         loader_waysAllocator <= _zz_loader_waysAllocator[0:0];
       end
     end
@@ -6707,48 +6734,48 @@ module DataCache (
 endmodule
 
 module InstructionCache (
-  input               io_flush,
-  input               io_cpu_prefetch_isValid,
-  output reg          io_cpu_prefetch_haltIt,
-  input      [31:0]   io_cpu_prefetch_pc,
-  input               io_cpu_fetch_isValid,
-  input               io_cpu_fetch_isStuck,
-  input               io_cpu_fetch_isRemoved,
-  input      [31:0]   io_cpu_fetch_pc,
-  output     [31:0]   io_cpu_fetch_data,
-  input      [31:0]   io_cpu_fetch_mmuRsp_physicalAddress,
-  input               io_cpu_fetch_mmuRsp_isIoAccess,
-  input               io_cpu_fetch_mmuRsp_isPaging,
-  input               io_cpu_fetch_mmuRsp_allowRead,
-  input               io_cpu_fetch_mmuRsp_allowWrite,
-  input               io_cpu_fetch_mmuRsp_allowExecute,
-  input               io_cpu_fetch_mmuRsp_exception,
-  input               io_cpu_fetch_mmuRsp_refilling,
-  input               io_cpu_fetch_mmuRsp_bypassTranslation,
-  output     [31:0]   io_cpu_fetch_physicalAddress,
-  input               io_cpu_decode_isValid,
-  input               io_cpu_decode_isStuck,
-  input      [31:0]   io_cpu_decode_pc,
-  output     [31:0]   io_cpu_decode_physicalAddress,
-  output     [31:0]   io_cpu_decode_data,
-  output              io_cpu_decode_cacheMiss,
-  output              io_cpu_decode_error,
-  output              io_cpu_decode_mmuRefilling,
-  output              io_cpu_decode_mmuException,
-  input               io_cpu_decode_isUser,
-  input               io_cpu_fill_valid,
-  input      [31:0]   io_cpu_fill_payload,
-  output              io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output     [31:0]   io_mem_cmd_payload_address,
-  output     [2:0]    io_mem_cmd_payload_size,
-  input               io_mem_rsp_valid,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input      [2:0]    _zz_when_Fetcher_l401,
-  input      [31:0]   _zz_io_cpu_fetch_data_regNextWhen,
-  input               clk,
-  input               reset
+  input  wire          io_flush,
+  input  wire          io_cpu_prefetch_isValid,
+  output reg           io_cpu_prefetch_haltIt,
+  input  wire [31:0]   io_cpu_prefetch_pc,
+  input  wire          io_cpu_fetch_isValid,
+  input  wire          io_cpu_fetch_isStuck,
+  input  wire          io_cpu_fetch_isRemoved,
+  input  wire [31:0]   io_cpu_fetch_pc,
+  output wire [31:0]   io_cpu_fetch_data,
+  input  wire [31:0]   io_cpu_fetch_mmuRsp_physicalAddress,
+  input  wire          io_cpu_fetch_mmuRsp_isIoAccess,
+  input  wire          io_cpu_fetch_mmuRsp_isPaging,
+  input  wire          io_cpu_fetch_mmuRsp_allowRead,
+  input  wire          io_cpu_fetch_mmuRsp_allowWrite,
+  input  wire          io_cpu_fetch_mmuRsp_allowExecute,
+  input  wire          io_cpu_fetch_mmuRsp_exception,
+  input  wire          io_cpu_fetch_mmuRsp_refilling,
+  input  wire          io_cpu_fetch_mmuRsp_bypassTranslation,
+  output wire [31:0]   io_cpu_fetch_physicalAddress,
+  input  wire          io_cpu_decode_isValid,
+  input  wire          io_cpu_decode_isStuck,
+  input  wire [31:0]   io_cpu_decode_pc,
+  output wire [31:0]   io_cpu_decode_physicalAddress,
+  output wire [31:0]   io_cpu_decode_data,
+  output wire          io_cpu_decode_cacheMiss,
+  output wire          io_cpu_decode_error,
+  output wire          io_cpu_decode_mmuRefilling,
+  output wire          io_cpu_decode_mmuException,
+  input  wire          io_cpu_decode_isUser,
+  input  wire          io_cpu_fill_valid,
+  input  wire [31:0]   io_cpu_fill_payload,
+  output wire          io_mem_cmd_valid,
+  input  wire          io_mem_cmd_ready,
+  output wire [31:0]   io_mem_cmd_payload_address,
+  output wire [2:0]    io_mem_cmd_payload_size,
+  input  wire          io_mem_rsp_valid,
+  input  wire [31:0]   io_mem_rsp_payload_data,
+  input  wire          io_mem_rsp_payload_error,
+  input  wire [2:0]    _zz_when_Fetcher_l411,
+  input  wire [31:0]   _zz_io_cpu_fetch_data_regNextWhen,
+  input  wire          clk,
+  input  wire          reset
 );
 
   reg        [31:0]   _zz_banks_0_port1;
@@ -6768,7 +6795,7 @@ module InstructionCache (
   wire                when_InstructionCache_l351;
   reg                 lineLoader_cmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_Utils_l515;
+  wire                when_Utils_l560;
   reg                 lineLoader_wayToAllocate_willIncrement;
   wire                lineLoader_wayToAllocate_willClear;
   wire                lineLoader_wayToAllocate_willOverflowIfInc;
@@ -6814,7 +6841,7 @@ module InstructionCache (
   reg                 decodeStage_hit_valid;
   wire                when_InstructionCache_l459_2;
   reg                 decodeStage_hit_error;
-  wire                when_Fetcher_l401;
+  wire                when_Fetcher_l411;
   (* no_rw_check , ram_style = "block" *) reg [31:0] banks_0 [0:1023];
   (* no_rw_check , ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
 
@@ -6884,12 +6911,12 @@ module InstructionCache (
   assign when_InstructionCache_l351 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
   assign io_mem_cmd_fire = (io_mem_cmd_valid && io_mem_cmd_ready);
   assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
-  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
+  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h00};
   assign io_mem_cmd_payload_size = 3'b101;
-  assign when_Utils_l515 = (! lineLoader_valid);
+  assign when_Utils_l560 = (! lineLoader_valid);
   always @(*) begin
     lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if(when_Utils_l515) begin
+    if(when_Utils_l560) begin
       lineLoader_wayToAllocate_willIncrement = 1'b1;
     end
   end
@@ -6933,7 +6960,7 @@ module InstructionCache (
   assign io_cpu_decode_mmuRefilling = decodeStage_mmuRsp_refilling;
   assign io_cpu_decode_mmuException = (((! decodeStage_mmuRsp_refilling) && decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute)));
   assign io_cpu_decode_physicalAddress = decodeStage_mmuRsp_physicalAddress;
-  assign when_Fetcher_l401 = (_zz_when_Fetcher_l401 != 3'b000);
+  assign when_Fetcher_l411 = (_zz_when_Fetcher_l411 != 3'b000);
   always @(posedge clk) begin
     if(reset) begin
       lineLoader_valid <= 1'b0;
@@ -6981,7 +7008,7 @@ module InstructionCache (
     end
     _zz_when_InstructionCache_l342 <= lineLoader_flushCounter[7];
     if(when_InstructionCache_l351) begin
-      lineLoader_flushCounter <= 8'h0;
+      lineLoader_flushCounter <= 8'h00;
     end
     if(when_InstructionCache_l435) begin
       io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;
@@ -7003,7 +7030,7 @@ module InstructionCache (
     if(when_InstructionCache_l459_2) begin
       decodeStage_hit_error <= fetchStage_hit_error;
     end
-    if(when_Fetcher_l401) begin
+    if(when_Fetcher_l411) begin
       io_cpu_fetch_data_regNextWhen <= _zz_io_cpu_fetch_data_regNextWhen;
     end
   end

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_IMAC.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_IMAC.v
@@ -1,38 +1,38 @@
-// Generator : SpinalHDL v1.7.1    git head : 0444bb76ab1d6e19f0ec46bc03c4769776deb7d5
+// Generator : SpinalHDL v1.9.4    git head : 270018552577f3bb8e5339ee2583c9c22d324215
 // Component : VexRiscv
-// Git hash  : 581fcb065adf7ea8b626f939ff51679d4c95872f
+// Git hash  : 63430af99f84cc1d11d58b556debe1cc3f238c67
 
 `timescale 1ns/1ps
 
 module VexRiscv (
-  input      [31:0]   externalResetVector,
-  input               timerInterrupt,
-  input               softwareInterrupt,
-  input      [31:0]   externalInterruptArray,
-  output reg          iBusWishbone_CYC,
-  output reg          iBusWishbone_STB,
-  input               iBusWishbone_ACK,
-  output              iBusWishbone_WE,
-  output     [29:0]   iBusWishbone_ADR,
-  input      [31:0]   iBusWishbone_DAT_MISO,
-  output     [31:0]   iBusWishbone_DAT_MOSI,
-  output     [3:0]    iBusWishbone_SEL,
-  input               iBusWishbone_ERR,
-  output     [2:0]    iBusWishbone_CTI,
-  output     [1:0]    iBusWishbone_BTE,
-  output              dBusWishbone_CYC,
-  output              dBusWishbone_STB,
-  input               dBusWishbone_ACK,
-  output              dBusWishbone_WE,
-  output     [29:0]   dBusWishbone_ADR,
-  input      [31:0]   dBusWishbone_DAT_MISO,
-  output     [31:0]   dBusWishbone_DAT_MOSI,
-  output     [3:0]    dBusWishbone_SEL,
-  input               dBusWishbone_ERR,
-  output     [2:0]    dBusWishbone_CTI,
-  output     [1:0]    dBusWishbone_BTE,
-  input               clk,
-  input               reset
+  input  wire [31:0]   externalResetVector,
+  input  wire          timerInterrupt,
+  input  wire          softwareInterrupt,
+  input  wire [31:0]   externalInterruptArray,
+  output reg           iBusWishbone_CYC,
+  output reg           iBusWishbone_STB,
+  input  wire          iBusWishbone_ACK,
+  output wire          iBusWishbone_WE,
+  output wire [29:0]   iBusWishbone_ADR,
+  input  wire [31:0]   iBusWishbone_DAT_MISO,
+  output wire [31:0]   iBusWishbone_DAT_MOSI,
+  output wire [3:0]    iBusWishbone_SEL,
+  input  wire          iBusWishbone_ERR,
+  output wire [2:0]    iBusWishbone_CTI,
+  output wire [1:0]    iBusWishbone_BTE,
+  output wire          dBusWishbone_CYC,
+  output wire          dBusWishbone_STB,
+  input  wire          dBusWishbone_ACK,
+  output wire          dBusWishbone_WE,
+  output wire [29:0]   dBusWishbone_ADR,
+  input  wire [31:0]   dBusWishbone_DAT_MISO,
+  output wire [31:0]   dBusWishbone_DAT_MOSI,
+  output wire [3:0]    dBusWishbone_SEL,
+  input  wire          dBusWishbone_ERR,
+  output wire [2:0]    dBusWishbone_CTI,
+  output wire [1:0]    dBusWishbone_BTE,
+  input  wire          clk,
+  input  wire          reset
 );
   localparam ShiftCtrlEnum_DISABLE_1 = 2'd0;
   localparam ShiftCtrlEnum_SLL_1 = 2'd1;
@@ -95,7 +95,6 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_flush_valid;
   wire                dataCache_1_io_cpu_flush_payload_singleLine;
   wire       [6:0]    dataCache_1_io_cpu_flush_payload_lineId;
-  wire                dataCache_1_io_mem_cmd_ready;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
@@ -123,6 +122,7 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_writeBack_exclusiveOk;
   wire                dataCache_1_io_cpu_flush_ready;
   wire                dataCache_1_io_cpu_redo;
+  wire                dataCache_1_io_cpu_writesPending;
   wire                dataCache_1_io_mem_cmd_valid;
   wire                dataCache_1_io_mem_cmd_payload_wr;
   wire                dataCache_1_io_mem_cmd_payload_uncached;
@@ -134,12 +134,11 @@ module VexRiscv (
   wire       [51:0]   _zz_memory_MUL_LOW;
   wire       [51:0]   _zz_memory_MUL_LOW_1;
   wire       [51:0]   _zz_memory_MUL_LOW_2;
-  wire       [51:0]   _zz_memory_MUL_LOW_3;
-  wire       [32:0]   _zz_memory_MUL_LOW_4;
-  wire       [51:0]   _zz_memory_MUL_LOW_5;
-  wire       [49:0]   _zz_memory_MUL_LOW_6;
-  wire       [51:0]   _zz_memory_MUL_LOW_7;
-  wire       [49:0]   _zz_memory_MUL_LOW_8;
+  wire       [32:0]   _zz_memory_MUL_LOW_3;
+  wire       [51:0]   _zz_memory_MUL_LOW_4;
+  wire       [49:0]   _zz_memory_MUL_LOW_5;
+  wire       [51:0]   _zz_memory_MUL_LOW_6;
+  wire       [49:0]   _zz_memory_MUL_LOW_7;
   wire       [31:0]   _zz_execute_SHIFT_RIGHT;
   wire       [32:0]   _zz_execute_SHIFT_RIGHT_1;
   wire       [32:0]   _zz_execute_SHIFT_RIGHT_2;
@@ -150,24 +149,19 @@ module VexRiscv (
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_2;
   wire                _zz_decode_LEGAL_INSTRUCTION_3;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_4;
-  wire       [16:0]   _zz_decode_LEGAL_INSTRUCTION_5;
+  wire       [15:0]   _zz_decode_LEGAL_INSTRUCTION_5;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_6;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_7;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_8;
   wire                _zz_decode_LEGAL_INSTRUCTION_9;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_10;
-  wire       [10:0]   _zz_decode_LEGAL_INSTRUCTION_11;
+  wire       [9:0]    _zz_decode_LEGAL_INSTRUCTION_11;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_12;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_13;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_14;
   wire                _zz_decode_LEGAL_INSTRUCTION_15;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_16;
-  wire       [4:0]    _zz_decode_LEGAL_INSTRUCTION_17;
-  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_18;
-  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_19;
-  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_20;
-  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_21;
-  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_22;
+  wire       [3:0]    _zz_decode_LEGAL_INSTRUCTION_17;
   wire       [3:0]    _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1;
   reg        [31:0]   _zz_IBusCachedPlugin_jump_pcLoad_payload_5;
   wire       [1:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_6;
@@ -218,158 +212,146 @@ module VexRiscv (
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_13;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_14;
   wire                _zz__zz_decode_IS_RS2_SIGNED_15;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_16;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_17;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_16;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_17;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_18;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_19;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_20;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_21;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_22;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_23;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_20;
+  wire       [22:0]   _zz__zz_decode_IS_RS2_SIGNED_21;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_22;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_23;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_24;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_25;
-  wire       [22:0]   _zz__zz_decode_IS_RS2_SIGNED_26;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_27;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_28;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_29;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_30;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_25;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_26;
+  wire       [19:0]   _zz__zz_decode_IS_RS2_SIGNED_27;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_28;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_29;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_30;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_31;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_32;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_33;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_32;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_33;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_34;
-  wire       [19:0]   _zz__zz_decode_IS_RS2_SIGNED_35;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_35;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_36;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_37;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_38;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_39;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_40;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_41;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_42;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_43;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_37;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_38;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_39;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_40;
+  wire       [15:0]   _zz__zz_decode_IS_RS2_SIGNED_41;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_42;
+  wire       [5:0]    _zz__zz_decode_IS_RS2_SIGNED_43;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_44;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_45;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_46;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_46;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_47;
-  wire       [16:0]   _zz__zz_decode_IS_RS2_SIGNED_48;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_49;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_50;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_51;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_52;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_53;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_48;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_49;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_50;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_51;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_52;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_53;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_54;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_55;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_56;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_57;
-  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_58;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_59;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_56;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_57;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_58;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_59;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_60;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_61;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_62;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_63;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_61;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_62;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_63;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_64;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_65;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_66;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_67;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_68;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_69;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_69;
   wire                _zz__zz_decode_IS_RS2_SIGNED_70;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_71;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_72;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_72;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_73;
-  wire       [12:0]   _zz__zz_decode_IS_RS2_SIGNED_74;
-  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_75;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_74;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_75;
   wire                _zz__zz_decode_IS_RS2_SIGNED_76;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_77;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_78;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_79;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_80;
-  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_81;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_82;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_83;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_84;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_85;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_86;
+  wire       [11:0]   _zz__zz_decode_IS_RS2_SIGNED_78;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_79;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_80;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_81;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_82;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_83;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_84;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_85;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_86;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_87;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_88;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_88;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_89;
-  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_90;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_91;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_92;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_90;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_91;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_92;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_93;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_94;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_95;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_96;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_97;
+  wire       [5:0]    _zz__zz_decode_IS_RS2_SIGNED_94;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_95;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_96;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_97;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_98;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_99;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_100;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_101;
-  wire       [6:0]    _zz__zz_decode_IS_RS2_SIGNED_102;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_99;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_100;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_101;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_102;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_103;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_104;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_105;
-  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_106;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_106;
   wire                _zz__zz_decode_IS_RS2_SIGNED_107;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_108;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_109;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_110;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_108;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_109;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_110;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_111;
-  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_112;
+  wire       [8:0]    _zz__zz_decode_IS_RS2_SIGNED_112;
   wire                _zz__zz_decode_IS_RS2_SIGNED_113;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_114;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_115;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_116;
-  wire       [9:0]    _zz__zz_decode_IS_RS2_SIGNED_117;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_118;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_117;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_118;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_119;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_120;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_120;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_121;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_122;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_123;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_124;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_125;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_126;
-  wire       [7:0]    _zz__zz_decode_IS_RS2_SIGNED_127;
+  wire       [6:0]    _zz__zz_decode_IS_RS2_SIGNED_122;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_123;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_124;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_125;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_126;
+  wire       [5:0]    _zz__zz_decode_IS_RS2_SIGNED_127;
   wire                _zz__zz_decode_IS_RS2_SIGNED_128;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_129;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_130;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_131;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_132;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_133;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_134;
-  wire       [5:0]    _zz__zz_decode_IS_RS2_SIGNED_135;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_136;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_137;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_138;
-  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_139;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_140;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_129;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_130;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_131;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_132;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_133;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_134;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_135;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_136;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_137;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_138;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_139;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_140;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_141;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_142;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_143;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_142;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_143;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_144;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_145;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_146;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_147;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_148;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_149;
-  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_150;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_151;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_152;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_145;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_146;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_147;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_148;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_149;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_150;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_151;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_152;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_153;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_154;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_155;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_156;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_157;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_158;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_159;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_160;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_161;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_162;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_163;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_164;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_165;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_166;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_167;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_154;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_155;
   wire                _zz_RegFilePlugin_regFile_port;
   wire                _zz_decode_RegFilePlugin_rs1Data;
   wire                _zz_RegFilePlugin_regFile_port_1;
@@ -377,14 +359,12 @@ module VexRiscv (
   wire       [0:0]    _zz__zz_execute_REGFILE_WRITE_DATA;
   wire       [2:0]    _zz__zz_execute_SRC1;
   wire       [4:0]    _zz__zz_execute_SRC1_1;
-  wire       [11:0]   _zz__zz_execute_SRC2_3;
+  wire       [11:0]   _zz__zz_execute_SRC2_2;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_1;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_2;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_3;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_4;
-  wire       [31:0]   _zz_execute_SrcPlugin_addSub_5;
-  wire       [31:0]   _zz_execute_SrcPlugin_addSub_6;
   wire       [19:0]   _zz__zz_execute_BranchPlugin_branch_src2_2;
   wire       [11:0]   _zz__zz_execute_BranchPlugin_branch_src2_4;
   wire                _zz_execute_BranchPlugin_branch_src2_6;
@@ -413,7 +393,7 @@ module VexRiscv (
   wire       [0:0]    _zz_memory_DivPlugin_rs1_3;
   wire       [31:0]   _zz_memory_DivPlugin_rs2_1;
   wire       [0:0]    _zz_memory_DivPlugin_rs2_2;
-  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_25;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_24;
   wire       [26:0]   _zz_iBusWishbone_ADR_1;
   wire       [51:0]   memory_MUL_LOW;
   wire       [33:0]   memory_MUL_HH;
@@ -530,7 +510,7 @@ module VexRiscv (
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_execute_SRC2;
+  wire       [31:0]   _zz_execute_to_memory_PC;
   wire       [1:0]    execute_SRC2_CTRL;
   wire       [1:0]    _zz_execute_SRC2_CTRL;
   wire                execute_IS_RVC;
@@ -714,8 +694,9 @@ module VexRiscv (
   wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
   wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
   wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
-  wire                CsrPlugin_csrMapping_allowCsrSignal;
+  reg                 CsrPlugin_csrMapping_allowCsrSignal;
   wire                CsrPlugin_csrMapping_hazardFree;
+  wire                CsrPlugin_csrMapping_doForceFailCsr;
   reg                 CsrPlugin_inWfi /* verilator public */ ;
   wire                CsrPlugin_thirdPartyWake;
   reg                 CsrPlugin_jumpInterface_valid;
@@ -734,6 +715,7 @@ module VexRiscv (
   wire                CsrPlugin_allowInterrupts;
   wire                CsrPlugin_allowException;
   wire                CsrPlugin_allowEbreakException;
+  wire                CsrPlugin_xretAwayFromMachine;
   wire                IBusCachedPlugin_externalFlush;
   wire                IBusCachedPlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
@@ -753,20 +735,19 @@ module VexRiscv (
   reg                 IBusCachedPlugin_fetchPc_pcRegPropagate;
   reg                 IBusCachedPlugin_fetchPc_booted;
   reg                 IBusCachedPlugin_fetchPc_inc;
-  wire                when_Fetcher_l134;
-  wire                IBusCachedPlugin_fetchPc_output_fire_1;
-  wire                when_Fetcher_l134_1;
+  wire                when_Fetcher_l133;
+  wire                when_Fetcher_l133_1;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pc;
   wire                IBusCachedPlugin_fetchPc_redo_valid;
   reg        [31:0]   IBusCachedPlugin_fetchPc_redo_payload;
   reg                 IBusCachedPlugin_fetchPc_flushed;
-  wire                when_Fetcher_l161;
+  wire                when_Fetcher_l160;
   reg                 IBusCachedPlugin_decodePc_flushed;
   reg        [31:0]   IBusCachedPlugin_decodePc_pcReg /* verilator public */ ;
   wire       [31:0]   IBusCachedPlugin_decodePc_pcPlus;
   wire                IBusCachedPlugin_decodePc_injectedDecode;
-  wire                when_Fetcher_l183;
-  wire                when_Fetcher_l195;
+  wire                when_Fetcher_l182;
+  wire                when_Fetcher_l194;
   reg                 IBusCachedPlugin_iBusRsp_redoFetch;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_ready;
@@ -786,8 +767,8 @@ module VexRiscv (
   wire                _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready;
   wire                IBusCachedPlugin_iBusRsp_flush;
   wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
-  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
-  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid;
+  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1;
   reg                 IBusCachedPlugin_iBusRsp_readyForError;
   wire                IBusCachedPlugin_iBusRsp_output_valid;
   wire                IBusCachedPlugin_iBusRsp_output_ready;
@@ -846,18 +827,19 @@ module VexRiscv (
   wire       [4:0]    _zz_IBusCachedPlugin_decompressor_decompressed_20;
   wire       [4:0]    _zz_IBusCachedPlugin_decompressor_decompressed_21;
   wire       [4:0]    switch_Misc_l44;
+  wire                when_Misc_l47;
   wire                _zz_IBusCachedPlugin_decompressor_decompressed_22;
-  wire       [1:0]    switch_Misc_l210;
-  wire       [1:0]    switch_Misc_l210_1;
+  wire       [1:0]    switch_Misc_l232;
+  wire       [1:0]    switch_Misc_l232_1;
   reg        [2:0]    _zz_IBusCachedPlugin_decompressor_decompressed_23;
   reg        [2:0]    _zz_IBusCachedPlugin_decompressor_decompressed_24;
   wire                _zz_IBusCachedPlugin_decompressor_decompressed_25;
   reg        [6:0]    _zz_IBusCachedPlugin_decompressor_decompressed_26;
   wire                IBusCachedPlugin_decompressor_output_fire;
   wire                IBusCachedPlugin_decompressor_bufferFill;
-  wire                when_Fetcher_l286;
-  wire                when_Fetcher_l289;
-  wire                when_Fetcher_l294;
+  wire                when_Fetcher_l285;
+  wire                when_Fetcher_l288;
+  wire                when_Fetcher_l293;
   wire                IBusCachedPlugin_injector_decodeInput_valid;
   wire                IBusCachedPlugin_injector_decodeInput_ready;
   wire       [31:0]   IBusCachedPlugin_injector_decodeInput_payload_pc;
@@ -870,13 +852,13 @@ module VexRiscv (
   reg        [31:0]   _zz_IBusCachedPlugin_injector_decodeInput_payload_rsp_inst;
   reg                 _zz_IBusCachedPlugin_injector_decodeInput_payload_isRvc;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
-  wire                when_Fetcher_l332;
+  wire                when_Fetcher_l331;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
-  wire                when_Fetcher_l332_1;
+  wire                when_Fetcher_l331_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
-  wire                when_Fetcher_l332_2;
+  wire                when_Fetcher_l331_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
-  wire                when_Fetcher_l332_3;
+  wire                when_Fetcher_l331_3;
   reg        [31:0]   IBusCachedPlugin_injector_formal_rawInDecode;
   wire                _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   reg        [18:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1;
@@ -897,71 +879,72 @@ module VexRiscv (
   wire                IBusCachedPlugin_rsp_iBusRspOutputHalt;
   wire                IBusCachedPlugin_rsp_issueDetected;
   reg                 IBusCachedPlugin_rsp_redoFetch;
-  wire                when_IBusCachedPlugin_l239;
-  wire                when_IBusCachedPlugin_l244;
+  wire                when_IBusCachedPlugin_l245;
   wire                when_IBusCachedPlugin_l250;
   wire                when_IBusCachedPlugin_l256;
-  wire                when_IBusCachedPlugin_l267;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_valid;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_ready;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_address;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_data;
-  wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_size;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_last;
-  reg                 dataCache_1_io_mem_cmd_rValid;
-  reg                 dataCache_1_io_mem_cmd_rData_wr;
-  reg                 dataCache_1_io_mem_cmd_rData_uncached;
-  reg        [31:0]   dataCache_1_io_mem_cmd_rData_address;
-  reg        [31:0]   dataCache_1_io_mem_cmd_rData_data;
-  reg        [3:0]    dataCache_1_io_mem_cmd_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_rData_size;
-  reg                 dataCache_1_io_mem_cmd_rData_last;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
-  wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data;
-  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
-  wire                when_Stream_l368;
+  wire                when_IBusCachedPlugin_l262;
+  wire                when_IBusCachedPlugin_l273;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_valid;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+  wire       [3:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+  wire       [2:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_size;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rValidN;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rData_wr;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rData_uncached;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_rData_address;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_rData_data;
+  reg        [3:0]    toplevel_dataCache_1_io_mem_cmd_rData_mask;
+  reg        [2:0]    toplevel_dataCache_1_io_mem_cmd_rData_size;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rData_last;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
+  wire       [3:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
+  wire       [2:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_address;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_data;
+  reg        [3:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
+  reg        [2:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_size;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  wire                when_Stream_l369;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
-  wire                when_DBusCachedPlugin_l308;
-  wire                when_DBusCachedPlugin_l316;
+  wire                when_DBusCachedPlugin_l352;
+  wire                when_DBusCachedPlugin_l360;
   wire       [1:0]    execute_DBusCachedPlugin_size;
   reg        [31:0]   _zz_execute_MEMORY_STORE_DATA_RF;
-  wire                dataCache_1_io_cpu_flush_isStall;
-  wire                when_DBusCachedPlugin_l350;
-  wire                when_DBusCachedPlugin_l366;
-  wire                when_DBusCachedPlugin_l393;
-  wire                when_DBusCachedPlugin_l446;
-  wire                when_DBusCachedPlugin_l466;
+  wire                toplevel_dataCache_1_io_cpu_flush_isStall;
+  wire                when_DBusCachedPlugin_l394;
+  wire                when_DBusCachedPlugin_l410;
+  wire                when_DBusCachedPlugin_l472;
+  wire                when_DBusCachedPlugin_l533;
+  wire                when_DBusCachedPlugin_l553;
+  wire       [31:0]   writeBack_DBusCachedPlugin_rspData;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_0;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_1;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_2;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspRf;
-  wire                when_DBusCachedPlugin_l482;
-  wire       [1:0]    switch_Misc_l210_2;
+  wire                when_DBusCachedPlugin_l570;
+  wire       [1:0]    switch_Misc_l232_2;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_1;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated_2;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
-  wire                when_DBusCachedPlugin_l492;
+  wire                when_DBusCachedPlugin_l580;
   wire       [33:0]   _zz_decode_IS_RS2_SIGNED;
   wire                _zz_decode_IS_RS2_SIGNED_1;
   wire                _zz_decode_IS_RS2_SIGNED_2;
@@ -986,15 +969,15 @@ module VexRiscv (
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
   reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
   reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_2;
+  reg                 _zz_5;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
   reg        [31:0]   _zz_execute_REGFILE_WRITE_DATA;
   reg        [31:0]   _zz_execute_SRC1;
-  wire                _zz_execute_SRC2_1;
-  reg        [19:0]   _zz_execute_SRC2_2;
-  wire                _zz_execute_SRC2_3;
-  reg        [19:0]   _zz_execute_SRC2_4;
-  reg        [31:0]   _zz_execute_SRC2_5;
+  wire                _zz_execute_SRC2;
+  reg        [19:0]   _zz_execute_SRC2_1;
+  wire                _zz_execute_SRC2_2;
+  reg        [19:0]   _zz_execute_SRC2_3;
+  reg        [31:0]   _zz_execute_SRC2_4;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   wire       [4:0]    execute_FullBarrelShifterPlugin_amplitude;
@@ -1031,7 +1014,7 @@ module VexRiscv (
   wire                when_HazardSimplePlugin_l108;
   wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    switch_Misc_l210_3;
+  wire       [2:0]    switch_Misc_l232_3;
   reg                 _zz_execute_BRANCH_COND_RESULT;
   reg                 _zz_execute_BRANCH_COND_RESULT_1;
   wire                execute_BranchPlugin_missAlignedTarget;
@@ -1044,8 +1027,8 @@ module VexRiscv (
   wire                _zz_execute_BranchPlugin_branch_src2_4;
   reg        [18:0]   _zz_execute_BranchPlugin_branch_src2_5;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
-  reg        [1:0]    CsrPlugin_misa_base;
-  reg        [25:0]   CsrPlugin_misa_extensions;
+  wire       [1:0]    CsrPlugin_misa_base;
+  wire       [25:0]   CsrPlugin_misa_extensions;
   reg        [1:0]    CsrPlugin_mtvec_mode;
   reg        [29:0]   CsrPlugin_mtvec_base;
   reg        [31:0]   CsrPlugin_mepc;
@@ -1064,9 +1047,9 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_mtval;
   reg        [63:0]   CsrPlugin_mcycle;
   reg        [63:0]   CsrPlugin_minstret;
-  wire                _zz_when_CsrPlugin_l965;
-  wire                _zz_when_CsrPlugin_l965_1;
-  wire                _zz_when_CsrPlugin_l965_2;
+  wire                _zz_when_CsrPlugin_l1302;
+  wire                _zz_when_CsrPlugin_l1302_1;
+  wire                _zz_when_CsrPlugin_l1302_2;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -1081,59 +1064,62 @@ module VexRiscv (
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
   wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code;
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
-  wire                when_CsrPlugin_l922;
-  wire                when_CsrPlugin_l922_1;
-  wire                when_CsrPlugin_l922_2;
-  wire                when_CsrPlugin_l922_3;
-  wire                when_CsrPlugin_l935;
+  wire                when_CsrPlugin_l1259;
+  wire                when_CsrPlugin_l1259_1;
+  wire                when_CsrPlugin_l1259_2;
+  wire                when_CsrPlugin_l1259_3;
+  wire                when_CsrPlugin_l1272;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
-  wire                when_CsrPlugin_l959;
-  wire                when_CsrPlugin_l965;
-  wire                when_CsrPlugin_l965_1;
-  wire                when_CsrPlugin_l965_2;
+  wire                when_CsrPlugin_l1296;
+  wire                when_CsrPlugin_l1302;
+  wire                when_CsrPlugin_l1302_1;
+  wire                when_CsrPlugin_l1302_2;
   wire                CsrPlugin_exception;
   reg                 CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
-  wire                when_CsrPlugin_l993;
-  wire                when_CsrPlugin_l993_1;
-  wire                when_CsrPlugin_l993_2;
-  wire                when_CsrPlugin_l998;
+  wire                when_CsrPlugin_l1335;
+  wire                when_CsrPlugin_l1335_1;
+  wire                when_CsrPlugin_l1335_2;
+  wire                when_CsrPlugin_l1340;
   reg                 CsrPlugin_pipelineLiberator_done;
-  wire                when_CsrPlugin_l1004;
+  wire                when_CsrPlugin_l1346;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
+  wire                CsrPlugin_trapCauseEbreakDebug;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
-  wire                when_CsrPlugin_l1032;
-  wire                when_CsrPlugin_l1077;
-  wire       [1:0]    switch_CsrPlugin_l1081;
+  wire                CsrPlugin_trapEnterDebug;
+  wire                when_CsrPlugin_l1390;
+  wire                when_CsrPlugin_l1398;
+  wire                when_CsrPlugin_l1456;
+  wire       [1:0]    switch_CsrPlugin_l1460;
   reg                 execute_CsrPlugin_wfiWake;
-  wire                when_CsrPlugin_l1121;
-  wire                when_CsrPlugin_l1123;
-  wire                when_CsrPlugin_l1129;
+  wire                when_CsrPlugin_l1519;
+  wire                when_CsrPlugin_l1521;
+  wire                when_CsrPlugin_l1527;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire                when_CsrPlugin_l1142;
-  wire                when_CsrPlugin_l1149;
-  wire                when_CsrPlugin_l1150;
-  wire                when_CsrPlugin_l1157;
+  wire                when_CsrPlugin_l1540;
+  wire                when_CsrPlugin_l1547;
+  wire                when_CsrPlugin_l1548;
+  wire                when_CsrPlugin_l1555;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   wire       [31:0]   execute_CsrPlugin_readToWriteData;
-  wire                switch_Misc_l210_4;
+  wire                switch_Misc_l232_4;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
-  wire                when_CsrPlugin_l1189;
-  wire                when_CsrPlugin_l1193;
+  wire                when_CsrPlugin_l1587;
+  wire                when_CsrPlugin_l1591;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg                 execute_MulPlugin_aSigned;
   reg                 execute_MulPlugin_bSigned;
@@ -1180,7 +1166,7 @@ module VexRiscv (
   reg        [32:0]   _zz_memory_DivPlugin_rs1_1;
   reg        [31:0]   externalInterruptArray_regNext;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit;
-  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
+  wire       [31:0]   _zz_externalInterrupt;
   wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
   wire                when_Pipeline_l124_1;
@@ -1321,60 +1307,61 @@ module VexRiscv (
   wire                when_Pipeline_l154_1;
   wire                when_Pipeline_l151_2;
   wire                when_Pipeline_l154_2;
-  wire                when_CsrPlugin_l1277;
+  wire                when_CsrPlugin_l1669;
   reg                 execute_CsrPlugin_csr_3264;
-  wire                when_CsrPlugin_l1277_1;
+  wire                when_CsrPlugin_l1669_1;
   reg                 execute_CsrPlugin_csr_3857;
-  wire                when_CsrPlugin_l1277_2;
+  wire                when_CsrPlugin_l1669_2;
   reg                 execute_CsrPlugin_csr_3858;
-  wire                when_CsrPlugin_l1277_3;
+  wire                when_CsrPlugin_l1669_3;
   reg                 execute_CsrPlugin_csr_3859;
-  wire                when_CsrPlugin_l1277_4;
+  wire                when_CsrPlugin_l1669_4;
   reg                 execute_CsrPlugin_csr_3860;
-  wire                when_CsrPlugin_l1277_5;
+  wire                when_CsrPlugin_l1669_5;
   reg                 execute_CsrPlugin_csr_769;
-  wire                when_CsrPlugin_l1277_6;
+  wire                when_CsrPlugin_l1669_6;
   reg                 execute_CsrPlugin_csr_768;
-  wire                when_CsrPlugin_l1277_7;
+  wire                when_CsrPlugin_l1669_7;
   reg                 execute_CsrPlugin_csr_836;
-  wire                when_CsrPlugin_l1277_8;
+  wire                when_CsrPlugin_l1669_8;
   reg                 execute_CsrPlugin_csr_772;
-  wire                when_CsrPlugin_l1277_9;
+  wire                when_CsrPlugin_l1669_9;
   reg                 execute_CsrPlugin_csr_773;
-  wire                when_CsrPlugin_l1277_10;
+  wire                when_CsrPlugin_l1669_10;
   reg                 execute_CsrPlugin_csr_833;
-  wire                when_CsrPlugin_l1277_11;
+  wire                when_CsrPlugin_l1669_11;
   reg                 execute_CsrPlugin_csr_832;
-  wire                when_CsrPlugin_l1277_12;
+  wire                when_CsrPlugin_l1669_12;
   reg                 execute_CsrPlugin_csr_834;
-  wire                when_CsrPlugin_l1277_13;
+  wire                when_CsrPlugin_l1669_13;
   reg                 execute_CsrPlugin_csr_835;
-  wire                when_CsrPlugin_l1277_14;
+  wire                when_CsrPlugin_l1669_14;
   reg                 execute_CsrPlugin_csr_2816;
-  wire                when_CsrPlugin_l1277_15;
+  wire                when_CsrPlugin_l1669_15;
   reg                 execute_CsrPlugin_csr_2944;
-  wire                when_CsrPlugin_l1277_16;
+  wire                when_CsrPlugin_l1669_16;
   reg                 execute_CsrPlugin_csr_2818;
-  wire                when_CsrPlugin_l1277_17;
+  wire                when_CsrPlugin_l1669_17;
   reg                 execute_CsrPlugin_csr_2946;
-  wire                when_CsrPlugin_l1277_18;
+  wire                when_CsrPlugin_l1669_18;
   reg                 execute_CsrPlugin_csr_3072;
-  wire                when_CsrPlugin_l1277_19;
+  wire                when_CsrPlugin_l1669_19;
   reg                 execute_CsrPlugin_csr_3200;
-  wire                when_CsrPlugin_l1277_20;
+  wire                when_CsrPlugin_l1669_20;
   reg                 execute_CsrPlugin_csr_3074;
-  wire                when_CsrPlugin_l1277_21;
+  wire                when_CsrPlugin_l1669_21;
   reg                 execute_CsrPlugin_csr_3202;
-  wire                when_CsrPlugin_l1277_22;
+  wire                when_CsrPlugin_l1669_22;
   reg                 execute_CsrPlugin_csr_3008;
-  wire                when_CsrPlugin_l1277_23;
+  wire                when_CsrPlugin_l1669_23;
   reg                 execute_CsrPlugin_csr_4032;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_5;
+  wire       [1:0]    switch_CsrPlugin_l1031;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_6;
-  wire       [1:0]    switch_CsrPlugin_l723;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_8;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
@@ -1392,19 +1379,22 @@ module VexRiscv (
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_21;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_22;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_23;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_24;
-  wire                when_CsrPlugin_l1310;
-  wire                when_CsrPlugin_l1315;
+  wire                when_CsrPlugin_l1702;
+  wire       [11:0]   _zz_when_CsrPlugin_l1709;
+  wire                when_CsrPlugin_l1709;
+  reg                 when_CsrPlugin_l1719;
+  wire                when_CsrPlugin_l1717;
+  wire                when_CsrPlugin_l1725;
   reg        [2:0]    _zz_iBusWishbone_ADR;
   wire                when_InstructionCache_l239;
   reg                 _zz_iBus_rsp_valid;
   reg        [31:0]   iBusWishbone_DAT_MISO_regNext;
-  reg        [2:0]    _zz_dBus_cmd_ready;
+  reg        [2:0]    _zz_dBusWishbone_ADR;
+  wire                _zz_dBusWishbone_CYC;
+  wire                _zz_dBus_cmd_ready;
   wire                _zz_dBus_cmd_ready_1;
   wire                _zz_dBus_cmd_ready_2;
-  wire                _zz_dBus_cmd_ready_3;
-  wire                _zz_dBus_cmd_ready_4;
-  wire                _zz_dBus_cmd_ready_5;
+  wire                _zz_dBusWishbone_ADR_1;
   reg                 _zz_dBus_rsp_valid;
   reg        [31:0]   dBusWishbone_DAT_MISO_regNext;
   `ifndef SYNTHESIS
@@ -1491,15 +1481,14 @@ module VexRiscv (
   (* no_rw_check , ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
   assign _zz_when = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
-  assign _zz_memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW_1) + $signed(_zz_memory_MUL_LOW_5));
-  assign _zz_memory_MUL_LOW_1 = ($signed(_zz_memory_MUL_LOW_2) + $signed(_zz_memory_MUL_LOW_3));
-  assign _zz_memory_MUL_LOW_2 = 52'h0;
-  assign _zz_memory_MUL_LOW_4 = {1'b0,memory_MUL_LL};
-  assign _zz_memory_MUL_LOW_3 = {{19{_zz_memory_MUL_LOW_4[32]}}, _zz_memory_MUL_LOW_4};
-  assign _zz_memory_MUL_LOW_6 = ({16'd0,memory_MUL_LH} <<< 16);
-  assign _zz_memory_MUL_LOW_5 = {{2{_zz_memory_MUL_LOW_6[49]}}, _zz_memory_MUL_LOW_6};
-  assign _zz_memory_MUL_LOW_8 = ({16'd0,memory_MUL_HL} <<< 16);
-  assign _zz_memory_MUL_LOW_7 = {{2{_zz_memory_MUL_LOW_8[49]}}, _zz_memory_MUL_LOW_8};
+  assign _zz_memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW_1) + $signed(_zz_memory_MUL_LOW_4));
+  assign _zz_memory_MUL_LOW_1 = ($signed(52'h0000000000000) + $signed(_zz_memory_MUL_LOW_2));
+  assign _zz_memory_MUL_LOW_3 = {1'b0,memory_MUL_LL};
+  assign _zz_memory_MUL_LOW_2 = {{19{_zz_memory_MUL_LOW_3[32]}}, _zz_memory_MUL_LOW_3};
+  assign _zz_memory_MUL_LOW_5 = ({16'd0,memory_MUL_LH} <<< 5'd16);
+  assign _zz_memory_MUL_LOW_4 = {{2{_zz_memory_MUL_LOW_5[49]}}, _zz_memory_MUL_LOW_5};
+  assign _zz_memory_MUL_LOW_7 = ({16'd0,memory_MUL_HL} <<< 5'd16);
+  assign _zz_memory_MUL_LOW_6 = {{2{_zz_memory_MUL_LOW_7[49]}}, _zz_memory_MUL_LOW_7};
   assign _zz_execute_SHIFT_RIGHT_1 = ($signed(_zz_execute_SHIFT_RIGHT_2) >>> execute_FullBarrelShifterPlugin_amplitude);
   assign _zz_execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT_1[31 : 0];
   assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == ShiftCtrlEnum_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
@@ -1510,7 +1499,7 @@ module VexRiscv (
   assign _zz_IBusCachedPlugin_fetchPc_pc = {29'd0, _zz_IBusCachedPlugin_fetchPc_pc_1};
   assign _zz_IBusCachedPlugin_decodePc_pcPlus_1 = (decode_IS_RVC ? 3'b010 : 3'b100);
   assign _zz_IBusCachedPlugin_decodePc_pcPlus = {29'd0, _zz_IBusCachedPlugin_decodePc_pcPlus_1};
-  assign _zz_IBusCachedPlugin_decompressor_decompressed_27 = {{_zz_IBusCachedPlugin_decompressor_decompressed_10,_zz_IBusCachedPlugin_decompressor_decompressed[6 : 2]},12'h0};
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_27 = {{_zz_IBusCachedPlugin_decompressor_decompressed_10,_zz_IBusCachedPlugin_decompressor_decompressed[6 : 2]},12'h000};
   assign _zz_IBusCachedPlugin_decompressor_decompressed_34 = {{{4'b0000,_zz_IBusCachedPlugin_decompressor_decompressed[8 : 7]},_zz_IBusCachedPlugin_decompressor_decompressed[12 : 9]},2'b00};
   assign _zz_IBusCachedPlugin_decompressor_decompressed_35 = {{{4'b0000,_zz_IBusCachedPlugin_decompressor_decompressed[8 : 7]},_zz_IBusCachedPlugin_decompressor_decompressed[12 : 9]},2'b00};
   assign _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
@@ -1518,28 +1507,26 @@ module VexRiscv (
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
   assign _zz_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId_1;
-  assign _zz_io_cpu_flush_payload_lineId_1 = (execute_RS1 >>> 5);
+  assign _zz_io_cpu_flush_payload_lineId_1 = (execute_RS1 >>> 3'd5);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code_1 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
   assign _zz_writeBack_DBusCachedPlugin_rspRf = (! dataCache_1_io_cpu_writeBack_exclusiveOk);
   assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
   assign _zz__zz_execute_SRC1 = (execute_IS_RVC ? 3'b010 : 3'b100);
   assign _zz__zz_execute_SRC1_1 = execute_INSTRUCTION[19 : 15];
-  assign _zz__zz_execute_SRC2_3 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz__zz_execute_SRC2_2 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
   assign _zz_execute_SrcPlugin_addSub = ($signed(_zz_execute_SrcPlugin_addSub_1) + $signed(_zz_execute_SrcPlugin_addSub_4));
   assign _zz_execute_SrcPlugin_addSub_1 = ($signed(_zz_execute_SrcPlugin_addSub_2) + $signed(_zz_execute_SrcPlugin_addSub_3));
   assign _zz_execute_SrcPlugin_addSub_2 = execute_SRC1;
   assign _zz_execute_SrcPlugin_addSub_3 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? _zz_execute_SrcPlugin_addSub_5 : _zz_execute_SrcPlugin_addSub_6);
-  assign _zz_execute_SrcPlugin_addSub_5 = 32'h00000001;
-  assign _zz_execute_SrcPlugin_addSub_6 = 32'h0;
+  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? 32'h00000001 : 32'h00000000);
   assign _zz__zz_execute_BranchPlugin_branch_src2_2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
   assign _zz__zz_execute_BranchPlugin_branch_src2_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
   assign _zz_execute_BranchPlugin_branch_src2_9 = (execute_IS_RVC ? 3'b010 : 3'b100);
   assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code & (~ _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1));
   assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code - 2'b01);
   assign _zz_writeBack_MulPlugin_result = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
-  assign _zz_writeBack_MulPlugin_result_1 = ({32'd0,writeBack_MUL_HH} <<< 32);
+  assign _zz_writeBack_MulPlugin_result_1 = ({32'd0,writeBack_MUL_HH} <<< 6'd32);
   assign _zz__zz_decode_RS2_2 = writeBack_MUL_LOW[31 : 0];
   assign _zz__zz_decode_RS2_2_1 = writeBack_MulPlugin_result[63 : 32];
   assign _zz_memory_DivPlugin_div_counter_valueNext_1 = memory_DivPlugin_div_counter_willIncrement;
@@ -1557,17 +1544,17 @@ module VexRiscv (
   assign _zz_memory_DivPlugin_rs1_2 = {32'd0, _zz_memory_DivPlugin_rs1_3};
   assign _zz_memory_DivPlugin_rs2_2 = _zz_memory_DivPlugin_rs2;
   assign _zz_memory_DivPlugin_rs2_1 = {31'd0, _zz_memory_DivPlugin_rs2_2};
-  assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 5);
+  assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 3'd5);
   assign _zz_decode_RegFilePlugin_rs1Data = 1'b1;
   assign _zz_decode_RegFilePlugin_rs2Data = 1'b1;
   assign _zz_IBusCachedPlugin_jump_pcLoad_payload_6 = {_zz_IBusCachedPlugin_jump_pcLoad_payload_4,_zz_IBusCachedPlugin_jump_pcLoad_payload_3};
   assign _zz_writeBack_DBusCachedPlugin_rspShifted_1 = dataCache_1_io_cpu_writeBack_address[1 : 0];
   assign _zz_writeBack_DBusCachedPlugin_rspShifted_3 = dataCache_1_io_cpu_writeBack_address[1 : 1];
-  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000107f;
-  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00002073;
-  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000207f;
+  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000407f);
+  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00004063;
+  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000107f) == 32'h00000013);
   assign _zz_decode_LEGAL_INSTRUCTION_5 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_6) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_7 == _zz_decode_LEGAL_INSTRUCTION_8),{_zz_decode_LEGAL_INSTRUCTION_9,{_zz_decode_LEGAL_INSTRUCTION_10,_zz_decode_LEGAL_INSTRUCTION_11}}}}}};
   assign _zz_decode_LEGAL_INSTRUCTION_6 = 32'h0000505f;
   assign _zz_decode_LEGAL_INSTRUCTION_7 = (decode_INSTRUCTION & 32'h0000707b);
@@ -1576,19 +1563,14 @@ module VexRiscv (
   assign _zz_decode_LEGAL_INSTRUCTION_10 = ((decode_INSTRUCTION & 32'h1800707f) == 32'h0000202f);
   assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033),{((decode_INSTRUCTION & 32'he800707f) == 32'h0800202f),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h0000500f),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,{_zz_decode_LEGAL_INSTRUCTION_16,_zz_decode_LEGAL_INSTRUCTION_17}}}}}};
   assign _zz_decode_LEGAL_INSTRUCTION_12 = 32'h01f0707f;
-  assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'hbc00707f);
+  assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'hbe00705f);
   assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h00005013;
-  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hfc00307f) == 32'h00001013);
-  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00005033);
-  assign _zz_decode_LEGAL_INSTRUCTION_17 = {((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033),{((decode_INSTRUCTION & 32'hf9f0707f) == 32'h1000202f),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_18) == 32'h10200073),{(_zz_decode_LEGAL_INSTRUCTION_19 == _zz_decode_LEGAL_INSTRUCTION_20),(_zz_decode_LEGAL_INSTRUCTION_21 == _zz_decode_LEGAL_INSTRUCTION_22)}}}};
-  assign _zz_decode_LEGAL_INSTRUCTION_18 = 32'hdfffffff;
-  assign _zz_decode_LEGAL_INSTRUCTION_19 = (decode_INSTRUCTION & 32'hffffffff);
-  assign _zz_decode_LEGAL_INSTRUCTION_20 = 32'h10500073;
-  assign _zz_decode_LEGAL_INSTRUCTION_21 = (decode_INSTRUCTION & 32'hffffffff);
-  assign _zz_decode_LEGAL_INSTRUCTION_22 = 32'h00000073;
+  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hfe00305f) == 32'h00001013);
+  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
+  assign _zz_decode_LEGAL_INSTRUCTION_17 = {((decode_INSTRUCTION & 32'hf9f0707f) == 32'h1000202f),{((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073),{((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073),((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073)}}};
   assign _zz_IBusCachedPlugin_decompressor_decompressed_28 = (_zz_IBusCachedPlugin_decompressor_decompressed[11 : 10] == 2'b01);
   assign _zz_IBusCachedPlugin_decompressor_decompressed_29 = ((_zz_IBusCachedPlugin_decompressor_decompressed[11 : 10] == 2'b11) && (_zz_IBusCachedPlugin_decompressor_decompressed[6 : 5] == 2'b00));
-  assign _zz_IBusCachedPlugin_decompressor_decompressed_30 = 7'h0;
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_30 = 7'h00;
   assign _zz_IBusCachedPlugin_decompressor_decompressed_31 = _zz_IBusCachedPlugin_decompressor_decompressed[6 : 2];
   assign _zz_IBusCachedPlugin_decompressor_decompressed_32 = _zz_IBusCachedPlugin_decompressor_decompressed[12];
   assign _zz_IBusCachedPlugin_decompressor_decompressed_33 = _zz_IBusCachedPlugin_decompressor_decompressed[11 : 7];
@@ -1603,172 +1585,160 @@ module VexRiscv (
   assign _zz__zz_decode_IS_RS2_SIGNED_3 = ((decode_INSTRUCTION & 32'h00203050) == 32'h00000050);
   assign _zz__zz_decode_IS_RS2_SIGNED_4 = (|((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_5) == 32'h00000050));
   assign _zz__zz_decode_IS_RS2_SIGNED_6 = (|{_zz__zz_decode_IS_RS2_SIGNED_7,_zz__zz_decode_IS_RS2_SIGNED_8});
-  assign _zz__zz_decode_IS_RS2_SIGNED_9 = {(|{_zz__zz_decode_IS_RS2_SIGNED_10,_zz__zz_decode_IS_RS2_SIGNED_11}),{(|_zz__zz_decode_IS_RS2_SIGNED_13),{_zz__zz_decode_IS_RS2_SIGNED_15,{_zz__zz_decode_IS_RS2_SIGNED_18,_zz__zz_decode_IS_RS2_SIGNED_26}}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_9 = {(|{_zz__zz_decode_IS_RS2_SIGNED_10,_zz__zz_decode_IS_RS2_SIGNED_11}),{(|_zz__zz_decode_IS_RS2_SIGNED_13),{_zz__zz_decode_IS_RS2_SIGNED_15,{_zz__zz_decode_IS_RS2_SIGNED_18,_zz__zz_decode_IS_RS2_SIGNED_21}}}};
   assign _zz__zz_decode_IS_RS2_SIGNED_5 = 32'h00403050;
   assign _zz__zz_decode_IS_RS2_SIGNED_7 = ((decode_INSTRUCTION & 32'h00001050) == 32'h00001050);
   assign _zz__zz_decode_IS_RS2_SIGNED_8 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002050);
   assign _zz__zz_decode_IS_RS2_SIGNED_10 = _zz_decode_IS_RS2_SIGNED_2;
   assign _zz__zz_decode_IS_RS2_SIGNED_11 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_12) == 32'h00000004);
   assign _zz__zz_decode_IS_RS2_SIGNED_13 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_14) == 32'h00000040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_15 = (|{_zz__zz_decode_IS_RS2_SIGNED_16,_zz__zz_decode_IS_RS2_SIGNED_17});
-  assign _zz__zz_decode_IS_RS2_SIGNED_18 = (|{_zz__zz_decode_IS_RS2_SIGNED_19,_zz__zz_decode_IS_RS2_SIGNED_21});
-  assign _zz__zz_decode_IS_RS2_SIGNED_26 = {(|_zz__zz_decode_IS_RS2_SIGNED_27),{_zz__zz_decode_IS_RS2_SIGNED_29,{_zz__zz_decode_IS_RS2_SIGNED_32,_zz__zz_decode_IS_RS2_SIGNED_35}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_15 = (|(_zz__zz_decode_IS_RS2_SIGNED_16 == _zz__zz_decode_IS_RS2_SIGNED_17));
+  assign _zz__zz_decode_IS_RS2_SIGNED_18 = (|{_zz__zz_decode_IS_RS2_SIGNED_19,_zz__zz_decode_IS_RS2_SIGNED_20});
+  assign _zz__zz_decode_IS_RS2_SIGNED_21 = {(|_zz__zz_decode_IS_RS2_SIGNED_22),{_zz__zz_decode_IS_RS2_SIGNED_23,{_zz__zz_decode_IS_RS2_SIGNED_25,_zz__zz_decode_IS_RS2_SIGNED_27}}};
   assign _zz__zz_decode_IS_RS2_SIGNED_12 = 32'h0000001c;
   assign _zz__zz_decode_IS_RS2_SIGNED_14 = 32'h00000058;
-  assign _zz__zz_decode_IS_RS2_SIGNED_16 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00005010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_17 = ((decode_INSTRUCTION & 32'h02007064) == 32'h00005020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_19 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_20) == 32'h40001010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_21 = {(_zz__zz_decode_IS_RS2_SIGNED_22 == _zz__zz_decode_IS_RS2_SIGNED_23),(_zz__zz_decode_IS_RS2_SIGNED_24 == _zz__zz_decode_IS_RS2_SIGNED_25)};
-  assign _zz__zz_decode_IS_RS2_SIGNED_27 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_28) == 32'h00001000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_29 = (|(_zz__zz_decode_IS_RS2_SIGNED_30 == _zz__zz_decode_IS_RS2_SIGNED_31));
-  assign _zz__zz_decode_IS_RS2_SIGNED_32 = (|{_zz__zz_decode_IS_RS2_SIGNED_33,_zz__zz_decode_IS_RS2_SIGNED_34});
-  assign _zz__zz_decode_IS_RS2_SIGNED_35 = {(|_zz__zz_decode_IS_RS2_SIGNED_36),{_zz__zz_decode_IS_RS2_SIGNED_37,{_zz__zz_decode_IS_RS2_SIGNED_39,_zz__zz_decode_IS_RS2_SIGNED_48}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_20 = 32'h40003054;
-  assign _zz__zz_decode_IS_RS2_SIGNED_22 = (decode_INSTRUCTION & 32'h00007034);
-  assign _zz__zz_decode_IS_RS2_SIGNED_23 = 32'h00001010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_24 = (decode_INSTRUCTION & 32'h02007054);
-  assign _zz__zz_decode_IS_RS2_SIGNED_25 = 32'h00001010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_28 = 32'h00001000;
-  assign _zz__zz_decode_IS_RS2_SIGNED_30 = (decode_INSTRUCTION & 32'h00003000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_31 = 32'h00002000;
-  assign _zz__zz_decode_IS_RS2_SIGNED_33 = _zz_decode_IS_RS2_SIGNED_7;
-  assign _zz__zz_decode_IS_RS2_SIGNED_34 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00001000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_36 = ((decode_INSTRUCTION & 32'h00004048) == 32'h00004008);
-  assign _zz__zz_decode_IS_RS2_SIGNED_37 = (|((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_38) == 32'h00000024));
-  assign _zz__zz_decode_IS_RS2_SIGNED_39 = (|{_zz__zz_decode_IS_RS2_SIGNED_40,{_zz__zz_decode_IS_RS2_SIGNED_41,_zz__zz_decode_IS_RS2_SIGNED_43}});
-  assign _zz__zz_decode_IS_RS2_SIGNED_48 = {(|_zz__zz_decode_IS_RS2_SIGNED_49),{(|_zz__zz_decode_IS_RS2_SIGNED_50),{_zz__zz_decode_IS_RS2_SIGNED_52,{_zz__zz_decode_IS_RS2_SIGNED_65,_zz__zz_decode_IS_RS2_SIGNED_74}}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_38 = 32'h00000064;
-  assign _zz__zz_decode_IS_RS2_SIGNED_40 = ((decode_INSTRUCTION & 32'h00000034) == 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_41 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_42) == 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_43 = {(_zz__zz_decode_IS_RS2_SIGNED_44 == _zz__zz_decode_IS_RS2_SIGNED_45),(_zz__zz_decode_IS_RS2_SIGNED_46 == _zz__zz_decode_IS_RS2_SIGNED_47)};
-  assign _zz__zz_decode_IS_RS2_SIGNED_49 = ((decode_INSTRUCTION & 32'h10000008) == 32'h00000008);
-  assign _zz__zz_decode_IS_RS2_SIGNED_50 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_51) == 32'h10000008);
-  assign _zz__zz_decode_IS_RS2_SIGNED_52 = (|{_zz__zz_decode_IS_RS2_SIGNED_53,{_zz__zz_decode_IS_RS2_SIGNED_55,_zz__zz_decode_IS_RS2_SIGNED_58}});
+  assign _zz__zz_decode_IS_RS2_SIGNED_16 = (decode_INSTRUCTION & 32'h02007054);
+  assign _zz__zz_decode_IS_RS2_SIGNED_17 = 32'h00005010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_19 = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_20 = ((decode_INSTRUCTION & 32'h02007054) == 32'h00001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_22 = ((decode_INSTRUCTION & 32'h00001000) == 32'h00001000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_23 = (|((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_24) == 32'h00002000));
+  assign _zz__zz_decode_IS_RS2_SIGNED_25 = (|{_zz_decode_IS_RS2_SIGNED_7,_zz__zz_decode_IS_RS2_SIGNED_26});
+  assign _zz__zz_decode_IS_RS2_SIGNED_27 = {(|_zz__zz_decode_IS_RS2_SIGNED_28),{(|_zz__zz_decode_IS_RS2_SIGNED_29),{_zz__zz_decode_IS_RS2_SIGNED_30,{_zz__zz_decode_IS_RS2_SIGNED_38,_zz__zz_decode_IS_RS2_SIGNED_41}}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_24 = 32'h00003000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_26 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00001000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_28 = ((decode_INSTRUCTION & 32'h00004048) == 32'h00004008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_29 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
+  assign _zz__zz_decode_IS_RS2_SIGNED_30 = (|{(_zz__zz_decode_IS_RS2_SIGNED_31 == _zz__zz_decode_IS_RS2_SIGNED_32),{_zz__zz_decode_IS_RS2_SIGNED_33,{_zz__zz_decode_IS_RS2_SIGNED_34,_zz__zz_decode_IS_RS2_SIGNED_36}}});
+  assign _zz__zz_decode_IS_RS2_SIGNED_38 = (|(_zz__zz_decode_IS_RS2_SIGNED_39 == _zz__zz_decode_IS_RS2_SIGNED_40));
+  assign _zz__zz_decode_IS_RS2_SIGNED_41 = {(|_zz__zz_decode_IS_RS2_SIGNED_42),{(|_zz__zz_decode_IS_RS2_SIGNED_43),{_zz__zz_decode_IS_RS2_SIGNED_56,{_zz__zz_decode_IS_RS2_SIGNED_65,_zz__zz_decode_IS_RS2_SIGNED_78}}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_31 = (decode_INSTRUCTION & 32'h00000034);
+  assign _zz__zz_decode_IS_RS2_SIGNED_32 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_33 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_34 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_35) == 32'h08000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_36 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_37) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_39 = (decode_INSTRUCTION & 32'h10000008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_40 = 32'h00000008;
+  assign _zz__zz_decode_IS_RS2_SIGNED_42 = ((decode_INSTRUCTION & 32'h10000008) == 32'h10000008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_43 = {(_zz__zz_decode_IS_RS2_SIGNED_44 == _zz__zz_decode_IS_RS2_SIGNED_45),{_zz__zz_decode_IS_RS2_SIGNED_46,{_zz__zz_decode_IS_RS2_SIGNED_48,_zz__zz_decode_IS_RS2_SIGNED_51}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_56 = (|{_zz__zz_decode_IS_RS2_SIGNED_57,{_zz__zz_decode_IS_RS2_SIGNED_59,_zz__zz_decode_IS_RS2_SIGNED_62}});
   assign _zz__zz_decode_IS_RS2_SIGNED_65 = (|{_zz__zz_decode_IS_RS2_SIGNED_66,_zz__zz_decode_IS_RS2_SIGNED_69});
-  assign _zz__zz_decode_IS_RS2_SIGNED_74 = {(|_zz__zz_decode_IS_RS2_SIGNED_75),{_zz__zz_decode_IS_RS2_SIGNED_88,{_zz__zz_decode_IS_RS2_SIGNED_101,_zz__zz_decode_IS_RS2_SIGNED_117}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_42 = 32'h00000064;
-  assign _zz__zz_decode_IS_RS2_SIGNED_44 = (decode_INSTRUCTION & 32'h08000070);
-  assign _zz__zz_decode_IS_RS2_SIGNED_45 = 32'h08000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_46 = (decode_INSTRUCTION & 32'h10000070);
-  assign _zz__zz_decode_IS_RS2_SIGNED_47 = 32'h00000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_51 = 32'h10000008;
-  assign _zz__zz_decode_IS_RS2_SIGNED_53 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_54) == 32'h00002040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_55 = (_zz__zz_decode_IS_RS2_SIGNED_56 == _zz__zz_decode_IS_RS2_SIGNED_57);
-  assign _zz__zz_decode_IS_RS2_SIGNED_58 = {_zz__zz_decode_IS_RS2_SIGNED_59,{_zz__zz_decode_IS_RS2_SIGNED_61,_zz__zz_decode_IS_RS2_SIGNED_62}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_78 = {(|_zz__zz_decode_IS_RS2_SIGNED_79),{_zz__zz_decode_IS_RS2_SIGNED_92,{_zz__zz_decode_IS_RS2_SIGNED_108,_zz__zz_decode_IS_RS2_SIGNED_112}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_35 = 32'h08000070;
+  assign _zz__zz_decode_IS_RS2_SIGNED_37 = 32'h10000070;
+  assign _zz__zz_decode_IS_RS2_SIGNED_44 = (decode_INSTRUCTION & 32'h00002040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_45 = 32'h00002040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_46 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_47) == 32'h00001040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_48 = (_zz__zz_decode_IS_RS2_SIGNED_49 == _zz__zz_decode_IS_RS2_SIGNED_50);
+  assign _zz__zz_decode_IS_RS2_SIGNED_51 = {_zz_decode_IS_RS2_SIGNED_7,{_zz__zz_decode_IS_RS2_SIGNED_52,_zz__zz_decode_IS_RS2_SIGNED_55}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_57 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_58) == 32'h08000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_59 = (_zz__zz_decode_IS_RS2_SIGNED_60 == _zz__zz_decode_IS_RS2_SIGNED_61);
+  assign _zz__zz_decode_IS_RS2_SIGNED_62 = (_zz__zz_decode_IS_RS2_SIGNED_63 == _zz__zz_decode_IS_RS2_SIGNED_64);
   assign _zz__zz_decode_IS_RS2_SIGNED_66 = (_zz__zz_decode_IS_RS2_SIGNED_67 == _zz__zz_decode_IS_RS2_SIGNED_68);
-  assign _zz__zz_decode_IS_RS2_SIGNED_69 = {_zz__zz_decode_IS_RS2_SIGNED_70,_zz__zz_decode_IS_RS2_SIGNED_72};
-  assign _zz__zz_decode_IS_RS2_SIGNED_75 = {_zz__zz_decode_IS_RS2_SIGNED_76,{_zz__zz_decode_IS_RS2_SIGNED_78,_zz__zz_decode_IS_RS2_SIGNED_81}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_88 = (|{_zz__zz_decode_IS_RS2_SIGNED_89,_zz__zz_decode_IS_RS2_SIGNED_90});
-  assign _zz__zz_decode_IS_RS2_SIGNED_101 = (|_zz__zz_decode_IS_RS2_SIGNED_102);
-  assign _zz__zz_decode_IS_RS2_SIGNED_117 = {_zz__zz_decode_IS_RS2_SIGNED_118,{_zz__zz_decode_IS_RS2_SIGNED_123,_zz__zz_decode_IS_RS2_SIGNED_127}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_54 = 32'h00002040;
-  assign _zz__zz_decode_IS_RS2_SIGNED_56 = (decode_INSTRUCTION & 32'h00001040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_57 = 32'h00001040;
-  assign _zz__zz_decode_IS_RS2_SIGNED_59 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_60) == 32'h00000040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_61 = _zz_decode_IS_RS2_SIGNED_7;
-  assign _zz__zz_decode_IS_RS2_SIGNED_62 = {_zz__zz_decode_IS_RS2_SIGNED_63,_zz_decode_IS_RS2_SIGNED_4};
-  assign _zz__zz_decode_IS_RS2_SIGNED_67 = (decode_INSTRUCTION & 32'h08000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_68 = 32'h08000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_70 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_71) == 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_72 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_73) == 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_76 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_77) == 32'h00000040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_78 = (_zz__zz_decode_IS_RS2_SIGNED_79 == _zz__zz_decode_IS_RS2_SIGNED_80);
-  assign _zz__zz_decode_IS_RS2_SIGNED_81 = {_zz__zz_decode_IS_RS2_SIGNED_82,{_zz__zz_decode_IS_RS2_SIGNED_84,_zz__zz_decode_IS_RS2_SIGNED_85}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_89 = _zz_decode_IS_RS2_SIGNED_6;
-  assign _zz__zz_decode_IS_RS2_SIGNED_90 = {_zz__zz_decode_IS_RS2_SIGNED_91,{_zz__zz_decode_IS_RS2_SIGNED_93,_zz__zz_decode_IS_RS2_SIGNED_96}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_102 = {_zz_decode_IS_RS2_SIGNED_2,{_zz__zz_decode_IS_RS2_SIGNED_103,_zz__zz_decode_IS_RS2_SIGNED_106}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_118 = (|{_zz__zz_decode_IS_RS2_SIGNED_119,_zz__zz_decode_IS_RS2_SIGNED_120});
+  assign _zz__zz_decode_IS_RS2_SIGNED_69 = {_zz__zz_decode_IS_RS2_SIGNED_70,{_zz__zz_decode_IS_RS2_SIGNED_72,_zz__zz_decode_IS_RS2_SIGNED_75}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_79 = {_zz_decode_IS_RS2_SIGNED_6,{_zz__zz_decode_IS_RS2_SIGNED_80,_zz__zz_decode_IS_RS2_SIGNED_83}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_92 = (|{_zz__zz_decode_IS_RS2_SIGNED_93,_zz__zz_decode_IS_RS2_SIGNED_94});
+  assign _zz__zz_decode_IS_RS2_SIGNED_108 = (|_zz__zz_decode_IS_RS2_SIGNED_109);
+  assign _zz__zz_decode_IS_RS2_SIGNED_112 = {_zz__zz_decode_IS_RS2_SIGNED_113,{_zz__zz_decode_IS_RS2_SIGNED_118,_zz__zz_decode_IS_RS2_SIGNED_122}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_47 = 32'h00001040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_49 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_50 = 32'h00000040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_52 = (_zz__zz_decode_IS_RS2_SIGNED_53 == _zz__zz_decode_IS_RS2_SIGNED_54);
+  assign _zz__zz_decode_IS_RS2_SIGNED_55 = _zz_decode_IS_RS2_SIGNED_4;
+  assign _zz__zz_decode_IS_RS2_SIGNED_58 = 32'h08000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_60 = (decode_INSTRUCTION & 32'h10000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_61 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_63 = (decode_INSTRUCTION & 32'h00000028);
+  assign _zz__zz_decode_IS_RS2_SIGNED_64 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_67 = (decode_INSTRUCTION & 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_68 = 32'h00000040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_70 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_71) == 32'h00004020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_72 = (_zz__zz_decode_IS_RS2_SIGNED_73 == _zz__zz_decode_IS_RS2_SIGNED_74);
+  assign _zz__zz_decode_IS_RS2_SIGNED_75 = {_zz__zz_decode_IS_RS2_SIGNED_76,_zz_decode_IS_RS2_SIGNED_6};
+  assign _zz__zz_decode_IS_RS2_SIGNED_80 = (_zz__zz_decode_IS_RS2_SIGNED_81 == _zz__zz_decode_IS_RS2_SIGNED_82);
+  assign _zz__zz_decode_IS_RS2_SIGNED_83 = {_zz__zz_decode_IS_RS2_SIGNED_84,{_zz__zz_decode_IS_RS2_SIGNED_86,_zz__zz_decode_IS_RS2_SIGNED_89}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_93 = _zz_decode_IS_RS2_SIGNED_2;
+  assign _zz__zz_decode_IS_RS2_SIGNED_94 = {_zz__zz_decode_IS_RS2_SIGNED_95,{_zz__zz_decode_IS_RS2_SIGNED_97,_zz__zz_decode_IS_RS2_SIGNED_100}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_109 = {_zz_decode_IS_RS2_SIGNED_5,_zz__zz_decode_IS_RS2_SIGNED_110};
+  assign _zz__zz_decode_IS_RS2_SIGNED_113 = (|{_zz__zz_decode_IS_RS2_SIGNED_114,_zz__zz_decode_IS_RS2_SIGNED_115});
+  assign _zz__zz_decode_IS_RS2_SIGNED_118 = (|_zz__zz_decode_IS_RS2_SIGNED_119);
+  assign _zz__zz_decode_IS_RS2_SIGNED_122 = {_zz__zz_decode_IS_RS2_SIGNED_123,{_zz__zz_decode_IS_RS2_SIGNED_126,_zz__zz_decode_IS_RS2_SIGNED_136}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_53 = (decode_INSTRUCTION & 32'h00400040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_54 = 32'h00000040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_71 = 32'h00004020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_73 = (decode_INSTRUCTION & 32'h00000030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_74 = 32'h00000010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_76 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_77) == 32'h00000010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_81 = (decode_INSTRUCTION & 32'h00002030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_82 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_84 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_85) == 32'h00000010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_86 = (_zz__zz_decode_IS_RS2_SIGNED_87 == _zz__zz_decode_IS_RS2_SIGNED_88);
+  assign _zz__zz_decode_IS_RS2_SIGNED_89 = (_zz__zz_decode_IS_RS2_SIGNED_90 == _zz__zz_decode_IS_RS2_SIGNED_91);
+  assign _zz__zz_decode_IS_RS2_SIGNED_95 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_96) == 32'h00001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_97 = (_zz__zz_decode_IS_RS2_SIGNED_98 == _zz__zz_decode_IS_RS2_SIGNED_99);
+  assign _zz__zz_decode_IS_RS2_SIGNED_100 = {_zz__zz_decode_IS_RS2_SIGNED_101,{_zz__zz_decode_IS_RS2_SIGNED_103,_zz__zz_decode_IS_RS2_SIGNED_106}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_110 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_111) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_114 = _zz_decode_IS_RS2_SIGNED_5;
+  assign _zz__zz_decode_IS_RS2_SIGNED_115 = (_zz__zz_decode_IS_RS2_SIGNED_116 == _zz__zz_decode_IS_RS2_SIGNED_117);
+  assign _zz__zz_decode_IS_RS2_SIGNED_119 = (_zz__zz_decode_IS_RS2_SIGNED_120 == _zz__zz_decode_IS_RS2_SIGNED_121);
   assign _zz__zz_decode_IS_RS2_SIGNED_123 = (|_zz__zz_decode_IS_RS2_SIGNED_124);
-  assign _zz__zz_decode_IS_RS2_SIGNED_127 = {_zz__zz_decode_IS_RS2_SIGNED_128,{_zz__zz_decode_IS_RS2_SIGNED_131,_zz__zz_decode_IS_RS2_SIGNED_135}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_60 = 32'h00000050;
-  assign _zz__zz_decode_IS_RS2_SIGNED_63 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_64) == 32'h00000040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_71 = 32'h10000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_73 = 32'h00000028;
-  assign _zz__zz_decode_IS_RS2_SIGNED_77 = 32'h00000040;
-  assign _zz__zz_decode_IS_RS2_SIGNED_79 = (decode_INSTRUCTION & 32'h00004020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_80 = 32'h00004020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_82 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_83) == 32'h00000010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_84 = _zz_decode_IS_RS2_SIGNED_6;
-  assign _zz__zz_decode_IS_RS2_SIGNED_85 = (_zz__zz_decode_IS_RS2_SIGNED_86 == _zz__zz_decode_IS_RS2_SIGNED_87);
-  assign _zz__zz_decode_IS_RS2_SIGNED_91 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_92) == 32'h00002010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_93 = (_zz__zz_decode_IS_RS2_SIGNED_94 == _zz__zz_decode_IS_RS2_SIGNED_95);
-  assign _zz__zz_decode_IS_RS2_SIGNED_96 = {_zz__zz_decode_IS_RS2_SIGNED_97,_zz__zz_decode_IS_RS2_SIGNED_99};
+  assign _zz__zz_decode_IS_RS2_SIGNED_126 = (|_zz__zz_decode_IS_RS2_SIGNED_127);
+  assign _zz__zz_decode_IS_RS2_SIGNED_136 = {_zz__zz_decode_IS_RS2_SIGNED_137,{_zz__zz_decode_IS_RS2_SIGNED_141,_zz__zz_decode_IS_RS2_SIGNED_147}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_77 = 32'h02000010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_85 = 32'h00001030;
+  assign _zz__zz_decode_IS_RS2_SIGNED_87 = (decode_INSTRUCTION & 32'h02003020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_88 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_90 = (decode_INSTRUCTION & 32'h02002068);
+  assign _zz__zz_decode_IS_RS2_SIGNED_91 = 32'h00002020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_96 = 32'h00001010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_98 = (decode_INSTRUCTION & 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_99 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_101 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_102) == 32'h00002008);
   assign _zz__zz_decode_IS_RS2_SIGNED_103 = (_zz__zz_decode_IS_RS2_SIGNED_104 == _zz__zz_decode_IS_RS2_SIGNED_105);
-  assign _zz__zz_decode_IS_RS2_SIGNED_106 = {_zz__zz_decode_IS_RS2_SIGNED_107,{_zz__zz_decode_IS_RS2_SIGNED_109,_zz__zz_decode_IS_RS2_SIGNED_112}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_119 = _zz_decode_IS_RS2_SIGNED_5;
-  assign _zz__zz_decode_IS_RS2_SIGNED_120 = (_zz__zz_decode_IS_RS2_SIGNED_121 == _zz__zz_decode_IS_RS2_SIGNED_122);
-  assign _zz__zz_decode_IS_RS2_SIGNED_124 = {_zz_decode_IS_RS2_SIGNED_5,_zz__zz_decode_IS_RS2_SIGNED_125};
-  assign _zz__zz_decode_IS_RS2_SIGNED_128 = (|_zz__zz_decode_IS_RS2_SIGNED_129);
-  assign _zz__zz_decode_IS_RS2_SIGNED_131 = (|_zz__zz_decode_IS_RS2_SIGNED_132);
-  assign _zz__zz_decode_IS_RS2_SIGNED_135 = {_zz__zz_decode_IS_RS2_SIGNED_136,{_zz__zz_decode_IS_RS2_SIGNED_146,_zz__zz_decode_IS_RS2_SIGNED_150}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_64 = 32'h00400040;
-  assign _zz__zz_decode_IS_RS2_SIGNED_83 = 32'h00000030;
-  assign _zz__zz_decode_IS_RS2_SIGNED_86 = (decode_INSTRUCTION & 32'h02000028);
-  assign _zz__zz_decode_IS_RS2_SIGNED_87 = 32'h00000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_92 = 32'h00002030;
-  assign _zz__zz_decode_IS_RS2_SIGNED_94 = (decode_INSTRUCTION & 32'h00001030);
-  assign _zz__zz_decode_IS_RS2_SIGNED_95 = 32'h00000010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_97 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_98) == 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_99 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_100) == 32'h00002020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_104 = (decode_INSTRUCTION & 32'h00001010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_105 = 32'h00001010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_107 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_108) == 32'h00002010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_109 = (_zz__zz_decode_IS_RS2_SIGNED_110 == _zz__zz_decode_IS_RS2_SIGNED_111);
-  assign _zz__zz_decode_IS_RS2_SIGNED_112 = {_zz__zz_decode_IS_RS2_SIGNED_113,{_zz__zz_decode_IS_RS2_SIGNED_114,_zz__zz_decode_IS_RS2_SIGNED_115}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_121 = (decode_INSTRUCTION & 32'h00000070);
-  assign _zz__zz_decode_IS_RS2_SIGNED_122 = 32'h00000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_125 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_126) == 32'h0);
-  assign _zz__zz_decode_IS_RS2_SIGNED_129 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_130) == 32'h00004010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_132 = (_zz__zz_decode_IS_RS2_SIGNED_133 == _zz__zz_decode_IS_RS2_SIGNED_134);
-  assign _zz__zz_decode_IS_RS2_SIGNED_136 = (|{_zz__zz_decode_IS_RS2_SIGNED_137,_zz__zz_decode_IS_RS2_SIGNED_139});
-  assign _zz__zz_decode_IS_RS2_SIGNED_146 = (|_zz__zz_decode_IS_RS2_SIGNED_147);
-  assign _zz__zz_decode_IS_RS2_SIGNED_150 = {_zz__zz_decode_IS_RS2_SIGNED_151,{_zz__zz_decode_IS_RS2_SIGNED_157,_zz__zz_decode_IS_RS2_SIGNED_162}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_98 = 32'h02003020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_100 = 32'h02002068;
-  assign _zz__zz_decode_IS_RS2_SIGNED_108 = 32'h00002010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_110 = (decode_INSTRUCTION & 32'h00002008);
-  assign _zz__zz_decode_IS_RS2_SIGNED_111 = 32'h00002008;
-  assign _zz__zz_decode_IS_RS2_SIGNED_113 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_114 = _zz_decode_IS_RS2_SIGNED_6;
-  assign _zz__zz_decode_IS_RS2_SIGNED_115 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_116) == 32'h0);
-  assign _zz__zz_decode_IS_RS2_SIGNED_126 = 32'h00000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_130 = 32'h00004014;
-  assign _zz__zz_decode_IS_RS2_SIGNED_133 = (decode_INSTRUCTION & 32'h00006014);
-  assign _zz__zz_decode_IS_RS2_SIGNED_134 = 32'h00002010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_137 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_138) == 32'h0);
-  assign _zz__zz_decode_IS_RS2_SIGNED_139 = {_zz_decode_IS_RS2_SIGNED_4,{_zz__zz_decode_IS_RS2_SIGNED_140,{_zz__zz_decode_IS_RS2_SIGNED_141,_zz__zz_decode_IS_RS2_SIGNED_143}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_147 = {_zz_decode_IS_RS2_SIGNED_3,(_zz__zz_decode_IS_RS2_SIGNED_148 == _zz__zz_decode_IS_RS2_SIGNED_149)};
-  assign _zz__zz_decode_IS_RS2_SIGNED_151 = (|{_zz__zz_decode_IS_RS2_SIGNED_152,{_zz__zz_decode_IS_RS2_SIGNED_153,_zz__zz_decode_IS_RS2_SIGNED_155}});
-  assign _zz__zz_decode_IS_RS2_SIGNED_157 = (|{_zz__zz_decode_IS_RS2_SIGNED_158,_zz__zz_decode_IS_RS2_SIGNED_159});
-  assign _zz__zz_decode_IS_RS2_SIGNED_162 = {(|_zz__zz_decode_IS_RS2_SIGNED_163),(|_zz__zz_decode_IS_RS2_SIGNED_166)};
-  assign _zz__zz_decode_IS_RS2_SIGNED_116 = 32'h00000028;
-  assign _zz__zz_decode_IS_RS2_SIGNED_138 = 32'h00000044;
-  assign _zz__zz_decode_IS_RS2_SIGNED_140 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_141 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_142) == 32'h00001000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_143 = {(_zz__zz_decode_IS_RS2_SIGNED_144 == _zz__zz_decode_IS_RS2_SIGNED_145),_zz_decode_IS_RS2_SIGNED_3};
-  assign _zz__zz_decode_IS_RS2_SIGNED_148 = (decode_INSTRUCTION & 32'h00000058);
-  assign _zz__zz_decode_IS_RS2_SIGNED_149 = 32'h0;
-  assign _zz__zz_decode_IS_RS2_SIGNED_152 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_153 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_154) == 32'h00002010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_155 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_156) == 32'h40000030);
-  assign _zz__zz_decode_IS_RS2_SIGNED_158 = _zz_decode_IS_RS2_SIGNED_2;
-  assign _zz__zz_decode_IS_RS2_SIGNED_159 = {_zz_decode_IS_RS2_SIGNED_1,(_zz__zz_decode_IS_RS2_SIGNED_160 == _zz__zz_decode_IS_RS2_SIGNED_161)};
-  assign _zz__zz_decode_IS_RS2_SIGNED_163 = {_zz_decode_IS_RS2_SIGNED_1,(_zz__zz_decode_IS_RS2_SIGNED_164 == _zz__zz_decode_IS_RS2_SIGNED_165)};
-  assign _zz__zz_decode_IS_RS2_SIGNED_166 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_167) == 32'h00001008);
-  assign _zz__zz_decode_IS_RS2_SIGNED_142 = 32'h00005004;
-  assign _zz__zz_decode_IS_RS2_SIGNED_144 = (decode_INSTRUCTION & 32'h00004050);
-  assign _zz__zz_decode_IS_RS2_SIGNED_145 = 32'h00004000;
-  assign _zz__zz_decode_IS_RS2_SIGNED_154 = 32'h00002014;
-  assign _zz__zz_decode_IS_RS2_SIGNED_156 = 32'h40000034;
-  assign _zz__zz_decode_IS_RS2_SIGNED_160 = (decode_INSTRUCTION & 32'h00002014);
-  assign _zz__zz_decode_IS_RS2_SIGNED_161 = 32'h00000004;
-  assign _zz__zz_decode_IS_RS2_SIGNED_164 = (decode_INSTRUCTION & 32'h0000004c);
-  assign _zz__zz_decode_IS_RS2_SIGNED_165 = 32'h00000004;
-  assign _zz__zz_decode_IS_RS2_SIGNED_167 = 32'h00005048;
+  assign _zz__zz_decode_IS_RS2_SIGNED_106 = {_zz_decode_IS_RS2_SIGNED_6,_zz__zz_decode_IS_RS2_SIGNED_107};
+  assign _zz__zz_decode_IS_RS2_SIGNED_111 = 32'h00000070;
+  assign _zz__zz_decode_IS_RS2_SIGNED_116 = (decode_INSTRUCTION & 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_117 = 32'h00000000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_120 = (decode_INSTRUCTION & 32'h00004014);
+  assign _zz__zz_decode_IS_RS2_SIGNED_121 = 32'h00004010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_124 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_125) == 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_127 = {_zz__zz_decode_IS_RS2_SIGNED_128,{_zz__zz_decode_IS_RS2_SIGNED_129,_zz__zz_decode_IS_RS2_SIGNED_130}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_137 = (|{_zz__zz_decode_IS_RS2_SIGNED_138,_zz__zz_decode_IS_RS2_SIGNED_139});
+  assign _zz__zz_decode_IS_RS2_SIGNED_141 = (|_zz__zz_decode_IS_RS2_SIGNED_142);
+  assign _zz__zz_decode_IS_RS2_SIGNED_147 = {_zz__zz_decode_IS_RS2_SIGNED_148,{_zz__zz_decode_IS_RS2_SIGNED_151,_zz__zz_decode_IS_RS2_SIGNED_154}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_102 = 32'h00002008;
+  assign _zz__zz_decode_IS_RS2_SIGNED_104 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_105 = 32'h00000010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_107 = ((decode_INSTRUCTION & 32'h00000028) == 32'h00000000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_125 = 32'h00006014;
+  assign _zz__zz_decode_IS_RS2_SIGNED_128 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_129 = _zz_decode_IS_RS2_SIGNED_4;
+  assign _zz__zz_decode_IS_RS2_SIGNED_130 = {(_zz__zz_decode_IS_RS2_SIGNED_131 == _zz__zz_decode_IS_RS2_SIGNED_132),{_zz__zz_decode_IS_RS2_SIGNED_133,{_zz__zz_decode_IS_RS2_SIGNED_134,_zz__zz_decode_IS_RS2_SIGNED_135}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_138 = _zz_decode_IS_RS2_SIGNED_3;
+  assign _zz__zz_decode_IS_RS2_SIGNED_139 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_140) == 32'h00000000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_142 = {(_zz__zz_decode_IS_RS2_SIGNED_143 == _zz__zz_decode_IS_RS2_SIGNED_144),{_zz__zz_decode_IS_RS2_SIGNED_145,_zz__zz_decode_IS_RS2_SIGNED_146}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_148 = (|{_zz_decode_IS_RS2_SIGNED_2,{_zz__zz_decode_IS_RS2_SIGNED_149,_zz__zz_decode_IS_RS2_SIGNED_150}});
+  assign _zz__zz_decode_IS_RS2_SIGNED_151 = (|{_zz__zz_decode_IS_RS2_SIGNED_152,_zz__zz_decode_IS_RS2_SIGNED_153});
+  assign _zz__zz_decode_IS_RS2_SIGNED_154 = (|_zz__zz_decode_IS_RS2_SIGNED_155);
+  assign _zz__zz_decode_IS_RS2_SIGNED_131 = (decode_INSTRUCTION & 32'h00006004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_132 = 32'h00002000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_133 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_134 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_135 = _zz_decode_IS_RS2_SIGNED_3;
+  assign _zz__zz_decode_IS_RS2_SIGNED_140 = 32'h00000058;
+  assign _zz__zz_decode_IS_RS2_SIGNED_143 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz__zz_decode_IS_RS2_SIGNED_144 = 32'h00000040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_145 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_146 = ((decode_INSTRUCTION & 32'h40000034) == 32'h40000030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_149 = _zz_decode_IS_RS2_SIGNED_1;
+  assign _zz__zz_decode_IS_RS2_SIGNED_150 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00000004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_152 = _zz_decode_IS_RS2_SIGNED_1;
+  assign _zz__zz_decode_IS_RS2_SIGNED_153 = ((decode_INSTRUCTION & 32'h0000004c) == 32'h00000004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_155 = ((decode_INSTRUCTION & 32'h00005048) == 32'h00001008);
   assign _zz_execute_BranchPlugin_branch_src2_6 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_7 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_8 = execute_INSTRUCTION[7];
-  assign _zz_CsrPlugin_csrMapping_readDataInit_25 = 32'h0;
+  assign _zz_CsrPlugin_csrMapping_readDataInit_24 = 32'h00000000;
   always @(posedge clk) begin
     if(_zz_decode_RegFilePlugin_rs1Data) begin
       _zz_RegFilePlugin_regFile_port0 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
@@ -1882,8 +1852,9 @@ module VexRiscv (
     .io_cpu_flush_ready                     (dataCache_1_io_cpu_flush_ready                   ), //o
     .io_cpu_flush_payload_singleLine        (dataCache_1_io_cpu_flush_payload_singleLine      ), //i
     .io_cpu_flush_payload_lineId            (dataCache_1_io_cpu_flush_payload_lineId[6:0]     ), //i
+    .io_cpu_writesPending                   (dataCache_1_io_cpu_writesPending                 ), //o
     .io_mem_cmd_valid                       (dataCache_1_io_mem_cmd_valid                     ), //o
-    .io_mem_cmd_ready                       (dataCache_1_io_mem_cmd_ready                     ), //i
+    .io_mem_cmd_ready                       (toplevel_dataCache_1_io_mem_cmd_rValidN          ), //i
     .io_mem_cmd_payload_wr                  (dataCache_1_io_mem_cmd_payload_wr                ), //o
     .io_mem_cmd_payload_uncached            (dataCache_1_io_mem_cmd_payload_uncached          ), //o
     .io_mem_cmd_payload_address             (dataCache_1_io_mem_cmd_payload_address[31:0]     ), //o
@@ -2610,7 +2581,7 @@ module VexRiscv (
   end
   `endif
 
-  assign memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW) + $signed(_zz_memory_MUL_LOW_7));
+  assign memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW) + $signed(_zz_memory_MUL_LOW_6));
   assign memory_MUL_HH = execute_to_memory_MUL_HH;
   assign execute_MUL_HH = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bHigh));
   assign execute_MUL_HL = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bSLow));
@@ -2623,7 +2594,7 @@ module VexRiscv (
   assign memory_MEMORY_STORE_DATA_RF = execute_to_memory_MEMORY_STORE_DATA_RF;
   assign execute_MEMORY_STORE_DATA_RF = _zz_execute_MEMORY_STORE_DATA_RF;
   assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
-  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
+  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h00)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h00))));
   assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
   assign decode_IS_RS2_SIGNED = _zz_decode_IS_RS2_SIGNED[33];
@@ -2689,7 +2660,7 @@ module VexRiscv (
   assign decode_RS1_USE = _zz_decode_IS_RS2_SIGNED[5];
   always @(*) begin
     _zz_decode_RS2 = execute_REGFILE_WRITE_DATA;
-    if(when_CsrPlugin_l1189) begin
+    if(when_CsrPlugin_l1587) begin
       _zz_decode_RS2 = CsrPlugin_csrMapping_readDataSignal;
     end
   end
@@ -2785,7 +2756,7 @@ module VexRiscv (
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_execute_SRC2 = execute_PC;
+  assign _zz_execute_to_memory_PC = execute_PC;
   assign execute_SRC2_CTRL = _zz_execute_SRC2_CTRL;
   assign execute_IS_RVC = decode_to_execute_IS_RVC;
   assign execute_SRC1_CTRL = _zz_execute_SRC1_CTRL;
@@ -2794,7 +2765,7 @@ module VexRiscv (
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
   assign execute_ALU_CTRL = _zz_execute_ALU_CTRL;
-  assign execute_SRC2 = _zz_execute_SRC2_5;
+  assign execute_SRC2 = _zz_execute_SRC2_4;
   assign execute_SRC1 = _zz_execute_SRC1;
   assign execute_ALU_BITWISE_CTRL = _zz_execute_ALU_BITWISE_CTRL;
   assign _zz_lastStageRegFileWrite_payload_address = writeBack_INSTRUCTION;
@@ -2814,10 +2785,10 @@ module VexRiscv (
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00001073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
+  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000107f) == 32'h00001073),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00002073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
   always @(*) begin
     _zz_decode_RS2_2 = writeBack_REGFILE_WRITE_DATA;
-    if(when_DBusCachedPlugin_l492) begin
+    if(when_DBusCachedPlugin_l580) begin
       _zz_decode_RS2_2 = writeBack_DBusCachedPlugin_rspFormated;
     end
     if(when_MulPlugin_l147) begin
@@ -2855,28 +2826,28 @@ module VexRiscv (
   assign decode_FLUSH_ALL = _zz_decode_IS_RS2_SIGNED[0];
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_4 = IBusCachedPlugin_rsp_issueDetected_3;
-    if(when_IBusCachedPlugin_l256) begin
+    if(when_IBusCachedPlugin_l262) begin
       IBusCachedPlugin_rsp_issueDetected_4 = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_3 = IBusCachedPlugin_rsp_issueDetected_2;
-    if(when_IBusCachedPlugin_l250) begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_rsp_issueDetected_3 = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
-    if(when_IBusCachedPlugin_l244) begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
-    if(when_IBusCachedPlugin_l239) begin
+    if(when_IBusCachedPlugin_l245) begin
       IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
@@ -2903,7 +2874,7 @@ module VexRiscv (
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
   always @(*) begin
     decode_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l308) begin
+    if(when_DBusCachedPlugin_l352) begin
       decode_arbitration_haltItself = 1'b1;
     end
   end
@@ -2916,7 +2887,7 @@ module VexRiscv (
     if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(when_CsrPlugin_l1129) begin
+    if(when_CsrPlugin_l1527) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
@@ -2944,15 +2915,15 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l350) begin
+    if(when_DBusCachedPlugin_l394) begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(when_CsrPlugin_l1121) begin
-      if(when_CsrPlugin_l1123) begin
+    if(when_CsrPlugin_l1519) begin
+      if(when_CsrPlugin_l1521) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(when_CsrPlugin_l1193) begin
+    if(when_CsrPlugin_l1591) begin
       if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
@@ -2961,7 +2932,7 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if(when_DBusCachedPlugin_l366) begin
+    if(when_DBusCachedPlugin_l410) begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
@@ -3011,7 +2982,7 @@ module VexRiscv (
 
   always @(*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l466) begin
+    if(when_DBusCachedPlugin_l553) begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
@@ -3042,10 +3013,10 @@ module VexRiscv (
     if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -3056,13 +3027,13 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @(*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(when_CsrPlugin_l935) begin
+    if(when_CsrPlugin_l1272) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
@@ -3079,11 +3050,21 @@ module VexRiscv (
   end
 
   assign BranchPlugin_inDebugNoFetchFlag = 1'b0;
-  assign CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+  always @(*) begin
+    CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+    if(when_CsrPlugin_l1702) begin
+      CsrPlugin_csrMapping_allowCsrSignal = 1'b1;
+    end
+    if(when_CsrPlugin_l1709) begin
+      CsrPlugin_csrMapping_allowCsrSignal = 1'b1;
+    end
+  end
+
+  assign CsrPlugin_csrMapping_doForceFailCsr = 1'b0;
   assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
   always @(*) begin
     CsrPlugin_inWfi = 1'b0;
-    if(when_CsrPlugin_l1121) begin
+    if(when_CsrPlugin_l1519) begin
       CsrPlugin_inWfi = 1'b1;
     end
   end
@@ -3091,21 +3072,21 @@ module VexRiscv (
   assign CsrPlugin_thirdPartyWake = 1'b0;
   always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(when_CsrPlugin_l1077) begin
-      case(switch_CsrPlugin_l1081)
+    if(when_CsrPlugin_l1456) begin
+      case(switch_CsrPlugin_l1460)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -3119,6 +3100,7 @@ module VexRiscv (
   assign CsrPlugin_allowInterrupts = 1'b1;
   assign CsrPlugin_allowException = 1'b1;
   assign CsrPlugin_allowEbreakException = 1'b1;
+  assign CsrPlugin_xretAwayFromMachine = 1'b0;
   assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
   assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusCachedPlugin_redoBranch_valid,IBusCachedPlugin_predictionJumpInterface_valid}}} != 4'b0000);
   assign _zz_IBusCachedPlugin_jump_pcLoad_payload = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
@@ -3146,9 +3128,8 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l134 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
-  assign IBusCachedPlugin_fetchPc_output_fire_1 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
-  assign when_Fetcher_l134_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
+  assign when_Fetcher_l133 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l133_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
   always @(*) begin
     IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_IBusCachedPlugin_fetchPc_pc);
     if(IBusCachedPlugin_fetchPc_inc) begin
@@ -3173,20 +3154,20 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l161 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
+  assign when_Fetcher_l160 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
   assign IBusCachedPlugin_fetchPc_output_valid = ((! IBusCachedPlugin_fetcherHalt) && IBusCachedPlugin_fetchPc_booted);
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
   always @(*) begin
     IBusCachedPlugin_decodePc_flushed = 1'b0;
-    if(when_Fetcher_l195) begin
+    if(when_Fetcher_l194) begin
       IBusCachedPlugin_decodePc_flushed = 1'b1;
     end
   end
 
   assign IBusCachedPlugin_decodePc_pcPlus = (IBusCachedPlugin_decodePc_pcReg + _zz_IBusCachedPlugin_decodePc_pcPlus);
   assign IBusCachedPlugin_decodePc_injectedDecode = 1'b0;
-  assign when_Fetcher_l183 = (decode_arbitration_isFiring && (! IBusCachedPlugin_decodePc_injectedDecode));
-  assign when_Fetcher_l195 = (IBusCachedPlugin_jump_pcLoad_valid && ((! decode_arbitration_isStuck) || decode_arbitration_removeIt));
+  assign when_Fetcher_l182 = (decode_arbitration_isFiring && (! IBusCachedPlugin_decodePc_injectedDecode));
+  assign when_Fetcher_l194 = (IBusCachedPlugin_jump_pcLoad_valid && ((! decode_arbitration_isStuck) || decode_arbitration_removeIt));
   always @(*) begin
     IBusCachedPlugin_iBusRsp_redoFetch = 1'b0;
     if(IBusCachedPlugin_rsp_redoFetch) begin
@@ -3213,7 +3194,7 @@ module VexRiscv (
     if(IBusCachedPlugin_mmuBus_busy) begin
       IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b1;
     end
-    if(when_IBusCachedPlugin_l267) begin
+    if(when_IBusCachedPlugin_l273) begin
       IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b1;
     end
   end
@@ -3232,9 +3213,9 @@ module VexRiscv (
 
   assign IBusCachedPlugin_iBusRsp_flush = (IBusCachedPlugin_externalFlush || IBusCachedPlugin_iBusRsp_redoFetch);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
-  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1 = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
   always @(*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
@@ -3261,10 +3242,13 @@ module VexRiscv (
   assign IBusCachedPlugin_decompressor_isRvc = (IBusCachedPlugin_decompressor_raw[1 : 0] != 2'b11);
   assign _zz_IBusCachedPlugin_decompressor_decompressed = IBusCachedPlugin_decompressor_raw[15 : 0];
   always @(*) begin
-    IBusCachedPlugin_decompressor_decompressed = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+    IBusCachedPlugin_decompressor_decompressed = 32'h00000000;
     case(switch_Misc_l44)
-      5'h0 : begin
+      5'h00 : begin
         IBusCachedPlugin_decompressor_decompressed = {{{{{{{{{2'b00,_zz_IBusCachedPlugin_decompressor_decompressed[10 : 7]},_zz_IBusCachedPlugin_decompressor_decompressed[12 : 11]},_zz_IBusCachedPlugin_decompressor_decompressed[5]},_zz_IBusCachedPlugin_decompressor_decompressed[6]},2'b00},5'h02},3'b000},_zz_IBusCachedPlugin_decompressor_decompressed_2},7'h13};
+        if(when_Misc_l47) begin
+          IBusCachedPlugin_decompressor_decompressed = 32'h00000000;
+        end
       end
       5'h02 : begin
         IBusCachedPlugin_decompressor_decompressed = {{{{_zz_IBusCachedPlugin_decompressor_decompressed_3,_zz_IBusCachedPlugin_decompressor_decompressed_1},3'b010},_zz_IBusCachedPlugin_decompressor_decompressed_2},7'h03};
@@ -3279,13 +3263,13 @@ module VexRiscv (
         IBusCachedPlugin_decompressor_decompressed = {{{{{_zz_IBusCachedPlugin_decompressor_decompressed_8[20],_zz_IBusCachedPlugin_decompressor_decompressed_8[10 : 1]},_zz_IBusCachedPlugin_decompressor_decompressed_8[11]},_zz_IBusCachedPlugin_decompressor_decompressed_8[19 : 12]},_zz_IBusCachedPlugin_decompressor_decompressed_20},7'h6f};
       end
       5'h0a : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{_zz_IBusCachedPlugin_decompressor_decompressed_5,5'h0},3'b000},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},7'h13};
+        IBusCachedPlugin_decompressor_decompressed = {{{{_zz_IBusCachedPlugin_decompressor_decompressed_5,5'h00},3'b000},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},7'h13};
       end
       5'h0b : begin
         IBusCachedPlugin_decompressor_decompressed = ((_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7] == 5'h02) ? {{{{{{{{{_zz_IBusCachedPlugin_decompressor_decompressed_12,_zz_IBusCachedPlugin_decompressor_decompressed[4 : 3]},_zz_IBusCachedPlugin_decompressor_decompressed[5]},_zz_IBusCachedPlugin_decompressor_decompressed[2]},_zz_IBusCachedPlugin_decompressor_decompressed[6]},4'b0000},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},3'b000},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},7'h13} : {{_zz_IBusCachedPlugin_decompressor_decompressed_27[31 : 12],_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},7'h37});
       end
       5'h0c : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{((_zz_IBusCachedPlugin_decompressor_decompressed[11 : 10] == 2'b10) ? _zz_IBusCachedPlugin_decompressor_decompressed_26 : {{1'b0,(_zz_IBusCachedPlugin_decompressor_decompressed_28 || _zz_IBusCachedPlugin_decompressor_decompressed_29)},5'h0}),(((! _zz_IBusCachedPlugin_decompressor_decompressed[11]) || _zz_IBusCachedPlugin_decompressor_decompressed_22) ? _zz_IBusCachedPlugin_decompressor_decompressed[6 : 2] : _zz_IBusCachedPlugin_decompressor_decompressed_2)},_zz_IBusCachedPlugin_decompressor_decompressed_1},_zz_IBusCachedPlugin_decompressor_decompressed_24},_zz_IBusCachedPlugin_decompressor_decompressed_1},(_zz_IBusCachedPlugin_decompressor_decompressed_22 ? 7'h13 : 7'h33)};
+        IBusCachedPlugin_decompressor_decompressed = {{{{{((_zz_IBusCachedPlugin_decompressor_decompressed[11 : 10] == 2'b10) ? _zz_IBusCachedPlugin_decompressor_decompressed_26 : {{1'b0,(_zz_IBusCachedPlugin_decompressor_decompressed_28 || _zz_IBusCachedPlugin_decompressor_decompressed_29)},5'h00}),(((! _zz_IBusCachedPlugin_decompressor_decompressed[11]) || _zz_IBusCachedPlugin_decompressor_decompressed_22) ? _zz_IBusCachedPlugin_decompressor_decompressed[6 : 2] : _zz_IBusCachedPlugin_decompressor_decompressed_2)},_zz_IBusCachedPlugin_decompressor_decompressed_1},_zz_IBusCachedPlugin_decompressor_decompressed_24},_zz_IBusCachedPlugin_decompressor_decompressed_1},(_zz_IBusCachedPlugin_decompressor_decompressed_22 ? 7'h13 : 7'h33)};
       end
       5'h0d : begin
         IBusCachedPlugin_decompressor_decompressed = {{{{{_zz_IBusCachedPlugin_decompressor_decompressed_15[20],_zz_IBusCachedPlugin_decompressor_decompressed_15[10 : 1]},_zz_IBusCachedPlugin_decompressor_decompressed_15[11]},_zz_IBusCachedPlugin_decompressor_decompressed_15[19 : 12]},_zz_IBusCachedPlugin_decompressor_decompressed_19},7'h6f};
@@ -3297,13 +3281,13 @@ module VexRiscv (
         IBusCachedPlugin_decompressor_decompressed = {{{{{{{_zz_IBusCachedPlugin_decompressor_decompressed_18[12],_zz_IBusCachedPlugin_decompressor_decompressed_18[10 : 5]},_zz_IBusCachedPlugin_decompressor_decompressed_19},_zz_IBusCachedPlugin_decompressor_decompressed_1},3'b001},_zz_IBusCachedPlugin_decompressor_decompressed_18[4 : 1]},_zz_IBusCachedPlugin_decompressor_decompressed_18[11]},7'h63};
       end
       5'h10 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{7'h0,_zz_IBusCachedPlugin_decompressor_decompressed[6 : 2]},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},3'b001},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},7'h13};
+        IBusCachedPlugin_decompressor_decompressed = {{{{{7'h00,_zz_IBusCachedPlugin_decompressor_decompressed[6 : 2]},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},3'b001},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},7'h13};
       end
       5'h12 : begin
         IBusCachedPlugin_decompressor_decompressed = {{{{{{{{4'b0000,_zz_IBusCachedPlugin_decompressor_decompressed[3 : 2]},_zz_IBusCachedPlugin_decompressor_decompressed[12]},_zz_IBusCachedPlugin_decompressor_decompressed[6 : 4]},2'b00},_zz_IBusCachedPlugin_decompressor_decompressed_21},3'b010},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},7'h03};
       end
       5'h14 : begin
-        IBusCachedPlugin_decompressor_decompressed = ((_zz_IBusCachedPlugin_decompressor_decompressed[12 : 2] == 11'h400) ? 32'h00100073 : ((_zz_IBusCachedPlugin_decompressor_decompressed[6 : 2] == 5'h0) ? {{{{12'h0,_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},3'b000},(_zz_IBusCachedPlugin_decompressor_decompressed[12] ? _zz_IBusCachedPlugin_decompressor_decompressed_20 : _zz_IBusCachedPlugin_decompressor_decompressed_19)},7'h67} : {{{{{_zz_IBusCachedPlugin_decompressor_decompressed_30,_zz_IBusCachedPlugin_decompressor_decompressed_31},(_zz_IBusCachedPlugin_decompressor_decompressed_32 ? _zz_IBusCachedPlugin_decompressor_decompressed_33 : _zz_IBusCachedPlugin_decompressor_decompressed_19)},3'b000},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},7'h33}));
+        IBusCachedPlugin_decompressor_decompressed = ((_zz_IBusCachedPlugin_decompressor_decompressed[12 : 2] == 11'h400) ? 32'h00100073 : ((_zz_IBusCachedPlugin_decompressor_decompressed[6 : 2] == 5'h00) ? {{{{12'h000,_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},3'b000},(_zz_IBusCachedPlugin_decompressor_decompressed[12] ? _zz_IBusCachedPlugin_decompressor_decompressed_20 : _zz_IBusCachedPlugin_decompressor_decompressed_19)},7'h67} : {{{{{_zz_IBusCachedPlugin_decompressor_decompressed_30,_zz_IBusCachedPlugin_decompressor_decompressed_31},(_zz_IBusCachedPlugin_decompressor_decompressed_32 ? _zz_IBusCachedPlugin_decompressor_decompressed_33 : _zz_IBusCachedPlugin_decompressor_decompressed_19)},3'b000},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},7'h33}));
       end
       5'h16 : begin
         IBusCachedPlugin_decompressor_decompressed = {{{{{_zz_IBusCachedPlugin_decompressor_decompressed_34[11 : 5],_zz_IBusCachedPlugin_decompressor_decompressed[6 : 2]},_zz_IBusCachedPlugin_decompressor_decompressed_21},3'b010},_zz_IBusCachedPlugin_decompressor_decompressed_35[4 : 0]},7'h23};
@@ -3315,7 +3299,7 @@ module VexRiscv (
 
   assign _zz_IBusCachedPlugin_decompressor_decompressed_1 = {2'b01,_zz_IBusCachedPlugin_decompressor_decompressed[9 : 7]};
   assign _zz_IBusCachedPlugin_decompressor_decompressed_2 = {2'b01,_zz_IBusCachedPlugin_decompressor_decompressed[4 : 2]};
-  assign _zz_IBusCachedPlugin_decompressor_decompressed_3 = {{{{5'h0,_zz_IBusCachedPlugin_decompressor_decompressed[5]},_zz_IBusCachedPlugin_decompressor_decompressed[12 : 10]},_zz_IBusCachedPlugin_decompressor_decompressed[6]},2'b00};
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_3 = {{{{5'h00,_zz_IBusCachedPlugin_decompressor_decompressed[5]},_zz_IBusCachedPlugin_decompressor_decompressed[12 : 10]},_zz_IBusCachedPlugin_decompressor_decompressed[6]},2'b00};
   assign _zz_IBusCachedPlugin_decompressor_decompressed_4 = _zz_IBusCachedPlugin_decompressor_decompressed[12];
   always @(*) begin
     _zz_IBusCachedPlugin_decompressor_decompressed_5[11] = _zz_IBusCachedPlugin_decompressor_decompressed_4;
@@ -3394,15 +3378,16 @@ module VexRiscv (
   end
 
   assign _zz_IBusCachedPlugin_decompressor_decompressed_18 = {{{{{_zz_IBusCachedPlugin_decompressor_decompressed_17,_zz_IBusCachedPlugin_decompressor_decompressed[6 : 5]},_zz_IBusCachedPlugin_decompressor_decompressed[2]},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 10]},_zz_IBusCachedPlugin_decompressor_decompressed[4 : 3]},1'b0};
-  assign _zz_IBusCachedPlugin_decompressor_decompressed_19 = 5'h0;
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_19 = 5'h00;
   assign _zz_IBusCachedPlugin_decompressor_decompressed_20 = 5'h01;
   assign _zz_IBusCachedPlugin_decompressor_decompressed_21 = 5'h02;
   assign switch_Misc_l44 = {_zz_IBusCachedPlugin_decompressor_decompressed[1 : 0],_zz_IBusCachedPlugin_decompressor_decompressed[15 : 13]};
+  assign when_Misc_l47 = (_zz_IBusCachedPlugin_decompressor_decompressed[12 : 2] == 11'h000);
   assign _zz_IBusCachedPlugin_decompressor_decompressed_22 = (_zz_IBusCachedPlugin_decompressor_decompressed[11 : 10] != 2'b11);
-  assign switch_Misc_l210 = _zz_IBusCachedPlugin_decompressor_decompressed[11 : 10];
-  assign switch_Misc_l210_1 = _zz_IBusCachedPlugin_decompressor_decompressed[6 : 5];
+  assign switch_Misc_l232 = _zz_IBusCachedPlugin_decompressor_decompressed[11 : 10];
+  assign switch_Misc_l232_1 = _zz_IBusCachedPlugin_decompressor_decompressed[6 : 5];
   always @(*) begin
-    case(switch_Misc_l210_1)
+    case(switch_Misc_l232_1)
       2'b00 : begin
         _zz_IBusCachedPlugin_decompressor_decompressed_23 = 3'b000;
       end
@@ -3419,7 +3404,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    case(switch_Misc_l210)
+    case(switch_Misc_l232)
       2'b00 : begin
         _zz_IBusCachedPlugin_decompressor_decompressed_24 = 3'b101;
       end
@@ -3453,19 +3438,19 @@ module VexRiscv (
   assign IBusCachedPlugin_decompressor_input_ready = (IBusCachedPlugin_decompressor_output_ready && (((! IBusCachedPlugin_iBusRsp_stages_1_input_valid) || IBusCachedPlugin_decompressor_flushNext) || ((! (IBusCachedPlugin_decompressor_bufferValid && IBusCachedPlugin_decompressor_isInputHighRvc)) && (! (((! IBusCachedPlugin_decompressor_unaligned) && IBusCachedPlugin_decompressor_isInputLowRvc) && IBusCachedPlugin_decompressor_isInputHighRvc)))));
   assign IBusCachedPlugin_decompressor_output_fire = (IBusCachedPlugin_decompressor_output_valid && IBusCachedPlugin_decompressor_output_ready);
   assign IBusCachedPlugin_decompressor_bufferFill = (((((! IBusCachedPlugin_decompressor_unaligned) && IBusCachedPlugin_decompressor_isInputLowRvc) && (! IBusCachedPlugin_decompressor_isInputHighRvc)) || (IBusCachedPlugin_decompressor_bufferValid && (! IBusCachedPlugin_decompressor_isInputHighRvc))) || ((IBusCachedPlugin_decompressor_throw2Bytes && (! IBusCachedPlugin_decompressor_isRvc)) && (! IBusCachedPlugin_decompressor_isInputHighRvc)));
-  assign when_Fetcher_l286 = (IBusCachedPlugin_decompressor_output_ready && IBusCachedPlugin_decompressor_input_valid);
-  assign when_Fetcher_l289 = (IBusCachedPlugin_decompressor_output_ready && IBusCachedPlugin_decompressor_input_valid);
-  assign when_Fetcher_l294 = (IBusCachedPlugin_externalFlush || IBusCachedPlugin_decompressor_consumeCurrent);
+  assign when_Fetcher_l285 = (IBusCachedPlugin_decompressor_output_ready && IBusCachedPlugin_decompressor_input_valid);
+  assign when_Fetcher_l288 = (IBusCachedPlugin_decompressor_output_ready && IBusCachedPlugin_decompressor_input_valid);
+  assign when_Fetcher_l293 = (IBusCachedPlugin_externalFlush || IBusCachedPlugin_decompressor_consumeCurrent);
   assign IBusCachedPlugin_decompressor_output_ready = ((1'b0 && (! IBusCachedPlugin_injector_decodeInput_valid)) || IBusCachedPlugin_injector_decodeInput_ready);
   assign IBusCachedPlugin_injector_decodeInput_valid = _zz_IBusCachedPlugin_injector_decodeInput_valid;
   assign IBusCachedPlugin_injector_decodeInput_payload_pc = _zz_IBusCachedPlugin_injector_decodeInput_payload_pc;
   assign IBusCachedPlugin_injector_decodeInput_payload_rsp_error = _zz_IBusCachedPlugin_injector_decodeInput_payload_rsp_error;
   assign IBusCachedPlugin_injector_decodeInput_payload_rsp_inst = _zz_IBusCachedPlugin_injector_decodeInput_payload_rsp_inst;
   assign IBusCachedPlugin_injector_decodeInput_payload_isRvc = _zz_IBusCachedPlugin_injector_decodeInput_payload_isRvc;
-  assign when_Fetcher_l332 = (! 1'b0);
-  assign when_Fetcher_l332_1 = (! execute_arbitration_isStuck);
-  assign when_Fetcher_l332_2 = (! memory_arbitration_isStuck);
-  assign when_Fetcher_l332_3 = (! writeBack_arbitration_isStuck);
+  assign when_Fetcher_l331 = (! 1'b0);
+  assign when_Fetcher_l331_1 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l331_2 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l331_3 = (! writeBack_arbitration_isStuck);
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_0;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
@@ -3563,90 +3548,89 @@ module VexRiscv (
   assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
   always @(*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(when_IBusCachedPlugin_l239) begin
+    if(when_IBusCachedPlugin_l245) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(when_IBusCachedPlugin_l250) begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_cache_io_cpu_fill_valid = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_fetch_mmuRefilling));
-    if(when_IBusCachedPlugin_l250) begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_cache_io_cpu_fill_valid = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_valid = 1'b0;
-    if(when_IBusCachedPlugin_l244) begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
-    if(when_IBusCachedPlugin_l256) begin
+    if(when_IBusCachedPlugin_l262) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_payload_code = 4'bxxxx;
-    if(when_IBusCachedPlugin_l244) begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b1100;
     end
-    if(when_IBusCachedPlugin_l256) begin
+    if(when_IBusCachedPlugin_l262) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b0001;
     end
   end
 
   assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_1_input_payload[31 : 2],2'b00};
-  assign when_IBusCachedPlugin_l239 = ((IBusCachedPlugin_cache_io_cpu_fetch_isValid && IBusCachedPlugin_cache_io_cpu_fetch_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign when_IBusCachedPlugin_l244 = ((IBusCachedPlugin_cache_io_cpu_fetch_isValid && IBusCachedPlugin_cache_io_cpu_fetch_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
-  assign when_IBusCachedPlugin_l250 = ((IBusCachedPlugin_cache_io_cpu_fetch_isValid && IBusCachedPlugin_cache_io_cpu_fetch_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
-  assign when_IBusCachedPlugin_l256 = ((IBusCachedPlugin_cache_io_cpu_fetch_isValid && IBusCachedPlugin_cache_io_cpu_fetch_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
-  assign when_IBusCachedPlugin_l267 = (IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt);
+  assign when_IBusCachedPlugin_l245 = ((IBusCachedPlugin_cache_io_cpu_fetch_isValid && IBusCachedPlugin_cache_io_cpu_fetch_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign when_IBusCachedPlugin_l250 = ((IBusCachedPlugin_cache_io_cpu_fetch_isValid && IBusCachedPlugin_cache_io_cpu_fetch_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign when_IBusCachedPlugin_l256 = ((IBusCachedPlugin_cache_io_cpu_fetch_isValid && IBusCachedPlugin_cache_io_cpu_fetch_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
+  assign when_IBusCachedPlugin_l262 = ((IBusCachedPlugin_cache_io_cpu_fetch_isValid && IBusCachedPlugin_cache_io_cpu_fetch_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
+  assign when_IBusCachedPlugin_l273 = (IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt);
   assign IBusCachedPlugin_iBusRsp_output_valid = IBusCachedPlugin_iBusRsp_stages_1_output_valid;
   assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
   assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_fetch_data;
   assign IBusCachedPlugin_iBusRsp_output_payload_pc = IBusCachedPlugin_iBusRsp_stages_1_output_payload;
   assign IBusCachedPlugin_cache_io_flush = (decode_arbitration_isValid && decode_FLUSH_ALL);
-  assign dataCache_1_io_mem_cmd_ready = (! dataCache_1_io_mem_cmd_rValid);
-  assign dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || dataCache_1_io_mem_cmd_rValid);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_wr : dataCache_1_io_mem_cmd_payload_wr);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_uncached : dataCache_1_io_mem_cmd_payload_uncached);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_address = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_address : dataCache_1_io_mem_cmd_payload_address);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_data = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_data : dataCache_1_io_mem_cmd_payload_data);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_mask : dataCache_1_io_mem_cmd_payload_mask);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_size = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_size : dataCache_1_io_mem_cmd_payload_size);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_last : dataCache_1_io_mem_cmd_payload_last);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || (! toplevel_dataCache_1_io_mem_cmd_rValidN));
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_wr : toplevel_dataCache_1_io_mem_cmd_rData_wr);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_uncached : toplevel_dataCache_1_io_mem_cmd_rData_uncached);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_address = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_address : toplevel_dataCache_1_io_mem_cmd_rData_address);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_data = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_data : toplevel_dataCache_1_io_mem_cmd_rData_data);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_mask : toplevel_dataCache_1_io_mem_cmd_rData_mask);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_size = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_size : toplevel_dataCache_1_io_mem_cmd_rData_size);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_last = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_last : toplevel_dataCache_1_io_mem_cmd_rData_last);
   always @(*) begin
-    dataCache_1_io_mem_cmd_s2mPipe_ready = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
-    if(when_Stream_l368) begin
-      dataCache_1_io_mem_cmd_s2mPipe_ready = 1'b1;
+    toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
+    if(when_Stream_l369) begin
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l368 = (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_rValid;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_rData_address;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_rData_data;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size = dataCache_1_io_mem_cmd_s2mPipe_rData_size;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_rData_last;
-  assign dBus_cmd_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
-  assign dBus_cmd_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
-  assign dBus_cmd_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
-  assign dBus_cmd_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
-  assign dBus_cmd_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
-  assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  assign dBus_cmd_payload_size = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
-  assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  assign when_DBusCachedPlugin_l308 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
+  assign when_Stream_l369 = (! toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_address;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_data;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_size;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  assign dBus_cmd_valid = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
+  assign dBus_cmd_payload_wr = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
+  assign dBus_cmd_payload_uncached = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
+  assign dBus_cmd_payload_address = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
+  assign dBus_cmd_payload_data = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
+  assign dBus_cmd_payload_mask = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
+  assign dBus_cmd_payload_size = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
+  assign dBus_cmd_payload_last = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  assign when_DBusCachedPlugin_l352 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
   always @(*) begin
     _zz_decode_MEMORY_FORCE_CONSTISTENCY = 1'b0;
-    if(when_DBusCachedPlugin_l316) begin
+    if(when_DBusCachedPlugin_l360) begin
       if(decode_MEMORY_LRSC) begin
         _zz_decode_MEMORY_FORCE_CONSTISTENCY = 1'b1;
       end
@@ -3656,7 +3640,7 @@ module VexRiscv (
     end
   end
 
-  assign when_DBusCachedPlugin_l316 = decode_INSTRUCTION[25];
+  assign when_DBusCachedPlugin_l360 = decode_INSTRUCTION[25];
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
   assign dataCache_1_io_cpu_execute_isValid = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
   assign dataCache_1_io_cpu_execute_address = execute_SRC_ADD;
@@ -3675,10 +3659,10 @@ module VexRiscv (
   end
 
   assign dataCache_1_io_cpu_flush_valid = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
-  assign dataCache_1_io_cpu_flush_payload_singleLine = (execute_INSTRUCTION[19 : 15] != 5'h0);
+  assign dataCache_1_io_cpu_flush_payload_singleLine = (execute_INSTRUCTION[19 : 15] != 5'h00);
   assign dataCache_1_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId[6:0];
-  assign dataCache_1_io_cpu_flush_isStall = (dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready));
-  assign when_DBusCachedPlugin_l350 = (dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
+  assign toplevel_dataCache_1_io_cpu_flush_isStall = (dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready));
+  assign when_DBusCachedPlugin_l394 = (toplevel_dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
   always @(*) begin
     dataCache_1_io_cpu_execute_args_isLrsc = 1'b0;
     if(execute_MEMORY_LRSC) begin
@@ -3688,7 +3672,7 @@ module VexRiscv (
 
   assign dataCache_1_io_cpu_execute_args_amoCtrl_alu = execute_INSTRUCTION[31 : 29];
   assign dataCache_1_io_cpu_execute_args_amoCtrl_swap = execute_INSTRUCTION[27];
-  assign when_DBusCachedPlugin_l366 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
+  assign when_DBusCachedPlugin_l410 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
   assign dataCache_1_io_cpu_memory_isValid = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
   assign dataCache_1_io_cpu_memory_address = memory_REGFILE_WRITE_DATA;
   assign DBusCachedPlugin_mmuBus_cmd_0_isValid = dataCache_1_io_cpu_memory_isValid;
@@ -3698,12 +3682,12 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
   always @(*) begin
     dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if(when_DBusCachedPlugin_l393) begin
+    if(when_DBusCachedPlugin_l472) begin
       dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = 1'b1;
     end
   end
 
-  assign when_DBusCachedPlugin_l393 = (1'b0 && (! dataCache_1_io_cpu_memory_isWrite));
+  assign when_DBusCachedPlugin_l472 = (1'b0 && (! dataCache_1_io_cpu_memory_isWrite));
   always @(*) begin
     dataCache_1_io_cpu_writeBack_isValid = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
     if(writeBack_arbitration_haltByOther) begin
@@ -3716,7 +3700,7 @@ module VexRiscv (
   assign dataCache_1_io_cpu_writeBack_storeData[31 : 0] = writeBack_MEMORY_STORE_DATA_RF;
   always @(*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(when_DBusCachedPlugin_l446) begin
+    if(when_DBusCachedPlugin_l533) begin
       if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
@@ -3726,7 +3710,7 @@ module VexRiscv (
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(when_DBusCachedPlugin_l446) begin
+    if(when_DBusCachedPlugin_l533) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
@@ -3745,7 +3729,7 @@ module VexRiscv (
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
-    if(when_DBusCachedPlugin_l446) begin
+    if(when_DBusCachedPlugin_l533) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code};
       end
@@ -3758,12 +3742,13 @@ module VexRiscv (
     end
   end
 
-  assign when_DBusCachedPlugin_l446 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign when_DBusCachedPlugin_l466 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
-  assign writeBack_DBusCachedPlugin_rspSplits_0 = dataCache_1_io_cpu_writeBack_data[7 : 0];
-  assign writeBack_DBusCachedPlugin_rspSplits_1 = dataCache_1_io_cpu_writeBack_data[15 : 8];
-  assign writeBack_DBusCachedPlugin_rspSplits_2 = dataCache_1_io_cpu_writeBack_data[23 : 16];
-  assign writeBack_DBusCachedPlugin_rspSplits_3 = dataCache_1_io_cpu_writeBack_data[31 : 24];
+  assign when_DBusCachedPlugin_l533 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l553 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
+  assign writeBack_DBusCachedPlugin_rspData = dataCache_1_io_cpu_writeBack_data;
+  assign writeBack_DBusCachedPlugin_rspSplits_0 = writeBack_DBusCachedPlugin_rspData[7 : 0];
+  assign writeBack_DBusCachedPlugin_rspSplits_1 = writeBack_DBusCachedPlugin_rspData[15 : 8];
+  assign writeBack_DBusCachedPlugin_rspSplits_2 = writeBack_DBusCachedPlugin_rspData[23 : 16];
+  assign writeBack_DBusCachedPlugin_rspSplits_3 = writeBack_DBusCachedPlugin_rspData[31 : 24];
   always @(*) begin
     writeBack_DBusCachedPlugin_rspShifted[7 : 0] = _zz_writeBack_DBusCachedPlugin_rspShifted;
     writeBack_DBusCachedPlugin_rspShifted[15 : 8] = _zz_writeBack_DBusCachedPlugin_rspShifted_2;
@@ -3773,13 +3758,13 @@ module VexRiscv (
 
   always @(*) begin
     writeBack_DBusCachedPlugin_rspRf = writeBack_DBusCachedPlugin_rspShifted[31 : 0];
-    if(when_DBusCachedPlugin_l482) begin
+    if(when_DBusCachedPlugin_l570) begin
       writeBack_DBusCachedPlugin_rspRf = {31'd0, _zz_writeBack_DBusCachedPlugin_rspRf};
     end
   end
 
-  assign when_DBusCachedPlugin_l482 = (writeBack_MEMORY_LRSC && writeBack_MEMORY_WR);
-  assign switch_Misc_l210_2 = writeBack_INSTRUCTION[13 : 12];
+  assign when_DBusCachedPlugin_l570 = (writeBack_MEMORY_LRSC && writeBack_MEMORY_WR);
+  assign switch_Misc_l232_2 = writeBack_INSTRUCTION[13 : 12];
   assign _zz_writeBack_DBusCachedPlugin_rspFormated = (writeBack_DBusCachedPlugin_rspRf[7] && (! writeBack_INSTRUCTION[14]));
   always @(*) begin
     _zz_writeBack_DBusCachedPlugin_rspFormated_1[31] = _zz_writeBack_DBusCachedPlugin_rspFormated;
@@ -3831,7 +3816,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    case(switch_Misc_l210_2)
+    case(switch_Misc_l232_2)
       2'b00 : begin
         writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_1;
       end
@@ -3844,7 +3829,7 @@ module VexRiscv (
     endcase
   end
 
-  assign when_DBusCachedPlugin_l492 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l580 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
   assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
@@ -3866,11 +3851,11 @@ module VexRiscv (
   assign _zz_decode_IS_RS2_SIGNED_1 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
   assign _zz_decode_IS_RS2_SIGNED_2 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
   assign _zz_decode_IS_RS2_SIGNED_3 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002000);
-  assign _zz_decode_IS_RS2_SIGNED_4 = ((decode_INSTRUCTION & 32'h00000018) == 32'h0);
+  assign _zz_decode_IS_RS2_SIGNED_4 = ((decode_INSTRUCTION & 32'h00000018) == 32'h00000000);
   assign _zz_decode_IS_RS2_SIGNED_5 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
   assign _zz_decode_IS_RS2_SIGNED_6 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
   assign _zz_decode_IS_RS2_SIGNED_7 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
-  assign _zz_decode_IS_RS2_SIGNED_8 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
+  assign _zz_decode_IS_RS2_SIGNED_8 = ((decode_INSTRUCTION & 32'h00001000) == 32'h00000000);
   assign _zz_decode_IS_RS2_SIGNED = {(|_zz_decode_IS_RS2_SIGNED_8),{(|_zz_decode_IS_RS2_SIGNED_8),{(|(_zz__zz_decode_IS_RS2_SIGNED == _zz__zz_decode_IS_RS2_SIGNED_1)),{(|_zz__zz_decode_IS_RS2_SIGNED_2),{(|_zz__zz_decode_IS_RS2_SIGNED_3),{_zz__zz_decode_IS_RS2_SIGNED_4,{_zz__zz_decode_IS_RS2_SIGNED_6,_zz__zz_decode_IS_RS2_SIGNED_9}}}}}}};
   assign _zz_decode_SRC1_CTRL_2 = _zz_decode_IS_RS2_SIGNED[2 : 1];
   assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
@@ -3889,29 +3874,29 @@ module VexRiscv (
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
-  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h0);
+  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h00);
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
   assign decode_RegFilePlugin_rs1Data = _zz_RegFilePlugin_regFile_port0;
   assign decode_RegFilePlugin_rs2Data = _zz_RegFilePlugin_regFile_port1;
   always @(*) begin
     lastStageRegFileWrite_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
-    if(_zz_2) begin
+    if(_zz_5) begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
   always @(*) begin
     lastStageRegFileWrite_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
-    if(_zz_2) begin
-      lastStageRegFileWrite_payload_address = 5'h0;
+    if(_zz_5) begin
+      lastStageRegFileWrite_payload_address = 5'h00;
     end
   end
 
   always @(*) begin
     lastStageRegFileWrite_payload_data = _zz_decode_RS2_2;
-    if(_zz_2) begin
-      lastStageRegFileWrite_payload_data = 32'h0;
+    if(_zz_5) begin
+      lastStageRegFileWrite_payload_data = 32'h00000000;
     end
   end
 
@@ -3952,7 +3937,7 @@ module VexRiscv (
         _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
       Src1CtrlEnum_IMU : begin
-        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h000};
       end
       default : begin
         _zz_execute_SRC1 = {27'd0, _zz__zz_execute_SRC1_1};
@@ -3960,67 +3945,67 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_execute_SRC2_1 = execute_INSTRUCTION[31];
+  assign _zz_execute_SRC2 = execute_INSTRUCTION[31];
   always @(*) begin
-    _zz_execute_SRC2_2[19] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[18] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[17] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[16] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[15] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[14] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[13] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[12] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[11] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[10] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[9] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[8] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[7] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[6] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[5] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[4] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[3] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[2] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[1] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[0] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_1[19] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[18] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[17] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[16] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[15] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[14] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[13] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[12] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[11] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[10] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[9] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[8] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[7] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[6] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[5] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[4] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[3] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[2] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[1] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[0] = _zz_execute_SRC2;
   end
 
-  assign _zz_execute_SRC2_3 = _zz__zz_execute_SRC2_3[11];
+  assign _zz_execute_SRC2_2 = _zz__zz_execute_SRC2_2[11];
   always @(*) begin
-    _zz_execute_SRC2_4[19] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[18] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[17] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[16] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[15] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[14] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[13] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[12] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[11] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[10] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[9] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[8] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[7] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[6] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[5] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[4] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[3] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[2] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[1] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[0] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_3[19] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[18] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[17] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[16] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[15] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[14] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[13] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[12] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[11] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[10] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[9] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[8] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[7] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[6] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[5] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[4] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[3] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[2] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[1] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[0] = _zz_execute_SRC2_2;
   end
 
   always @(*) begin
     case(execute_SRC2_CTRL)
       Src2CtrlEnum_RS : begin
-        _zz_execute_SRC2_5 = execute_RS2;
+        _zz_execute_SRC2_4 = execute_RS2;
       end
       Src2CtrlEnum_IMI : begin
-        _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
+        _zz_execute_SRC2_4 = {_zz_execute_SRC2_1,execute_INSTRUCTION[31 : 20]};
       end
       Src2CtrlEnum_IMS : begin
-        _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_execute_SRC2_4 = {_zz_execute_SRC2_3,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_execute_SRC2_5 = _zz_execute_SRC2;
+        _zz_execute_SRC2_4 = _zz_execute_to_memory_PC;
       end
     endcase
   end
@@ -4186,16 +4171,19 @@ module VexRiscv (
   assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
   assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign switch_Misc_l210_3 = execute_INSTRUCTION[14 : 12];
+  assign switch_Misc_l232_3 = execute_INSTRUCTION[14 : 12];
   always @(*) begin
-    casez(switch_Misc_l210_3)
+    case(switch_Misc_l232_3)
       3'b000 : begin
         _zz_execute_BRANCH_COND_RESULT = execute_BranchPlugin_eq;
       end
       3'b001 : begin
         _zz_execute_BRANCH_COND_RESULT = (! execute_BranchPlugin_eq);
       end
-      3'b1?1 : begin
+      3'b101 : begin
+        _zz_execute_BRANCH_COND_RESULT = (! execute_SRC_LESS);
+      end
+      3'b111 : begin
         _zz_execute_BRANCH_COND_RESULT = (! execute_SRC_LESS);
       end
       default : begin
@@ -4320,9 +4308,11 @@ module VexRiscv (
     end
   end
 
-  assign _zz_when_CsrPlugin_l965 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_when_CsrPlugin_l965_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_when_CsrPlugin_l965_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign CsrPlugin_misa_base = 2'b01;
+  assign CsrPlugin_misa_extensions = 26'h0000042;
+  assign _zz_when_CsrPlugin_l1302 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l1302_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l1302_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
   assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
@@ -4364,28 +4354,28 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l922 = (! decode_arbitration_isStuck);
-  assign when_CsrPlugin_l922_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l922_2 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l922_3 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l935 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
+  assign when_CsrPlugin_l1259 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l1272 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-  assign when_CsrPlugin_l959 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign when_CsrPlugin_l965 = ((_zz_when_CsrPlugin_l965 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l965_1 = ((_zz_when_CsrPlugin_l965_1 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l965_2 = ((_zz_when_CsrPlugin_l965_2 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1296 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l1302 = ((_zz_when_CsrPlugin_l1302 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1302_1 = ((_zz_when_CsrPlugin_l1302_1 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1302_2 = ((_zz_when_CsrPlugin_l1302_2 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  assign when_CsrPlugin_l993 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l993_1 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l993_2 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l998 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  assign when_CsrPlugin_l1335 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1335_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l1335_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l1340 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
   always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(when_CsrPlugin_l1004) begin
+    if(when_CsrPlugin_l1346) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException) begin
@@ -4393,7 +4383,7 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l1004 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
+  assign when_CsrPlugin_l1346 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
   always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
@@ -4409,6 +4399,7 @@ module VexRiscv (
     end
   end
 
+  assign CsrPlugin_trapCauseEbreakDebug = 1'b0;
   always @(*) begin
     CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
@@ -4431,13 +4422,15 @@ module VexRiscv (
     endcase
   end
 
-  assign when_CsrPlugin_l1032 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign when_CsrPlugin_l1077 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
-  assign switch_CsrPlugin_l1081 = writeBack_INSTRUCTION[29 : 28];
+  assign CsrPlugin_trapEnterDebug = 1'b0;
+  assign when_CsrPlugin_l1390 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1398 = (! CsrPlugin_trapEnterDebug);
+  assign when_CsrPlugin_l1456 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign switch_CsrPlugin_l1460 = writeBack_INSTRUCTION[29 : 28];
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign when_CsrPlugin_l1121 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_WFI));
-  assign when_CsrPlugin_l1123 = (! execute_CsrPlugin_wfiWake);
-  assign when_CsrPlugin_l1129 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
+  assign when_CsrPlugin_l1519 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_WFI));
+  assign when_CsrPlugin_l1521 = (! execute_CsrPlugin_wfiWake);
+  assign when_CsrPlugin_l1527 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
   assign execute_CsrPlugin_blockedBySideEffects = ((|{writeBack_arbitration_isValid,memory_arbitration_isValid}) || 1'b0);
   always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
@@ -4536,18 +4529,18 @@ module VexRiscv (
     if(CsrPlugin_csrMapping_allowCsrSignal) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(when_CsrPlugin_l1315) begin
+    if(when_CsrPlugin_l1725) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if(when_CsrPlugin_l1149) begin
-      if(when_CsrPlugin_l1150) begin
+    if(when_CsrPlugin_l1547) begin
+      if(when_CsrPlugin_l1548) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
@@ -4555,20 +4548,20 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(when_CsrPlugin_l1142) begin
+    if(when_CsrPlugin_l1540) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1157) begin
+    if(when_CsrPlugin_l1555) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(when_CsrPlugin_l1142) begin
+    if(when_CsrPlugin_l1540) begin
       CsrPlugin_selfException_payload_code = 4'b0010;
     end
-    if(when_CsrPlugin_l1157) begin
+    if(when_CsrPlugin_l1555) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -4581,20 +4574,20 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  assign when_CsrPlugin_l1142 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
-  assign when_CsrPlugin_l1149 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
-  assign when_CsrPlugin_l1150 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
-  assign when_CsrPlugin_l1157 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
+  assign when_CsrPlugin_l1540 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
+  assign when_CsrPlugin_l1547 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign when_CsrPlugin_l1548 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1555 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
   always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -4603,9 +4596,9 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
   assign execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
-  assign switch_Misc_l210_4 = execute_INSTRUCTION[13];
+  assign switch_Misc_l232_4 = execute_INSTRUCTION[13];
   always @(*) begin
-    case(switch_Misc_l210_4)
+    case(switch_Misc_l232_4)
       1'b0 : begin
         _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
@@ -4616,8 +4609,8 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
-  assign when_CsrPlugin_l1189 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign when_CsrPlugin_l1193 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
+  assign when_CsrPlugin_l1587 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1591 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
@@ -4680,12 +4673,12 @@ module VexRiscv (
   assign memory_DivPlugin_div_counter_willOverflow = (memory_DivPlugin_div_counter_willOverflowIfInc && memory_DivPlugin_div_counter_willIncrement);
   always @(*) begin
     if(memory_DivPlugin_div_counter_willOverflow) begin
-      memory_DivPlugin_div_counter_valueNext = 6'h0;
+      memory_DivPlugin_div_counter_valueNext = 6'h00;
     end else begin
       memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_memory_DivPlugin_div_counter_valueNext);
     end
     if(memory_DivPlugin_div_counter_willClear) begin
-      memory_DivPlugin_div_counter_valueNext = 6'h0;
+      memory_DivPlugin_div_counter_valueNext = 6'h00;
     end
   end
 
@@ -4709,8 +4702,8 @@ module VexRiscv (
     _zz_memory_DivPlugin_rs1_1[31 : 0] = execute_RS1;
   end
 
-  assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
-  assign externalInterrupt = (|_zz_CsrPlugin_csrMapping_readDataInit_1);
+  assign _zz_externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
+  assign externalInterrupt = (|_zz_externalInterrupt);
   assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
@@ -4831,205 +4824,214 @@ module VexRiscv (
   assign when_Pipeline_l154_1 = ((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt));
   assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
   assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
-  assign when_CsrPlugin_l1277 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_2 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_3 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_4 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_5 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_6 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_7 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_8 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_9 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_10 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_11 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_12 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_13 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_14 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_15 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_16 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_17 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_18 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_19 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_20 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_21 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_22 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_23 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_8 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_9 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_10 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_11 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_12 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_13 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_14 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_15 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_16 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_17 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_18 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_19 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_20 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_21 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_22 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_23 = (! execute_arbitration_isStuck);
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_1 = 32'h00000000;
     if(execute_CsrPlugin_csr_3264) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_2[12 : 0] = 13'h1000;
-      _zz_CsrPlugin_csrMapping_readDataInit_2[25 : 20] = 6'h20;
+      _zz_CsrPlugin_csrMapping_readDataInit_1[12 : 0] = 13'h1000;
+      _zz_CsrPlugin_csrMapping_readDataInit_1[25 : 20] = 6'h20;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h00000000;
     if(execute_CsrPlugin_csr_3857) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_3[3 : 0] = 4'b1011;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[3 : 0] = 4'b1011;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h00000000;
     if(execute_CsrPlugin_csr_3858) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_4[4 : 0] = 5'h16;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[4 : 0] = 5'h16;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h00000000;
     if(execute_CsrPlugin_csr_3859) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_5[5 : 0] = 6'h21;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[5 : 0] = 6'h21;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h00000000;
     if(execute_CsrPlugin_csr_769) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_6[31 : 30] = CsrPlugin_misa_base;
-      _zz_CsrPlugin_csrMapping_readDataInit_6[25 : 0] = CsrPlugin_misa_extensions;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[31 : 30] = CsrPlugin_misa_base;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[25 : 0] = CsrPlugin_misa_extensions;
     end
   end
 
-  assign switch_CsrPlugin_l723 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
+  assign switch_CsrPlugin_l1031 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h00000000;
     if(execute_CsrPlugin_csr_768) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_7[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_7[3 : 3] = CsrPlugin_mstatus_MIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_7[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[12 : 11] = CsrPlugin_mstatus_MPP;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h00000000;
     if(execute_CsrPlugin_csr_836) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_8[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_8[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_8[3 : 3] = CsrPlugin_mip_MSIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[3 : 3] = CsrPlugin_mip_MSIP;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h00000000;
     if(execute_CsrPlugin_csr_772) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_9[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_9[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_9[3 : 3] = CsrPlugin_mie_MSIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_8[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_8[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_8[3 : 3] = CsrPlugin_mie_MSIE;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_10 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h00000000;
     if(execute_CsrPlugin_csr_773) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_10[31 : 2] = CsrPlugin_mtvec_base;
-      _zz_CsrPlugin_csrMapping_readDataInit_10[1 : 0] = CsrPlugin_mtvec_mode;
+      _zz_CsrPlugin_csrMapping_readDataInit_9[31 : 2] = CsrPlugin_mtvec_base;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_11 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_10 = 32'h00000000;
     if(execute_CsrPlugin_csr_833) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_11[31 : 0] = CsrPlugin_mepc;
+      _zz_CsrPlugin_csrMapping_readDataInit_10[31 : 0] = CsrPlugin_mepc;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_12 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_11 = 32'h00000000;
     if(execute_CsrPlugin_csr_832) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_12[31 : 0] = CsrPlugin_mscratch;
+      _zz_CsrPlugin_csrMapping_readDataInit_11[31 : 0] = CsrPlugin_mscratch;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_13 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_12 = 32'h00000000;
     if(execute_CsrPlugin_csr_834) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_13[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_CsrPlugin_csrMapping_readDataInit_13[3 : 0] = CsrPlugin_mcause_exceptionCode;
+      _zz_CsrPlugin_csrMapping_readDataInit_12[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_CsrPlugin_csrMapping_readDataInit_12[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_14 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_13 = 32'h00000000;
     if(execute_CsrPlugin_csr_835) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_14[31 : 0] = CsrPlugin_mtval;
+      _zz_CsrPlugin_csrMapping_readDataInit_13[31 : 0] = CsrPlugin_mtval;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_15 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_14 = 32'h00000000;
     if(execute_CsrPlugin_csr_2816) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_15[31 : 0] = CsrPlugin_mcycle[31 : 0];
+      _zz_CsrPlugin_csrMapping_readDataInit_14[31 : 0] = CsrPlugin_mcycle[31 : 0];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_16 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_15 = 32'h00000000;
     if(execute_CsrPlugin_csr_2944) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_16[31 : 0] = CsrPlugin_mcycle[63 : 32];
+      _zz_CsrPlugin_csrMapping_readDataInit_15[31 : 0] = CsrPlugin_mcycle[63 : 32];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_17 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_16 = 32'h00000000;
     if(execute_CsrPlugin_csr_2818) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_17[31 : 0] = CsrPlugin_minstret[31 : 0];
+      _zz_CsrPlugin_csrMapping_readDataInit_16[31 : 0] = CsrPlugin_minstret[31 : 0];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_18 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_17 = 32'h00000000;
     if(execute_CsrPlugin_csr_2946) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_18[31 : 0] = CsrPlugin_minstret[63 : 32];
+      _zz_CsrPlugin_csrMapping_readDataInit_17[31 : 0] = CsrPlugin_minstret[63 : 32];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_19 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_18 = 32'h00000000;
     if(execute_CsrPlugin_csr_3072) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_19[31 : 0] = CsrPlugin_mcycle[31 : 0];
+      _zz_CsrPlugin_csrMapping_readDataInit_18[31 : 0] = CsrPlugin_mcycle[31 : 0];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_20 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_19 = 32'h00000000;
     if(execute_CsrPlugin_csr_3200) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_20[31 : 0] = CsrPlugin_mcycle[63 : 32];
+      _zz_CsrPlugin_csrMapping_readDataInit_19[31 : 0] = CsrPlugin_mcycle[63 : 32];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_21 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_20 = 32'h00000000;
     if(execute_CsrPlugin_csr_3074) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_21[31 : 0] = CsrPlugin_minstret[31 : 0];
+      _zz_CsrPlugin_csrMapping_readDataInit_20[31 : 0] = CsrPlugin_minstret[31 : 0];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_22 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_21 = 32'h00000000;
     if(execute_CsrPlugin_csr_3202) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_22[31 : 0] = CsrPlugin_minstret[63 : 32];
+      _zz_CsrPlugin_csrMapping_readDataInit_21[31 : 0] = CsrPlugin_minstret[63 : 32];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_23 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_22 = 32'h00000000;
     if(execute_CsrPlugin_csr_3008) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_23[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
+      _zz_CsrPlugin_csrMapping_readDataInit_22[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_24 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_23 = 32'h00000000;
     if(execute_CsrPlugin_csr_4032) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_24[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_1;
+      _zz_CsrPlugin_csrMapping_readDataInit_23[31 : 0] = _zz_externalInterrupt;
     end
   end
 
-  assign CsrPlugin_csrMapping_readDataInit = (((((_zz_CsrPlugin_csrMapping_readDataInit_2 | _zz_CsrPlugin_csrMapping_readDataInit_3) | (_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5)) | ((_zz_CsrPlugin_csrMapping_readDataInit_25 | _zz_CsrPlugin_csrMapping_readDataInit_6) | (_zz_CsrPlugin_csrMapping_readDataInit_7 | _zz_CsrPlugin_csrMapping_readDataInit_8))) | (((_zz_CsrPlugin_csrMapping_readDataInit_9 | _zz_CsrPlugin_csrMapping_readDataInit_10) | (_zz_CsrPlugin_csrMapping_readDataInit_11 | _zz_CsrPlugin_csrMapping_readDataInit_12)) | ((_zz_CsrPlugin_csrMapping_readDataInit_13 | _zz_CsrPlugin_csrMapping_readDataInit_14) | (_zz_CsrPlugin_csrMapping_readDataInit_15 | _zz_CsrPlugin_csrMapping_readDataInit_16)))) | (((_zz_CsrPlugin_csrMapping_readDataInit_17 | _zz_CsrPlugin_csrMapping_readDataInit_18) | (_zz_CsrPlugin_csrMapping_readDataInit_19 | _zz_CsrPlugin_csrMapping_readDataInit_20)) | ((_zz_CsrPlugin_csrMapping_readDataInit_21 | _zz_CsrPlugin_csrMapping_readDataInit_22) | (_zz_CsrPlugin_csrMapping_readDataInit_23 | _zz_CsrPlugin_csrMapping_readDataInit_24))));
-  assign when_CsrPlugin_l1310 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign when_CsrPlugin_l1315 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign CsrPlugin_csrMapping_readDataInit = (((((_zz_CsrPlugin_csrMapping_readDataInit_1 | _zz_CsrPlugin_csrMapping_readDataInit_2) | (_zz_CsrPlugin_csrMapping_readDataInit_3 | _zz_CsrPlugin_csrMapping_readDataInit_4)) | ((_zz_CsrPlugin_csrMapping_readDataInit_24 | _zz_CsrPlugin_csrMapping_readDataInit_5) | (_zz_CsrPlugin_csrMapping_readDataInit_6 | _zz_CsrPlugin_csrMapping_readDataInit_7))) | (((_zz_CsrPlugin_csrMapping_readDataInit_8 | _zz_CsrPlugin_csrMapping_readDataInit_9) | (_zz_CsrPlugin_csrMapping_readDataInit_10 | _zz_CsrPlugin_csrMapping_readDataInit_11)) | ((_zz_CsrPlugin_csrMapping_readDataInit_12 | _zz_CsrPlugin_csrMapping_readDataInit_13) | (_zz_CsrPlugin_csrMapping_readDataInit_14 | _zz_CsrPlugin_csrMapping_readDataInit_15)))) | (((_zz_CsrPlugin_csrMapping_readDataInit_16 | _zz_CsrPlugin_csrMapping_readDataInit_17) | (_zz_CsrPlugin_csrMapping_readDataInit_18 | _zz_CsrPlugin_csrMapping_readDataInit_19)) | ((_zz_CsrPlugin_csrMapping_readDataInit_20 | _zz_CsrPlugin_csrMapping_readDataInit_21) | (_zz_CsrPlugin_csrMapping_readDataInit_22 | _zz_CsrPlugin_csrMapping_readDataInit_23))));
+  assign when_CsrPlugin_l1702 = ((execute_arbitration_isValid && execute_IS_CSR) && (({execute_CsrPlugin_csrAddress[11 : 2],2'b00} == 12'h3a0) || ({execute_CsrPlugin_csrAddress[11 : 4],4'b0000} == 12'h3b0)));
+  assign _zz_when_CsrPlugin_l1709 = (execute_CsrPlugin_csrAddress & 12'hf60);
+  assign when_CsrPlugin_l1709 = (((execute_arbitration_isValid && execute_IS_CSR) && (5'h03 <= execute_CsrPlugin_csrAddress[4 : 0])) && (((_zz_when_CsrPlugin_l1709 == 12'hb00) || (((_zz_when_CsrPlugin_l1709 == 12'hc00) && (! execute_CsrPlugin_writeInstruction)) && (CsrPlugin_privilege == 2'b11))) || ((execute_CsrPlugin_csrAddress & 12'hfe0) == 12'h320)));
+  always @(*) begin
+    when_CsrPlugin_l1719 = CsrPlugin_csrMapping_doForceFailCsr;
+    if(when_CsrPlugin_l1717) begin
+      when_CsrPlugin_l1719 = 1'b1;
+    end
+  end
+
+  assign when_CsrPlugin_l1717 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1725 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
   assign iBusWishbone_ADR = {_zz_iBusWishbone_ADR_1,_zz_iBusWishbone_ADR};
   assign iBusWishbone_CTI = ((_zz_iBusWishbone_ADR == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
@@ -5055,20 +5057,20 @@ module VexRiscv (
   assign iBus_rsp_valid = _zz_iBus_rsp_valid;
   assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
   assign iBus_rsp_payload_error = 1'b0;
-  assign _zz_dBus_cmd_ready_5 = (dBus_cmd_payload_size == 3'b101);
-  assign _zz_dBus_cmd_ready_1 = dBus_cmd_valid;
-  assign _zz_dBus_cmd_ready_3 = dBus_cmd_payload_wr;
-  assign _zz_dBus_cmd_ready_4 = ((! _zz_dBus_cmd_ready_5) || (_zz_dBus_cmd_ready == 3'b111));
-  assign dBus_cmd_ready = (_zz_dBus_cmd_ready_2 && (_zz_dBus_cmd_ready_3 || _zz_dBus_cmd_ready_4));
-  assign dBusWishbone_ADR = ((_zz_dBus_cmd_ready_5 ? {{dBus_cmd_payload_address[31 : 5],_zz_dBus_cmd_ready},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
-  assign dBusWishbone_CTI = (_zz_dBus_cmd_ready_5 ? (_zz_dBus_cmd_ready_4 ? 3'b111 : 3'b010) : 3'b000);
+  assign _zz_dBusWishbone_ADR_1 = (dBus_cmd_payload_size == 3'b101);
+  assign _zz_dBusWishbone_CYC = dBus_cmd_valid;
+  assign _zz_dBus_cmd_ready_1 = dBus_cmd_payload_wr;
+  assign _zz_dBus_cmd_ready_2 = ((! _zz_dBusWishbone_ADR_1) || (_zz_dBusWishbone_ADR == 3'b111));
+  assign dBus_cmd_ready = (_zz_dBus_cmd_ready && (_zz_dBus_cmd_ready_1 || _zz_dBus_cmd_ready_2));
+  assign dBusWishbone_ADR = ((_zz_dBusWishbone_ADR_1 ? {{dBus_cmd_payload_address[31 : 5],_zz_dBusWishbone_ADR},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2'd2);
+  assign dBusWishbone_CTI = (_zz_dBusWishbone_ADR_1 ? (_zz_dBus_cmd_ready_2 ? 3'b111 : 3'b010) : 3'b000);
   assign dBusWishbone_BTE = 2'b00;
-  assign dBusWishbone_SEL = (_zz_dBus_cmd_ready_3 ? dBus_cmd_payload_mask : 4'b1111);
-  assign dBusWishbone_WE = _zz_dBus_cmd_ready_3;
+  assign dBusWishbone_SEL = (_zz_dBus_cmd_ready_1 ? dBus_cmd_payload_mask : 4'b1111);
+  assign dBusWishbone_WE = _zz_dBus_cmd_ready_1;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_payload_data;
-  assign _zz_dBus_cmd_ready_2 = (_zz_dBus_cmd_ready_1 && dBusWishbone_ACK);
-  assign dBusWishbone_CYC = _zz_dBus_cmd_ready_1;
-  assign dBusWishbone_STB = _zz_dBus_cmd_ready_1;
+  assign _zz_dBus_cmd_ready = (_zz_dBusWishbone_CYC && dBusWishbone_ACK);
+  assign dBusWishbone_CYC = _zz_dBusWishbone_CYC;
+  assign dBusWishbone_STB = _zz_dBusWishbone_CYC;
   assign dBus_rsp_valid = _zz_dBus_rsp_valid;
   assign dBus_rsp_payload_data = dBusWishbone_DAT_MISO_regNext;
   assign dBus_rsp_payload_error = 1'b0;
@@ -5079,7 +5081,7 @@ module VexRiscv (
       IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
       IBusCachedPlugin_decodePc_pcReg <= externalResetVector;
-      _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+      _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= 1'b0;
       IBusCachedPlugin_decompressor_bufferValid <= 1'b0;
       IBusCachedPlugin_decompressor_throw2BytesReg <= 1'b0;
       _zz_IBusCachedPlugin_injector_decodeInput_valid <= 1'b0;
@@ -5087,22 +5089,20 @@ module VexRiscv (
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= 32'h0;
-      dataCache_1_io_mem_cmd_rValid <= 1'b0;
-      dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= 32'h0;
-      _zz_2 <= 1'b1;
+      IBusCachedPlugin_rspCounter <= 32'h00000000;
+      toplevel_dataCache_1_io_mem_cmd_rValidN <= 1'b1;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
+      DBusCachedPlugin_rspCounter <= 32'h00000000;
+      _zz_5 <= 1'b1;
       HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
-      CsrPlugin_misa_base <= 2'b01;
-      CsrPlugin_misa_extensions <= 26'h0000042;
       CsrPlugin_mstatus_MIE <= 1'b0;
       CsrPlugin_mstatus_MPIE <= 1'b0;
       CsrPlugin_mstatus_MPP <= 2'b11;
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
-      CsrPlugin_mcycle <= 64'h0;
-      CsrPlugin_minstret <= 64'h0;
+      CsrPlugin_mcycle <= 64'h0000000000000000;
+      CsrPlugin_minstret <= 64'h0000000000000000;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= 1'b0;
@@ -5114,14 +5114,14 @@ module VexRiscv (
       CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
-      memory_DivPlugin_div_counter_value <= 6'h0;
-      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h0;
+      memory_DivPlugin_div_counter_value <= 6'h00;
+      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h00000000;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
       _zz_iBusWishbone_ADR <= 3'b000;
       _zz_iBus_rsp_valid <= 1'b0;
-      _zz_dBus_cmd_ready <= 3'b000;
+      _zz_dBusWishbone_ADR <= 3'b000;
       _zz_dBus_rsp_valid <= 1'b0;
     end else begin
       if(IBusCachedPlugin_fetchPc_correction) begin
@@ -5131,42 +5131,42 @@ module VexRiscv (
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusCachedPlugin_fetchPc_booted <= 1'b1;
-      if(when_Fetcher_l134) begin
+      if(when_Fetcher_l133) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_output_fire_1) begin
+      if(IBusCachedPlugin_fetchPc_output_fire) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b1;
       end
-      if(when_Fetcher_l134_1) begin
+      if(when_Fetcher_l133_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(when_Fetcher_l161) begin
+      if(when_Fetcher_l160) begin
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
-      if(when_Fetcher_l183) begin
+      if(when_Fetcher_l182) begin
         IBusCachedPlugin_decodePc_pcReg <= IBusCachedPlugin_decodePc_pcPlus;
       end
-      if(when_Fetcher_l195) begin
+      if(when_Fetcher_l194) begin
         IBusCachedPlugin_decodePc_pcReg <= IBusCachedPlugin_jump_pcLoad_payload;
       end
       if(IBusCachedPlugin_iBusRsp_flush) begin
-        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= 1'b0;
       end
       if(_zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready) begin
-        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
       if(IBusCachedPlugin_decompressor_output_fire) begin
         IBusCachedPlugin_decompressor_throw2BytesReg <= ((((! IBusCachedPlugin_decompressor_unaligned) && IBusCachedPlugin_decompressor_isInputLowRvc) && IBusCachedPlugin_decompressor_isInputHighRvc) || (IBusCachedPlugin_decompressor_bufferValid && IBusCachedPlugin_decompressor_isInputHighRvc));
       end
-      if(when_Fetcher_l286) begin
+      if(when_Fetcher_l285) begin
         IBusCachedPlugin_decompressor_bufferValid <= 1'b0;
       end
-      if(when_Fetcher_l289) begin
+      if(when_Fetcher_l288) begin
         if(IBusCachedPlugin_decompressor_bufferFill) begin
           IBusCachedPlugin_decompressor_bufferValid <= 1'b1;
         end
       end
-      if(when_Fetcher_l294) begin
+      if(when_Fetcher_l293) begin
         IBusCachedPlugin_decompressor_throw2BytesReg <= 1'b0;
         IBusCachedPlugin_decompressor_bufferValid <= 1'b0;
       end
@@ -5176,25 +5176,25 @@ module VexRiscv (
       if(IBusCachedPlugin_decompressor_output_ready) begin
         _zz_IBusCachedPlugin_injector_decodeInput_valid <= (IBusCachedPlugin_decompressor_output_valid && (! IBusCachedPlugin_externalFlush));
       end
-      if(when_Fetcher_l332) begin
+      if(when_Fetcher_l331) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
       if(IBusCachedPlugin_decodePc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if(when_Fetcher_l332_1) begin
+      if(when_Fetcher_l331_1) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= IBusCachedPlugin_injector_nextPcCalc_valids_0;
       end
       if(IBusCachedPlugin_decodePc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(when_Fetcher_l332_2) begin
+      if(when_Fetcher_l331_2) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= IBusCachedPlugin_injector_nextPcCalc_valids_1;
       end
       if(IBusCachedPlugin_decodePc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(when_Fetcher_l332_3) begin
+      if(when_Fetcher_l331_3) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
       end
       if(IBusCachedPlugin_decodePc_flushed) begin
@@ -5204,68 +5204,68 @@ module VexRiscv (
         IBusCachedPlugin_rspCounter <= (IBusCachedPlugin_rspCounter + 32'h00000001);
       end
       if(dataCache_1_io_mem_cmd_valid) begin
-        dataCache_1_io_mem_cmd_rValid <= 1'b1;
+        toplevel_dataCache_1_io_mem_cmd_rValidN <= 1'b0;
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
-        dataCache_1_io_mem_cmd_rValid <= 1'b0;
+      if(toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+        toplevel_dataCache_1_io_mem_cmd_rValidN <= 1'b1;
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
-        dataCache_1_io_mem_cmd_s2mPipe_rValid <= dataCache_1_io_mem_cmd_s2mPipe_valid;
+      if(toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+        toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_valid;
       end
       if(dBus_rsp_valid) begin
         DBusCachedPlugin_rspCounter <= (DBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      _zz_2 <= 1'b0;
+      _zz_5 <= 1'b0;
       HazardSimplePlugin_writeBackBuffer_valid <= HazardSimplePlugin_writeBackWrites_valid;
       CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
       if(writeBack_arbitration_isFiring) begin
         CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
       end
-      if(when_CsrPlugin_l922) begin
+      if(when_CsrPlugin_l1259) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if(when_CsrPlugin_l922_1) begin
+      if(when_CsrPlugin_l1259_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if(when_CsrPlugin_l922_2) begin
+      if(when_CsrPlugin_l1259_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if(when_CsrPlugin_l922_3) begin
+      if(when_CsrPlugin_l1259_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(when_CsrPlugin_l959) begin
-        if(when_CsrPlugin_l965) begin
+      if(when_CsrPlugin_l1296) begin
+        if(when_CsrPlugin_l1302) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_1) begin
+        if(when_CsrPlugin_l1302_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_2) begin
+        if(when_CsrPlugin_l1302_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
       CsrPlugin_lastStageWasWfi <= (writeBack_arbitration_isFiring && (writeBack_ENV_CTRL == EnvCtrlEnum_WFI));
       if(CsrPlugin_pipelineLiberator_active) begin
-        if(when_CsrPlugin_l993) begin
+        if(when_CsrPlugin_l1335) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if(when_CsrPlugin_l993_1) begin
+        if(when_CsrPlugin_l1335_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if(when_CsrPlugin_l993_2) begin
+        if(when_CsrPlugin_l1335_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(when_CsrPlugin_l998) begin
+      if(when_CsrPlugin_l1340) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
@@ -5274,19 +5274,21 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(when_CsrPlugin_l1032) begin
-        case(CsrPlugin_targetPrivilege)
-          2'b11 : begin
-            CsrPlugin_mstatus_MIE <= 1'b0;
-            CsrPlugin_mstatus_MPIE <= CsrPlugin_mstatus_MIE;
-            CsrPlugin_mstatus_MPP <= CsrPlugin_privilege;
-          end
-          default : begin
-          end
-        endcase
+      if(when_CsrPlugin_l1390) begin
+        if(when_CsrPlugin_l1398) begin
+          case(CsrPlugin_targetPrivilege)
+            2'b11 : begin
+              CsrPlugin_mstatus_MIE <= 1'b0;
+              CsrPlugin_mstatus_MPIE <= CsrPlugin_mstatus_MIE;
+              CsrPlugin_mstatus_MPP <= CsrPlugin_privilege;
+            end
+            default : begin
+            end
+          endcase
+        end
       end
-      if(when_CsrPlugin_l1077) begin
-        case(switch_CsrPlugin_l1081)
+      if(when_CsrPlugin_l1456) begin
+        case(switch_CsrPlugin_l1460)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -5296,7 +5298,7 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l965_2,{_zz_when_CsrPlugin_l965_1,_zz_when_CsrPlugin_l965}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l1302_2,{_zz_when_CsrPlugin_l1302_1,_zz_when_CsrPlugin_l1302}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
       if(when_Pipeline_l151) begin
         execute_arbitration_isValid <= 1'b0;
@@ -5316,17 +5318,11 @@ module VexRiscv (
       if(when_Pipeline_l154_2) begin
         writeBack_arbitration_isValid <= memory_arbitration_isValid;
       end
-      if(execute_CsrPlugin_csr_769) begin
-        if(execute_CsrPlugin_writeEnable) begin
-          CsrPlugin_misa_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 30];
-          CsrPlugin_misa_extensions <= CsrPlugin_csrMapping_writeDataSignal[25 : 0];
-        end
-      end
       if(execute_CsrPlugin_csr_768) begin
         if(execute_CsrPlugin_writeEnable) begin
           CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
           CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
-          case(switch_CsrPlugin_l723)
+          case(switch_CsrPlugin_l1031)
             2'b11 : begin
               CsrPlugin_mstatus_MPP <= 2'b11;
             end
@@ -5373,13 +5369,13 @@ module VexRiscv (
         end
       end
       _zz_iBus_rsp_valid <= (iBusWishbone_CYC && iBusWishbone_ACK);
-      if((_zz_dBus_cmd_ready_1 && _zz_dBus_cmd_ready_2)) begin
-        _zz_dBus_cmd_ready <= (_zz_dBus_cmd_ready + 3'b001);
-        if(_zz_dBus_cmd_ready_4) begin
-          _zz_dBus_cmd_ready <= 3'b000;
+      if((_zz_dBusWishbone_CYC && _zz_dBus_cmd_ready)) begin
+        _zz_dBusWishbone_ADR <= (_zz_dBusWishbone_ADR + 3'b001);
+        if(_zz_dBus_cmd_ready_2) begin
+          _zz_dBusWishbone_ADR <= 3'b000;
         end
       end
-      _zz_dBus_rsp_valid <= ((_zz_dBus_cmd_ready_1 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
+      _zz_dBus_rsp_valid <= ((_zz_dBusWishbone_CYC && (! dBusWishbone_WE)) && dBusWishbone_ACK);
     end
   end
 
@@ -5390,7 +5386,7 @@ module VexRiscv (
     if(IBusCachedPlugin_decompressor_input_valid) begin
       IBusCachedPlugin_decompressor_throw2BytesLatch <= IBusCachedPlugin_decompressor_throw2Bytes;
     end
-    if(when_Fetcher_l289) begin
+    if(when_Fetcher_l288) begin
       IBusCachedPlugin_decompressor_bufferData <= IBusCachedPlugin_decompressor_input_payload_rsp_inst[31 : 16];
     end
     if(IBusCachedPlugin_decompressor_output_ready) begin
@@ -5405,23 +5401,23 @@ module VexRiscv (
     if(IBusCachedPlugin_iBusRsp_stages_1_input_ready) begin
       IBusCachedPlugin_s1_tightlyCoupledHit <= IBusCachedPlugin_s0_tightlyCoupledHit;
     end
-    if(dataCache_1_io_mem_cmd_ready) begin
-      dataCache_1_io_mem_cmd_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
-      dataCache_1_io_mem_cmd_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
-      dataCache_1_io_mem_cmd_rData_address <= dataCache_1_io_mem_cmd_payload_address;
-      dataCache_1_io_mem_cmd_rData_data <= dataCache_1_io_mem_cmd_payload_data;
-      dataCache_1_io_mem_cmd_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
-      dataCache_1_io_mem_cmd_rData_size <= dataCache_1_io_mem_cmd_payload_size;
-      dataCache_1_io_mem_cmd_rData_last <= dataCache_1_io_mem_cmd_payload_last;
+    if(toplevel_dataCache_1_io_mem_cmd_rValidN) begin
+      toplevel_dataCache_1_io_mem_cmd_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
+      toplevel_dataCache_1_io_mem_cmd_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
+      toplevel_dataCache_1_io_mem_cmd_rData_address <= dataCache_1_io_mem_cmd_payload_address;
+      toplevel_dataCache_1_io_mem_cmd_rData_data <= dataCache_1_io_mem_cmd_payload_data;
+      toplevel_dataCache_1_io_mem_cmd_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
+      toplevel_dataCache_1_io_mem_cmd_rData_size <= dataCache_1_io_mem_cmd_payload_size;
+      toplevel_dataCache_1_io_mem_cmd_rData_last <= dataCache_1_io_mem_cmd_payload_last;
     end
-    if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
-      dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_address <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_data <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_size <= dataCache_1_io_mem_cmd_s2mPipe_payload_size;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_last <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+    if(toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_address <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_data <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_size <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_size;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_last <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_last;
     end
     HazardSimplePlugin_writeBackBuffer_payload_address <= HazardSimplePlugin_writeBackWrites_payload_address;
     HazardSimplePlugin_writeBackBuffer_payload_data <= HazardSimplePlugin_writeBackWrites_payload_data;
@@ -5440,33 +5436,35 @@ module VexRiscv (
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(when_CsrPlugin_l959) begin
-      if(when_CsrPlugin_l965) begin
+    if(when_CsrPlugin_l1296) begin
+      if(when_CsrPlugin_l1302) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l965_1) begin
+      if(when_CsrPlugin_l1302_1) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l965_2) begin
+      if(when_CsrPlugin_l1302_2) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(when_CsrPlugin_l1032) begin
-      case(CsrPlugin_targetPrivilege)
-        2'b11 : begin
-          CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
-          CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
-          CsrPlugin_mepc <= writeBack_PC;
-          if(CsrPlugin_hadException) begin
-            CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
+    if(when_CsrPlugin_l1390) begin
+      if(when_CsrPlugin_l1398) begin
+        case(CsrPlugin_targetPrivilege)
+          2'b11 : begin
+            CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
+            CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
+            CsrPlugin_mepc <= writeBack_PC;
+            if(CsrPlugin_hadException) begin
+              CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
+            end
           end
-        end
-        default : begin
-        end
-      endcase
+          default : begin
+          end
+        endcase
+      end
     end
     if(when_MulDivIterativePlugin_l126) begin
       memory_DivPlugin_div_done <= 1'b1;
@@ -5484,17 +5482,17 @@ module VexRiscv (
       end
     end
     if(when_MulDivIterativePlugin_l162) begin
-      memory_DivPlugin_accumulator <= 65'h0;
+      memory_DivPlugin_accumulator <= 65'h00000000000000000;
       memory_DivPlugin_rs1 <= ((_zz_memory_DivPlugin_rs1 ? (~ _zz_memory_DivPlugin_rs1_1) : _zz_memory_DivPlugin_rs1_1) + _zz_memory_DivPlugin_rs1_2);
       memory_DivPlugin_rs2 <= ((_zz_memory_DivPlugin_rs2 ? (~ execute_RS2) : execute_RS2) + _zz_memory_DivPlugin_rs2_1);
-      memory_DivPlugin_div_needRevert <= ((_zz_memory_DivPlugin_rs1 ^ (_zz_memory_DivPlugin_rs2 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
+      memory_DivPlugin_div_needRevert <= ((_zz_memory_DivPlugin_rs1 ^ (_zz_memory_DivPlugin_rs2 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h00000000) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
     end
     externalInterruptArray_regNext <= externalInterruptArray;
     if(when_Pipeline_l124) begin
       decode_to_execute_PC <= decode_PC;
     end
     if(when_Pipeline_l124_1) begin
-      execute_to_memory_PC <= _zz_execute_SRC2;
+      execute_to_memory_PC <= _zz_execute_to_memory_PC;
     end
     if(when_Pipeline_l124_2) begin
       memory_to_writeBack_PC <= memory_PC;
@@ -5691,76 +5689,76 @@ module VexRiscv (
     if(when_Pipeline_l124_66) begin
       memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
     end
-    if(when_CsrPlugin_l1277) begin
+    if(when_CsrPlugin_l1669) begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
     end
-    if(when_CsrPlugin_l1277_1) begin
+    if(when_CsrPlugin_l1669_1) begin
       execute_CsrPlugin_csr_3857 <= (decode_INSTRUCTION[31 : 20] == 12'hf11);
     end
-    if(when_CsrPlugin_l1277_2) begin
+    if(when_CsrPlugin_l1669_2) begin
       execute_CsrPlugin_csr_3858 <= (decode_INSTRUCTION[31 : 20] == 12'hf12);
     end
-    if(when_CsrPlugin_l1277_3) begin
+    if(when_CsrPlugin_l1669_3) begin
       execute_CsrPlugin_csr_3859 <= (decode_INSTRUCTION[31 : 20] == 12'hf13);
     end
-    if(when_CsrPlugin_l1277_4) begin
+    if(when_CsrPlugin_l1669_4) begin
       execute_CsrPlugin_csr_3860 <= (decode_INSTRUCTION[31 : 20] == 12'hf14);
     end
-    if(when_CsrPlugin_l1277_5) begin
+    if(when_CsrPlugin_l1669_5) begin
       execute_CsrPlugin_csr_769 <= (decode_INSTRUCTION[31 : 20] == 12'h301);
     end
-    if(when_CsrPlugin_l1277_6) begin
+    if(when_CsrPlugin_l1669_6) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if(when_CsrPlugin_l1277_7) begin
+    if(when_CsrPlugin_l1669_7) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if(when_CsrPlugin_l1277_8) begin
+    if(when_CsrPlugin_l1669_8) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if(when_CsrPlugin_l1277_9) begin
+    if(when_CsrPlugin_l1669_9) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if(when_CsrPlugin_l1277_10) begin
+    if(when_CsrPlugin_l1669_10) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if(when_CsrPlugin_l1277_11) begin
+    if(when_CsrPlugin_l1669_11) begin
       execute_CsrPlugin_csr_832 <= (decode_INSTRUCTION[31 : 20] == 12'h340);
     end
-    if(when_CsrPlugin_l1277_12) begin
+    if(when_CsrPlugin_l1669_12) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if(when_CsrPlugin_l1277_13) begin
+    if(when_CsrPlugin_l1669_13) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if(when_CsrPlugin_l1277_14) begin
+    if(when_CsrPlugin_l1669_14) begin
       execute_CsrPlugin_csr_2816 <= (decode_INSTRUCTION[31 : 20] == 12'hb00);
     end
-    if(when_CsrPlugin_l1277_15) begin
+    if(when_CsrPlugin_l1669_15) begin
       execute_CsrPlugin_csr_2944 <= (decode_INSTRUCTION[31 : 20] == 12'hb80);
     end
-    if(when_CsrPlugin_l1277_16) begin
+    if(when_CsrPlugin_l1669_16) begin
       execute_CsrPlugin_csr_2818 <= (decode_INSTRUCTION[31 : 20] == 12'hb02);
     end
-    if(when_CsrPlugin_l1277_17) begin
+    if(when_CsrPlugin_l1669_17) begin
       execute_CsrPlugin_csr_2946 <= (decode_INSTRUCTION[31 : 20] == 12'hb82);
     end
-    if(when_CsrPlugin_l1277_18) begin
+    if(when_CsrPlugin_l1669_18) begin
       execute_CsrPlugin_csr_3072 <= (decode_INSTRUCTION[31 : 20] == 12'hc00);
     end
-    if(when_CsrPlugin_l1277_19) begin
+    if(when_CsrPlugin_l1669_19) begin
       execute_CsrPlugin_csr_3200 <= (decode_INSTRUCTION[31 : 20] == 12'hc80);
     end
-    if(when_CsrPlugin_l1277_20) begin
+    if(when_CsrPlugin_l1669_20) begin
       execute_CsrPlugin_csr_3074 <= (decode_INSTRUCTION[31 : 20] == 12'hc02);
     end
-    if(when_CsrPlugin_l1277_21) begin
+    if(when_CsrPlugin_l1669_21) begin
       execute_CsrPlugin_csr_3202 <= (decode_INSTRUCTION[31 : 20] == 12'hc82);
     end
-    if(when_CsrPlugin_l1277_22) begin
+    if(when_CsrPlugin_l1669_22) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if(when_CsrPlugin_l1277_23) begin
+    if(when_CsrPlugin_l1669_23) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
     if(execute_CsrPlugin_csr_836) begin
@@ -5771,7 +5769,6 @@ module VexRiscv (
     if(execute_CsrPlugin_csr_773) begin
       if(execute_CsrPlugin_writeEnable) begin
         CsrPlugin_mtvec_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 2];
-        CsrPlugin_mtvec_mode <= CsrPlugin_csrMapping_writeDataSignal[1 : 0];
       end
     end
     if(execute_CsrPlugin_csr_833) begin
@@ -5803,88 +5800,85 @@ module VexRiscv (
 endmodule
 
 module DataCache (
-  input               io_cpu_execute_isValid,
-  input      [31:0]   io_cpu_execute_address,
-  output reg          io_cpu_execute_haltIt,
-  input               io_cpu_execute_args_wr,
-  input      [1:0]    io_cpu_execute_args_size,
-  input               io_cpu_execute_args_isLrsc,
-  input               io_cpu_execute_args_isAmo,
-  input               io_cpu_execute_args_amoCtrl_swap,
-  input      [2:0]    io_cpu_execute_args_amoCtrl_alu,
-  input               io_cpu_execute_args_totalyConsistent,
-  output              io_cpu_execute_refilling,
-  input               io_cpu_memory_isValid,
-  input               io_cpu_memory_isStuck,
-  output              io_cpu_memory_isWrite,
-  input      [31:0]   io_cpu_memory_address,
-  input      [31:0]   io_cpu_memory_mmuRsp_physicalAddress,
-  input               io_cpu_memory_mmuRsp_isIoAccess,
-  input               io_cpu_memory_mmuRsp_isPaging,
-  input               io_cpu_memory_mmuRsp_allowRead,
-  input               io_cpu_memory_mmuRsp_allowWrite,
-  input               io_cpu_memory_mmuRsp_allowExecute,
-  input               io_cpu_memory_mmuRsp_exception,
-  input               io_cpu_memory_mmuRsp_refilling,
-  input               io_cpu_memory_mmuRsp_bypassTranslation,
-  input               io_cpu_writeBack_isValid,
-  input               io_cpu_writeBack_isStuck,
-  input               io_cpu_writeBack_isFiring,
-  input               io_cpu_writeBack_isUser,
-  output reg          io_cpu_writeBack_haltIt,
-  output              io_cpu_writeBack_isWrite,
-  input      [31:0]   io_cpu_writeBack_storeData,
-  output reg [31:0]   io_cpu_writeBack_data,
-  input      [31:0]   io_cpu_writeBack_address,
-  output              io_cpu_writeBack_mmuException,
-  output              io_cpu_writeBack_unalignedAccess,
-  output reg          io_cpu_writeBack_accessError,
-  output              io_cpu_writeBack_keepMemRspData,
-  input               io_cpu_writeBack_fence_SW,
-  input               io_cpu_writeBack_fence_SR,
-  input               io_cpu_writeBack_fence_SO,
-  input               io_cpu_writeBack_fence_SI,
-  input               io_cpu_writeBack_fence_PW,
-  input               io_cpu_writeBack_fence_PR,
-  input               io_cpu_writeBack_fence_PO,
-  input               io_cpu_writeBack_fence_PI,
-  input      [3:0]    io_cpu_writeBack_fence_FM,
-  output              io_cpu_writeBack_exclusiveOk,
-  output reg          io_cpu_redo,
-  input               io_cpu_flush_valid,
-  output              io_cpu_flush_ready,
-  input               io_cpu_flush_payload_singleLine,
-  input      [6:0]    io_cpu_flush_payload_lineId,
-  output reg          io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output reg          io_mem_cmd_payload_wr,
-  output              io_mem_cmd_payload_uncached,
-  output reg [31:0]   io_mem_cmd_payload_address,
-  output     [31:0]   io_mem_cmd_payload_data,
-  output     [3:0]    io_mem_cmd_payload_mask,
-  output reg [2:0]    io_mem_cmd_payload_size,
-  output              io_mem_cmd_payload_last,
-  input               io_mem_rsp_valid,
-  input               io_mem_rsp_payload_last,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input               clk,
-  input               reset
+  input  wire          io_cpu_execute_isValid,
+  input  wire [31:0]   io_cpu_execute_address,
+  output reg           io_cpu_execute_haltIt,
+  input  wire          io_cpu_execute_args_wr,
+  input  wire [1:0]    io_cpu_execute_args_size,
+  input  wire          io_cpu_execute_args_isLrsc,
+  input  wire          io_cpu_execute_args_isAmo,
+  input  wire          io_cpu_execute_args_amoCtrl_swap,
+  input  wire [2:0]    io_cpu_execute_args_amoCtrl_alu,
+  input  wire          io_cpu_execute_args_totalyConsistent,
+  output wire          io_cpu_execute_refilling,
+  input  wire          io_cpu_memory_isValid,
+  input  wire          io_cpu_memory_isStuck,
+  output wire          io_cpu_memory_isWrite,
+  input  wire [31:0]   io_cpu_memory_address,
+  input  wire [31:0]   io_cpu_memory_mmuRsp_physicalAddress,
+  input  wire          io_cpu_memory_mmuRsp_isIoAccess,
+  input  wire          io_cpu_memory_mmuRsp_isPaging,
+  input  wire          io_cpu_memory_mmuRsp_allowRead,
+  input  wire          io_cpu_memory_mmuRsp_allowWrite,
+  input  wire          io_cpu_memory_mmuRsp_allowExecute,
+  input  wire          io_cpu_memory_mmuRsp_exception,
+  input  wire          io_cpu_memory_mmuRsp_refilling,
+  input  wire          io_cpu_memory_mmuRsp_bypassTranslation,
+  input  wire          io_cpu_writeBack_isValid,
+  input  wire          io_cpu_writeBack_isStuck,
+  input  wire          io_cpu_writeBack_isFiring,
+  input  wire          io_cpu_writeBack_isUser,
+  output reg           io_cpu_writeBack_haltIt,
+  output wire          io_cpu_writeBack_isWrite,
+  input  wire [31:0]   io_cpu_writeBack_storeData,
+  output reg  [31:0]   io_cpu_writeBack_data,
+  input  wire [31:0]   io_cpu_writeBack_address,
+  output wire          io_cpu_writeBack_mmuException,
+  output wire          io_cpu_writeBack_unalignedAccess,
+  output reg           io_cpu_writeBack_accessError,
+  output wire          io_cpu_writeBack_keepMemRspData,
+  input  wire          io_cpu_writeBack_fence_SW,
+  input  wire          io_cpu_writeBack_fence_SR,
+  input  wire          io_cpu_writeBack_fence_SO,
+  input  wire          io_cpu_writeBack_fence_SI,
+  input  wire          io_cpu_writeBack_fence_PW,
+  input  wire          io_cpu_writeBack_fence_PR,
+  input  wire          io_cpu_writeBack_fence_PO,
+  input  wire          io_cpu_writeBack_fence_PI,
+  input  wire [3:0]    io_cpu_writeBack_fence_FM,
+  output wire          io_cpu_writeBack_exclusiveOk,
+  output reg           io_cpu_redo,
+  input  wire          io_cpu_flush_valid,
+  output wire          io_cpu_flush_ready,
+  input  wire          io_cpu_flush_payload_singleLine,
+  input  wire [6:0]    io_cpu_flush_payload_lineId,
+  output wire          io_cpu_writesPending,
+  output reg           io_mem_cmd_valid,
+  input  wire          io_mem_cmd_ready,
+  output reg           io_mem_cmd_payload_wr,
+  output wire          io_mem_cmd_payload_uncached,
+  output reg  [31:0]   io_mem_cmd_payload_address,
+  output wire [31:0]   io_mem_cmd_payload_data,
+  output wire [3:0]    io_mem_cmd_payload_mask,
+  output reg  [2:0]    io_mem_cmd_payload_size,
+  output wire          io_mem_cmd_payload_last,
+  input  wire          io_mem_rsp_valid,
+  input  wire          io_mem_rsp_payload_last,
+  input  wire [31:0]   io_mem_rsp_payload_data,
+  input  wire          io_mem_rsp_payload_error,
+  input  wire          clk,
+  input  wire          reset
 );
 
   reg        [21:0]   _zz_ways_0_tags_port0;
   reg        [31:0]   _zz_ways_0_data_port0;
   wire       [21:0]   _zz_ways_0_tags_port;
-  wire       [9:0]    _zz_stage0_dataColisions;
-  wire       [9:0]    _zz__zz_stageA_dataColisions;
   wire       [31:0]   _zz_stageB_amo_addSub;
   wire       [31:0]   _zz_stageB_amo_addSub_1;
   wire       [31:0]   _zz_stageB_amo_addSub_2;
   wire       [31:0]   _zz_stageB_amo_addSub_3;
   wire       [31:0]   _zz_stageB_amo_addSub_4;
   wire       [1:0]    _zz_stageB_amo_addSub_5;
-  wire       [1:0]    _zz_stageB_amo_addSub_6;
-  wire       [1:0]    _zz_stageB_amo_addSub_7;
   wire       [0:0]    _zz_when;
   wire       [2:0]    _zz_loader_counter_valueNext;
   wire       [0:0]    _zz_loader_counter_valueNext_1;
@@ -5921,19 +5915,19 @@ module DataCache (
   wire                _zz_ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRsp;
-  wire                when_DataCache_l642;
   wire                when_DataCache_l645;
-  wire                when_DataCache_l664;
+  wire                when_DataCache_l648;
+  wire                when_DataCache_l667;
   wire                rspSync;
   wire                rspLast;
   reg                 memCmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_DataCache_l686;
+  wire                when_DataCache_l689;
   reg        [3:0]    _zz_stage0_mask;
   wire       [3:0]    stage0_mask;
   wire       [0:0]    stage0_dataColisions;
   wire       [0:0]    stage0_wayInvalidate;
-  wire                when_DataCache_l771;
+  wire                when_DataCache_l776;
   reg                 stageA_request_wr;
   reg        [1:0]    stageA_request_size;
   reg                 stageA_request_isLrsc;
@@ -5941,16 +5935,16 @@ module DataCache (
   reg                 stageA_request_amoCtrl_swap;
   reg        [2:0]    stageA_request_amoCtrl_alu;
   reg                 stageA_request_totalyConsistent;
-  wire                when_DataCache_l771_1;
+  wire                when_DataCache_l776_1;
   reg        [3:0]    stageA_mask;
   wire       [0:0]    stageA_wayHits;
-  wire                when_DataCache_l771_2;
+  wire                when_DataCache_l776_2;
   reg        [0:0]    stageA_wayInvalidate;
-  wire                when_DataCache_l771_3;
+  wire                when_DataCache_l776_3;
   reg        [0:0]    stage0_dataColisions_regNextWhen;
   wire       [0:0]    _zz_stageA_dataColisions;
   wire       [0:0]    stageA_dataColisions;
-  wire                when_DataCache_l822;
+  wire                when_DataCache_l827;
   reg                 stageB_request_wr;
   reg        [1:0]    stageB_request_size;
   reg                 stageB_request_isLrsc;
@@ -5959,7 +5953,7 @@ module DataCache (
   reg        [2:0]    stageB_request_amoCtrl_alu;
   reg                 stageB_request_totalyConsistent;
   reg                 stageB_mmuRspFreeze;
-  wire                when_DataCache_l824;
+  wire                when_DataCache_l829;
   reg        [31:0]   stageB_mmuRsp_physicalAddress;
   reg                 stageB_mmuRsp_isIoAccess;
   reg                 stageB_mmuRsp_isPaging;
@@ -5969,36 +5963,38 @@ module DataCache (
   reg                 stageB_mmuRsp_exception;
   reg                 stageB_mmuRsp_refilling;
   reg                 stageB_mmuRsp_bypassTranslation;
-  wire                when_DataCache_l821;
+  wire                when_DataCache_l826;
   reg                 stageB_tagsReadRsp_0_valid;
   reg                 stageB_tagsReadRsp_0_error;
   reg        [19:0]   stageB_tagsReadRsp_0_address;
-  wire                when_DataCache_l821_1;
+  wire                when_DataCache_l826_1;
   reg        [31:0]   stageB_dataReadRsp_0;
-  wire                when_DataCache_l820;
+  wire                when_DataCache_l825;
   reg        [0:0]    stageB_wayInvalidate;
   wire                stageB_consistancyHazard;
-  wire                when_DataCache_l820_1;
+  wire                when_DataCache_l825_1;
   reg        [0:0]    stageB_dataColisions;
-  wire                when_DataCache_l820_2;
+  wire                when_DataCache_l825_2;
   reg                 stageB_unaligned;
-  wire                when_DataCache_l820_3;
+  wire                when_DataCache_l825_3;
   reg        [0:0]    stageB_waysHitsBeforeInvalidate;
   wire       [0:0]    stageB_waysHits;
   wire                stageB_waysHit;
   wire       [31:0]   stageB_dataMux;
-  wire                when_DataCache_l820_4;
+  wire                when_DataCache_l825_4;
   reg        [3:0]    stageB_mask;
   reg                 stageB_loaderValid;
   wire       [31:0]   stageB_ioMemRspMuxed;
   reg                 stageB_flusher_waitDone;
   wire                stageB_flusher_hold;
   reg        [7:0]    stageB_flusher_counter;
-  wire                when_DataCache_l850;
-  wire                when_DataCache_l856;
+  wire                when_DataCache_l855;
+  wire                when_DataCache_l861;
+  wire                when_DataCache_l863;
   reg                 stageB_flusher_start;
+  wire                when_DataCache_l877;
   reg                 stageB_lrSc_reserved;
-  wire                when_DataCache_l880;
+  wire                when_DataCache_l885;
   wire                stageB_isExternalLsrc;
   wire                stageB_isExternalAmo;
   reg        [31:0]   stageB_requestDataBypass;
@@ -6007,26 +6003,26 @@ module DataCache (
   wire       [31:0]   stageB_amo_addSub;
   wire                stageB_amo_less;
   wire                stageB_amo_selectRf;
-  wire       [2:0]    switch_Misc_l210;
+  wire       [2:0]    switch_Misc_l232;
   reg        [31:0]   stageB_amo_result;
   reg        [31:0]   stageB_amo_resultReg;
   reg                 stageB_amo_internal_resultRegValid;
   reg                 stageB_cpuWriteToCache;
-  wire                when_DataCache_l926;
+  wire                when_DataCache_l931;
   wire                stageB_badPermissions;
   wire                stageB_loadStoreFault;
   wire                stageB_bypassCache;
-  wire                when_DataCache_l995;
-  wire                when_DataCache_l999;
+  wire                when_DataCache_l1000;
   wire                when_DataCache_l1004;
   wire                when_DataCache_l1009;
-  wire                when_DataCache_l1012;
-  wire                when_DataCache_l1020;
+  wire                when_DataCache_l1014;
+  wire                when_DataCache_l1017;
   wire                when_DataCache_l1025;
-  wire                when_DataCache_l1032;
-  wire                when_DataCache_l991;
-  wire                when_DataCache_l1066;
-  wire                when_DataCache_l1075;
+  wire                when_DataCache_l1030;
+  wire                when_DataCache_l1037;
+  wire                when_DataCache_l996;
+  wire                when_DataCache_l1072;
+  wire                when_DataCache_l1081;
   reg                 loader_valid;
   reg                 loader_counter_willIncrement;
   wire                loader_counter_willClear;
@@ -6038,12 +6034,12 @@ module DataCache (
   reg                 loader_error;
   wire                loader_kill;
   reg                 loader_killReg;
-  wire                when_DataCache_l1090;
+  wire                when_DataCache_l1097;
   wire                loader_done;
-  wire                when_DataCache_l1118;
-  reg                 loader_valid_regNext;
-  wire                when_DataCache_l1122;
   wire                when_DataCache_l1125;
+  reg                 loader_valid_regNext;
+  wire                when_DataCache_l1129;
+  wire                when_DataCache_l1132;
   (* no_rw_check , ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
   (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
   (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
@@ -6054,16 +6050,12 @@ module DataCache (
   reg [7:0] _zz_ways_0_datasymbol_read_2;
   reg [7:0] _zz_ways_0_datasymbol_read_3;
 
-  assign _zz_stage0_dataColisions = (io_cpu_execute_address[11 : 2] >>> 0);
-  assign _zz__zz_stageA_dataColisions = (io_cpu_memory_address[11 : 2] >>> 0);
   assign _zz_stageB_amo_addSub = ($signed(_zz_stageB_amo_addSub_1) + $signed(_zz_stageB_amo_addSub_4));
   assign _zz_stageB_amo_addSub_1 = ($signed(_zz_stageB_amo_addSub_2) + $signed(_zz_stageB_amo_addSub_3));
   assign _zz_stageB_amo_addSub_2 = io_cpu_writeBack_storeData[31 : 0];
   assign _zz_stageB_amo_addSub_3 = (stageB_amo_compare ? (~ stageB_dataMux[31 : 0]) : stageB_dataMux[31 : 0]);
-  assign _zz_stageB_amo_addSub_5 = (stageB_amo_compare ? _zz_stageB_amo_addSub_6 : _zz_stageB_amo_addSub_7);
+  assign _zz_stageB_amo_addSub_5 = (stageB_amo_compare ? 2'b01 : 2'b00);
   assign _zz_stageB_amo_addSub_4 = {{30{_zz_stageB_amo_addSub_5[1]}}, _zz_stageB_amo_addSub_5};
-  assign _zz_stageB_amo_addSub_6 = 2'b01;
-  assign _zz_stageB_amo_addSub_7 = 2'b00;
   assign _zz_when = 1'b1;
   assign _zz_loader_counter_valueNext_1 = loader_counter_willIncrement;
   assign _zz_loader_counter_valueNext = {2'd0, _zz_loader_counter_valueNext_1};
@@ -6110,14 +6102,14 @@ module DataCache (
 
   always @(*) begin
     _zz_1 = 1'b0;
-    if(when_DataCache_l645) begin
+    if(when_DataCache_l648) begin
       _zz_1 = 1'b1;
     end
   end
 
   always @(*) begin
     _zz_2 = 1'b0;
-    if(when_DataCache_l642) begin
+    if(when_DataCache_l645) begin
       _zz_2 = 1'b1;
     end
   end
@@ -6131,43 +6123,45 @@ module DataCache (
   assign _zz_ways_0_dataReadRspMem = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
   assign ways_0_dataReadRspMem = _zz_ways_0_data_port0;
   assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
-  assign when_DataCache_l642 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
-  assign when_DataCache_l645 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
+  assign when_DataCache_l645 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
+  assign when_DataCache_l648 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
   always @(*) begin
     tagsReadCmd_valid = 1'b0;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       tagsReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     tagsReadCmd_payload = 7'bxxxxxxx;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
     end
   end
 
   always @(*) begin
     dataReadCmd_valid = 1'b0;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       dataReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     dataReadCmd_payload = 10'bxxxxxxxxxx;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       dataReadCmd_payload = io_cpu_execute_address[11 : 2];
     end
   end
 
   always @(*) begin
     tagsWriteCmd_valid = 1'b0;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_valid = 1'b1;
     end
-    if(when_DataCache_l1066) begin
-      tagsWriteCmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        tagsWriteCmd_valid = 1'b0;
+      end
     end
     if(loader_done) begin
       tagsWriteCmd_valid = 1'b1;
@@ -6176,7 +6170,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_way = 1'bx;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_payload_way = 1'b1;
     end
     if(loader_done) begin
@@ -6186,7 +6180,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_address = 7'bxxxxxxx;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_payload_address = stageB_flusher_counter[6:0];
     end
     if(loader_done) begin
@@ -6196,7 +6190,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_data_valid = 1'bx;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_payload_data_valid = 1'b0;
     end
     if(loader_done) begin
@@ -6221,30 +6215,32 @@ module DataCache (
   always @(*) begin
     dataWriteCmd_valid = 1'b0;
     if(stageB_cpuWriteToCache) begin
-      if(when_DataCache_l926) begin
+      if(when_DataCache_l931) begin
         dataWriteCmd_valid = 1'b1;
       end
     end
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(when_DataCache_l1009) begin
             if(stageB_request_isAmo) begin
-              if(when_DataCache_l1012) begin
+              if(when_DataCache_l1017) begin
                 dataWriteCmd_valid = 1'b0;
               end
             end
-            if(when_DataCache_l1025) begin
+            if(when_DataCache_l1030) begin
               dataWriteCmd_valid = 1'b0;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1066) begin
-      dataWriteCmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        dataWriteCmd_valid = 1'b0;
+      end
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_valid = 1'b1;
     end
   end
@@ -6254,7 +6250,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_way = stageB_waysHits;
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_way = loader_waysAllocator;
     end
   end
@@ -6264,7 +6260,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
     end
   end
@@ -6274,7 +6270,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_data = io_mem_rsp_payload_data;
     end
   end
@@ -6287,15 +6283,15 @@ module DataCache (
         dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
       end
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_mask = 4'b1111;
     end
   end
 
-  assign when_DataCache_l664 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  assign when_DataCache_l667 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
   always @(*) begin
     io_cpu_execute_haltIt = 1'b0;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       io_cpu_execute_haltIt = 1'b1;
     end
   end
@@ -6303,7 +6299,7 @@ module DataCache (
   assign rspSync = 1'b1;
   assign rspLast = 1'b1;
   assign io_mem_cmd_fire = (io_mem_cmd_valid && io_mem_cmd_ready);
-  assign when_DataCache_l686 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l689 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     _zz_stage0_mask = 4'bxxxx;
     case(io_cpu_execute_args_size)
@@ -6322,42 +6318,42 @@ module DataCache (
   end
 
   assign stage0_mask = (_zz_stage0_mask <<< io_cpu_execute_address[1 : 0]);
-  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_stage0_dataColisions)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_execute_address[11 : 2])) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stage0_wayInvalidate = 1'b0;
-  assign when_DataCache_l771 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l771_1 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l776 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l776_1 = (! io_cpu_memory_isStuck);
   assign io_cpu_memory_isWrite = stageA_request_wr;
   assign stageA_wayHits = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign when_DataCache_l771_2 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l771_3 = (! io_cpu_memory_isStuck);
-  assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz__zz_stageA_dataColisions)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign when_DataCache_l776_2 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l776_3 = (! io_cpu_memory_isStuck);
+  assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_memory_address[11 : 2])) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_stageA_dataColisions);
-  assign when_DataCache_l822 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l827 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_mmuRspFreeze = 1'b0;
-    if(when_DataCache_l1125) begin
+    if(when_DataCache_l1132) begin
       stageB_mmuRspFreeze = 1'b1;
     end
   end
 
-  assign when_DataCache_l824 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
-  assign when_DataCache_l821 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l821_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l820 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l829 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
+  assign when_DataCache_l826 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l826_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825 = (! io_cpu_writeBack_isStuck);
   assign stageB_consistancyHazard = 1'b0;
-  assign when_DataCache_l820_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l820_2 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l820_3 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_2 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_3 = (! io_cpu_writeBack_isStuck);
   assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
   assign stageB_waysHit = (|stageB_waysHits);
   assign stageB_dataMux = stageB_dataReadRsp_0;
-  assign when_DataCache_l820_4 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_4 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_loaderValid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
             if(io_mem_cmd_ready) begin
               stageB_loaderValid = 1'b1;
             end
@@ -6365,8 +6361,10 @@ module DataCache (
         end
       end
     end
-    if(when_DataCache_l1066) begin
-      stageB_loaderValid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        stageB_loaderValid = 1'b0;
+      end
     end
   end
 
@@ -6375,40 +6373,44 @@ module DataCache (
     io_cpu_writeBack_haltIt = 1'b1;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l991) begin
-          if(when_DataCache_l995) begin
+        if(when_DataCache_l996) begin
+          if(when_DataCache_l1000) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
-          if(when_DataCache_l999) begin
+          if(when_DataCache_l1004) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
         end else begin
-          if(when_DataCache_l1004) begin
-            if(when_DataCache_l1009) begin
+          if(when_DataCache_l1009) begin
+            if(when_DataCache_l1014) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
             if(stageB_request_isAmo) begin
-              if(when_DataCache_l1012) begin
+              if(when_DataCache_l1017) begin
                 io_cpu_writeBack_haltIt = 1'b1;
               end
             end
-            if(when_DataCache_l1025) begin
+            if(when_DataCache_l1030) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1066) begin
-      io_cpu_writeBack_haltIt = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        io_cpu_writeBack_haltIt = 1'b0;
+      end
     end
   end
 
   assign stageB_flusher_hold = 1'b0;
-  assign when_DataCache_l850 = (! stageB_flusher_counter[7]);
-  assign when_DataCache_l856 = (! stageB_flusher_hold);
+  assign when_DataCache_l855 = (! stageB_flusher_counter[7]);
+  assign when_DataCache_l861 = (! stageB_flusher_hold);
+  assign when_DataCache_l863 = (io_cpu_flush_valid && io_cpu_flush_payload_singleLine);
   assign io_cpu_flush_ready = (stageB_flusher_waitDone && stageB_flusher_counter[7]);
-  assign when_DataCache_l880 = (io_cpu_writeBack_isValid && io_cpu_writeBack_isFiring);
+  assign when_DataCache_l877 = (io_cpu_flush_valid && io_cpu_flush_payload_singleLine);
+  assign when_DataCache_l885 = (io_cpu_writeBack_isValid && io_cpu_writeBack_isFiring);
   assign stageB_isExternalLsrc = 1'b0;
   assign stageB_isExternalAmo = 1'b0;
   always @(*) begin
@@ -6423,9 +6425,9 @@ module DataCache (
   assign stageB_amo_addSub = _zz_stageB_amo_addSub;
   assign stageB_amo_less = ((io_cpu_writeBack_storeData[31] == stageB_dataMux[31]) ? stageB_amo_addSub[31] : (stageB_amo_unsigned ? stageB_dataMux[31] : io_cpu_writeBack_storeData[31]));
   assign stageB_amo_selectRf = (stageB_request_amoCtrl_swap ? 1'b1 : (stageB_request_amoCtrl_alu[0] ^ stageB_amo_less));
-  assign switch_Misc_l210 = (stageB_request_amoCtrl_alu | {stageB_request_amoCtrl_swap,2'b00});
+  assign switch_Misc_l232 = (stageB_request_amoCtrl_alu | {stageB_request_amoCtrl_swap,2'b00});
   always @(*) begin
-    case(switch_Misc_l210)
+    case(switch_Misc_l232)
       3'b000 : begin
         stageB_amo_result = stageB_amo_addSub;
       end
@@ -6448,8 +6450,8 @@ module DataCache (
     stageB_cpuWriteToCache = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(when_DataCache_l1009) begin
             stageB_cpuWriteToCache = 1'b1;
           end
         end
@@ -6457,26 +6459,28 @@ module DataCache (
     end
   end
 
-  assign when_DataCache_l926 = (stageB_request_wr && stageB_waysHit);
+  assign when_DataCache_l931 = (stageB_request_wr && stageB_waysHit);
   assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_request_isAmo)));
   assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
   always @(*) begin
     io_cpu_redo = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(when_DataCache_l1004) begin
-            if(when_DataCache_l1020) begin
+        if(!when_DataCache_l996) begin
+          if(when_DataCache_l1009) begin
+            if(when_DataCache_l1025) begin
               io_cpu_redo = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1075) begin
-      io_cpu_redo = 1'b1;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1081) begin
+        io_cpu_redo = 1'b1;
+      end
     end
-    if(when_DataCache_l1122) begin
+    if(when_DataCache_l1129) begin
       io_cpu_redo = 1'b1;
     end
   end
@@ -6497,37 +6501,39 @@ module DataCache (
     io_mem_cmd_valid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l991) begin
+        if(when_DataCache_l996) begin
           io_mem_cmd_valid = (! memCmdSent);
-          if(when_DataCache_l999) begin
+          if(when_DataCache_l1004) begin
             io_mem_cmd_valid = 1'b0;
           end
         end else begin
-          if(when_DataCache_l1004) begin
+          if(when_DataCache_l1009) begin
             if(stageB_request_wr) begin
               io_mem_cmd_valid = 1'b1;
             end
             if(stageB_request_isAmo) begin
-              if(when_DataCache_l1012) begin
+              if(when_DataCache_l1017) begin
                 io_mem_cmd_valid = 1'b0;
               end
-            end
-            if(when_DataCache_l1020) begin
-              io_mem_cmd_valid = 1'b0;
             end
             if(when_DataCache_l1025) begin
               io_mem_cmd_valid = 1'b0;
             end
+            if(when_DataCache_l1030) begin
+              io_mem_cmd_valid = 1'b0;
+            end
           end else begin
-            if(when_DataCache_l1032) begin
+            if(when_DataCache_l1037) begin
               io_mem_cmd_valid = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1066) begin
-      io_mem_cmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        io_mem_cmd_valid = 1'b0;
+      end
     end
   end
 
@@ -6535,9 +6541,9 @@ module DataCache (
     io_mem_cmd_payload_address = stageB_mmuRsp_physicalAddress;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
-            io_mem_cmd_payload_address[4 : 0] = 5'h0;
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
+            io_mem_cmd_payload_address[4 : 0] = 5'h00;
           end
         end
       end
@@ -6549,8 +6555,8 @@ module DataCache (
     io_mem_cmd_payload_wr = stageB_request_wr;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
             io_mem_cmd_payload_wr = 1'b0;
           end
         end
@@ -6565,8 +6571,8 @@ module DataCache (
     io_mem_cmd_payload_size = {1'd0, stageB_request_size};
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
             io_mem_cmd_payload_size = 3'b101;
           end
         end
@@ -6576,15 +6582,15 @@ module DataCache (
 
   assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
   assign io_cpu_writeBack_keepMemRspData = 1'b0;
-  assign when_DataCache_l995 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
-  assign when_DataCache_l999 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
-  assign when_DataCache_l1004 = (stageB_waysHit || (stageB_request_wr && (! stageB_request_isAmo)));
-  assign when_DataCache_l1009 = ((! stageB_request_wr) || io_mem_cmd_ready);
-  assign when_DataCache_l1012 = (! stageB_amo_internal_resultRegValid);
-  assign when_DataCache_l1020 = (((! stageB_request_wr) || stageB_request_isAmo) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
-  assign when_DataCache_l1025 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
-  assign when_DataCache_l1032 = (! memCmdSent);
-  assign when_DataCache_l991 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  assign when_DataCache_l1000 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
+  assign when_DataCache_l1004 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
+  assign when_DataCache_l1009 = (stageB_waysHit || (stageB_request_wr && (! stageB_request_isAmo)));
+  assign when_DataCache_l1014 = ((! stageB_request_wr) || io_mem_cmd_ready);
+  assign when_DataCache_l1017 = (! stageB_amo_internal_resultRegValid);
+  assign when_DataCache_l1025 = (((! stageB_request_wr) || stageB_request_isAmo) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
+  assign when_DataCache_l1030 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
+  assign when_DataCache_l1037 = (! memCmdSent);
+  assign when_DataCache_l996 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
   always @(*) begin
     if(stageB_bypassCache) begin
       io_cpu_writeBack_data = stageB_ioMemRspMuxed;
@@ -6594,11 +6600,11 @@ module DataCache (
   end
 
   assign io_cpu_writeBack_exclusiveOk = stageB_lrSc_reserved;
-  assign when_DataCache_l1066 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign when_DataCache_l1075 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
+  assign when_DataCache_l1072 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign when_DataCache_l1081 = (stageB_mmuRsp_refilling || stageB_consistancyHazard);
   always @(*) begin
     loader_counter_willIncrement = 1'b0;
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       loader_counter_willIncrement = 1'b1;
     end
   end
@@ -6614,12 +6620,12 @@ module DataCache (
   end
 
   assign loader_kill = 1'b0;
-  assign when_DataCache_l1090 = ((loader_valid && io_mem_rsp_valid) && rspLast);
+  assign when_DataCache_l1097 = ((loader_valid && io_mem_rsp_valid) && rspLast);
   assign loader_done = loader_counter_willOverflow;
-  assign when_DataCache_l1118 = (! loader_valid);
-  assign when_DataCache_l1122 = (loader_valid && (! loader_valid_regNext));
+  assign when_DataCache_l1125 = (! loader_valid);
+  assign when_DataCache_l1129 = (loader_valid && (! loader_valid_regNext));
   assign io_cpu_execute_refilling = loader_valid;
-  assign when_DataCache_l1125 = (stageB_loaderValid || loader_valid);
+  assign when_DataCache_l1132 = (stageB_loaderValid || loader_valid);
   always @(posedge clk) begin
     tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
     tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
@@ -6627,7 +6633,7 @@ module DataCache (
     tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
     tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
     tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if(when_DataCache_l771) begin
+    if(when_DataCache_l776) begin
       stageA_request_wr <= io_cpu_execute_args_wr;
       stageA_request_size <= io_cpu_execute_args_size;
       stageA_request_isLrsc <= io_cpu_execute_args_isLrsc;
@@ -6636,16 +6642,16 @@ module DataCache (
       stageA_request_amoCtrl_alu <= io_cpu_execute_args_amoCtrl_alu;
       stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
     end
-    if(when_DataCache_l771_1) begin
+    if(when_DataCache_l776_1) begin
       stageA_mask <= stage0_mask;
     end
-    if(when_DataCache_l771_2) begin
+    if(when_DataCache_l776_2) begin
       stageA_wayInvalidate <= stage0_wayInvalidate;
     end
-    if(when_DataCache_l771_3) begin
+    if(when_DataCache_l776_3) begin
       stage0_dataColisions_regNextWhen <= stage0_dataColisions;
     end
-    if(when_DataCache_l822) begin
+    if(when_DataCache_l827) begin
       stageB_request_wr <= stageA_request_wr;
       stageB_request_size <= stageA_request_size;
       stageB_request_isLrsc <= stageA_request_isLrsc;
@@ -6654,7 +6660,7 @@ module DataCache (
       stageB_request_amoCtrl_alu <= stageA_request_amoCtrl_alu;
       stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
     end
-    if(when_DataCache_l824) begin
+    if(when_DataCache_l829) begin
       stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
       stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
       stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
@@ -6665,27 +6671,27 @@ module DataCache (
       stageB_mmuRsp_refilling <= io_cpu_memory_mmuRsp_refilling;
       stageB_mmuRsp_bypassTranslation <= io_cpu_memory_mmuRsp_bypassTranslation;
     end
-    if(when_DataCache_l821) begin
+    if(when_DataCache_l826) begin
       stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
       stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
       stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
     end
-    if(when_DataCache_l821_1) begin
+    if(when_DataCache_l826_1) begin
       stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
     end
-    if(when_DataCache_l820) begin
+    if(when_DataCache_l825) begin
       stageB_wayInvalidate <= stageA_wayInvalidate;
     end
-    if(when_DataCache_l820_1) begin
+    if(when_DataCache_l825_1) begin
       stageB_dataColisions <= stageA_dataColisions;
     end
-    if(when_DataCache_l820_2) begin
+    if(when_DataCache_l825_2) begin
       stageB_unaligned <= ({((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)),((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0))} != 2'b00);
     end
-    if(when_DataCache_l820_3) begin
+    if(when_DataCache_l825_3) begin
       stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
     end
-    if(when_DataCache_l820_4) begin
+    if(when_DataCache_l825_4) begin
       stageB_mask <= stageA_mask;
     end
     stageB_amo_internal_resultRegValid <= io_cpu_writeBack_isStuck;
@@ -6697,7 +6703,7 @@ module DataCache (
     if(reset) begin
       memCmdSent <= 1'b0;
       stageB_flusher_waitDone <= 1'b0;
-      stageB_flusher_counter <= 8'h0;
+      stageB_flusher_counter <= 8'h00;
       stageB_flusher_start <= 1'b1;
       stageB_lrSc_reserved <= 1'b0;
       loader_valid <= 1'b0;
@@ -6709,16 +6715,16 @@ module DataCache (
       if(io_mem_cmd_fire) begin
         memCmdSent <= 1'b1;
       end
-      if(when_DataCache_l686) begin
+      if(when_DataCache_l689) begin
         memCmdSent <= 1'b0;
       end
       if(io_cpu_flush_ready) begin
         stageB_flusher_waitDone <= 1'b0;
       end
-      if(when_DataCache_l850) begin
-        if(when_DataCache_l856) begin
+      if(when_DataCache_l855) begin
+        if(when_DataCache_l861) begin
           stageB_flusher_counter <= (stageB_flusher_counter + 8'h01);
-          if(io_cpu_flush_payload_singleLine) begin
+          if(when_DataCache_l863) begin
             stageB_flusher_counter[7] <= 1'b1;
           end
         end
@@ -6726,12 +6732,12 @@ module DataCache (
       stageB_flusher_start <= (((((((! stageB_flusher_waitDone) && (! stageB_flusher_start)) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
       if(stageB_flusher_start) begin
         stageB_flusher_waitDone <= 1'b1;
-        stageB_flusher_counter <= 8'h0;
-        if(io_cpu_flush_payload_singleLine) begin
+        stageB_flusher_counter <= 8'h00;
+        if(when_DataCache_l877) begin
           stageB_flusher_counter <= {1'b0,io_cpu_flush_payload_lineId};
         end
       end
-      if(when_DataCache_l880) begin
+      if(when_DataCache_l885) begin
         if(stageB_request_isLrsc) begin
           stageB_lrSc_reserved <= 1'b1;
         end
@@ -6739,15 +6745,17 @@ module DataCache (
           stageB_lrSc_reserved <= 1'b0;
         end
       end
-      if(when_DataCache_l1066) begin
-        stageB_lrSc_reserved <= stageB_lrSc_reserved;
+      if(io_cpu_writeBack_isValid) begin
+        if(when_DataCache_l1072) begin
+          stageB_lrSc_reserved <= stageB_lrSc_reserved;
+        end
       end
       `ifndef SYNTHESIS
         `ifdef FORMAL
-          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))); // DataCache.scala:L1077
+          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))); // DataCache.scala:L1084
         `else
           if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-            $display("ERROR writeBack stuck by another plugin is not allowed"); // DataCache.scala:L1077
+            $display("ERROR writeBack stuck by another plugin is not allowed"); // DataCache.scala:L1084
           end
         `endif
       `endif
@@ -6758,7 +6766,7 @@ module DataCache (
       if(loader_kill) begin
         loader_killReg <= 1'b1;
       end
-      if(when_DataCache_l1090) begin
+      if(when_DataCache_l1097) begin
         loader_error <= (loader_error || io_mem_rsp_payload_error);
       end
       if(loader_done) begin
@@ -6766,7 +6774,7 @@ module DataCache (
         loader_error <= 1'b0;
         loader_killReg <= 1'b0;
       end
-      if(when_DataCache_l1118) begin
+      if(when_DataCache_l1125) begin
         loader_waysAllocator <= _zz_loader_waysAllocator[0:0];
       end
     end
@@ -6776,46 +6784,46 @@ module DataCache (
 endmodule
 
 module InstructionCache (
-  input               io_flush,
-  input               io_cpu_prefetch_isValid,
-  output reg          io_cpu_prefetch_haltIt,
-  input      [31:0]   io_cpu_prefetch_pc,
-  input               io_cpu_fetch_isValid,
-  input               io_cpu_fetch_isStuck,
-  input               io_cpu_fetch_isRemoved,
-  input      [31:0]   io_cpu_fetch_pc,
-  output     [31:0]   io_cpu_fetch_data,
-  input      [31:0]   io_cpu_fetch_mmuRsp_physicalAddress,
-  input               io_cpu_fetch_mmuRsp_isIoAccess,
-  input               io_cpu_fetch_mmuRsp_isPaging,
-  input               io_cpu_fetch_mmuRsp_allowRead,
-  input               io_cpu_fetch_mmuRsp_allowWrite,
-  input               io_cpu_fetch_mmuRsp_allowExecute,
-  input               io_cpu_fetch_mmuRsp_exception,
-  input               io_cpu_fetch_mmuRsp_refilling,
-  input               io_cpu_fetch_mmuRsp_bypassTranslation,
-  output     [31:0]   io_cpu_fetch_physicalAddress,
-  output              io_cpu_fetch_cacheMiss,
-  output              io_cpu_fetch_error,
-  output              io_cpu_fetch_mmuRefilling,
-  output              io_cpu_fetch_mmuException,
-  input               io_cpu_fetch_isUser,
-  input               io_cpu_decode_isValid,
-  input               io_cpu_decode_isStuck,
-  input      [31:0]   io_cpu_decode_pc,
-  output     [31:0]   io_cpu_decode_physicalAddress,
-  output     [31:0]   io_cpu_decode_data,
-  input               io_cpu_fill_valid,
-  input      [31:0]   io_cpu_fill_payload,
-  output              io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output     [31:0]   io_mem_cmd_payload_address,
-  output     [2:0]    io_mem_cmd_payload_size,
-  input               io_mem_rsp_valid,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input               clk,
-  input               reset
+  input  wire          io_flush,
+  input  wire          io_cpu_prefetch_isValid,
+  output reg           io_cpu_prefetch_haltIt,
+  input  wire [31:0]   io_cpu_prefetch_pc,
+  input  wire          io_cpu_fetch_isValid,
+  input  wire          io_cpu_fetch_isStuck,
+  input  wire          io_cpu_fetch_isRemoved,
+  input  wire [31:0]   io_cpu_fetch_pc,
+  output wire [31:0]   io_cpu_fetch_data,
+  input  wire [31:0]   io_cpu_fetch_mmuRsp_physicalAddress,
+  input  wire          io_cpu_fetch_mmuRsp_isIoAccess,
+  input  wire          io_cpu_fetch_mmuRsp_isPaging,
+  input  wire          io_cpu_fetch_mmuRsp_allowRead,
+  input  wire          io_cpu_fetch_mmuRsp_allowWrite,
+  input  wire          io_cpu_fetch_mmuRsp_allowExecute,
+  input  wire          io_cpu_fetch_mmuRsp_exception,
+  input  wire          io_cpu_fetch_mmuRsp_refilling,
+  input  wire          io_cpu_fetch_mmuRsp_bypassTranslation,
+  output wire [31:0]   io_cpu_fetch_physicalAddress,
+  output wire          io_cpu_fetch_cacheMiss,
+  output wire          io_cpu_fetch_error,
+  output wire          io_cpu_fetch_mmuRefilling,
+  output wire          io_cpu_fetch_mmuException,
+  input  wire          io_cpu_fetch_isUser,
+  input  wire          io_cpu_decode_isValid,
+  input  wire          io_cpu_decode_isStuck,
+  input  wire [31:0]   io_cpu_decode_pc,
+  output wire [31:0]   io_cpu_decode_physicalAddress,
+  output wire [31:0]   io_cpu_decode_data,
+  input  wire          io_cpu_fill_valid,
+  input  wire [31:0]   io_cpu_fill_payload,
+  output wire          io_mem_cmd_valid,
+  input  wire          io_mem_cmd_ready,
+  output wire [31:0]   io_mem_cmd_payload_address,
+  output wire [2:0]    io_mem_cmd_payload_size,
+  input  wire          io_mem_rsp_valid,
+  input  wire [31:0]   io_mem_rsp_payload_data,
+  input  wire          io_mem_rsp_payload_error,
+  input  wire          clk,
+  input  wire          reset
 );
 
   reg        [31:0]   _zz_banks_0_port1;
@@ -6835,7 +6843,7 @@ module InstructionCache (
   wire                when_InstructionCache_l351;
   reg                 lineLoader_cmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_Utils_l515;
+  wire                when_Utils_l560;
   reg                 lineLoader_wayToAllocate_willIncrement;
   wire                lineLoader_wayToAllocate_willClear;
   wire                lineLoader_wayToAllocate_willOverflowIfInc;
@@ -6934,12 +6942,12 @@ module InstructionCache (
   assign when_InstructionCache_l351 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
   assign io_mem_cmd_fire = (io_mem_cmd_valid && io_mem_cmd_ready);
   assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
-  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
+  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h00};
   assign io_mem_cmd_payload_size = 3'b101;
-  assign when_Utils_l515 = (! lineLoader_valid);
+  assign when_Utils_l560 = (! lineLoader_valid);
   always @(*) begin
     lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if(when_Utils_l515) begin
+    if(when_Utils_l560) begin
       lineLoader_wayToAllocate_willIncrement = 1'b1;
     end
   end
@@ -7024,7 +7032,7 @@ module InstructionCache (
     end
     _zz_when_InstructionCache_l342 <= lineLoader_flushCounter[7];
     if(when_InstructionCache_l351) begin
-      lineLoader_flushCounter <= 8'h0;
+      lineLoader_flushCounter <= 8'h00;
     end
   end
 

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_IMACDebug.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_IMACDebug.v
@@ -1,46 +1,46 @@
-// Generator : SpinalHDL v1.7.1    git head : 0444bb76ab1d6e19f0ec46bc03c4769776deb7d5
+// Generator : SpinalHDL v1.9.4    git head : 270018552577f3bb8e5339ee2583c9c22d324215
 // Component : VexRiscv
-// Git hash  : 581fcb065adf7ea8b626f939ff51679d4c95872f
+// Git hash  : 63430af99f84cc1d11d58b556debe1cc3f238c67
 
 `timescale 1ns/1ps
 
 module VexRiscv (
-  input      [31:0]   externalResetVector,
-  input               timerInterrupt,
-  input               softwareInterrupt,
-  input      [31:0]   externalInterruptArray,
-  input               debug_bus_cmd_valid,
-  output reg          debug_bus_cmd_ready,
-  input               debug_bus_cmd_payload_wr,
-  input      [7:0]    debug_bus_cmd_payload_address,
-  input      [31:0]   debug_bus_cmd_payload_data,
-  output reg [31:0]   debug_bus_rsp_data,
-  output              debug_resetOut,
-  output reg          iBusWishbone_CYC,
-  output reg          iBusWishbone_STB,
-  input               iBusWishbone_ACK,
-  output              iBusWishbone_WE,
-  output     [29:0]   iBusWishbone_ADR,
-  input      [31:0]   iBusWishbone_DAT_MISO,
-  output     [31:0]   iBusWishbone_DAT_MOSI,
-  output     [3:0]    iBusWishbone_SEL,
-  input               iBusWishbone_ERR,
-  output     [2:0]    iBusWishbone_CTI,
-  output     [1:0]    iBusWishbone_BTE,
-  output              dBusWishbone_CYC,
-  output              dBusWishbone_STB,
-  input               dBusWishbone_ACK,
-  output              dBusWishbone_WE,
-  output     [29:0]   dBusWishbone_ADR,
-  input      [31:0]   dBusWishbone_DAT_MISO,
-  output     [31:0]   dBusWishbone_DAT_MOSI,
-  output     [3:0]    dBusWishbone_SEL,
-  input               dBusWishbone_ERR,
-  output     [2:0]    dBusWishbone_CTI,
-  output     [1:0]    dBusWishbone_BTE,
-  input               clk,
-  input               reset,
-  input               debugReset
+  input  wire [31:0]   externalResetVector,
+  input  wire          timerInterrupt,
+  input  wire          softwareInterrupt,
+  input  wire [31:0]   externalInterruptArray,
+  input  wire          debug_bus_cmd_valid,
+  output reg           debug_bus_cmd_ready,
+  input  wire          debug_bus_cmd_payload_wr,
+  input  wire [7:0]    debug_bus_cmd_payload_address,
+  input  wire [31:0]   debug_bus_cmd_payload_data,
+  output reg  [31:0]   debug_bus_rsp_data,
+  output wire          debug_resetOut,
+  output reg           iBusWishbone_CYC,
+  output reg           iBusWishbone_STB,
+  input  wire          iBusWishbone_ACK,
+  output wire          iBusWishbone_WE,
+  output wire [29:0]   iBusWishbone_ADR,
+  input  wire [31:0]   iBusWishbone_DAT_MISO,
+  output wire [31:0]   iBusWishbone_DAT_MOSI,
+  output wire [3:0]    iBusWishbone_SEL,
+  input  wire          iBusWishbone_ERR,
+  output wire [2:0]    iBusWishbone_CTI,
+  output wire [1:0]    iBusWishbone_BTE,
+  output wire          dBusWishbone_CYC,
+  output wire          dBusWishbone_STB,
+  input  wire          dBusWishbone_ACK,
+  output wire          dBusWishbone_WE,
+  output wire [29:0]   dBusWishbone_ADR,
+  input  wire [31:0]   dBusWishbone_DAT_MISO,
+  output wire [31:0]   dBusWishbone_DAT_MOSI,
+  output wire [3:0]    dBusWishbone_SEL,
+  input  wire          dBusWishbone_ERR,
+  output wire [2:0]    dBusWishbone_CTI,
+  output wire [1:0]    dBusWishbone_BTE,
+  input  wire          clk,
+  input  wire          reset,
+  input  wire          debugReset
 );
   localparam ShiftCtrlEnum_DISABLE_1 = 2'd0;
   localparam ShiftCtrlEnum_SLL_1 = 2'd1;
@@ -103,7 +103,6 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_flush_valid;
   wire                dataCache_1_io_cpu_flush_payload_singleLine;
   wire       [6:0]    dataCache_1_io_cpu_flush_payload_lineId;
-  wire                dataCache_1_io_mem_cmd_ready;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
@@ -131,6 +130,7 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_writeBack_exclusiveOk;
   wire                dataCache_1_io_cpu_flush_ready;
   wire                dataCache_1_io_cpu_redo;
+  wire                dataCache_1_io_cpu_writesPending;
   wire                dataCache_1_io_mem_cmd_valid;
   wire                dataCache_1_io_mem_cmd_payload_wr;
   wire                dataCache_1_io_mem_cmd_payload_uncached;
@@ -142,12 +142,11 @@ module VexRiscv (
   wire       [51:0]   _zz_memory_MUL_LOW;
   wire       [51:0]   _zz_memory_MUL_LOW_1;
   wire       [51:0]   _zz_memory_MUL_LOW_2;
-  wire       [51:0]   _zz_memory_MUL_LOW_3;
-  wire       [32:0]   _zz_memory_MUL_LOW_4;
-  wire       [51:0]   _zz_memory_MUL_LOW_5;
-  wire       [49:0]   _zz_memory_MUL_LOW_6;
-  wire       [51:0]   _zz_memory_MUL_LOW_7;
-  wire       [49:0]   _zz_memory_MUL_LOW_8;
+  wire       [32:0]   _zz_memory_MUL_LOW_3;
+  wire       [51:0]   _zz_memory_MUL_LOW_4;
+  wire       [49:0]   _zz_memory_MUL_LOW_5;
+  wire       [51:0]   _zz_memory_MUL_LOW_6;
+  wire       [49:0]   _zz_memory_MUL_LOW_7;
   wire       [31:0]   _zz_execute_SHIFT_RIGHT;
   wire       [32:0]   _zz_execute_SHIFT_RIGHT_1;
   wire       [32:0]   _zz_execute_SHIFT_RIGHT_2;
@@ -160,24 +159,19 @@ module VexRiscv (
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_2;
   wire                _zz_decode_LEGAL_INSTRUCTION_3;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_4;
-  wire       [16:0]   _zz_decode_LEGAL_INSTRUCTION_5;
+  wire       [15:0]   _zz_decode_LEGAL_INSTRUCTION_5;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_6;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_7;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_8;
   wire                _zz_decode_LEGAL_INSTRUCTION_9;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_10;
-  wire       [10:0]   _zz_decode_LEGAL_INSTRUCTION_11;
+  wire       [9:0]    _zz_decode_LEGAL_INSTRUCTION_11;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_12;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_13;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_14;
   wire                _zz_decode_LEGAL_INSTRUCTION_15;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_16;
-  wire       [4:0]    _zz_decode_LEGAL_INSTRUCTION_17;
-  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_18;
-  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_19;
-  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_20;
-  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_21;
-  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_22;
+  wire       [3:0]    _zz_decode_LEGAL_INSTRUCTION_17;
   wire       [3:0]    _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1;
   reg        [31:0]   _zz_IBusCachedPlugin_jump_pcLoad_payload_5;
   wire       [1:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_6;
@@ -234,153 +228,151 @@ module VexRiscv (
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_19;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_20;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_21;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_22;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_23;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_24;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_22;
+  wire       [23:0]   _zz__zz_decode_IS_RS2_SIGNED_23;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_24;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_25;
-  wire       [23:0]   _zz__zz_decode_IS_RS2_SIGNED_26;
-  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_27;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_26;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_27;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_28;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_29;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_30;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_31;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_32;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_33;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_34;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_29;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_30;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_31;
+  wire       [20:0]   _zz__zz_decode_IS_RS2_SIGNED_32;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_33;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_34;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_35;
   wire                _zz__zz_decode_IS_RS2_SIGNED_36;
-  wire       [20:0]   _zz__zz_decode_IS_RS2_SIGNED_37;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_38;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_39;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_40;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_41;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_42;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_37;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_38;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_39;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_40;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_41;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_42;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_43;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_44;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_45;
-  wire       [17:0]   _zz__zz_decode_IS_RS2_SIGNED_46;
-  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_47;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_48;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_49;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_44;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_45;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_46;
+  wire       [16:0]   _zz__zz_decode_IS_RS2_SIGNED_47;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_48;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_49;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_50;
   wire                _zz__zz_decode_IS_RS2_SIGNED_51;
   wire                _zz__zz_decode_IS_RS2_SIGNED_52;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_53;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_54;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_55;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_53;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_54;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_55;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_56;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_57;
-  wire       [14:0]   _zz__zz_decode_IS_RS2_SIGNED_58;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_59;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_60;
-  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_61;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_57;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_58;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_59;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_60;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_61;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_62;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_63;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_64;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_65;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_66;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_63;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_64;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_65;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_66;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_67;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_68;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_69;
-  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_70;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_71;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_68;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_69;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_70;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_71;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_72;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_73;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_74;
+  wire       [12:0]   _zz__zz_decode_IS_RS2_SIGNED_73;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_74;
   wire                _zz__zz_decode_IS_RS2_SIGNED_75;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_76;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_77;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_78;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_77;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_78;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_79;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_80;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_81;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_80;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_81;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_82;
-  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_83;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_84;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_83;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_84;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_85;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_86;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_87;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_88;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_89;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_90;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_91;
-  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_92;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_93;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_87;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_88;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_89;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_90;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_91;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_92;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_93;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_94;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_95;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_96;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_95;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_96;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_97;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_98;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_99;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_100;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_101;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_102;
-  wire       [10:0]   _zz__zz_decode_IS_RS2_SIGNED_103;
-  wire       [6:0]    _zz__zz_decode_IS_RS2_SIGNED_104;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_105;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_106;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_98;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_99;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_100;
+  wire       [6:0]    _zz__zz_decode_IS_RS2_SIGNED_101;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_102;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_103;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_104;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_105;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_106;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_107;
-  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_108;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_109;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_108;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_109;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_110;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_111;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_112;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_113;
-  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_114;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_115;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_116;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_117;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_118;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_119;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_120;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_121;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_122;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_123;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_124;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_125;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_126;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_127;
-  wire       [7:0]    _zz__zz_decode_IS_RS2_SIGNED_128;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_129;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_130;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_131;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_132;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_133;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_134;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_135;
-  wire       [5:0]    _zz__zz_decode_IS_RS2_SIGNED_136;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_137;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_138;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_139;
-  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_140;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_141;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_142;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_111;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_112;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_113;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_114;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_115;
+  wire       [9:0]    _zz__zz_decode_IS_RS2_SIGNED_116;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_117;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_118;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_119;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_120;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_121;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_122;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_123;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_124;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_125;
+  wire       [7:0]    _zz__zz_decode_IS_RS2_SIGNED_126;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_127;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_128;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_129;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_130;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_131;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_132;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_133;
+  wire       [5:0]    _zz__zz_decode_IS_RS2_SIGNED_134;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_135;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_136;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_137;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_138;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_139;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_140;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_141;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_142;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_143;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_144;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_145;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_146;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_147;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_148;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_149;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_150;
-  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_151;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_152;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_153;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_144;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_145;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_146;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_147;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_148;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_149;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_150;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_151;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_152;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_153;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_154;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_155;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_156;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_157;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_158;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_159;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_160;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_161;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_162;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_163;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_164;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_165;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_157;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_158;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_159;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_160;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_161;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_162;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_163;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_164;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_165;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_166;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_167;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_168;
   wire                _zz_RegFilePlugin_regFile_port;
   wire                _zz_decode_RegFilePlugin_rs1Data;
   wire                _zz_RegFilePlugin_regFile_port_1;
@@ -388,14 +380,12 @@ module VexRiscv (
   wire       [0:0]    _zz__zz_execute_REGFILE_WRITE_DATA;
   wire       [2:0]    _zz__zz_execute_SRC1;
   wire       [4:0]    _zz__zz_execute_SRC1_1;
-  wire       [11:0]   _zz__zz_execute_SRC2_3;
+  wire       [11:0]   _zz__zz_execute_SRC2_2;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_1;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_2;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_3;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_4;
-  wire       [31:0]   _zz_execute_SrcPlugin_addSub_5;
-  wire       [31:0]   _zz_execute_SrcPlugin_addSub_6;
   wire       [19:0]   _zz__zz_execute_BranchPlugin_branch_src2_2;
   wire       [11:0]   _zz__zz_execute_BranchPlugin_branch_src2_4;
   wire                _zz_execute_BranchPlugin_branch_src2_6;
@@ -424,7 +414,7 @@ module VexRiscv (
   wire       [0:0]    _zz_memory_DivPlugin_rs1_3;
   wire       [31:0]   _zz_memory_DivPlugin_rs2_1;
   wire       [0:0]    _zz_memory_DivPlugin_rs2_2;
-  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_25;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_24;
   wire       [26:0]   _zz_iBusWishbone_ADR_1;
   wire       [51:0]   memory_MUL_LOW;
   wire       [33:0]   memory_MUL_HH;
@@ -544,7 +534,7 @@ module VexRiscv (
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_execute_SRC2;
+  wire       [31:0]   _zz_execute_to_memory_PC;
   wire       [1:0]    execute_SRC2_CTRL;
   wire       [1:0]    _zz_execute_SRC2_CTRL;
   wire                execute_IS_RVC;
@@ -719,7 +709,7 @@ module VexRiscv (
   reg                 DBusCachedPlugin_exceptionBus_valid;
   reg        [3:0]    DBusCachedPlugin_exceptionBus_payload_code;
   wire       [31:0]   DBusCachedPlugin_exceptionBus_payload_badAddr;
-  reg                 _zz_when_DBusCachedPlugin_l393;
+  reg                 _zz_when_DBusCachedPlugin_l472;
   wire                decodeExceptionPort_valid;
   wire       [3:0]    decodeExceptionPort_payload_code;
   wire       [31:0]   decodeExceptionPort_payload_badAddr;
@@ -729,8 +719,9 @@ module VexRiscv (
   wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
   wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
   wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
-  wire                CsrPlugin_csrMapping_allowCsrSignal;
+  reg                 CsrPlugin_csrMapping_allowCsrSignal;
   wire                CsrPlugin_csrMapping_hazardFree;
+  wire                CsrPlugin_csrMapping_doForceFailCsr;
   reg                 CsrPlugin_inWfi /* verilator public */ ;
   reg                 CsrPlugin_thirdPartyWake;
   reg                 CsrPlugin_jumpInterface_valid;
@@ -749,9 +740,10 @@ module VexRiscv (
   reg                 CsrPlugin_allowInterrupts;
   reg                 CsrPlugin_allowException;
   reg                 CsrPlugin_allowEbreakException;
-  reg                 IBusCachedPlugin_injectionPort_valid;
-  reg                 IBusCachedPlugin_injectionPort_ready;
-  wire       [31:0]   IBusCachedPlugin_injectionPort_payload;
+  wire                CsrPlugin_xretAwayFromMachine;
+  reg                 DebugPlugin_injectionPort_valid;
+  reg                 DebugPlugin_injectionPort_ready;
+  wire       [31:0]   DebugPlugin_injectionPort_payload;
   wire                IBusCachedPlugin_externalFlush;
   wire                IBusCachedPlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
@@ -771,20 +763,19 @@ module VexRiscv (
   reg                 IBusCachedPlugin_fetchPc_pcRegPropagate;
   reg                 IBusCachedPlugin_fetchPc_booted;
   reg                 IBusCachedPlugin_fetchPc_inc;
-  wire                when_Fetcher_l134;
-  wire                IBusCachedPlugin_fetchPc_output_fire_1;
-  wire                when_Fetcher_l134_1;
+  wire                when_Fetcher_l133;
+  wire                when_Fetcher_l133_1;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pc;
   wire                IBusCachedPlugin_fetchPc_redo_valid;
   reg        [31:0]   IBusCachedPlugin_fetchPc_redo_payload;
   reg                 IBusCachedPlugin_fetchPc_flushed;
-  wire                when_Fetcher_l161;
+  wire                when_Fetcher_l160;
   reg                 IBusCachedPlugin_decodePc_flushed;
   reg        [31:0]   IBusCachedPlugin_decodePc_pcReg /* verilator public */ ;
   wire       [31:0]   IBusCachedPlugin_decodePc_pcPlus;
   reg                 IBusCachedPlugin_decodePc_injectedDecode;
-  wire                when_Fetcher_l183;
-  wire                when_Fetcher_l195;
+  wire                when_Fetcher_l182;
+  wire                when_Fetcher_l194;
   reg                 IBusCachedPlugin_iBusRsp_redoFetch;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_ready;
@@ -804,8 +795,8 @@ module VexRiscv (
   wire                _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready;
   wire                IBusCachedPlugin_iBusRsp_flush;
   wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
-  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
-  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid;
+  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1;
   reg                 IBusCachedPlugin_iBusRsp_readyForError;
   wire                IBusCachedPlugin_iBusRsp_output_valid;
   wire                IBusCachedPlugin_iBusRsp_output_ready;
@@ -864,18 +855,19 @@ module VexRiscv (
   wire       [4:0]    _zz_IBusCachedPlugin_decompressor_decompressed_20;
   wire       [4:0]    _zz_IBusCachedPlugin_decompressor_decompressed_21;
   wire       [4:0]    switch_Misc_l44;
+  wire                when_Misc_l47;
   wire                _zz_IBusCachedPlugin_decompressor_decompressed_22;
-  wire       [1:0]    switch_Misc_l210;
-  wire       [1:0]    switch_Misc_l210_1;
+  wire       [1:0]    switch_Misc_l232;
+  wire       [1:0]    switch_Misc_l232_1;
   reg        [2:0]    _zz_IBusCachedPlugin_decompressor_decompressed_23;
   reg        [2:0]    _zz_IBusCachedPlugin_decompressor_decompressed_24;
   wire                _zz_IBusCachedPlugin_decompressor_decompressed_25;
   reg        [6:0]    _zz_IBusCachedPlugin_decompressor_decompressed_26;
   wire                IBusCachedPlugin_decompressor_output_fire;
   wire                IBusCachedPlugin_decompressor_bufferFill;
-  wire                when_Fetcher_l286;
-  wire                when_Fetcher_l289;
-  wire                when_Fetcher_l294;
+  wire                when_Fetcher_l285;
+  wire                when_Fetcher_l288;
+  wire                when_Fetcher_l293;
   wire                IBusCachedPlugin_injector_decodeInput_valid;
   wire                IBusCachedPlugin_injector_decodeInput_ready;
   wire       [31:0]   IBusCachedPlugin_injector_decodeInput_payload_pc;
@@ -888,13 +880,13 @@ module VexRiscv (
   reg        [31:0]   _zz_IBusCachedPlugin_injector_decodeInput_payload_rsp_inst;
   reg                 _zz_IBusCachedPlugin_injector_decodeInput_payload_isRvc;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
-  wire                when_Fetcher_l332;
+  wire                when_Fetcher_l331;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
-  wire                when_Fetcher_l332_1;
+  wire                when_Fetcher_l331_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
-  wire                when_Fetcher_l332_2;
+  wire                when_Fetcher_l331_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
-  wire                when_Fetcher_l332_3;
+  wire                when_Fetcher_l331_3;
   reg        [31:0]   IBusCachedPlugin_injector_formal_rawInDecode;
   wire                _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   reg        [18:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1;
@@ -915,71 +907,72 @@ module VexRiscv (
   wire                IBusCachedPlugin_rsp_iBusRspOutputHalt;
   wire                IBusCachedPlugin_rsp_issueDetected;
   reg                 IBusCachedPlugin_rsp_redoFetch;
-  wire                when_IBusCachedPlugin_l239;
-  wire                when_IBusCachedPlugin_l244;
+  wire                when_IBusCachedPlugin_l245;
   wire                when_IBusCachedPlugin_l250;
   wire                when_IBusCachedPlugin_l256;
-  wire                when_IBusCachedPlugin_l267;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_valid;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_ready;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_address;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_data;
-  wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_size;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_last;
-  reg                 dataCache_1_io_mem_cmd_rValid;
-  reg                 dataCache_1_io_mem_cmd_rData_wr;
-  reg                 dataCache_1_io_mem_cmd_rData_uncached;
-  reg        [31:0]   dataCache_1_io_mem_cmd_rData_address;
-  reg        [31:0]   dataCache_1_io_mem_cmd_rData_data;
-  reg        [3:0]    dataCache_1_io_mem_cmd_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_rData_size;
-  reg                 dataCache_1_io_mem_cmd_rData_last;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
-  wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data;
-  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
-  wire                when_Stream_l368;
+  wire                when_IBusCachedPlugin_l262;
+  wire                when_IBusCachedPlugin_l273;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_valid;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+  wire       [3:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+  wire       [2:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_size;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rValidN;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rData_wr;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rData_uncached;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_rData_address;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_rData_data;
+  reg        [3:0]    toplevel_dataCache_1_io_mem_cmd_rData_mask;
+  reg        [2:0]    toplevel_dataCache_1_io_mem_cmd_rData_size;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rData_last;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
+  wire       [3:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
+  wire       [2:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_address;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_data;
+  reg        [3:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
+  reg        [2:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_size;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  wire                when_Stream_l369;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
-  wire                when_DBusCachedPlugin_l308;
-  wire                when_DBusCachedPlugin_l316;
+  wire                when_DBusCachedPlugin_l352;
+  wire                when_DBusCachedPlugin_l360;
   wire       [1:0]    execute_DBusCachedPlugin_size;
   reg        [31:0]   _zz_execute_MEMORY_STORE_DATA_RF;
-  wire                dataCache_1_io_cpu_flush_isStall;
-  wire                when_DBusCachedPlugin_l350;
-  wire                when_DBusCachedPlugin_l366;
-  wire                when_DBusCachedPlugin_l393;
-  wire                when_DBusCachedPlugin_l446;
-  wire                when_DBusCachedPlugin_l466;
+  wire                toplevel_dataCache_1_io_cpu_flush_isStall;
+  wire                when_DBusCachedPlugin_l394;
+  wire                when_DBusCachedPlugin_l410;
+  wire                when_DBusCachedPlugin_l472;
+  wire                when_DBusCachedPlugin_l533;
+  wire                when_DBusCachedPlugin_l553;
+  wire       [31:0]   writeBack_DBusCachedPlugin_rspData;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_0;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_1;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_2;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspRf;
-  wire                when_DBusCachedPlugin_l482;
-  wire       [1:0]    switch_Misc_l210_2;
+  wire                when_DBusCachedPlugin_l570;
+  wire       [1:0]    switch_Misc_l232_2;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_1;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated_2;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
-  wire                when_DBusCachedPlugin_l492;
+  wire                when_DBusCachedPlugin_l580;
   wire       [34:0]   _zz_decode_IS_RS2_SIGNED;
   wire                _zz_decode_IS_RS2_SIGNED_1;
   wire                _zz_decode_IS_RS2_SIGNED_2;
@@ -1004,15 +997,15 @@ module VexRiscv (
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
   reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
   reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_2;
+  reg                 _zz_5;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
   reg        [31:0]   _zz_execute_REGFILE_WRITE_DATA;
   reg        [31:0]   _zz_execute_SRC1;
-  wire                _zz_execute_SRC2_1;
-  reg        [19:0]   _zz_execute_SRC2_2;
-  wire                _zz_execute_SRC2_3;
-  reg        [19:0]   _zz_execute_SRC2_4;
-  reg        [31:0]   _zz_execute_SRC2_5;
+  wire                _zz_execute_SRC2;
+  reg        [19:0]   _zz_execute_SRC2_1;
+  wire                _zz_execute_SRC2_2;
+  reg        [19:0]   _zz_execute_SRC2_3;
+  reg        [31:0]   _zz_execute_SRC2_4;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   wire       [4:0]    execute_FullBarrelShifterPlugin_amplitude;
@@ -1049,7 +1042,7 @@ module VexRiscv (
   wire                when_HazardSimplePlugin_l108;
   wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    switch_Misc_l210_3;
+  wire       [2:0]    switch_Misc_l232_3;
   reg                 _zz_execute_BRANCH_COND_RESULT;
   reg                 _zz_execute_BRANCH_COND_RESULT_1;
   wire                execute_BranchPlugin_missAlignedTarget;
@@ -1062,8 +1055,8 @@ module VexRiscv (
   wire                _zz_execute_BranchPlugin_branch_src2_4;
   reg        [18:0]   _zz_execute_BranchPlugin_branch_src2_5;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
-  reg        [1:0]    CsrPlugin_misa_base;
-  reg        [25:0]   CsrPlugin_misa_extensions;
+  wire       [1:0]    CsrPlugin_misa_base;
+  wire       [25:0]   CsrPlugin_misa_extensions;
   reg        [1:0]    CsrPlugin_mtvec_mode;
   reg        [29:0]   CsrPlugin_mtvec_base;
   reg        [31:0]   CsrPlugin_mepc;
@@ -1082,9 +1075,9 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_mtval;
   reg        [63:0]   CsrPlugin_mcycle;
   reg        [63:0]   CsrPlugin_minstret;
-  wire                _zz_when_CsrPlugin_l965;
-  wire                _zz_when_CsrPlugin_l965_1;
-  wire                _zz_when_CsrPlugin_l965_2;
+  wire                _zz_when_CsrPlugin_l1302;
+  wire                _zz_when_CsrPlugin_l1302_1;
+  wire                _zz_when_CsrPlugin_l1302_2;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -1099,59 +1092,62 @@ module VexRiscv (
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
   wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code;
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
-  wire                when_CsrPlugin_l922;
-  wire                when_CsrPlugin_l922_1;
-  wire                when_CsrPlugin_l922_2;
-  wire                when_CsrPlugin_l922_3;
-  wire                when_CsrPlugin_l935;
+  wire                when_CsrPlugin_l1259;
+  wire                when_CsrPlugin_l1259_1;
+  wire                when_CsrPlugin_l1259_2;
+  wire                when_CsrPlugin_l1259_3;
+  wire                when_CsrPlugin_l1272;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
-  wire                when_CsrPlugin_l959;
-  wire                when_CsrPlugin_l965;
-  wire                when_CsrPlugin_l965_1;
-  wire                when_CsrPlugin_l965_2;
+  wire                when_CsrPlugin_l1296;
+  wire                when_CsrPlugin_l1302;
+  wire                when_CsrPlugin_l1302_1;
+  wire                when_CsrPlugin_l1302_2;
   wire                CsrPlugin_exception;
   reg                 CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
-  wire                when_CsrPlugin_l993;
-  wire                when_CsrPlugin_l993_1;
-  wire                when_CsrPlugin_l993_2;
-  wire                when_CsrPlugin_l998;
+  wire                when_CsrPlugin_l1335;
+  wire                when_CsrPlugin_l1335_1;
+  wire                when_CsrPlugin_l1335_2;
+  wire                when_CsrPlugin_l1340;
   reg                 CsrPlugin_pipelineLiberator_done;
-  wire                when_CsrPlugin_l1004;
+  wire                when_CsrPlugin_l1346;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
+  wire                CsrPlugin_trapCauseEbreakDebug;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
-  wire                when_CsrPlugin_l1032;
-  wire                when_CsrPlugin_l1077;
-  wire       [1:0]    switch_CsrPlugin_l1081;
+  wire                CsrPlugin_trapEnterDebug;
+  wire                when_CsrPlugin_l1390;
+  wire                when_CsrPlugin_l1398;
+  wire                when_CsrPlugin_l1456;
+  wire       [1:0]    switch_CsrPlugin_l1460;
   reg                 execute_CsrPlugin_wfiWake;
-  wire                when_CsrPlugin_l1121;
-  wire                when_CsrPlugin_l1123;
-  wire                when_CsrPlugin_l1129;
+  wire                when_CsrPlugin_l1519;
+  wire                when_CsrPlugin_l1521;
+  wire                when_CsrPlugin_l1527;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire                when_CsrPlugin_l1142;
-  wire                when_CsrPlugin_l1149;
-  wire                when_CsrPlugin_l1150;
-  wire                when_CsrPlugin_l1157;
+  wire                when_CsrPlugin_l1540;
+  wire                when_CsrPlugin_l1547;
+  wire                when_CsrPlugin_l1548;
+  wire                when_CsrPlugin_l1555;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   wire       [31:0]   execute_CsrPlugin_readToWriteData;
-  wire                switch_Misc_l210_4;
+  wire                switch_Misc_l232_4;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
-  wire                when_CsrPlugin_l1189;
-  wire                when_CsrPlugin_l1193;
+  wire                when_CsrPlugin_l1587;
+  wire                when_CsrPlugin_l1591;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg                 execute_MulPlugin_aSigned;
   reg                 execute_MulPlugin_bSigned;
@@ -1198,7 +1194,7 @@ module VexRiscv (
   reg        [32:0]   _zz_memory_DivPlugin_rs1_1;
   reg        [31:0]   externalInterruptArray_regNext;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit;
-  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
+  wire       [31:0]   _zz_externalInterrupt;
   reg                 DebugPlugin_firstCycle;
   reg                 DebugPlugin_secondCycle;
   reg                 DebugPlugin_resetIt;
@@ -1206,7 +1202,7 @@ module VexRiscv (
   reg                 DebugPlugin_stepIt;
   reg                 DebugPlugin_isPipBusy;
   reg                 DebugPlugin_godmode;
-  wire                when_DebugPlugin_l225;
+  wire                when_DebugPlugin_l238;
   reg                 DebugPlugin_haltedByBreak;
   reg                 DebugPlugin_debugUsed /* verilator public */ ;
   reg                 DebugPlugin_disableEbreak;
@@ -1216,23 +1212,23 @@ module VexRiscv (
   reg                 DebugPlugin_hardwareBreakpoints_1_valid;
   reg        [30:0]   DebugPlugin_hardwareBreakpoints_1_pc;
   reg        [31:0]   DebugPlugin_busReadDataReg;
-  reg                 _zz_when_DebugPlugin_l244;
-  wire                when_DebugPlugin_l244;
-  wire       [5:0]    switch_DebugPlugin_l267;
-  wire                when_DebugPlugin_l271;
-  wire                when_DebugPlugin_l271_1;
-  wire                when_DebugPlugin_l272;
-  wire                when_DebugPlugin_l272_1;
-  wire                when_DebugPlugin_l273;
-  wire                when_DebugPlugin_l274;
-  wire                when_DebugPlugin_l275;
-  wire                when_DebugPlugin_l275_1;
-  wire                when_DebugPlugin_l295;
-  wire                when_DebugPlugin_l298;
+  reg                 _zz_when_DebugPlugin_l257;
+  wire                when_DebugPlugin_l257;
+  wire       [5:0]    switch_DebugPlugin_l280;
+  wire                when_DebugPlugin_l284;
+  wire                when_DebugPlugin_l284_1;
+  wire                when_DebugPlugin_l285;
+  wire                when_DebugPlugin_l285_1;
+  wire                when_DebugPlugin_l286;
+  wire                when_DebugPlugin_l287;
+  wire                when_DebugPlugin_l288;
+  wire                when_DebugPlugin_l288_1;
+  wire                when_DebugPlugin_l308;
   wire                when_DebugPlugin_l311;
-  reg                 _zz_3;
+  wire                when_DebugPlugin_l324;
+  reg                 _zz_6;
   reg                 DebugPlugin_resetIt_regNext;
-  wire                when_DebugPlugin_l331;
+  wire                when_DebugPlugin_l344;
   wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
   wire                when_Pipeline_l124_1;
@@ -1375,64 +1371,65 @@ module VexRiscv (
   wire                when_Pipeline_l154_1;
   wire                when_Pipeline_l151_2;
   wire                when_Pipeline_l154_2;
-  reg        [2:0]    switch_Fetcher_l365;
-  wire                when_Fetcher_l363;
-  wire                when_Fetcher_l381;
-  wire                when_Fetcher_l401;
-  wire                when_CsrPlugin_l1277;
+  reg        [2:0]    IBusCachedPlugin_injector_port_state;
+  wire                when_Fetcher_l373;
+  wire                when_Fetcher_l391;
+  wire                when_Fetcher_l411;
+  wire                when_CsrPlugin_l1669;
   reg                 execute_CsrPlugin_csr_3264;
-  wire                when_CsrPlugin_l1277_1;
+  wire                when_CsrPlugin_l1669_1;
   reg                 execute_CsrPlugin_csr_3857;
-  wire                when_CsrPlugin_l1277_2;
+  wire                when_CsrPlugin_l1669_2;
   reg                 execute_CsrPlugin_csr_3858;
-  wire                when_CsrPlugin_l1277_3;
+  wire                when_CsrPlugin_l1669_3;
   reg                 execute_CsrPlugin_csr_3859;
-  wire                when_CsrPlugin_l1277_4;
+  wire                when_CsrPlugin_l1669_4;
   reg                 execute_CsrPlugin_csr_3860;
-  wire                when_CsrPlugin_l1277_5;
+  wire                when_CsrPlugin_l1669_5;
   reg                 execute_CsrPlugin_csr_769;
-  wire                when_CsrPlugin_l1277_6;
+  wire                when_CsrPlugin_l1669_6;
   reg                 execute_CsrPlugin_csr_768;
-  wire                when_CsrPlugin_l1277_7;
+  wire                when_CsrPlugin_l1669_7;
   reg                 execute_CsrPlugin_csr_836;
-  wire                when_CsrPlugin_l1277_8;
+  wire                when_CsrPlugin_l1669_8;
   reg                 execute_CsrPlugin_csr_772;
-  wire                when_CsrPlugin_l1277_9;
+  wire                when_CsrPlugin_l1669_9;
   reg                 execute_CsrPlugin_csr_773;
-  wire                when_CsrPlugin_l1277_10;
+  wire                when_CsrPlugin_l1669_10;
   reg                 execute_CsrPlugin_csr_833;
-  wire                when_CsrPlugin_l1277_11;
+  wire                when_CsrPlugin_l1669_11;
   reg                 execute_CsrPlugin_csr_832;
-  wire                when_CsrPlugin_l1277_12;
+  wire                when_CsrPlugin_l1669_12;
   reg                 execute_CsrPlugin_csr_834;
-  wire                when_CsrPlugin_l1277_13;
+  wire                when_CsrPlugin_l1669_13;
   reg                 execute_CsrPlugin_csr_835;
-  wire                when_CsrPlugin_l1277_14;
+  wire                when_CsrPlugin_l1669_14;
   reg                 execute_CsrPlugin_csr_2816;
-  wire                when_CsrPlugin_l1277_15;
+  wire                when_CsrPlugin_l1669_15;
   reg                 execute_CsrPlugin_csr_2944;
-  wire                when_CsrPlugin_l1277_16;
+  wire                when_CsrPlugin_l1669_16;
   reg                 execute_CsrPlugin_csr_2818;
-  wire                when_CsrPlugin_l1277_17;
+  wire                when_CsrPlugin_l1669_17;
   reg                 execute_CsrPlugin_csr_2946;
-  wire                when_CsrPlugin_l1277_18;
+  wire                when_CsrPlugin_l1669_18;
   reg                 execute_CsrPlugin_csr_3072;
-  wire                when_CsrPlugin_l1277_19;
+  wire                when_CsrPlugin_l1669_19;
   reg                 execute_CsrPlugin_csr_3200;
-  wire                when_CsrPlugin_l1277_20;
+  wire                when_CsrPlugin_l1669_20;
   reg                 execute_CsrPlugin_csr_3074;
-  wire                when_CsrPlugin_l1277_21;
+  wire                when_CsrPlugin_l1669_21;
   reg                 execute_CsrPlugin_csr_3202;
-  wire                when_CsrPlugin_l1277_22;
+  wire                when_CsrPlugin_l1669_22;
   reg                 execute_CsrPlugin_csr_3008;
-  wire                when_CsrPlugin_l1277_23;
+  wire                when_CsrPlugin_l1669_23;
   reg                 execute_CsrPlugin_csr_4032;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_5;
+  wire       [1:0]    switch_CsrPlugin_l1031;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_6;
-  wire       [1:0]    switch_CsrPlugin_l723;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_8;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
@@ -1450,19 +1447,22 @@ module VexRiscv (
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_21;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_22;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_23;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_24;
-  wire                when_CsrPlugin_l1310;
-  wire                when_CsrPlugin_l1315;
+  wire                when_CsrPlugin_l1702;
+  wire       [11:0]   _zz_when_CsrPlugin_l1709;
+  wire                when_CsrPlugin_l1709;
+  reg                 when_CsrPlugin_l1719;
+  wire                when_CsrPlugin_l1717;
+  wire                when_CsrPlugin_l1725;
   reg        [2:0]    _zz_iBusWishbone_ADR;
   wire                when_InstructionCache_l239;
   reg                 _zz_iBus_rsp_valid;
   reg        [31:0]   iBusWishbone_DAT_MISO_regNext;
-  reg        [2:0]    _zz_dBus_cmd_ready;
+  reg        [2:0]    _zz_dBusWishbone_ADR;
+  wire                _zz_dBusWishbone_CYC;
+  wire                _zz_dBus_cmd_ready;
   wire                _zz_dBus_cmd_ready_1;
   wire                _zz_dBus_cmd_ready_2;
-  wire                _zz_dBus_cmd_ready_3;
-  wire                _zz_dBus_cmd_ready_4;
-  wire                _zz_dBus_cmd_ready_5;
+  wire                _zz_dBusWishbone_ADR_1;
   reg                 _zz_dBus_rsp_valid;
   reg        [31:0]   dBusWishbone_DAT_MISO_regNext;
   `ifndef SYNTHESIS
@@ -1549,20 +1549,19 @@ module VexRiscv (
   (* no_rw_check , ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
   assign _zz_when = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
-  assign _zz_memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW_1) + $signed(_zz_memory_MUL_LOW_5));
-  assign _zz_memory_MUL_LOW_1 = ($signed(_zz_memory_MUL_LOW_2) + $signed(_zz_memory_MUL_LOW_3));
-  assign _zz_memory_MUL_LOW_2 = 52'h0;
-  assign _zz_memory_MUL_LOW_4 = {1'b0,memory_MUL_LL};
-  assign _zz_memory_MUL_LOW_3 = {{19{_zz_memory_MUL_LOW_4[32]}}, _zz_memory_MUL_LOW_4};
-  assign _zz_memory_MUL_LOW_6 = ({16'd0,memory_MUL_LH} <<< 16);
-  assign _zz_memory_MUL_LOW_5 = {{2{_zz_memory_MUL_LOW_6[49]}}, _zz_memory_MUL_LOW_6};
-  assign _zz_memory_MUL_LOW_8 = ({16'd0,memory_MUL_HL} <<< 16);
-  assign _zz_memory_MUL_LOW_7 = {{2{_zz_memory_MUL_LOW_8[49]}}, _zz_memory_MUL_LOW_8};
+  assign _zz_memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW_1) + $signed(_zz_memory_MUL_LOW_4));
+  assign _zz_memory_MUL_LOW_1 = ($signed(52'h0000000000000) + $signed(_zz_memory_MUL_LOW_2));
+  assign _zz_memory_MUL_LOW_3 = {1'b0,memory_MUL_LL};
+  assign _zz_memory_MUL_LOW_2 = {{19{_zz_memory_MUL_LOW_3[32]}}, _zz_memory_MUL_LOW_3};
+  assign _zz_memory_MUL_LOW_5 = ({16'd0,memory_MUL_LH} <<< 5'd16);
+  assign _zz_memory_MUL_LOW_4 = {{2{_zz_memory_MUL_LOW_5[49]}}, _zz_memory_MUL_LOW_5};
+  assign _zz_memory_MUL_LOW_7 = ({16'd0,memory_MUL_HL} <<< 5'd16);
+  assign _zz_memory_MUL_LOW_6 = {{2{_zz_memory_MUL_LOW_7[49]}}, _zz_memory_MUL_LOW_7};
   assign _zz_execute_SHIFT_RIGHT_1 = ($signed(_zz_execute_SHIFT_RIGHT_2) >>> execute_FullBarrelShifterPlugin_amplitude);
   assign _zz_execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT_1[31 : 0];
   assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == ShiftCtrlEnum_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
-  assign _zz_decode_DO_EBREAK = (decode_PC >>> 1);
-  assign _zz_decode_DO_EBREAK_1 = (decode_PC >>> 1);
+  assign _zz_decode_DO_EBREAK = (decode_PC >>> 1'd1);
+  assign _zz_decode_DO_EBREAK_1 = (decode_PC >>> 1'd1);
   assign _zz_decode_FORMAL_PC_NEXT_1 = (decode_IS_RVC ? 3'b010 : 3'b100);
   assign _zz_decode_FORMAL_PC_NEXT = {29'd0, _zz_decode_FORMAL_PC_NEXT_1};
   assign _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload - 4'b0001);
@@ -1570,7 +1569,7 @@ module VexRiscv (
   assign _zz_IBusCachedPlugin_fetchPc_pc = {29'd0, _zz_IBusCachedPlugin_fetchPc_pc_1};
   assign _zz_IBusCachedPlugin_decodePc_pcPlus_1 = (decode_IS_RVC ? 3'b010 : 3'b100);
   assign _zz_IBusCachedPlugin_decodePc_pcPlus = {29'd0, _zz_IBusCachedPlugin_decodePc_pcPlus_1};
-  assign _zz_IBusCachedPlugin_decompressor_decompressed_27 = {{_zz_IBusCachedPlugin_decompressor_decompressed_10,_zz_IBusCachedPlugin_decompressor_decompressed[6 : 2]},12'h0};
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_27 = {{_zz_IBusCachedPlugin_decompressor_decompressed_10,_zz_IBusCachedPlugin_decompressor_decompressed[6 : 2]},12'h000};
   assign _zz_IBusCachedPlugin_decompressor_decompressed_34 = {{{4'b0000,_zz_IBusCachedPlugin_decompressor_decompressed[8 : 7]},_zz_IBusCachedPlugin_decompressor_decompressed[12 : 9]},2'b00};
   assign _zz_IBusCachedPlugin_decompressor_decompressed_35 = {{{4'b0000,_zz_IBusCachedPlugin_decompressor_decompressed[8 : 7]},_zz_IBusCachedPlugin_decompressor_decompressed[12 : 9]},2'b00};
   assign _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
@@ -1578,28 +1577,26 @@ module VexRiscv (
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
   assign _zz_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId_1;
-  assign _zz_io_cpu_flush_payload_lineId_1 = (execute_RS1 >>> 5);
+  assign _zz_io_cpu_flush_payload_lineId_1 = (execute_RS1 >>> 3'd5);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code_1 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
   assign _zz_writeBack_DBusCachedPlugin_rspRf = (! dataCache_1_io_cpu_writeBack_exclusiveOk);
   assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
   assign _zz__zz_execute_SRC1 = (execute_IS_RVC ? 3'b010 : 3'b100);
   assign _zz__zz_execute_SRC1_1 = execute_INSTRUCTION[19 : 15];
-  assign _zz__zz_execute_SRC2_3 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz__zz_execute_SRC2_2 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
   assign _zz_execute_SrcPlugin_addSub = ($signed(_zz_execute_SrcPlugin_addSub_1) + $signed(_zz_execute_SrcPlugin_addSub_4));
   assign _zz_execute_SrcPlugin_addSub_1 = ($signed(_zz_execute_SrcPlugin_addSub_2) + $signed(_zz_execute_SrcPlugin_addSub_3));
   assign _zz_execute_SrcPlugin_addSub_2 = execute_SRC1;
   assign _zz_execute_SrcPlugin_addSub_3 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? _zz_execute_SrcPlugin_addSub_5 : _zz_execute_SrcPlugin_addSub_6);
-  assign _zz_execute_SrcPlugin_addSub_5 = 32'h00000001;
-  assign _zz_execute_SrcPlugin_addSub_6 = 32'h0;
+  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? 32'h00000001 : 32'h00000000);
   assign _zz__zz_execute_BranchPlugin_branch_src2_2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
   assign _zz__zz_execute_BranchPlugin_branch_src2_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
   assign _zz_execute_BranchPlugin_branch_src2_9 = (execute_IS_RVC ? 3'b010 : 3'b100);
   assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code & (~ _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1));
   assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code - 2'b01);
   assign _zz_writeBack_MulPlugin_result = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
-  assign _zz_writeBack_MulPlugin_result_1 = ({32'd0,writeBack_MUL_HH} <<< 32);
+  assign _zz_writeBack_MulPlugin_result_1 = ({32'd0,writeBack_MUL_HH} <<< 6'd32);
   assign _zz__zz_decode_RS2_2 = writeBack_MUL_LOW[31 : 0];
   assign _zz__zz_decode_RS2_2_1 = writeBack_MulPlugin_result[63 : 32];
   assign _zz_memory_DivPlugin_div_counter_valueNext_1 = memory_DivPlugin_div_counter_willIncrement;
@@ -1617,17 +1614,17 @@ module VexRiscv (
   assign _zz_memory_DivPlugin_rs1_2 = {32'd0, _zz_memory_DivPlugin_rs1_3};
   assign _zz_memory_DivPlugin_rs2_2 = _zz_memory_DivPlugin_rs2;
   assign _zz_memory_DivPlugin_rs2_1 = {31'd0, _zz_memory_DivPlugin_rs2_2};
-  assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 5);
+  assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 3'd5);
   assign _zz_decode_RegFilePlugin_rs1Data = 1'b1;
   assign _zz_decode_RegFilePlugin_rs2Data = 1'b1;
   assign _zz_IBusCachedPlugin_jump_pcLoad_payload_6 = {_zz_IBusCachedPlugin_jump_pcLoad_payload_4,_zz_IBusCachedPlugin_jump_pcLoad_payload_3};
   assign _zz_writeBack_DBusCachedPlugin_rspShifted_1 = dataCache_1_io_cpu_writeBack_address[1 : 0];
   assign _zz_writeBack_DBusCachedPlugin_rspShifted_3 = dataCache_1_io_cpu_writeBack_address[1 : 1];
-  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000107f;
-  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00002073;
-  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000207f;
+  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000407f);
+  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00004063;
+  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000107f) == 32'h00000013);
   assign _zz_decode_LEGAL_INSTRUCTION_5 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_6) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_7 == _zz_decode_LEGAL_INSTRUCTION_8),{_zz_decode_LEGAL_INSTRUCTION_9,{_zz_decode_LEGAL_INSTRUCTION_10,_zz_decode_LEGAL_INSTRUCTION_11}}}}}};
   assign _zz_decode_LEGAL_INSTRUCTION_6 = 32'h0000505f;
   assign _zz_decode_LEGAL_INSTRUCTION_7 = (decode_INSTRUCTION & 32'h0000707b);
@@ -1636,19 +1633,14 @@ module VexRiscv (
   assign _zz_decode_LEGAL_INSTRUCTION_10 = ((decode_INSTRUCTION & 32'h1800707f) == 32'h0000202f);
   assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033),{((decode_INSTRUCTION & 32'he800707f) == 32'h0800202f),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h0000500f),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,{_zz_decode_LEGAL_INSTRUCTION_16,_zz_decode_LEGAL_INSTRUCTION_17}}}}}};
   assign _zz_decode_LEGAL_INSTRUCTION_12 = 32'h01f0707f;
-  assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'hbc00707f);
+  assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'hbe00705f);
   assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h00005013;
-  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hfc00307f) == 32'h00001013);
-  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00005033);
-  assign _zz_decode_LEGAL_INSTRUCTION_17 = {((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033),{((decode_INSTRUCTION & 32'hf9f0707f) == 32'h1000202f),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_18) == 32'h10200073),{(_zz_decode_LEGAL_INSTRUCTION_19 == _zz_decode_LEGAL_INSTRUCTION_20),(_zz_decode_LEGAL_INSTRUCTION_21 == _zz_decode_LEGAL_INSTRUCTION_22)}}}};
-  assign _zz_decode_LEGAL_INSTRUCTION_18 = 32'hdfffffff;
-  assign _zz_decode_LEGAL_INSTRUCTION_19 = (decode_INSTRUCTION & 32'hffefffff);
-  assign _zz_decode_LEGAL_INSTRUCTION_20 = 32'h00000073;
-  assign _zz_decode_LEGAL_INSTRUCTION_21 = (decode_INSTRUCTION & 32'hffffffff);
-  assign _zz_decode_LEGAL_INSTRUCTION_22 = 32'h10500073;
+  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hfe00305f) == 32'h00001013);
+  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
+  assign _zz_decode_LEGAL_INSTRUCTION_17 = {((decode_INSTRUCTION & 32'hf9f0707f) == 32'h1000202f),{((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073),{((decode_INSTRUCTION & 32'hffefffff) == 32'h00000073),((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073)}}};
   assign _zz_IBusCachedPlugin_decompressor_decompressed_28 = (_zz_IBusCachedPlugin_decompressor_decompressed[11 : 10] == 2'b01);
   assign _zz_IBusCachedPlugin_decompressor_decompressed_29 = ((_zz_IBusCachedPlugin_decompressor_decompressed[11 : 10] == 2'b11) && (_zz_IBusCachedPlugin_decompressor_decompressed[6 : 5] == 2'b00));
-  assign _zz_IBusCachedPlugin_decompressor_decompressed_30 = 7'h0;
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_30 = 7'h00;
   assign _zz_IBusCachedPlugin_decompressor_decompressed_31 = _zz_IBusCachedPlugin_decompressor_decompressed[6 : 2];
   assign _zz_IBusCachedPlugin_decompressor_decompressed_32 = _zz_IBusCachedPlugin_decompressor_decompressed[12];
   assign _zz_IBusCachedPlugin_decompressor_decompressed_33 = _zz_IBusCachedPlugin_decompressor_decompressed[11 : 7];
@@ -1661,7 +1653,7 @@ module VexRiscv (
   assign _zz__zz_decode_IS_RS2_SIGNED_1 = ((decode_INSTRUCTION & 32'h02004074) == 32'h02000030);
   assign _zz__zz_decode_IS_RS2_SIGNED_2 = (|{(_zz__zz_decode_IS_RS2_SIGNED_3 == _zz__zz_decode_IS_RS2_SIGNED_4),(_zz__zz_decode_IS_RS2_SIGNED_5 == _zz__zz_decode_IS_RS2_SIGNED_6)});
   assign _zz__zz_decode_IS_RS2_SIGNED_7 = (|(_zz__zz_decode_IS_RS2_SIGNED_8 == _zz__zz_decode_IS_RS2_SIGNED_9));
-  assign _zz__zz_decode_IS_RS2_SIGNED_10 = {(|{_zz__zz_decode_IS_RS2_SIGNED_11,_zz__zz_decode_IS_RS2_SIGNED_13}),{(|_zz__zz_decode_IS_RS2_SIGNED_15),{_zz__zz_decode_IS_RS2_SIGNED_18,{_zz__zz_decode_IS_RS2_SIGNED_21,_zz__zz_decode_IS_RS2_SIGNED_26}}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_10 = {(|{_zz__zz_decode_IS_RS2_SIGNED_11,_zz__zz_decode_IS_RS2_SIGNED_13}),{(|_zz__zz_decode_IS_RS2_SIGNED_15),{_zz__zz_decode_IS_RS2_SIGNED_18,{_zz__zz_decode_IS_RS2_SIGNED_21,_zz__zz_decode_IS_RS2_SIGNED_23}}}};
   assign _zz__zz_decode_IS_RS2_SIGNED_3 = (decode_INSTRUCTION & 32'h10203050);
   assign _zz__zz_decode_IS_RS2_SIGNED_4 = 32'h10000050;
   assign _zz__zz_decode_IS_RS2_SIGNED_5 = (decode_INSTRUCTION & 32'h10103050);
@@ -1672,164 +1664,162 @@ module VexRiscv (
   assign _zz__zz_decode_IS_RS2_SIGNED_13 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_14) == 32'h00002050);
   assign _zz__zz_decode_IS_RS2_SIGNED_15 = {_zz_decode_IS_RS2_SIGNED_2,(_zz__zz_decode_IS_RS2_SIGNED_16 == _zz__zz_decode_IS_RS2_SIGNED_17)};
   assign _zz__zz_decode_IS_RS2_SIGNED_18 = (|(_zz__zz_decode_IS_RS2_SIGNED_19 == _zz__zz_decode_IS_RS2_SIGNED_20));
-  assign _zz__zz_decode_IS_RS2_SIGNED_21 = (|{_zz__zz_decode_IS_RS2_SIGNED_22,_zz__zz_decode_IS_RS2_SIGNED_24});
-  assign _zz__zz_decode_IS_RS2_SIGNED_26 = {(|_zz__zz_decode_IS_RS2_SIGNED_27),{_zz__zz_decode_IS_RS2_SIGNED_32,{_zz__zz_decode_IS_RS2_SIGNED_35,_zz__zz_decode_IS_RS2_SIGNED_37}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_21 = (|_zz__zz_decode_IS_RS2_SIGNED_22);
+  assign _zz__zz_decode_IS_RS2_SIGNED_23 = {(|_zz__zz_decode_IS_RS2_SIGNED_24),{_zz__zz_decode_IS_RS2_SIGNED_27,{_zz__zz_decode_IS_RS2_SIGNED_29,_zz__zz_decode_IS_RS2_SIGNED_32}}};
   assign _zz__zz_decode_IS_RS2_SIGNED_12 = 32'h00001050;
   assign _zz__zz_decode_IS_RS2_SIGNED_14 = 32'h00002050;
   assign _zz__zz_decode_IS_RS2_SIGNED_16 = (decode_INSTRUCTION & 32'h0000001c);
   assign _zz__zz_decode_IS_RS2_SIGNED_17 = 32'h00000004;
   assign _zz__zz_decode_IS_RS2_SIGNED_19 = (decode_INSTRUCTION & 32'h00000058);
   assign _zz__zz_decode_IS_RS2_SIGNED_20 = 32'h00000040;
-  assign _zz__zz_decode_IS_RS2_SIGNED_22 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_23) == 32'h00005010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_24 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_25) == 32'h00005020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_27 = {(_zz__zz_decode_IS_RS2_SIGNED_28 == _zz__zz_decode_IS_RS2_SIGNED_29),{_zz__zz_decode_IS_RS2_SIGNED_30,_zz__zz_decode_IS_RS2_SIGNED_31}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_32 = (|(_zz__zz_decode_IS_RS2_SIGNED_33 == _zz__zz_decode_IS_RS2_SIGNED_34));
-  assign _zz__zz_decode_IS_RS2_SIGNED_35 = (|_zz__zz_decode_IS_RS2_SIGNED_36);
-  assign _zz__zz_decode_IS_RS2_SIGNED_37 = {(|_zz__zz_decode_IS_RS2_SIGNED_38),{_zz__zz_decode_IS_RS2_SIGNED_41,{_zz__zz_decode_IS_RS2_SIGNED_44,_zz__zz_decode_IS_RS2_SIGNED_46}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_23 = 32'h00007034;
-  assign _zz__zz_decode_IS_RS2_SIGNED_25 = 32'h02007064;
-  assign _zz__zz_decode_IS_RS2_SIGNED_28 = (decode_INSTRUCTION & 32'h40003054);
-  assign _zz__zz_decode_IS_RS2_SIGNED_29 = 32'h40001010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_30 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00001010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_31 = ((decode_INSTRUCTION & 32'h02007054) == 32'h00001010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_33 = (decode_INSTRUCTION & 32'h00001000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_34 = 32'h00001000;
-  assign _zz__zz_decode_IS_RS2_SIGNED_36 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_38 = {_zz_decode_IS_RS2_SIGNED_7,(_zz__zz_decode_IS_RS2_SIGNED_39 == _zz__zz_decode_IS_RS2_SIGNED_40)};
-  assign _zz__zz_decode_IS_RS2_SIGNED_41 = (|(_zz__zz_decode_IS_RS2_SIGNED_42 == _zz__zz_decode_IS_RS2_SIGNED_43));
-  assign _zz__zz_decode_IS_RS2_SIGNED_44 = (|_zz__zz_decode_IS_RS2_SIGNED_45);
-  assign _zz__zz_decode_IS_RS2_SIGNED_46 = {(|_zz__zz_decode_IS_RS2_SIGNED_47),{_zz__zz_decode_IS_RS2_SIGNED_53,{_zz__zz_decode_IS_RS2_SIGNED_55,_zz__zz_decode_IS_RS2_SIGNED_58}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_39 = (decode_INSTRUCTION & 32'h00005000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_40 = 32'h00001000;
-  assign _zz__zz_decode_IS_RS2_SIGNED_42 = (decode_INSTRUCTION & 32'h00004048);
-  assign _zz__zz_decode_IS_RS2_SIGNED_43 = 32'h00004008;
-  assign _zz__zz_decode_IS_RS2_SIGNED_45 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
-  assign _zz__zz_decode_IS_RS2_SIGNED_47 = {((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_48) == 32'h00000020),{(_zz__zz_decode_IS_RS2_SIGNED_49 == _zz__zz_decode_IS_RS2_SIGNED_50),{_zz__zz_decode_IS_RS2_SIGNED_51,_zz__zz_decode_IS_RS2_SIGNED_52}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_53 = (|((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_54) == 32'h00000008));
-  assign _zz__zz_decode_IS_RS2_SIGNED_55 = (|(_zz__zz_decode_IS_RS2_SIGNED_56 == _zz__zz_decode_IS_RS2_SIGNED_57));
-  assign _zz__zz_decode_IS_RS2_SIGNED_58 = {(|{_zz__zz_decode_IS_RS2_SIGNED_59,_zz__zz_decode_IS_RS2_SIGNED_61}),{(|_zz__zz_decode_IS_RS2_SIGNED_70),{_zz__zz_decode_IS_RS2_SIGNED_77,{_zz__zz_decode_IS_RS2_SIGNED_90,_zz__zz_decode_IS_RS2_SIGNED_103}}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_48 = 32'h00000034;
-  assign _zz__zz_decode_IS_RS2_SIGNED_49 = (decode_INSTRUCTION & 32'h00000064);
-  assign _zz__zz_decode_IS_RS2_SIGNED_50 = 32'h00000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_51 = ((decode_INSTRUCTION & 32'h08000070) == 32'h08000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_52 = ((decode_INSTRUCTION & 32'h10000070) == 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_54 = 32'h10000008;
-  assign _zz__zz_decode_IS_RS2_SIGNED_56 = (decode_INSTRUCTION & 32'h10000008);
-  assign _zz__zz_decode_IS_RS2_SIGNED_57 = 32'h10000008;
-  assign _zz__zz_decode_IS_RS2_SIGNED_59 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_60) == 32'h00002040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_61 = {(_zz__zz_decode_IS_RS2_SIGNED_62 == _zz__zz_decode_IS_RS2_SIGNED_63),{_zz__zz_decode_IS_RS2_SIGNED_64,{_zz__zz_decode_IS_RS2_SIGNED_66,_zz__zz_decode_IS_RS2_SIGNED_69}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_70 = {(_zz__zz_decode_IS_RS2_SIGNED_71 == _zz__zz_decode_IS_RS2_SIGNED_72),{_zz__zz_decode_IS_RS2_SIGNED_73,_zz__zz_decode_IS_RS2_SIGNED_75}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_77 = (|{_zz__zz_decode_IS_RS2_SIGNED_78,{_zz__zz_decode_IS_RS2_SIGNED_80,_zz__zz_decode_IS_RS2_SIGNED_83}});
-  assign _zz__zz_decode_IS_RS2_SIGNED_90 = (|{_zz__zz_decode_IS_RS2_SIGNED_91,_zz__zz_decode_IS_RS2_SIGNED_92});
-  assign _zz__zz_decode_IS_RS2_SIGNED_103 = {(|_zz__zz_decode_IS_RS2_SIGNED_104),{_zz__zz_decode_IS_RS2_SIGNED_119,{_zz__zz_decode_IS_RS2_SIGNED_124,_zz__zz_decode_IS_RS2_SIGNED_128}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_60 = 32'h00002040;
-  assign _zz__zz_decode_IS_RS2_SIGNED_62 = (decode_INSTRUCTION & 32'h00001040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_63 = 32'h00001040;
-  assign _zz__zz_decode_IS_RS2_SIGNED_64 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_65) == 32'h00000040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_66 = (_zz__zz_decode_IS_RS2_SIGNED_67 == _zz__zz_decode_IS_RS2_SIGNED_68);
-  assign _zz__zz_decode_IS_RS2_SIGNED_69 = {_zz_decode_IS_RS2_SIGNED_7,_zz_decode_IS_RS2_SIGNED_4};
-  assign _zz__zz_decode_IS_RS2_SIGNED_71 = (decode_INSTRUCTION & 32'h08000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_72 = 32'h08000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_73 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_74) == 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_75 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_76) == 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_78 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_79) == 32'h00000040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_80 = (_zz__zz_decode_IS_RS2_SIGNED_81 == _zz__zz_decode_IS_RS2_SIGNED_82);
-  assign _zz__zz_decode_IS_RS2_SIGNED_83 = {_zz__zz_decode_IS_RS2_SIGNED_84,{_zz__zz_decode_IS_RS2_SIGNED_86,_zz__zz_decode_IS_RS2_SIGNED_87}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_91 = _zz_decode_IS_RS2_SIGNED_6;
-  assign _zz__zz_decode_IS_RS2_SIGNED_92 = {_zz__zz_decode_IS_RS2_SIGNED_93,{_zz__zz_decode_IS_RS2_SIGNED_95,_zz__zz_decode_IS_RS2_SIGNED_98}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_104 = {_zz_decode_IS_RS2_SIGNED_2,{_zz__zz_decode_IS_RS2_SIGNED_105,_zz__zz_decode_IS_RS2_SIGNED_108}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_119 = (|{_zz__zz_decode_IS_RS2_SIGNED_120,_zz__zz_decode_IS_RS2_SIGNED_121});
-  assign _zz__zz_decode_IS_RS2_SIGNED_124 = (|_zz__zz_decode_IS_RS2_SIGNED_125);
-  assign _zz__zz_decode_IS_RS2_SIGNED_128 = {_zz__zz_decode_IS_RS2_SIGNED_129,{_zz__zz_decode_IS_RS2_SIGNED_132,_zz__zz_decode_IS_RS2_SIGNED_136}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_65 = 32'h00100040;
-  assign _zz__zz_decode_IS_RS2_SIGNED_67 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz__zz_decode_IS_RS2_SIGNED_68 = 32'h00000040;
-  assign _zz__zz_decode_IS_RS2_SIGNED_74 = 32'h10000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_76 = 32'h00000028;
-  assign _zz__zz_decode_IS_RS2_SIGNED_79 = 32'h00000040;
-  assign _zz__zz_decode_IS_RS2_SIGNED_81 = (decode_INSTRUCTION & 32'h00004020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_82 = 32'h00004020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_84 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_85) == 32'h00000010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_22 = ((decode_INSTRUCTION & 32'h02007054) == 32'h00005010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_24 = {((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_25) == 32'h40001010),((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_26) == 32'h00001010)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_27 = (|((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_28) == 32'h00001000));
+  assign _zz__zz_decode_IS_RS2_SIGNED_29 = (|(_zz__zz_decode_IS_RS2_SIGNED_30 == _zz__zz_decode_IS_RS2_SIGNED_31));
+  assign _zz__zz_decode_IS_RS2_SIGNED_32 = {(|{_zz__zz_decode_IS_RS2_SIGNED_33,_zz__zz_decode_IS_RS2_SIGNED_34}),{(|_zz__zz_decode_IS_RS2_SIGNED_35),{_zz__zz_decode_IS_RS2_SIGNED_36,{_zz__zz_decode_IS_RS2_SIGNED_38,_zz__zz_decode_IS_RS2_SIGNED_47}}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_25 = 32'h40003054;
+  assign _zz__zz_decode_IS_RS2_SIGNED_26 = 32'h02007054;
+  assign _zz__zz_decode_IS_RS2_SIGNED_28 = 32'h00001000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_30 = (decode_INSTRUCTION & 32'h00003000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_31 = 32'h00002000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_33 = _zz_decode_IS_RS2_SIGNED_7;
+  assign _zz__zz_decode_IS_RS2_SIGNED_34 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00001000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_35 = ((decode_INSTRUCTION & 32'h00004048) == 32'h00004008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_36 = (|((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_37) == 32'h00000024));
+  assign _zz__zz_decode_IS_RS2_SIGNED_38 = (|{_zz__zz_decode_IS_RS2_SIGNED_39,{_zz__zz_decode_IS_RS2_SIGNED_40,_zz__zz_decode_IS_RS2_SIGNED_42}});
+  assign _zz__zz_decode_IS_RS2_SIGNED_47 = {(|_zz__zz_decode_IS_RS2_SIGNED_48),{(|_zz__zz_decode_IS_RS2_SIGNED_49),{_zz__zz_decode_IS_RS2_SIGNED_51,{_zz__zz_decode_IS_RS2_SIGNED_64,_zz__zz_decode_IS_RS2_SIGNED_73}}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_37 = 32'h00000064;
+  assign _zz__zz_decode_IS_RS2_SIGNED_39 = ((decode_INSTRUCTION & 32'h00000034) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_40 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_41) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_42 = {(_zz__zz_decode_IS_RS2_SIGNED_43 == _zz__zz_decode_IS_RS2_SIGNED_44),(_zz__zz_decode_IS_RS2_SIGNED_45 == _zz__zz_decode_IS_RS2_SIGNED_46)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_48 = ((decode_INSTRUCTION & 32'h10000008) == 32'h00000008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_49 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_50) == 32'h10000008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_51 = (|{_zz__zz_decode_IS_RS2_SIGNED_52,{_zz__zz_decode_IS_RS2_SIGNED_54,_zz__zz_decode_IS_RS2_SIGNED_57}});
+  assign _zz__zz_decode_IS_RS2_SIGNED_64 = (|{_zz__zz_decode_IS_RS2_SIGNED_65,_zz__zz_decode_IS_RS2_SIGNED_68});
+  assign _zz__zz_decode_IS_RS2_SIGNED_73 = {(|_zz__zz_decode_IS_RS2_SIGNED_74),{_zz__zz_decode_IS_RS2_SIGNED_87,{_zz__zz_decode_IS_RS2_SIGNED_100,_zz__zz_decode_IS_RS2_SIGNED_116}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_41 = 32'h00000064;
+  assign _zz__zz_decode_IS_RS2_SIGNED_43 = (decode_INSTRUCTION & 32'h08000070);
+  assign _zz__zz_decode_IS_RS2_SIGNED_44 = 32'h08000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_45 = (decode_INSTRUCTION & 32'h10000070);
+  assign _zz__zz_decode_IS_RS2_SIGNED_46 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_50 = 32'h10000008;
+  assign _zz__zz_decode_IS_RS2_SIGNED_52 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_53) == 32'h00002040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_54 = (_zz__zz_decode_IS_RS2_SIGNED_55 == _zz__zz_decode_IS_RS2_SIGNED_56);
+  assign _zz__zz_decode_IS_RS2_SIGNED_57 = {_zz__zz_decode_IS_RS2_SIGNED_58,{_zz__zz_decode_IS_RS2_SIGNED_60,_zz__zz_decode_IS_RS2_SIGNED_63}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_65 = (_zz__zz_decode_IS_RS2_SIGNED_66 == _zz__zz_decode_IS_RS2_SIGNED_67);
+  assign _zz__zz_decode_IS_RS2_SIGNED_68 = {_zz__zz_decode_IS_RS2_SIGNED_69,_zz__zz_decode_IS_RS2_SIGNED_71};
+  assign _zz__zz_decode_IS_RS2_SIGNED_74 = {_zz__zz_decode_IS_RS2_SIGNED_75,{_zz__zz_decode_IS_RS2_SIGNED_77,_zz__zz_decode_IS_RS2_SIGNED_80}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_87 = (|{_zz__zz_decode_IS_RS2_SIGNED_88,_zz__zz_decode_IS_RS2_SIGNED_89});
+  assign _zz__zz_decode_IS_RS2_SIGNED_100 = (|_zz__zz_decode_IS_RS2_SIGNED_101);
+  assign _zz__zz_decode_IS_RS2_SIGNED_116 = {_zz__zz_decode_IS_RS2_SIGNED_117,{_zz__zz_decode_IS_RS2_SIGNED_122,_zz__zz_decode_IS_RS2_SIGNED_126}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_53 = 32'h00002040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_55 = (decode_INSTRUCTION & 32'h00001040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_56 = 32'h00001040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_58 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_59) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_60 = (_zz__zz_decode_IS_RS2_SIGNED_61 == _zz__zz_decode_IS_RS2_SIGNED_62);
+  assign _zz__zz_decode_IS_RS2_SIGNED_63 = {_zz_decode_IS_RS2_SIGNED_7,_zz_decode_IS_RS2_SIGNED_4};
+  assign _zz__zz_decode_IS_RS2_SIGNED_66 = (decode_INSTRUCTION & 32'h08000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_67 = 32'h08000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_69 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_70) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_71 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_72) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_75 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_76) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_77 = (_zz__zz_decode_IS_RS2_SIGNED_78 == _zz__zz_decode_IS_RS2_SIGNED_79);
+  assign _zz__zz_decode_IS_RS2_SIGNED_80 = {_zz__zz_decode_IS_RS2_SIGNED_81,{_zz__zz_decode_IS_RS2_SIGNED_83,_zz__zz_decode_IS_RS2_SIGNED_86}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_88 = _zz_decode_IS_RS2_SIGNED_6;
+  assign _zz__zz_decode_IS_RS2_SIGNED_89 = {_zz__zz_decode_IS_RS2_SIGNED_90,{_zz__zz_decode_IS_RS2_SIGNED_92,_zz__zz_decode_IS_RS2_SIGNED_95}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_101 = {_zz_decode_IS_RS2_SIGNED_2,{_zz__zz_decode_IS_RS2_SIGNED_102,_zz__zz_decode_IS_RS2_SIGNED_105}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_117 = (|{_zz__zz_decode_IS_RS2_SIGNED_118,_zz__zz_decode_IS_RS2_SIGNED_119});
+  assign _zz__zz_decode_IS_RS2_SIGNED_122 = (|_zz__zz_decode_IS_RS2_SIGNED_123);
+  assign _zz__zz_decode_IS_RS2_SIGNED_126 = {_zz__zz_decode_IS_RS2_SIGNED_127,{_zz__zz_decode_IS_RS2_SIGNED_130,_zz__zz_decode_IS_RS2_SIGNED_134}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_59 = 32'h00100040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_61 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_62 = 32'h00000040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_70 = 32'h10000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_72 = 32'h00000028;
+  assign _zz__zz_decode_IS_RS2_SIGNED_76 = 32'h00000040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_78 = (decode_INSTRUCTION & 32'h00004020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_79 = 32'h00004020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_81 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_82) == 32'h00000010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_83 = (_zz__zz_decode_IS_RS2_SIGNED_84 == _zz__zz_decode_IS_RS2_SIGNED_85);
   assign _zz__zz_decode_IS_RS2_SIGNED_86 = _zz_decode_IS_RS2_SIGNED_6;
-  assign _zz__zz_decode_IS_RS2_SIGNED_87 = (_zz__zz_decode_IS_RS2_SIGNED_88 == _zz__zz_decode_IS_RS2_SIGNED_89);
-  assign _zz__zz_decode_IS_RS2_SIGNED_93 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_94) == 32'h00002010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_95 = (_zz__zz_decode_IS_RS2_SIGNED_96 == _zz__zz_decode_IS_RS2_SIGNED_97);
-  assign _zz__zz_decode_IS_RS2_SIGNED_98 = {_zz__zz_decode_IS_RS2_SIGNED_99,_zz__zz_decode_IS_RS2_SIGNED_101};
-  assign _zz__zz_decode_IS_RS2_SIGNED_105 = (_zz__zz_decode_IS_RS2_SIGNED_106 == _zz__zz_decode_IS_RS2_SIGNED_107);
-  assign _zz__zz_decode_IS_RS2_SIGNED_108 = {_zz__zz_decode_IS_RS2_SIGNED_109,{_zz__zz_decode_IS_RS2_SIGNED_111,_zz__zz_decode_IS_RS2_SIGNED_114}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_120 = _zz_decode_IS_RS2_SIGNED_5;
-  assign _zz__zz_decode_IS_RS2_SIGNED_121 = (_zz__zz_decode_IS_RS2_SIGNED_122 == _zz__zz_decode_IS_RS2_SIGNED_123);
-  assign _zz__zz_decode_IS_RS2_SIGNED_125 = {_zz_decode_IS_RS2_SIGNED_5,_zz__zz_decode_IS_RS2_SIGNED_126};
-  assign _zz__zz_decode_IS_RS2_SIGNED_129 = (|_zz__zz_decode_IS_RS2_SIGNED_130);
-  assign _zz__zz_decode_IS_RS2_SIGNED_132 = (|_zz__zz_decode_IS_RS2_SIGNED_133);
-  assign _zz__zz_decode_IS_RS2_SIGNED_136 = {_zz__zz_decode_IS_RS2_SIGNED_137,{_zz__zz_decode_IS_RS2_SIGNED_147,_zz__zz_decode_IS_RS2_SIGNED_151}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_85 = 32'h00000030;
-  assign _zz__zz_decode_IS_RS2_SIGNED_88 = (decode_INSTRUCTION & 32'h02000028);
-  assign _zz__zz_decode_IS_RS2_SIGNED_89 = 32'h00000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_94 = 32'h00002030;
-  assign _zz__zz_decode_IS_RS2_SIGNED_96 = (decode_INSTRUCTION & 32'h00001030);
-  assign _zz__zz_decode_IS_RS2_SIGNED_97 = 32'h00000010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_99 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_100) == 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_101 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_102) == 32'h00002020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_106 = (decode_INSTRUCTION & 32'h00001010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_107 = 32'h00001010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_109 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_110) == 32'h00002010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_111 = (_zz__zz_decode_IS_RS2_SIGNED_112 == _zz__zz_decode_IS_RS2_SIGNED_113);
-  assign _zz__zz_decode_IS_RS2_SIGNED_114 = {_zz__zz_decode_IS_RS2_SIGNED_115,{_zz__zz_decode_IS_RS2_SIGNED_116,_zz__zz_decode_IS_RS2_SIGNED_117}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_122 = (decode_INSTRUCTION & 32'h00000070);
-  assign _zz__zz_decode_IS_RS2_SIGNED_123 = 32'h00000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_126 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_127) == 32'h0);
-  assign _zz__zz_decode_IS_RS2_SIGNED_130 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_131) == 32'h00004010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_133 = (_zz__zz_decode_IS_RS2_SIGNED_134 == _zz__zz_decode_IS_RS2_SIGNED_135);
-  assign _zz__zz_decode_IS_RS2_SIGNED_137 = (|{_zz__zz_decode_IS_RS2_SIGNED_138,_zz__zz_decode_IS_RS2_SIGNED_140});
-  assign _zz__zz_decode_IS_RS2_SIGNED_147 = (|_zz__zz_decode_IS_RS2_SIGNED_148);
-  assign _zz__zz_decode_IS_RS2_SIGNED_151 = {_zz__zz_decode_IS_RS2_SIGNED_152,{_zz__zz_decode_IS_RS2_SIGNED_158,_zz__zz_decode_IS_RS2_SIGNED_163}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_100 = 32'h02003020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_102 = 32'h02002068;
-  assign _zz__zz_decode_IS_RS2_SIGNED_110 = 32'h00002010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_112 = (decode_INSTRUCTION & 32'h00002008);
-  assign _zz__zz_decode_IS_RS2_SIGNED_113 = 32'h00002008;
-  assign _zz__zz_decode_IS_RS2_SIGNED_115 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_116 = _zz_decode_IS_RS2_SIGNED_6;
-  assign _zz__zz_decode_IS_RS2_SIGNED_117 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_118) == 32'h0);
-  assign _zz__zz_decode_IS_RS2_SIGNED_127 = 32'h00000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_131 = 32'h00004014;
-  assign _zz__zz_decode_IS_RS2_SIGNED_134 = (decode_INSTRUCTION & 32'h00006014);
-  assign _zz__zz_decode_IS_RS2_SIGNED_135 = 32'h00002010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_138 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_139) == 32'h0);
-  assign _zz__zz_decode_IS_RS2_SIGNED_140 = {_zz_decode_IS_RS2_SIGNED_4,{_zz__zz_decode_IS_RS2_SIGNED_141,{_zz__zz_decode_IS_RS2_SIGNED_142,_zz__zz_decode_IS_RS2_SIGNED_144}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_148 = {_zz_decode_IS_RS2_SIGNED_3,(_zz__zz_decode_IS_RS2_SIGNED_149 == _zz__zz_decode_IS_RS2_SIGNED_150)};
-  assign _zz__zz_decode_IS_RS2_SIGNED_152 = (|{_zz__zz_decode_IS_RS2_SIGNED_153,{_zz__zz_decode_IS_RS2_SIGNED_154,_zz__zz_decode_IS_RS2_SIGNED_156}});
-  assign _zz__zz_decode_IS_RS2_SIGNED_158 = (|{_zz__zz_decode_IS_RS2_SIGNED_159,_zz__zz_decode_IS_RS2_SIGNED_160});
-  assign _zz__zz_decode_IS_RS2_SIGNED_163 = {(|_zz__zz_decode_IS_RS2_SIGNED_164),(|_zz__zz_decode_IS_RS2_SIGNED_167)};
-  assign _zz__zz_decode_IS_RS2_SIGNED_118 = 32'h00000028;
-  assign _zz__zz_decode_IS_RS2_SIGNED_139 = 32'h00000044;
-  assign _zz__zz_decode_IS_RS2_SIGNED_141 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_142 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_143) == 32'h00001000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_144 = {(_zz__zz_decode_IS_RS2_SIGNED_145 == _zz__zz_decode_IS_RS2_SIGNED_146),_zz_decode_IS_RS2_SIGNED_3};
-  assign _zz__zz_decode_IS_RS2_SIGNED_149 = (decode_INSTRUCTION & 32'h00000058);
-  assign _zz__zz_decode_IS_RS2_SIGNED_150 = 32'h0;
-  assign _zz__zz_decode_IS_RS2_SIGNED_153 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_154 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_155) == 32'h00002010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_156 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_157) == 32'h40000030);
-  assign _zz__zz_decode_IS_RS2_SIGNED_159 = _zz_decode_IS_RS2_SIGNED_2;
-  assign _zz__zz_decode_IS_RS2_SIGNED_160 = {_zz_decode_IS_RS2_SIGNED_1,(_zz__zz_decode_IS_RS2_SIGNED_161 == _zz__zz_decode_IS_RS2_SIGNED_162)};
-  assign _zz__zz_decode_IS_RS2_SIGNED_164 = {_zz_decode_IS_RS2_SIGNED_1,(_zz__zz_decode_IS_RS2_SIGNED_165 == _zz__zz_decode_IS_RS2_SIGNED_166)};
-  assign _zz__zz_decode_IS_RS2_SIGNED_167 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_168) == 32'h00001008);
-  assign _zz__zz_decode_IS_RS2_SIGNED_143 = 32'h00005004;
-  assign _zz__zz_decode_IS_RS2_SIGNED_145 = (decode_INSTRUCTION & 32'h00004050);
-  assign _zz__zz_decode_IS_RS2_SIGNED_146 = 32'h00004000;
-  assign _zz__zz_decode_IS_RS2_SIGNED_155 = 32'h00002014;
-  assign _zz__zz_decode_IS_RS2_SIGNED_157 = 32'h40000034;
-  assign _zz__zz_decode_IS_RS2_SIGNED_161 = (decode_INSTRUCTION & 32'h00002014);
-  assign _zz__zz_decode_IS_RS2_SIGNED_162 = 32'h00000004;
-  assign _zz__zz_decode_IS_RS2_SIGNED_165 = (decode_INSTRUCTION & 32'h0000004c);
-  assign _zz__zz_decode_IS_RS2_SIGNED_166 = 32'h00000004;
-  assign _zz__zz_decode_IS_RS2_SIGNED_168 = 32'h00005048;
+  assign _zz__zz_decode_IS_RS2_SIGNED_90 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_91) == 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_92 = (_zz__zz_decode_IS_RS2_SIGNED_93 == _zz__zz_decode_IS_RS2_SIGNED_94);
+  assign _zz__zz_decode_IS_RS2_SIGNED_95 = {_zz__zz_decode_IS_RS2_SIGNED_96,_zz__zz_decode_IS_RS2_SIGNED_98};
+  assign _zz__zz_decode_IS_RS2_SIGNED_102 = (_zz__zz_decode_IS_RS2_SIGNED_103 == _zz__zz_decode_IS_RS2_SIGNED_104);
+  assign _zz__zz_decode_IS_RS2_SIGNED_105 = {_zz__zz_decode_IS_RS2_SIGNED_106,{_zz__zz_decode_IS_RS2_SIGNED_108,_zz__zz_decode_IS_RS2_SIGNED_111}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_118 = _zz_decode_IS_RS2_SIGNED_5;
+  assign _zz__zz_decode_IS_RS2_SIGNED_119 = (_zz__zz_decode_IS_RS2_SIGNED_120 == _zz__zz_decode_IS_RS2_SIGNED_121);
+  assign _zz__zz_decode_IS_RS2_SIGNED_123 = {_zz_decode_IS_RS2_SIGNED_5,_zz__zz_decode_IS_RS2_SIGNED_124};
+  assign _zz__zz_decode_IS_RS2_SIGNED_127 = (|_zz__zz_decode_IS_RS2_SIGNED_128);
+  assign _zz__zz_decode_IS_RS2_SIGNED_130 = (|_zz__zz_decode_IS_RS2_SIGNED_131);
+  assign _zz__zz_decode_IS_RS2_SIGNED_134 = {_zz__zz_decode_IS_RS2_SIGNED_135,{_zz__zz_decode_IS_RS2_SIGNED_145,_zz__zz_decode_IS_RS2_SIGNED_149}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_82 = 32'h00000030;
+  assign _zz__zz_decode_IS_RS2_SIGNED_84 = (decode_INSTRUCTION & 32'h02000010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_85 = 32'h00000010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_91 = 32'h00002030;
+  assign _zz__zz_decode_IS_RS2_SIGNED_93 = (decode_INSTRUCTION & 32'h00001030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_94 = 32'h00000010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_96 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_97) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_98 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_99) == 32'h00002020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_103 = (decode_INSTRUCTION & 32'h00001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_104 = 32'h00001010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_106 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_107) == 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_108 = (_zz__zz_decode_IS_RS2_SIGNED_109 == _zz__zz_decode_IS_RS2_SIGNED_110);
+  assign _zz__zz_decode_IS_RS2_SIGNED_111 = {_zz__zz_decode_IS_RS2_SIGNED_112,{_zz__zz_decode_IS_RS2_SIGNED_113,_zz__zz_decode_IS_RS2_SIGNED_114}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_120 = (decode_INSTRUCTION & 32'h00000070);
+  assign _zz__zz_decode_IS_RS2_SIGNED_121 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_124 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_125) == 32'h00000000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_128 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_129) == 32'h00004010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_131 = (_zz__zz_decode_IS_RS2_SIGNED_132 == _zz__zz_decode_IS_RS2_SIGNED_133);
+  assign _zz__zz_decode_IS_RS2_SIGNED_135 = (|{_zz__zz_decode_IS_RS2_SIGNED_136,_zz__zz_decode_IS_RS2_SIGNED_138});
+  assign _zz__zz_decode_IS_RS2_SIGNED_145 = (|_zz__zz_decode_IS_RS2_SIGNED_146);
+  assign _zz__zz_decode_IS_RS2_SIGNED_149 = {_zz__zz_decode_IS_RS2_SIGNED_150,{_zz__zz_decode_IS_RS2_SIGNED_156,_zz__zz_decode_IS_RS2_SIGNED_161}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_97 = 32'h02003020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_99 = 32'h02002068;
+  assign _zz__zz_decode_IS_RS2_SIGNED_107 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_109 = (decode_INSTRUCTION & 32'h00002008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_110 = 32'h00002008;
+  assign _zz__zz_decode_IS_RS2_SIGNED_112 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_113 = _zz_decode_IS_RS2_SIGNED_6;
+  assign _zz__zz_decode_IS_RS2_SIGNED_114 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_115) == 32'h00000000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_125 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_129 = 32'h00004014;
+  assign _zz__zz_decode_IS_RS2_SIGNED_132 = (decode_INSTRUCTION & 32'h00006014);
+  assign _zz__zz_decode_IS_RS2_SIGNED_133 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_136 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_137) == 32'h00000000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_138 = {_zz_decode_IS_RS2_SIGNED_4,{_zz__zz_decode_IS_RS2_SIGNED_139,{_zz__zz_decode_IS_RS2_SIGNED_140,_zz__zz_decode_IS_RS2_SIGNED_142}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_146 = {_zz_decode_IS_RS2_SIGNED_3,(_zz__zz_decode_IS_RS2_SIGNED_147 == _zz__zz_decode_IS_RS2_SIGNED_148)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_150 = (|{_zz__zz_decode_IS_RS2_SIGNED_151,{_zz__zz_decode_IS_RS2_SIGNED_152,_zz__zz_decode_IS_RS2_SIGNED_154}});
+  assign _zz__zz_decode_IS_RS2_SIGNED_156 = (|{_zz__zz_decode_IS_RS2_SIGNED_157,_zz__zz_decode_IS_RS2_SIGNED_158});
+  assign _zz__zz_decode_IS_RS2_SIGNED_161 = {(|_zz__zz_decode_IS_RS2_SIGNED_162),(|_zz__zz_decode_IS_RS2_SIGNED_165)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_115 = 32'h00000028;
+  assign _zz__zz_decode_IS_RS2_SIGNED_137 = 32'h00000044;
+  assign _zz__zz_decode_IS_RS2_SIGNED_139 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_140 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_141) == 32'h00001000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_142 = {(_zz__zz_decode_IS_RS2_SIGNED_143 == _zz__zz_decode_IS_RS2_SIGNED_144),_zz_decode_IS_RS2_SIGNED_3};
+  assign _zz__zz_decode_IS_RS2_SIGNED_147 = (decode_INSTRUCTION & 32'h00000058);
+  assign _zz__zz_decode_IS_RS2_SIGNED_148 = 32'h00000000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_151 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_152 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_153) == 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_154 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_155) == 32'h40000030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_157 = _zz_decode_IS_RS2_SIGNED_2;
+  assign _zz__zz_decode_IS_RS2_SIGNED_158 = {_zz_decode_IS_RS2_SIGNED_1,(_zz__zz_decode_IS_RS2_SIGNED_159 == _zz__zz_decode_IS_RS2_SIGNED_160)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_162 = {_zz_decode_IS_RS2_SIGNED_1,(_zz__zz_decode_IS_RS2_SIGNED_163 == _zz__zz_decode_IS_RS2_SIGNED_164)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_165 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_166) == 32'h00001008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_141 = 32'h00005004;
+  assign _zz__zz_decode_IS_RS2_SIGNED_143 = (decode_INSTRUCTION & 32'h00004050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_144 = 32'h00004000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_153 = 32'h00002014;
+  assign _zz__zz_decode_IS_RS2_SIGNED_155 = 32'h40000034;
+  assign _zz__zz_decode_IS_RS2_SIGNED_159 = (decode_INSTRUCTION & 32'h00002014);
+  assign _zz__zz_decode_IS_RS2_SIGNED_160 = 32'h00000004;
+  assign _zz__zz_decode_IS_RS2_SIGNED_163 = (decode_INSTRUCTION & 32'h0000004c);
+  assign _zz__zz_decode_IS_RS2_SIGNED_164 = 32'h00000004;
+  assign _zz__zz_decode_IS_RS2_SIGNED_166 = 32'h00005048;
   assign _zz_execute_BranchPlugin_branch_src2_6 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_7 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_8 = execute_INSTRUCTION[7];
-  assign _zz_CsrPlugin_csrMapping_readDataInit_25 = 32'h0;
+  assign _zz_CsrPlugin_csrMapping_readDataInit_24 = 32'h00000000;
   always @(posedge clk) begin
     if(_zz_decode_RegFilePlugin_rs1Data) begin
       _zz_RegFilePlugin_regFile_port0 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
@@ -1943,8 +1933,9 @@ module VexRiscv (
     .io_cpu_flush_ready                     (dataCache_1_io_cpu_flush_ready                   ), //o
     .io_cpu_flush_payload_singleLine        (dataCache_1_io_cpu_flush_payload_singleLine      ), //i
     .io_cpu_flush_payload_lineId            (dataCache_1_io_cpu_flush_payload_lineId[6:0]     ), //i
+    .io_cpu_writesPending                   (dataCache_1_io_cpu_writesPending                 ), //o
     .io_mem_cmd_valid                       (dataCache_1_io_mem_cmd_valid                     ), //o
-    .io_mem_cmd_ready                       (dataCache_1_io_mem_cmd_ready                     ), //i
+    .io_mem_cmd_ready                       (toplevel_dataCache_1_io_mem_cmd_rValidN          ), //i
     .io_mem_cmd_payload_wr                  (dataCache_1_io_mem_cmd_payload_wr                ), //o
     .io_mem_cmd_payload_uncached            (dataCache_1_io_mem_cmd_payload_uncached          ), //o
     .io_mem_cmd_payload_address             (dataCache_1_io_mem_cmd_payload_address[31:0]     ), //o
@@ -2671,7 +2662,7 @@ module VexRiscv (
   end
   `endif
 
-  assign memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW) + $signed(_zz_memory_MUL_LOW_7));
+  assign memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW) + $signed(_zz_memory_MUL_LOW_6));
   assign memory_MUL_HH = execute_to_memory_MUL_HH;
   assign execute_MUL_HH = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bHigh));
   assign execute_MUL_HL = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bSLow));
@@ -2685,7 +2676,7 @@ module VexRiscv (
   assign execute_MEMORY_STORE_DATA_RF = _zz_execute_MEMORY_STORE_DATA_RF;
   assign decode_DO_EBREAK = (((! DebugPlugin_haltIt) && (decode_IS_EBREAK || ((1'b0 || (DebugPlugin_hardwareBreakpoints_0_valid && (DebugPlugin_hardwareBreakpoints_0_pc == _zz_decode_DO_EBREAK))) || (DebugPlugin_hardwareBreakpoints_1_valid && (DebugPlugin_hardwareBreakpoints_1_pc == _zz_decode_DO_EBREAK_1))))) && DebugPlugin_allowEBreak);
   assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
-  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
+  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h00)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h00))));
   assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
   assign decode_IS_RS2_SIGNED = _zz_decode_IS_RS2_SIGNED[33];
@@ -2753,7 +2744,7 @@ module VexRiscv (
   assign decode_RS1_USE = _zz_decode_IS_RS2_SIGNED[5];
   always @(*) begin
     _zz_decode_RS2 = execute_REGFILE_WRITE_DATA;
-    if(when_CsrPlugin_l1189) begin
+    if(when_CsrPlugin_l1587) begin
       _zz_decode_RS2 = CsrPlugin_csrMapping_readDataSignal;
     end
   end
@@ -2849,7 +2840,7 @@ module VexRiscv (
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_execute_SRC2 = execute_PC;
+  assign _zz_execute_to_memory_PC = execute_PC;
   assign execute_SRC2_CTRL = _zz_execute_SRC2_CTRL;
   assign execute_IS_RVC = decode_to_execute_IS_RVC;
   assign execute_SRC1_CTRL = _zz_execute_SRC1_CTRL;
@@ -2858,7 +2849,7 @@ module VexRiscv (
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
   assign execute_ALU_CTRL = _zz_execute_ALU_CTRL;
-  assign execute_SRC2 = _zz_execute_SRC2_5;
+  assign execute_SRC2 = _zz_execute_SRC2_4;
   assign execute_SRC1 = _zz_execute_SRC1;
   assign execute_ALU_BITWISE_CTRL = _zz_execute_ALU_BITWISE_CTRL;
   assign _zz_lastStageRegFileWrite_payload_address = writeBack_INSTRUCTION;
@@ -2878,10 +2869,10 @@ module VexRiscv (
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00001073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
+  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000107f) == 32'h00001073),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00002073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
   always @(*) begin
     _zz_decode_RS2_2 = writeBack_REGFILE_WRITE_DATA;
-    if(when_DBusCachedPlugin_l492) begin
+    if(when_DBusCachedPlugin_l580) begin
       _zz_decode_RS2_2 = writeBack_DBusCachedPlugin_rspFormated;
     end
     if(when_MulPlugin_l147) begin
@@ -2919,28 +2910,28 @@ module VexRiscv (
   assign decode_FLUSH_ALL = _zz_decode_IS_RS2_SIGNED[0];
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_4 = IBusCachedPlugin_rsp_issueDetected_3;
-    if(when_IBusCachedPlugin_l256) begin
+    if(when_IBusCachedPlugin_l262) begin
       IBusCachedPlugin_rsp_issueDetected_4 = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_3 = IBusCachedPlugin_rsp_issueDetected_2;
-    if(when_IBusCachedPlugin_l250) begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_rsp_issueDetected_3 = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
-    if(when_IBusCachedPlugin_l244) begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
-    if(when_IBusCachedPlugin_l239) begin
+    if(when_IBusCachedPlugin_l245) begin
       IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
@@ -2967,10 +2958,10 @@ module VexRiscv (
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
   always @(*) begin
     decode_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l308) begin
+    if(when_DBusCachedPlugin_l352) begin
       decode_arbitration_haltItself = 1'b1;
     end
-    case(switch_Fetcher_l365)
+    case(IBusCachedPlugin_injector_port_state)
       3'b010 : begin
         decode_arbitration_haltItself = 1'b1;
       end
@@ -2987,7 +2978,7 @@ module VexRiscv (
     if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(when_CsrPlugin_l1129) begin
+    if(when_CsrPlugin_l1527) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
@@ -3015,15 +3006,15 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l350) begin
+    if(when_DBusCachedPlugin_l394) begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(when_CsrPlugin_l1121) begin
-      if(when_CsrPlugin_l1123) begin
+    if(when_CsrPlugin_l1519) begin
+      if(when_CsrPlugin_l1521) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(when_CsrPlugin_l1193) begin
+    if(when_CsrPlugin_l1591) begin
       if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
@@ -3032,10 +3023,10 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if(when_DBusCachedPlugin_l366) begin
+    if(when_DBusCachedPlugin_l410) begin
       execute_arbitration_haltByOther = 1'b1;
     end
-    if(when_DebugPlugin_l295) begin
+    if(when_DebugPlugin_l308) begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
@@ -3052,8 +3043,8 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_flushIt = 1'b0;
-    if(when_DebugPlugin_l295) begin
-      if(when_DebugPlugin_l298) begin
+    if(when_DebugPlugin_l308) begin
+      if(when_DebugPlugin_l311) begin
         execute_arbitration_flushIt = 1'b1;
       end
     end
@@ -3064,15 +3055,15 @@ module VexRiscv (
     if(CsrPlugin_selfException_valid) begin
       execute_arbitration_flushNext = 1'b1;
     end
-    if(when_DebugPlugin_l295) begin
-      if(when_DebugPlugin_l298) begin
+    if(when_DebugPlugin_l308) begin
+      if(when_DebugPlugin_l311) begin
         execute_arbitration_flushNext = 1'b1;
       end
     end
-    if(_zz_3) begin
+    if(_zz_6) begin
       execute_arbitration_flushNext = 1'b1;
     end
-    if(_zz_3) begin
+    if(_zz_6) begin
       execute_arbitration_flushNext = 1'b1;
     end
   end
@@ -3104,7 +3095,7 @@ module VexRiscv (
 
   always @(*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l466) begin
+    if(when_DBusCachedPlugin_l553) begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
@@ -3135,10 +3126,10 @@ module VexRiscv (
     if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -3149,31 +3140,31 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @(*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(when_CsrPlugin_l935) begin
+    if(when_CsrPlugin_l1272) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_DebugPlugin_l295) begin
-      if(when_DebugPlugin_l298) begin
+    if(when_DebugPlugin_l308) begin
+      if(when_DebugPlugin_l311) begin
         IBusCachedPlugin_fetcherHalt = 1'b1;
       end
     end
     if(DebugPlugin_haltIt) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_DebugPlugin_l311) begin
+    if(when_DebugPlugin_l324) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_forceNoDecodeCond = 1'b0;
-    if(_zz_3) begin
+    if(_zz_6) begin
       IBusCachedPlugin_forceNoDecodeCond = 1'b1;
     end
   end
@@ -3189,9 +3180,9 @@ module VexRiscv (
   end
 
   always @(*) begin
-    _zz_when_DBusCachedPlugin_l393 = 1'b0;
+    _zz_when_DBusCachedPlugin_l472 = 1'b0;
     if(DebugPlugin_godmode) begin
-      _zz_when_DBusCachedPlugin_l393 = 1'b1;
+      _zz_when_DBusCachedPlugin_l472 = 1'b1;
     end
   end
 
@@ -3202,11 +3193,21 @@ module VexRiscv (
     end
   end
 
-  assign CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+  always @(*) begin
+    CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+    if(when_CsrPlugin_l1702) begin
+      CsrPlugin_csrMapping_allowCsrSignal = 1'b1;
+    end
+    if(when_CsrPlugin_l1709) begin
+      CsrPlugin_csrMapping_allowCsrSignal = 1'b1;
+    end
+  end
+
+  assign CsrPlugin_csrMapping_doForceFailCsr = 1'b0;
   assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
   always @(*) begin
     CsrPlugin_inWfi = 1'b0;
-    if(when_CsrPlugin_l1121) begin
+    if(when_CsrPlugin_l1519) begin
       CsrPlugin_inWfi = 1'b1;
     end
   end
@@ -3220,21 +3221,21 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(when_CsrPlugin_l1077) begin
-      case(switch_CsrPlugin_l1081)
+    if(when_CsrPlugin_l1456) begin
+      case(switch_CsrPlugin_l1460)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -3253,7 +3254,7 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_allowInterrupts = 1'b1;
-    if(when_DebugPlugin_l331) begin
+    if(when_DebugPlugin_l344) begin
       CsrPlugin_allowInterrupts = 1'b0;
     end
   end
@@ -3272,6 +3273,7 @@ module VexRiscv (
     end
   end
 
+  assign CsrPlugin_xretAwayFromMachine = 1'b0;
   assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
   assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusCachedPlugin_redoBranch_valid,IBusCachedPlugin_predictionJumpInterface_valid}}} != 4'b0000);
   assign _zz_IBusCachedPlugin_jump_pcLoad_payload = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
@@ -3299,9 +3301,8 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l134 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
-  assign IBusCachedPlugin_fetchPc_output_fire_1 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
-  assign when_Fetcher_l134_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
+  assign when_Fetcher_l133 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l133_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
   always @(*) begin
     IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_IBusCachedPlugin_fetchPc_pc);
     if(IBusCachedPlugin_fetchPc_inc) begin
@@ -3326,12 +3327,12 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l161 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
+  assign when_Fetcher_l160 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
   assign IBusCachedPlugin_fetchPc_output_valid = ((! IBusCachedPlugin_fetcherHalt) && IBusCachedPlugin_fetchPc_booted);
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
   always @(*) begin
     IBusCachedPlugin_decodePc_flushed = 1'b0;
-    if(when_Fetcher_l195) begin
+    if(when_Fetcher_l194) begin
       IBusCachedPlugin_decodePc_flushed = 1'b1;
     end
   end
@@ -3339,13 +3340,13 @@ module VexRiscv (
   assign IBusCachedPlugin_decodePc_pcPlus = (IBusCachedPlugin_decodePc_pcReg + _zz_IBusCachedPlugin_decodePc_pcPlus);
   always @(*) begin
     IBusCachedPlugin_decodePc_injectedDecode = 1'b0;
-    if(when_Fetcher_l363) begin
+    if(when_Fetcher_l373) begin
       IBusCachedPlugin_decodePc_injectedDecode = 1'b1;
     end
   end
 
-  assign when_Fetcher_l183 = (decode_arbitration_isFiring && (! IBusCachedPlugin_decodePc_injectedDecode));
-  assign when_Fetcher_l195 = (IBusCachedPlugin_jump_pcLoad_valid && ((! decode_arbitration_isStuck) || decode_arbitration_removeIt));
+  assign when_Fetcher_l182 = (decode_arbitration_isFiring && (! IBusCachedPlugin_decodePc_injectedDecode));
+  assign when_Fetcher_l194 = (IBusCachedPlugin_jump_pcLoad_valid && ((! decode_arbitration_isStuck) || decode_arbitration_removeIt));
   always @(*) begin
     IBusCachedPlugin_iBusRsp_redoFetch = 1'b0;
     if(IBusCachedPlugin_rsp_redoFetch) begin
@@ -3372,7 +3373,7 @@ module VexRiscv (
     if(IBusCachedPlugin_mmuBus_busy) begin
       IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b1;
     end
-    if(when_IBusCachedPlugin_l267) begin
+    if(when_IBusCachedPlugin_l273) begin
       IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b1;
     end
   end
@@ -3391,9 +3392,9 @@ module VexRiscv (
 
   assign IBusCachedPlugin_iBusRsp_flush = (IBusCachedPlugin_externalFlush || IBusCachedPlugin_iBusRsp_redoFetch);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
-  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1 = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
   always @(*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
@@ -3420,10 +3421,13 @@ module VexRiscv (
   assign IBusCachedPlugin_decompressor_isRvc = (IBusCachedPlugin_decompressor_raw[1 : 0] != 2'b11);
   assign _zz_IBusCachedPlugin_decompressor_decompressed = IBusCachedPlugin_decompressor_raw[15 : 0];
   always @(*) begin
-    IBusCachedPlugin_decompressor_decompressed = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+    IBusCachedPlugin_decompressor_decompressed = 32'h00000000;
     case(switch_Misc_l44)
-      5'h0 : begin
+      5'h00 : begin
         IBusCachedPlugin_decompressor_decompressed = {{{{{{{{{2'b00,_zz_IBusCachedPlugin_decompressor_decompressed[10 : 7]},_zz_IBusCachedPlugin_decompressor_decompressed[12 : 11]},_zz_IBusCachedPlugin_decompressor_decompressed[5]},_zz_IBusCachedPlugin_decompressor_decompressed[6]},2'b00},5'h02},3'b000},_zz_IBusCachedPlugin_decompressor_decompressed_2},7'h13};
+        if(when_Misc_l47) begin
+          IBusCachedPlugin_decompressor_decompressed = 32'h00000000;
+        end
       end
       5'h02 : begin
         IBusCachedPlugin_decompressor_decompressed = {{{{_zz_IBusCachedPlugin_decompressor_decompressed_3,_zz_IBusCachedPlugin_decompressor_decompressed_1},3'b010},_zz_IBusCachedPlugin_decompressor_decompressed_2},7'h03};
@@ -3438,13 +3442,13 @@ module VexRiscv (
         IBusCachedPlugin_decompressor_decompressed = {{{{{_zz_IBusCachedPlugin_decompressor_decompressed_8[20],_zz_IBusCachedPlugin_decompressor_decompressed_8[10 : 1]},_zz_IBusCachedPlugin_decompressor_decompressed_8[11]},_zz_IBusCachedPlugin_decompressor_decompressed_8[19 : 12]},_zz_IBusCachedPlugin_decompressor_decompressed_20},7'h6f};
       end
       5'h0a : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{_zz_IBusCachedPlugin_decompressor_decompressed_5,5'h0},3'b000},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},7'h13};
+        IBusCachedPlugin_decompressor_decompressed = {{{{_zz_IBusCachedPlugin_decompressor_decompressed_5,5'h00},3'b000},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},7'h13};
       end
       5'h0b : begin
         IBusCachedPlugin_decompressor_decompressed = ((_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7] == 5'h02) ? {{{{{{{{{_zz_IBusCachedPlugin_decompressor_decompressed_12,_zz_IBusCachedPlugin_decompressor_decompressed[4 : 3]},_zz_IBusCachedPlugin_decompressor_decompressed[5]},_zz_IBusCachedPlugin_decompressor_decompressed[2]},_zz_IBusCachedPlugin_decompressor_decompressed[6]},4'b0000},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},3'b000},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},7'h13} : {{_zz_IBusCachedPlugin_decompressor_decompressed_27[31 : 12],_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},7'h37});
       end
       5'h0c : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{((_zz_IBusCachedPlugin_decompressor_decompressed[11 : 10] == 2'b10) ? _zz_IBusCachedPlugin_decompressor_decompressed_26 : {{1'b0,(_zz_IBusCachedPlugin_decompressor_decompressed_28 || _zz_IBusCachedPlugin_decompressor_decompressed_29)},5'h0}),(((! _zz_IBusCachedPlugin_decompressor_decompressed[11]) || _zz_IBusCachedPlugin_decompressor_decompressed_22) ? _zz_IBusCachedPlugin_decompressor_decompressed[6 : 2] : _zz_IBusCachedPlugin_decompressor_decompressed_2)},_zz_IBusCachedPlugin_decompressor_decompressed_1},_zz_IBusCachedPlugin_decompressor_decompressed_24},_zz_IBusCachedPlugin_decompressor_decompressed_1},(_zz_IBusCachedPlugin_decompressor_decompressed_22 ? 7'h13 : 7'h33)};
+        IBusCachedPlugin_decompressor_decompressed = {{{{{((_zz_IBusCachedPlugin_decompressor_decompressed[11 : 10] == 2'b10) ? _zz_IBusCachedPlugin_decompressor_decompressed_26 : {{1'b0,(_zz_IBusCachedPlugin_decompressor_decompressed_28 || _zz_IBusCachedPlugin_decompressor_decompressed_29)},5'h00}),(((! _zz_IBusCachedPlugin_decompressor_decompressed[11]) || _zz_IBusCachedPlugin_decompressor_decompressed_22) ? _zz_IBusCachedPlugin_decompressor_decompressed[6 : 2] : _zz_IBusCachedPlugin_decompressor_decompressed_2)},_zz_IBusCachedPlugin_decompressor_decompressed_1},_zz_IBusCachedPlugin_decompressor_decompressed_24},_zz_IBusCachedPlugin_decompressor_decompressed_1},(_zz_IBusCachedPlugin_decompressor_decompressed_22 ? 7'h13 : 7'h33)};
       end
       5'h0d : begin
         IBusCachedPlugin_decompressor_decompressed = {{{{{_zz_IBusCachedPlugin_decompressor_decompressed_15[20],_zz_IBusCachedPlugin_decompressor_decompressed_15[10 : 1]},_zz_IBusCachedPlugin_decompressor_decompressed_15[11]},_zz_IBusCachedPlugin_decompressor_decompressed_15[19 : 12]},_zz_IBusCachedPlugin_decompressor_decompressed_19},7'h6f};
@@ -3456,13 +3460,13 @@ module VexRiscv (
         IBusCachedPlugin_decompressor_decompressed = {{{{{{{_zz_IBusCachedPlugin_decompressor_decompressed_18[12],_zz_IBusCachedPlugin_decompressor_decompressed_18[10 : 5]},_zz_IBusCachedPlugin_decompressor_decompressed_19},_zz_IBusCachedPlugin_decompressor_decompressed_1},3'b001},_zz_IBusCachedPlugin_decompressor_decompressed_18[4 : 1]},_zz_IBusCachedPlugin_decompressor_decompressed_18[11]},7'h63};
       end
       5'h10 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{7'h0,_zz_IBusCachedPlugin_decompressor_decompressed[6 : 2]},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},3'b001},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},7'h13};
+        IBusCachedPlugin_decompressor_decompressed = {{{{{7'h00,_zz_IBusCachedPlugin_decompressor_decompressed[6 : 2]},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},3'b001},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},7'h13};
       end
       5'h12 : begin
         IBusCachedPlugin_decompressor_decompressed = {{{{{{{{4'b0000,_zz_IBusCachedPlugin_decompressor_decompressed[3 : 2]},_zz_IBusCachedPlugin_decompressor_decompressed[12]},_zz_IBusCachedPlugin_decompressor_decompressed[6 : 4]},2'b00},_zz_IBusCachedPlugin_decompressor_decompressed_21},3'b010},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},7'h03};
       end
       5'h14 : begin
-        IBusCachedPlugin_decompressor_decompressed = ((_zz_IBusCachedPlugin_decompressor_decompressed[12 : 2] == 11'h400) ? 32'h00100073 : ((_zz_IBusCachedPlugin_decompressor_decompressed[6 : 2] == 5'h0) ? {{{{12'h0,_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},3'b000},(_zz_IBusCachedPlugin_decompressor_decompressed[12] ? _zz_IBusCachedPlugin_decompressor_decompressed_20 : _zz_IBusCachedPlugin_decompressor_decompressed_19)},7'h67} : {{{{{_zz_IBusCachedPlugin_decompressor_decompressed_30,_zz_IBusCachedPlugin_decompressor_decompressed_31},(_zz_IBusCachedPlugin_decompressor_decompressed_32 ? _zz_IBusCachedPlugin_decompressor_decompressed_33 : _zz_IBusCachedPlugin_decompressor_decompressed_19)},3'b000},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},7'h33}));
+        IBusCachedPlugin_decompressor_decompressed = ((_zz_IBusCachedPlugin_decompressor_decompressed[12 : 2] == 11'h400) ? 32'h00100073 : ((_zz_IBusCachedPlugin_decompressor_decompressed[6 : 2] == 5'h00) ? {{{{12'h000,_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},3'b000},(_zz_IBusCachedPlugin_decompressor_decompressed[12] ? _zz_IBusCachedPlugin_decompressor_decompressed_20 : _zz_IBusCachedPlugin_decompressor_decompressed_19)},7'h67} : {{{{{_zz_IBusCachedPlugin_decompressor_decompressed_30,_zz_IBusCachedPlugin_decompressor_decompressed_31},(_zz_IBusCachedPlugin_decompressor_decompressed_32 ? _zz_IBusCachedPlugin_decompressor_decompressed_33 : _zz_IBusCachedPlugin_decompressor_decompressed_19)},3'b000},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},7'h33}));
       end
       5'h16 : begin
         IBusCachedPlugin_decompressor_decompressed = {{{{{_zz_IBusCachedPlugin_decompressor_decompressed_34[11 : 5],_zz_IBusCachedPlugin_decompressor_decompressed[6 : 2]},_zz_IBusCachedPlugin_decompressor_decompressed_21},3'b010},_zz_IBusCachedPlugin_decompressor_decompressed_35[4 : 0]},7'h23};
@@ -3474,7 +3478,7 @@ module VexRiscv (
 
   assign _zz_IBusCachedPlugin_decompressor_decompressed_1 = {2'b01,_zz_IBusCachedPlugin_decompressor_decompressed[9 : 7]};
   assign _zz_IBusCachedPlugin_decompressor_decompressed_2 = {2'b01,_zz_IBusCachedPlugin_decompressor_decompressed[4 : 2]};
-  assign _zz_IBusCachedPlugin_decompressor_decompressed_3 = {{{{5'h0,_zz_IBusCachedPlugin_decompressor_decompressed[5]},_zz_IBusCachedPlugin_decompressor_decompressed[12 : 10]},_zz_IBusCachedPlugin_decompressor_decompressed[6]},2'b00};
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_3 = {{{{5'h00,_zz_IBusCachedPlugin_decompressor_decompressed[5]},_zz_IBusCachedPlugin_decompressor_decompressed[12 : 10]},_zz_IBusCachedPlugin_decompressor_decompressed[6]},2'b00};
   assign _zz_IBusCachedPlugin_decompressor_decompressed_4 = _zz_IBusCachedPlugin_decompressor_decompressed[12];
   always @(*) begin
     _zz_IBusCachedPlugin_decompressor_decompressed_5[11] = _zz_IBusCachedPlugin_decompressor_decompressed_4;
@@ -3553,15 +3557,16 @@ module VexRiscv (
   end
 
   assign _zz_IBusCachedPlugin_decompressor_decompressed_18 = {{{{{_zz_IBusCachedPlugin_decompressor_decompressed_17,_zz_IBusCachedPlugin_decompressor_decompressed[6 : 5]},_zz_IBusCachedPlugin_decompressor_decompressed[2]},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 10]},_zz_IBusCachedPlugin_decompressor_decompressed[4 : 3]},1'b0};
-  assign _zz_IBusCachedPlugin_decompressor_decompressed_19 = 5'h0;
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_19 = 5'h00;
   assign _zz_IBusCachedPlugin_decompressor_decompressed_20 = 5'h01;
   assign _zz_IBusCachedPlugin_decompressor_decompressed_21 = 5'h02;
   assign switch_Misc_l44 = {_zz_IBusCachedPlugin_decompressor_decompressed[1 : 0],_zz_IBusCachedPlugin_decompressor_decompressed[15 : 13]};
+  assign when_Misc_l47 = (_zz_IBusCachedPlugin_decompressor_decompressed[12 : 2] == 11'h000);
   assign _zz_IBusCachedPlugin_decompressor_decompressed_22 = (_zz_IBusCachedPlugin_decompressor_decompressed[11 : 10] != 2'b11);
-  assign switch_Misc_l210 = _zz_IBusCachedPlugin_decompressor_decompressed[11 : 10];
-  assign switch_Misc_l210_1 = _zz_IBusCachedPlugin_decompressor_decompressed[6 : 5];
+  assign switch_Misc_l232 = _zz_IBusCachedPlugin_decompressor_decompressed[11 : 10];
+  assign switch_Misc_l232_1 = _zz_IBusCachedPlugin_decompressor_decompressed[6 : 5];
   always @(*) begin
-    case(switch_Misc_l210_1)
+    case(switch_Misc_l232_1)
       2'b00 : begin
         _zz_IBusCachedPlugin_decompressor_decompressed_23 = 3'b000;
       end
@@ -3578,7 +3583,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    case(switch_Misc_l210)
+    case(switch_Misc_l232)
       2'b00 : begin
         _zz_IBusCachedPlugin_decompressor_decompressed_24 = 3'b101;
       end
@@ -3612,19 +3617,19 @@ module VexRiscv (
   assign IBusCachedPlugin_decompressor_input_ready = (IBusCachedPlugin_decompressor_output_ready && (((! IBusCachedPlugin_iBusRsp_stages_1_input_valid) || IBusCachedPlugin_decompressor_flushNext) || ((! (IBusCachedPlugin_decompressor_bufferValid && IBusCachedPlugin_decompressor_isInputHighRvc)) && (! (((! IBusCachedPlugin_decompressor_unaligned) && IBusCachedPlugin_decompressor_isInputLowRvc) && IBusCachedPlugin_decompressor_isInputHighRvc)))));
   assign IBusCachedPlugin_decompressor_output_fire = (IBusCachedPlugin_decompressor_output_valid && IBusCachedPlugin_decompressor_output_ready);
   assign IBusCachedPlugin_decompressor_bufferFill = (((((! IBusCachedPlugin_decompressor_unaligned) && IBusCachedPlugin_decompressor_isInputLowRvc) && (! IBusCachedPlugin_decompressor_isInputHighRvc)) || (IBusCachedPlugin_decompressor_bufferValid && (! IBusCachedPlugin_decompressor_isInputHighRvc))) || ((IBusCachedPlugin_decompressor_throw2Bytes && (! IBusCachedPlugin_decompressor_isRvc)) && (! IBusCachedPlugin_decompressor_isInputHighRvc)));
-  assign when_Fetcher_l286 = (IBusCachedPlugin_decompressor_output_ready && IBusCachedPlugin_decompressor_input_valid);
-  assign when_Fetcher_l289 = (IBusCachedPlugin_decompressor_output_ready && IBusCachedPlugin_decompressor_input_valid);
-  assign when_Fetcher_l294 = (IBusCachedPlugin_externalFlush || IBusCachedPlugin_decompressor_consumeCurrent);
+  assign when_Fetcher_l285 = (IBusCachedPlugin_decompressor_output_ready && IBusCachedPlugin_decompressor_input_valid);
+  assign when_Fetcher_l288 = (IBusCachedPlugin_decompressor_output_ready && IBusCachedPlugin_decompressor_input_valid);
+  assign when_Fetcher_l293 = (IBusCachedPlugin_externalFlush || IBusCachedPlugin_decompressor_consumeCurrent);
   assign IBusCachedPlugin_decompressor_output_ready = ((1'b0 && (! IBusCachedPlugin_injector_decodeInput_valid)) || IBusCachedPlugin_injector_decodeInput_ready);
   assign IBusCachedPlugin_injector_decodeInput_valid = _zz_IBusCachedPlugin_injector_decodeInput_valid;
   assign IBusCachedPlugin_injector_decodeInput_payload_pc = _zz_IBusCachedPlugin_injector_decodeInput_payload_pc;
   assign IBusCachedPlugin_injector_decodeInput_payload_rsp_error = _zz_IBusCachedPlugin_injector_decodeInput_payload_rsp_error;
   assign IBusCachedPlugin_injector_decodeInput_payload_rsp_inst = _zz_IBusCachedPlugin_injector_decodeInput_payload_rsp_inst;
   assign IBusCachedPlugin_injector_decodeInput_payload_isRvc = _zz_IBusCachedPlugin_injector_decodeInput_payload_isRvc;
-  assign when_Fetcher_l332 = (! 1'b0);
-  assign when_Fetcher_l332_1 = (! execute_arbitration_isStuck);
-  assign when_Fetcher_l332_2 = (! memory_arbitration_isStuck);
-  assign when_Fetcher_l332_3 = (! writeBack_arbitration_isStuck);
+  assign when_Fetcher_l331 = (! 1'b0);
+  assign when_Fetcher_l331_1 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l331_2 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l331_3 = (! writeBack_arbitration_isStuck);
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_0;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
@@ -3632,7 +3637,7 @@ module VexRiscv (
   assign IBusCachedPlugin_injector_decodeInput_ready = (! decode_arbitration_isStuck);
   always @(*) begin
     decode_arbitration_isValid = IBusCachedPlugin_injector_decodeInput_valid;
-    case(switch_Fetcher_l365)
+    case(IBusCachedPlugin_injector_port_state)
       3'b010 : begin
         decode_arbitration_isValid = 1'b1;
       end
@@ -3732,90 +3737,89 @@ module VexRiscv (
   assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
   always @(*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(when_IBusCachedPlugin_l239) begin
+    if(when_IBusCachedPlugin_l245) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(when_IBusCachedPlugin_l250) begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_cache_io_cpu_fill_valid = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_fetch_mmuRefilling));
-    if(when_IBusCachedPlugin_l250) begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_cache_io_cpu_fill_valid = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_valid = 1'b0;
-    if(when_IBusCachedPlugin_l244) begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
-    if(when_IBusCachedPlugin_l256) begin
+    if(when_IBusCachedPlugin_l262) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_payload_code = 4'bxxxx;
-    if(when_IBusCachedPlugin_l244) begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b1100;
     end
-    if(when_IBusCachedPlugin_l256) begin
+    if(when_IBusCachedPlugin_l262) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b0001;
     end
   end
 
   assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_1_input_payload[31 : 2],2'b00};
-  assign when_IBusCachedPlugin_l239 = ((IBusCachedPlugin_cache_io_cpu_fetch_isValid && IBusCachedPlugin_cache_io_cpu_fetch_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign when_IBusCachedPlugin_l244 = ((IBusCachedPlugin_cache_io_cpu_fetch_isValid && IBusCachedPlugin_cache_io_cpu_fetch_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
-  assign when_IBusCachedPlugin_l250 = ((IBusCachedPlugin_cache_io_cpu_fetch_isValid && IBusCachedPlugin_cache_io_cpu_fetch_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
-  assign when_IBusCachedPlugin_l256 = ((IBusCachedPlugin_cache_io_cpu_fetch_isValid && IBusCachedPlugin_cache_io_cpu_fetch_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
-  assign when_IBusCachedPlugin_l267 = (IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt);
+  assign when_IBusCachedPlugin_l245 = ((IBusCachedPlugin_cache_io_cpu_fetch_isValid && IBusCachedPlugin_cache_io_cpu_fetch_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign when_IBusCachedPlugin_l250 = ((IBusCachedPlugin_cache_io_cpu_fetch_isValid && IBusCachedPlugin_cache_io_cpu_fetch_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign when_IBusCachedPlugin_l256 = ((IBusCachedPlugin_cache_io_cpu_fetch_isValid && IBusCachedPlugin_cache_io_cpu_fetch_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
+  assign when_IBusCachedPlugin_l262 = ((IBusCachedPlugin_cache_io_cpu_fetch_isValid && IBusCachedPlugin_cache_io_cpu_fetch_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
+  assign when_IBusCachedPlugin_l273 = (IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt);
   assign IBusCachedPlugin_iBusRsp_output_valid = IBusCachedPlugin_iBusRsp_stages_1_output_valid;
   assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
   assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_fetch_data;
   assign IBusCachedPlugin_iBusRsp_output_payload_pc = IBusCachedPlugin_iBusRsp_stages_1_output_payload;
   assign IBusCachedPlugin_cache_io_flush = (decode_arbitration_isValid && decode_FLUSH_ALL);
-  assign dataCache_1_io_mem_cmd_ready = (! dataCache_1_io_mem_cmd_rValid);
-  assign dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || dataCache_1_io_mem_cmd_rValid);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_wr : dataCache_1_io_mem_cmd_payload_wr);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_uncached : dataCache_1_io_mem_cmd_payload_uncached);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_address = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_address : dataCache_1_io_mem_cmd_payload_address);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_data = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_data : dataCache_1_io_mem_cmd_payload_data);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_mask : dataCache_1_io_mem_cmd_payload_mask);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_size = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_size : dataCache_1_io_mem_cmd_payload_size);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_last : dataCache_1_io_mem_cmd_payload_last);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || (! toplevel_dataCache_1_io_mem_cmd_rValidN));
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_wr : toplevel_dataCache_1_io_mem_cmd_rData_wr);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_uncached : toplevel_dataCache_1_io_mem_cmd_rData_uncached);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_address = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_address : toplevel_dataCache_1_io_mem_cmd_rData_address);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_data = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_data : toplevel_dataCache_1_io_mem_cmd_rData_data);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_mask : toplevel_dataCache_1_io_mem_cmd_rData_mask);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_size = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_size : toplevel_dataCache_1_io_mem_cmd_rData_size);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_last = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_last : toplevel_dataCache_1_io_mem_cmd_rData_last);
   always @(*) begin
-    dataCache_1_io_mem_cmd_s2mPipe_ready = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
-    if(when_Stream_l368) begin
-      dataCache_1_io_mem_cmd_s2mPipe_ready = 1'b1;
+    toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
+    if(when_Stream_l369) begin
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l368 = (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_rValid;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_rData_address;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_rData_data;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size = dataCache_1_io_mem_cmd_s2mPipe_rData_size;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_rData_last;
-  assign dBus_cmd_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
-  assign dBus_cmd_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
-  assign dBus_cmd_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
-  assign dBus_cmd_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
-  assign dBus_cmd_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
-  assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  assign dBus_cmd_payload_size = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
-  assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  assign when_DBusCachedPlugin_l308 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
+  assign when_Stream_l369 = (! toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_address;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_data;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_size;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  assign dBus_cmd_valid = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
+  assign dBus_cmd_payload_wr = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
+  assign dBus_cmd_payload_uncached = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
+  assign dBus_cmd_payload_address = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
+  assign dBus_cmd_payload_data = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
+  assign dBus_cmd_payload_mask = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
+  assign dBus_cmd_payload_size = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
+  assign dBus_cmd_payload_last = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  assign when_DBusCachedPlugin_l352 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
   always @(*) begin
     _zz_decode_MEMORY_FORCE_CONSTISTENCY = 1'b0;
-    if(when_DBusCachedPlugin_l316) begin
+    if(when_DBusCachedPlugin_l360) begin
       if(decode_MEMORY_LRSC) begin
         _zz_decode_MEMORY_FORCE_CONSTISTENCY = 1'b1;
       end
@@ -3825,7 +3829,7 @@ module VexRiscv (
     end
   end
 
-  assign when_DBusCachedPlugin_l316 = decode_INSTRUCTION[25];
+  assign when_DBusCachedPlugin_l360 = decode_INSTRUCTION[25];
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
   assign dataCache_1_io_cpu_execute_isValid = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
   assign dataCache_1_io_cpu_execute_address = execute_SRC_ADD;
@@ -3844,10 +3848,10 @@ module VexRiscv (
   end
 
   assign dataCache_1_io_cpu_flush_valid = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
-  assign dataCache_1_io_cpu_flush_payload_singleLine = (execute_INSTRUCTION[19 : 15] != 5'h0);
+  assign dataCache_1_io_cpu_flush_payload_singleLine = (execute_INSTRUCTION[19 : 15] != 5'h00);
   assign dataCache_1_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId[6:0];
-  assign dataCache_1_io_cpu_flush_isStall = (dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready));
-  assign when_DBusCachedPlugin_l350 = (dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
+  assign toplevel_dataCache_1_io_cpu_flush_isStall = (dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready));
+  assign when_DBusCachedPlugin_l394 = (toplevel_dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
   always @(*) begin
     dataCache_1_io_cpu_execute_args_isLrsc = 1'b0;
     if(execute_MEMORY_LRSC) begin
@@ -3857,7 +3861,7 @@ module VexRiscv (
 
   assign dataCache_1_io_cpu_execute_args_amoCtrl_alu = execute_INSTRUCTION[31 : 29];
   assign dataCache_1_io_cpu_execute_args_amoCtrl_swap = execute_INSTRUCTION[27];
-  assign when_DBusCachedPlugin_l366 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
+  assign when_DBusCachedPlugin_l410 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
   assign dataCache_1_io_cpu_memory_isValid = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
   assign dataCache_1_io_cpu_memory_address = memory_REGFILE_WRITE_DATA;
   assign DBusCachedPlugin_mmuBus_cmd_0_isValid = dataCache_1_io_cpu_memory_isValid;
@@ -3867,12 +3871,12 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
   always @(*) begin
     dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if(when_DBusCachedPlugin_l393) begin
+    if(when_DBusCachedPlugin_l472) begin
       dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = 1'b1;
     end
   end
 
-  assign when_DBusCachedPlugin_l393 = (_zz_when_DBusCachedPlugin_l393 && (! dataCache_1_io_cpu_memory_isWrite));
+  assign when_DBusCachedPlugin_l472 = (_zz_when_DBusCachedPlugin_l472 && (! dataCache_1_io_cpu_memory_isWrite));
   always @(*) begin
     dataCache_1_io_cpu_writeBack_isValid = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
     if(writeBack_arbitration_haltByOther) begin
@@ -3885,7 +3889,7 @@ module VexRiscv (
   assign dataCache_1_io_cpu_writeBack_storeData[31 : 0] = writeBack_MEMORY_STORE_DATA_RF;
   always @(*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(when_DBusCachedPlugin_l446) begin
+    if(when_DBusCachedPlugin_l533) begin
       if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
@@ -3895,7 +3899,7 @@ module VexRiscv (
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(when_DBusCachedPlugin_l446) begin
+    if(when_DBusCachedPlugin_l533) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
@@ -3914,7 +3918,7 @@ module VexRiscv (
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
-    if(when_DBusCachedPlugin_l446) begin
+    if(when_DBusCachedPlugin_l533) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code};
       end
@@ -3927,12 +3931,13 @@ module VexRiscv (
     end
   end
 
-  assign when_DBusCachedPlugin_l446 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign when_DBusCachedPlugin_l466 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
-  assign writeBack_DBusCachedPlugin_rspSplits_0 = dataCache_1_io_cpu_writeBack_data[7 : 0];
-  assign writeBack_DBusCachedPlugin_rspSplits_1 = dataCache_1_io_cpu_writeBack_data[15 : 8];
-  assign writeBack_DBusCachedPlugin_rspSplits_2 = dataCache_1_io_cpu_writeBack_data[23 : 16];
-  assign writeBack_DBusCachedPlugin_rspSplits_3 = dataCache_1_io_cpu_writeBack_data[31 : 24];
+  assign when_DBusCachedPlugin_l533 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l553 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
+  assign writeBack_DBusCachedPlugin_rspData = dataCache_1_io_cpu_writeBack_data;
+  assign writeBack_DBusCachedPlugin_rspSplits_0 = writeBack_DBusCachedPlugin_rspData[7 : 0];
+  assign writeBack_DBusCachedPlugin_rspSplits_1 = writeBack_DBusCachedPlugin_rspData[15 : 8];
+  assign writeBack_DBusCachedPlugin_rspSplits_2 = writeBack_DBusCachedPlugin_rspData[23 : 16];
+  assign writeBack_DBusCachedPlugin_rspSplits_3 = writeBack_DBusCachedPlugin_rspData[31 : 24];
   always @(*) begin
     writeBack_DBusCachedPlugin_rspShifted[7 : 0] = _zz_writeBack_DBusCachedPlugin_rspShifted;
     writeBack_DBusCachedPlugin_rspShifted[15 : 8] = _zz_writeBack_DBusCachedPlugin_rspShifted_2;
@@ -3942,13 +3947,13 @@ module VexRiscv (
 
   always @(*) begin
     writeBack_DBusCachedPlugin_rspRf = writeBack_DBusCachedPlugin_rspShifted[31 : 0];
-    if(when_DBusCachedPlugin_l482) begin
+    if(when_DBusCachedPlugin_l570) begin
       writeBack_DBusCachedPlugin_rspRf = {31'd0, _zz_writeBack_DBusCachedPlugin_rspRf};
     end
   end
 
-  assign when_DBusCachedPlugin_l482 = (writeBack_MEMORY_LRSC && writeBack_MEMORY_WR);
-  assign switch_Misc_l210_2 = writeBack_INSTRUCTION[13 : 12];
+  assign when_DBusCachedPlugin_l570 = (writeBack_MEMORY_LRSC && writeBack_MEMORY_WR);
+  assign switch_Misc_l232_2 = writeBack_INSTRUCTION[13 : 12];
   assign _zz_writeBack_DBusCachedPlugin_rspFormated = (writeBack_DBusCachedPlugin_rspRf[7] && (! writeBack_INSTRUCTION[14]));
   always @(*) begin
     _zz_writeBack_DBusCachedPlugin_rspFormated_1[31] = _zz_writeBack_DBusCachedPlugin_rspFormated;
@@ -4000,7 +4005,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    case(switch_Misc_l210_2)
+    case(switch_Misc_l232_2)
       2'b00 : begin
         writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_1;
       end
@@ -4013,7 +4018,7 @@ module VexRiscv (
     endcase
   end
 
-  assign when_DBusCachedPlugin_l492 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l580 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
   assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
@@ -4035,11 +4040,11 @@ module VexRiscv (
   assign _zz_decode_IS_RS2_SIGNED_1 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
   assign _zz_decode_IS_RS2_SIGNED_2 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
   assign _zz_decode_IS_RS2_SIGNED_3 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002000);
-  assign _zz_decode_IS_RS2_SIGNED_4 = ((decode_INSTRUCTION & 32'h00000018) == 32'h0);
+  assign _zz_decode_IS_RS2_SIGNED_4 = ((decode_INSTRUCTION & 32'h00000018) == 32'h00000000);
   assign _zz_decode_IS_RS2_SIGNED_5 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
   assign _zz_decode_IS_RS2_SIGNED_6 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
   assign _zz_decode_IS_RS2_SIGNED_7 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
-  assign _zz_decode_IS_RS2_SIGNED_8 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
+  assign _zz_decode_IS_RS2_SIGNED_8 = ((decode_INSTRUCTION & 32'h00001000) == 32'h00000000);
   assign _zz_decode_IS_RS2_SIGNED = {(|((decode_INSTRUCTION & 32'h10103050) == 32'h00100050)),{(|_zz_decode_IS_RS2_SIGNED_8),{(|_zz_decode_IS_RS2_SIGNED_8),{(|_zz__zz_decode_IS_RS2_SIGNED),{(|_zz__zz_decode_IS_RS2_SIGNED_1),{_zz__zz_decode_IS_RS2_SIGNED_2,{_zz__zz_decode_IS_RS2_SIGNED_7,_zz__zz_decode_IS_RS2_SIGNED_10}}}}}}};
   assign _zz_decode_SRC1_CTRL_2 = _zz_decode_IS_RS2_SIGNED[2 : 1];
   assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
@@ -4058,29 +4063,29 @@ module VexRiscv (
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
-  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h0);
+  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h00);
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
   assign decode_RegFilePlugin_rs1Data = _zz_RegFilePlugin_regFile_port0;
   assign decode_RegFilePlugin_rs2Data = _zz_RegFilePlugin_regFile_port1;
   always @(*) begin
     lastStageRegFileWrite_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
-    if(_zz_2) begin
+    if(_zz_5) begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
   always @(*) begin
     lastStageRegFileWrite_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
-    if(_zz_2) begin
-      lastStageRegFileWrite_payload_address = 5'h0;
+    if(_zz_5) begin
+      lastStageRegFileWrite_payload_address = 5'h00;
     end
   end
 
   always @(*) begin
     lastStageRegFileWrite_payload_data = _zz_decode_RS2_2;
-    if(_zz_2) begin
-      lastStageRegFileWrite_payload_data = 32'h0;
+    if(_zz_5) begin
+      lastStageRegFileWrite_payload_data = 32'h00000000;
     end
   end
 
@@ -4121,7 +4126,7 @@ module VexRiscv (
         _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
       Src1CtrlEnum_IMU : begin
-        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h000};
       end
       default : begin
         _zz_execute_SRC1 = {27'd0, _zz__zz_execute_SRC1_1};
@@ -4129,67 +4134,67 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_execute_SRC2_1 = execute_INSTRUCTION[31];
+  assign _zz_execute_SRC2 = execute_INSTRUCTION[31];
   always @(*) begin
-    _zz_execute_SRC2_2[19] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[18] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[17] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[16] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[15] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[14] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[13] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[12] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[11] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[10] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[9] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[8] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[7] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[6] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[5] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[4] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[3] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[2] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[1] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[0] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_1[19] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[18] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[17] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[16] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[15] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[14] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[13] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[12] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[11] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[10] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[9] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[8] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[7] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[6] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[5] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[4] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[3] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[2] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[1] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[0] = _zz_execute_SRC2;
   end
 
-  assign _zz_execute_SRC2_3 = _zz__zz_execute_SRC2_3[11];
+  assign _zz_execute_SRC2_2 = _zz__zz_execute_SRC2_2[11];
   always @(*) begin
-    _zz_execute_SRC2_4[19] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[18] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[17] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[16] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[15] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[14] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[13] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[12] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[11] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[10] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[9] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[8] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[7] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[6] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[5] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[4] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[3] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[2] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[1] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[0] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_3[19] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[18] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[17] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[16] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[15] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[14] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[13] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[12] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[11] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[10] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[9] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[8] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[7] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[6] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[5] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[4] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[3] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[2] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[1] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[0] = _zz_execute_SRC2_2;
   end
 
   always @(*) begin
     case(execute_SRC2_CTRL)
       Src2CtrlEnum_RS : begin
-        _zz_execute_SRC2_5 = execute_RS2;
+        _zz_execute_SRC2_4 = execute_RS2;
       end
       Src2CtrlEnum_IMI : begin
-        _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
+        _zz_execute_SRC2_4 = {_zz_execute_SRC2_1,execute_INSTRUCTION[31 : 20]};
       end
       Src2CtrlEnum_IMS : begin
-        _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_execute_SRC2_4 = {_zz_execute_SRC2_3,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_execute_SRC2_5 = _zz_execute_SRC2;
+        _zz_execute_SRC2_4 = _zz_execute_to_memory_PC;
       end
     endcase
   end
@@ -4355,16 +4360,19 @@ module VexRiscv (
   assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
   assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign switch_Misc_l210_3 = execute_INSTRUCTION[14 : 12];
+  assign switch_Misc_l232_3 = execute_INSTRUCTION[14 : 12];
   always @(*) begin
-    casez(switch_Misc_l210_3)
+    case(switch_Misc_l232_3)
       3'b000 : begin
         _zz_execute_BRANCH_COND_RESULT = execute_BranchPlugin_eq;
       end
       3'b001 : begin
         _zz_execute_BRANCH_COND_RESULT = (! execute_BranchPlugin_eq);
       end
-      3'b1?1 : begin
+      3'b101 : begin
+        _zz_execute_BRANCH_COND_RESULT = (! execute_SRC_LESS);
+      end
+      3'b111 : begin
         _zz_execute_BRANCH_COND_RESULT = (! execute_SRC_LESS);
       end
       default : begin
@@ -4489,9 +4497,11 @@ module VexRiscv (
     end
   end
 
-  assign _zz_when_CsrPlugin_l965 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_when_CsrPlugin_l965_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_when_CsrPlugin_l965_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign CsrPlugin_misa_base = 2'b01;
+  assign CsrPlugin_misa_extensions = 26'h0000042;
+  assign _zz_when_CsrPlugin_l1302 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l1302_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l1302_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
   assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
@@ -4533,28 +4543,28 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l922 = (! decode_arbitration_isStuck);
-  assign when_CsrPlugin_l922_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l922_2 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l922_3 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l935 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
+  assign when_CsrPlugin_l1259 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l1272 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-  assign when_CsrPlugin_l959 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign when_CsrPlugin_l965 = ((_zz_when_CsrPlugin_l965 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l965_1 = ((_zz_when_CsrPlugin_l965_1 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l965_2 = ((_zz_when_CsrPlugin_l965_2 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1296 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l1302 = ((_zz_when_CsrPlugin_l1302 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1302_1 = ((_zz_when_CsrPlugin_l1302_1 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1302_2 = ((_zz_when_CsrPlugin_l1302_2 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  assign when_CsrPlugin_l993 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l993_1 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l993_2 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l998 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  assign when_CsrPlugin_l1335 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1335_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l1335_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l1340 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
   always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(when_CsrPlugin_l1004) begin
+    if(when_CsrPlugin_l1346) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException) begin
@@ -4562,7 +4572,7 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l1004 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
+  assign when_CsrPlugin_l1346 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
   always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
@@ -4578,6 +4588,7 @@ module VexRiscv (
     end
   end
 
+  assign CsrPlugin_trapCauseEbreakDebug = 1'b0;
   always @(*) begin
     CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
@@ -4600,13 +4611,15 @@ module VexRiscv (
     endcase
   end
 
-  assign when_CsrPlugin_l1032 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign when_CsrPlugin_l1077 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
-  assign switch_CsrPlugin_l1081 = writeBack_INSTRUCTION[29 : 28];
+  assign CsrPlugin_trapEnterDebug = 1'b0;
+  assign when_CsrPlugin_l1390 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1398 = (! CsrPlugin_trapEnterDebug);
+  assign when_CsrPlugin_l1456 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign switch_CsrPlugin_l1460 = writeBack_INSTRUCTION[29 : 28];
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign when_CsrPlugin_l1121 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_WFI));
-  assign when_CsrPlugin_l1123 = (! execute_CsrPlugin_wfiWake);
-  assign when_CsrPlugin_l1129 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
+  assign when_CsrPlugin_l1519 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_WFI));
+  assign when_CsrPlugin_l1521 = (! execute_CsrPlugin_wfiWake);
+  assign when_CsrPlugin_l1527 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
   assign execute_CsrPlugin_blockedBySideEffects = ((|{writeBack_arbitration_isValid,memory_arbitration_isValid}) || 1'b0);
   always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
@@ -4705,18 +4718,18 @@ module VexRiscv (
     if(CsrPlugin_csrMapping_allowCsrSignal) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(when_CsrPlugin_l1315) begin
+    if(when_CsrPlugin_l1725) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if(when_CsrPlugin_l1149) begin
-      if(when_CsrPlugin_l1150) begin
+    if(when_CsrPlugin_l1547) begin
+      if(when_CsrPlugin_l1548) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
@@ -4724,20 +4737,20 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(when_CsrPlugin_l1142) begin
+    if(when_CsrPlugin_l1540) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1157) begin
+    if(when_CsrPlugin_l1555) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(when_CsrPlugin_l1142) begin
+    if(when_CsrPlugin_l1540) begin
       CsrPlugin_selfException_payload_code = 4'b0010;
     end
-    if(when_CsrPlugin_l1157) begin
+    if(when_CsrPlugin_l1555) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -4750,20 +4763,20 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  assign when_CsrPlugin_l1142 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
-  assign when_CsrPlugin_l1149 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
-  assign when_CsrPlugin_l1150 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
-  assign when_CsrPlugin_l1157 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
+  assign when_CsrPlugin_l1540 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
+  assign when_CsrPlugin_l1547 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign when_CsrPlugin_l1548 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1555 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
   always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -4772,9 +4785,9 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
   assign execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
-  assign switch_Misc_l210_4 = execute_INSTRUCTION[13];
+  assign switch_Misc_l232_4 = execute_INSTRUCTION[13];
   always @(*) begin
-    case(switch_Misc_l210_4)
+    case(switch_Misc_l232_4)
       1'b0 : begin
         _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
@@ -4785,8 +4798,8 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
-  assign when_CsrPlugin_l1189 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign when_CsrPlugin_l1193 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
+  assign when_CsrPlugin_l1587 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1591 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
@@ -4849,12 +4862,12 @@ module VexRiscv (
   assign memory_DivPlugin_div_counter_willOverflow = (memory_DivPlugin_div_counter_willOverflowIfInc && memory_DivPlugin_div_counter_willIncrement);
   always @(*) begin
     if(memory_DivPlugin_div_counter_willOverflow) begin
-      memory_DivPlugin_div_counter_valueNext = 6'h0;
+      memory_DivPlugin_div_counter_valueNext = 6'h00;
     end else begin
       memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_memory_DivPlugin_div_counter_valueNext);
     end
     if(memory_DivPlugin_div_counter_willClear) begin
-      memory_DivPlugin_div_counter_valueNext = 6'h0;
+      memory_DivPlugin_div_counter_valueNext = 6'h00;
     end
   end
 
@@ -4878,17 +4891,17 @@ module VexRiscv (
     _zz_memory_DivPlugin_rs1_1[31 : 0] = execute_RS1;
   end
 
-  assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
-  assign externalInterrupt = (|_zz_CsrPlugin_csrMapping_readDataInit_1);
-  assign when_DebugPlugin_l225 = (DebugPlugin_haltIt && (! DebugPlugin_isPipBusy));
+  assign _zz_externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
+  assign externalInterrupt = (|_zz_externalInterrupt);
+  assign when_DebugPlugin_l238 = (DebugPlugin_haltIt && (! DebugPlugin_isPipBusy));
   assign DebugPlugin_allowEBreak = (DebugPlugin_debugUsed && (! DebugPlugin_disableEbreak));
   always @(*) begin
     debug_bus_cmd_ready = 1'b1;
     if(debug_bus_cmd_valid) begin
-      case(switch_DebugPlugin_l267)
+      case(switch_DebugPlugin_l280)
         6'h01 : begin
           if(debug_bus_cmd_payload_wr) begin
-            debug_bus_cmd_ready = IBusCachedPlugin_injectionPort_ready;
+            debug_bus_cmd_ready = DebugPlugin_injectionPort_ready;
           end
         end
         default : begin
@@ -4899,7 +4912,7 @@ module VexRiscv (
 
   always @(*) begin
     debug_bus_rsp_data = DebugPlugin_busReadDataReg;
-    if(when_DebugPlugin_l244) begin
+    if(when_DebugPlugin_l257) begin
       debug_bus_rsp_data[0] = DebugPlugin_resetIt;
       debug_bus_rsp_data[1] = DebugPlugin_haltIt;
       debug_bus_rsp_data[2] = DebugPlugin_isPipBusy;
@@ -4908,14 +4921,14 @@ module VexRiscv (
     end
   end
 
-  assign when_DebugPlugin_l244 = (! _zz_when_DebugPlugin_l244);
+  assign when_DebugPlugin_l257 = (! _zz_when_DebugPlugin_l257);
   always @(*) begin
-    IBusCachedPlugin_injectionPort_valid = 1'b0;
+    DebugPlugin_injectionPort_valid = 1'b0;
     if(debug_bus_cmd_valid) begin
-      case(switch_DebugPlugin_l267)
+      case(switch_DebugPlugin_l280)
         6'h01 : begin
           if(debug_bus_cmd_payload_wr) begin
-            IBusCachedPlugin_injectionPort_valid = 1'b1;
+            DebugPlugin_injectionPort_valid = 1'b1;
           end
         end
         default : begin
@@ -4924,21 +4937,21 @@ module VexRiscv (
     end
   end
 
-  assign IBusCachedPlugin_injectionPort_payload = debug_bus_cmd_payload_data;
-  assign switch_DebugPlugin_l267 = debug_bus_cmd_payload_address[7 : 2];
-  assign when_DebugPlugin_l271 = debug_bus_cmd_payload_data[16];
-  assign when_DebugPlugin_l271_1 = debug_bus_cmd_payload_data[24];
-  assign when_DebugPlugin_l272 = debug_bus_cmd_payload_data[17];
-  assign when_DebugPlugin_l272_1 = debug_bus_cmd_payload_data[25];
-  assign when_DebugPlugin_l273 = debug_bus_cmd_payload_data[25];
-  assign when_DebugPlugin_l274 = debug_bus_cmd_payload_data[25];
-  assign when_DebugPlugin_l275 = debug_bus_cmd_payload_data[18];
-  assign when_DebugPlugin_l275_1 = debug_bus_cmd_payload_data[26];
-  assign when_DebugPlugin_l295 = (execute_arbitration_isValid && execute_DO_EBREAK);
-  assign when_DebugPlugin_l298 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
-  assign when_DebugPlugin_l311 = (DebugPlugin_stepIt && IBusCachedPlugin_incomingInstruction);
+  assign DebugPlugin_injectionPort_payload = debug_bus_cmd_payload_data;
+  assign switch_DebugPlugin_l280 = debug_bus_cmd_payload_address[7 : 2];
+  assign when_DebugPlugin_l284 = debug_bus_cmd_payload_data[16];
+  assign when_DebugPlugin_l284_1 = debug_bus_cmd_payload_data[24];
+  assign when_DebugPlugin_l285 = debug_bus_cmd_payload_data[17];
+  assign when_DebugPlugin_l285_1 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l286 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l287 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l288 = debug_bus_cmd_payload_data[18];
+  assign when_DebugPlugin_l288_1 = debug_bus_cmd_payload_data[26];
+  assign when_DebugPlugin_l308 = (execute_arbitration_isValid && execute_DO_EBREAK);
+  assign when_DebugPlugin_l311 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
+  assign when_DebugPlugin_l324 = (DebugPlugin_stepIt && IBusCachedPlugin_incomingInstruction);
   assign debug_resetOut = DebugPlugin_resetIt_regNext;
-  assign when_DebugPlugin_l331 = (DebugPlugin_haltIt || DebugPlugin_stepIt);
+  assign when_DebugPlugin_l344 = (DebugPlugin_haltIt || DebugPlugin_stepIt);
   assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
@@ -5061,218 +5074,227 @@ module VexRiscv (
   assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
   assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
   always @(*) begin
-    IBusCachedPlugin_injectionPort_ready = 1'b0;
-    case(switch_Fetcher_l365)
+    DebugPlugin_injectionPort_ready = 1'b0;
+    case(IBusCachedPlugin_injector_port_state)
       3'b100 : begin
-        IBusCachedPlugin_injectionPort_ready = 1'b1;
+        DebugPlugin_injectionPort_ready = 1'b1;
       end
       default : begin
       end
     endcase
   end
 
-  assign when_Fetcher_l363 = (switch_Fetcher_l365 != 3'b000);
-  assign when_Fetcher_l381 = (! decode_arbitration_isStuck);
-  assign when_Fetcher_l401 = (switch_Fetcher_l365 != 3'b000);
-  assign when_CsrPlugin_l1277 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_2 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_3 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_4 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_5 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_6 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_7 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_8 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_9 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_10 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_11 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_12 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_13 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_14 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_15 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_16 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_17 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_18 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_19 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_20 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_21 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_22 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_23 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l373 = (IBusCachedPlugin_injector_port_state != 3'b000);
+  assign when_Fetcher_l391 = (! decode_arbitration_isStuck);
+  assign when_Fetcher_l411 = (IBusCachedPlugin_injector_port_state != 3'b000);
+  assign when_CsrPlugin_l1669 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_8 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_9 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_10 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_11 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_12 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_13 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_14 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_15 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_16 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_17 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_18 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_19 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_20 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_21 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_22 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_23 = (! execute_arbitration_isStuck);
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_1 = 32'h00000000;
     if(execute_CsrPlugin_csr_3264) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_2[12 : 0] = 13'h1000;
-      _zz_CsrPlugin_csrMapping_readDataInit_2[25 : 20] = 6'h20;
+      _zz_CsrPlugin_csrMapping_readDataInit_1[12 : 0] = 13'h1000;
+      _zz_CsrPlugin_csrMapping_readDataInit_1[25 : 20] = 6'h20;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h00000000;
     if(execute_CsrPlugin_csr_3857) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_3[3 : 0] = 4'b1011;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[3 : 0] = 4'b1011;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h00000000;
     if(execute_CsrPlugin_csr_3858) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_4[4 : 0] = 5'h16;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[4 : 0] = 5'h16;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h00000000;
     if(execute_CsrPlugin_csr_3859) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_5[5 : 0] = 6'h21;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[5 : 0] = 6'h21;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h00000000;
     if(execute_CsrPlugin_csr_769) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_6[31 : 30] = CsrPlugin_misa_base;
-      _zz_CsrPlugin_csrMapping_readDataInit_6[25 : 0] = CsrPlugin_misa_extensions;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[31 : 30] = CsrPlugin_misa_base;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[25 : 0] = CsrPlugin_misa_extensions;
     end
   end
 
-  assign switch_CsrPlugin_l723 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
+  assign switch_CsrPlugin_l1031 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h00000000;
     if(execute_CsrPlugin_csr_768) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_7[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_7[3 : 3] = CsrPlugin_mstatus_MIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_7[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[12 : 11] = CsrPlugin_mstatus_MPP;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h00000000;
     if(execute_CsrPlugin_csr_836) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_8[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_8[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_8[3 : 3] = CsrPlugin_mip_MSIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[3 : 3] = CsrPlugin_mip_MSIP;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h00000000;
     if(execute_CsrPlugin_csr_772) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_9[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_9[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_9[3 : 3] = CsrPlugin_mie_MSIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_8[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_8[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_8[3 : 3] = CsrPlugin_mie_MSIE;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_10 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h00000000;
     if(execute_CsrPlugin_csr_773) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_10[31 : 2] = CsrPlugin_mtvec_base;
-      _zz_CsrPlugin_csrMapping_readDataInit_10[1 : 0] = CsrPlugin_mtvec_mode;
+      _zz_CsrPlugin_csrMapping_readDataInit_9[31 : 2] = CsrPlugin_mtvec_base;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_11 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_10 = 32'h00000000;
     if(execute_CsrPlugin_csr_833) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_11[31 : 0] = CsrPlugin_mepc;
+      _zz_CsrPlugin_csrMapping_readDataInit_10[31 : 0] = CsrPlugin_mepc;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_12 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_11 = 32'h00000000;
     if(execute_CsrPlugin_csr_832) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_12[31 : 0] = CsrPlugin_mscratch;
+      _zz_CsrPlugin_csrMapping_readDataInit_11[31 : 0] = CsrPlugin_mscratch;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_13 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_12 = 32'h00000000;
     if(execute_CsrPlugin_csr_834) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_13[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_CsrPlugin_csrMapping_readDataInit_13[3 : 0] = CsrPlugin_mcause_exceptionCode;
+      _zz_CsrPlugin_csrMapping_readDataInit_12[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_CsrPlugin_csrMapping_readDataInit_12[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_14 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_13 = 32'h00000000;
     if(execute_CsrPlugin_csr_835) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_14[31 : 0] = CsrPlugin_mtval;
+      _zz_CsrPlugin_csrMapping_readDataInit_13[31 : 0] = CsrPlugin_mtval;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_15 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_14 = 32'h00000000;
     if(execute_CsrPlugin_csr_2816) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_15[31 : 0] = CsrPlugin_mcycle[31 : 0];
+      _zz_CsrPlugin_csrMapping_readDataInit_14[31 : 0] = CsrPlugin_mcycle[31 : 0];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_16 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_15 = 32'h00000000;
     if(execute_CsrPlugin_csr_2944) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_16[31 : 0] = CsrPlugin_mcycle[63 : 32];
+      _zz_CsrPlugin_csrMapping_readDataInit_15[31 : 0] = CsrPlugin_mcycle[63 : 32];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_17 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_16 = 32'h00000000;
     if(execute_CsrPlugin_csr_2818) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_17[31 : 0] = CsrPlugin_minstret[31 : 0];
+      _zz_CsrPlugin_csrMapping_readDataInit_16[31 : 0] = CsrPlugin_minstret[31 : 0];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_18 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_17 = 32'h00000000;
     if(execute_CsrPlugin_csr_2946) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_18[31 : 0] = CsrPlugin_minstret[63 : 32];
+      _zz_CsrPlugin_csrMapping_readDataInit_17[31 : 0] = CsrPlugin_minstret[63 : 32];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_19 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_18 = 32'h00000000;
     if(execute_CsrPlugin_csr_3072) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_19[31 : 0] = CsrPlugin_mcycle[31 : 0];
+      _zz_CsrPlugin_csrMapping_readDataInit_18[31 : 0] = CsrPlugin_mcycle[31 : 0];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_20 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_19 = 32'h00000000;
     if(execute_CsrPlugin_csr_3200) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_20[31 : 0] = CsrPlugin_mcycle[63 : 32];
+      _zz_CsrPlugin_csrMapping_readDataInit_19[31 : 0] = CsrPlugin_mcycle[63 : 32];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_21 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_20 = 32'h00000000;
     if(execute_CsrPlugin_csr_3074) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_21[31 : 0] = CsrPlugin_minstret[31 : 0];
+      _zz_CsrPlugin_csrMapping_readDataInit_20[31 : 0] = CsrPlugin_minstret[31 : 0];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_22 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_21 = 32'h00000000;
     if(execute_CsrPlugin_csr_3202) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_22[31 : 0] = CsrPlugin_minstret[63 : 32];
+      _zz_CsrPlugin_csrMapping_readDataInit_21[31 : 0] = CsrPlugin_minstret[63 : 32];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_23 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_22 = 32'h00000000;
     if(execute_CsrPlugin_csr_3008) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_23[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
+      _zz_CsrPlugin_csrMapping_readDataInit_22[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_24 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_23 = 32'h00000000;
     if(execute_CsrPlugin_csr_4032) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_24[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_1;
+      _zz_CsrPlugin_csrMapping_readDataInit_23[31 : 0] = _zz_externalInterrupt;
     end
   end
 
-  assign CsrPlugin_csrMapping_readDataInit = (((((_zz_CsrPlugin_csrMapping_readDataInit_2 | _zz_CsrPlugin_csrMapping_readDataInit_3) | (_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5)) | ((_zz_CsrPlugin_csrMapping_readDataInit_25 | _zz_CsrPlugin_csrMapping_readDataInit_6) | (_zz_CsrPlugin_csrMapping_readDataInit_7 | _zz_CsrPlugin_csrMapping_readDataInit_8))) | (((_zz_CsrPlugin_csrMapping_readDataInit_9 | _zz_CsrPlugin_csrMapping_readDataInit_10) | (_zz_CsrPlugin_csrMapping_readDataInit_11 | _zz_CsrPlugin_csrMapping_readDataInit_12)) | ((_zz_CsrPlugin_csrMapping_readDataInit_13 | _zz_CsrPlugin_csrMapping_readDataInit_14) | (_zz_CsrPlugin_csrMapping_readDataInit_15 | _zz_CsrPlugin_csrMapping_readDataInit_16)))) | (((_zz_CsrPlugin_csrMapping_readDataInit_17 | _zz_CsrPlugin_csrMapping_readDataInit_18) | (_zz_CsrPlugin_csrMapping_readDataInit_19 | _zz_CsrPlugin_csrMapping_readDataInit_20)) | ((_zz_CsrPlugin_csrMapping_readDataInit_21 | _zz_CsrPlugin_csrMapping_readDataInit_22) | (_zz_CsrPlugin_csrMapping_readDataInit_23 | _zz_CsrPlugin_csrMapping_readDataInit_24))));
-  assign when_CsrPlugin_l1310 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign when_CsrPlugin_l1315 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign CsrPlugin_csrMapping_readDataInit = (((((_zz_CsrPlugin_csrMapping_readDataInit_1 | _zz_CsrPlugin_csrMapping_readDataInit_2) | (_zz_CsrPlugin_csrMapping_readDataInit_3 | _zz_CsrPlugin_csrMapping_readDataInit_4)) | ((_zz_CsrPlugin_csrMapping_readDataInit_24 | _zz_CsrPlugin_csrMapping_readDataInit_5) | (_zz_CsrPlugin_csrMapping_readDataInit_6 | _zz_CsrPlugin_csrMapping_readDataInit_7))) | (((_zz_CsrPlugin_csrMapping_readDataInit_8 | _zz_CsrPlugin_csrMapping_readDataInit_9) | (_zz_CsrPlugin_csrMapping_readDataInit_10 | _zz_CsrPlugin_csrMapping_readDataInit_11)) | ((_zz_CsrPlugin_csrMapping_readDataInit_12 | _zz_CsrPlugin_csrMapping_readDataInit_13) | (_zz_CsrPlugin_csrMapping_readDataInit_14 | _zz_CsrPlugin_csrMapping_readDataInit_15)))) | (((_zz_CsrPlugin_csrMapping_readDataInit_16 | _zz_CsrPlugin_csrMapping_readDataInit_17) | (_zz_CsrPlugin_csrMapping_readDataInit_18 | _zz_CsrPlugin_csrMapping_readDataInit_19)) | ((_zz_CsrPlugin_csrMapping_readDataInit_20 | _zz_CsrPlugin_csrMapping_readDataInit_21) | (_zz_CsrPlugin_csrMapping_readDataInit_22 | _zz_CsrPlugin_csrMapping_readDataInit_23))));
+  assign when_CsrPlugin_l1702 = ((execute_arbitration_isValid && execute_IS_CSR) && (({execute_CsrPlugin_csrAddress[11 : 2],2'b00} == 12'h3a0) || ({execute_CsrPlugin_csrAddress[11 : 4],4'b0000} == 12'h3b0)));
+  assign _zz_when_CsrPlugin_l1709 = (execute_CsrPlugin_csrAddress & 12'hf60);
+  assign when_CsrPlugin_l1709 = (((execute_arbitration_isValid && execute_IS_CSR) && (5'h03 <= execute_CsrPlugin_csrAddress[4 : 0])) && (((_zz_when_CsrPlugin_l1709 == 12'hb00) || (((_zz_when_CsrPlugin_l1709 == 12'hc00) && (! execute_CsrPlugin_writeInstruction)) && (CsrPlugin_privilege == 2'b11))) || ((execute_CsrPlugin_csrAddress & 12'hfe0) == 12'h320)));
+  always @(*) begin
+    when_CsrPlugin_l1719 = CsrPlugin_csrMapping_doForceFailCsr;
+    if(when_CsrPlugin_l1717) begin
+      when_CsrPlugin_l1719 = 1'b1;
+    end
+  end
+
+  assign when_CsrPlugin_l1717 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1725 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
   assign iBusWishbone_ADR = {_zz_iBusWishbone_ADR_1,_zz_iBusWishbone_ADR};
   assign iBusWishbone_CTI = ((_zz_iBusWishbone_ADR == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
@@ -5298,20 +5320,20 @@ module VexRiscv (
   assign iBus_rsp_valid = _zz_iBus_rsp_valid;
   assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
   assign iBus_rsp_payload_error = 1'b0;
-  assign _zz_dBus_cmd_ready_5 = (dBus_cmd_payload_size == 3'b101);
-  assign _zz_dBus_cmd_ready_1 = dBus_cmd_valid;
-  assign _zz_dBus_cmd_ready_3 = dBus_cmd_payload_wr;
-  assign _zz_dBus_cmd_ready_4 = ((! _zz_dBus_cmd_ready_5) || (_zz_dBus_cmd_ready == 3'b111));
-  assign dBus_cmd_ready = (_zz_dBus_cmd_ready_2 && (_zz_dBus_cmd_ready_3 || _zz_dBus_cmd_ready_4));
-  assign dBusWishbone_ADR = ((_zz_dBus_cmd_ready_5 ? {{dBus_cmd_payload_address[31 : 5],_zz_dBus_cmd_ready},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
-  assign dBusWishbone_CTI = (_zz_dBus_cmd_ready_5 ? (_zz_dBus_cmd_ready_4 ? 3'b111 : 3'b010) : 3'b000);
+  assign _zz_dBusWishbone_ADR_1 = (dBus_cmd_payload_size == 3'b101);
+  assign _zz_dBusWishbone_CYC = dBus_cmd_valid;
+  assign _zz_dBus_cmd_ready_1 = dBus_cmd_payload_wr;
+  assign _zz_dBus_cmd_ready_2 = ((! _zz_dBusWishbone_ADR_1) || (_zz_dBusWishbone_ADR == 3'b111));
+  assign dBus_cmd_ready = (_zz_dBus_cmd_ready && (_zz_dBus_cmd_ready_1 || _zz_dBus_cmd_ready_2));
+  assign dBusWishbone_ADR = ((_zz_dBusWishbone_ADR_1 ? {{dBus_cmd_payload_address[31 : 5],_zz_dBusWishbone_ADR},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2'd2);
+  assign dBusWishbone_CTI = (_zz_dBusWishbone_ADR_1 ? (_zz_dBus_cmd_ready_2 ? 3'b111 : 3'b010) : 3'b000);
   assign dBusWishbone_BTE = 2'b00;
-  assign dBusWishbone_SEL = (_zz_dBus_cmd_ready_3 ? dBus_cmd_payload_mask : 4'b1111);
-  assign dBusWishbone_WE = _zz_dBus_cmd_ready_3;
+  assign dBusWishbone_SEL = (_zz_dBus_cmd_ready_1 ? dBus_cmd_payload_mask : 4'b1111);
+  assign dBusWishbone_WE = _zz_dBus_cmd_ready_1;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_payload_data;
-  assign _zz_dBus_cmd_ready_2 = (_zz_dBus_cmd_ready_1 && dBusWishbone_ACK);
-  assign dBusWishbone_CYC = _zz_dBus_cmd_ready_1;
-  assign dBusWishbone_STB = _zz_dBus_cmd_ready_1;
+  assign _zz_dBus_cmd_ready = (_zz_dBusWishbone_CYC && dBusWishbone_ACK);
+  assign dBusWishbone_CYC = _zz_dBusWishbone_CYC;
+  assign dBusWishbone_STB = _zz_dBusWishbone_CYC;
   assign dBus_rsp_valid = _zz_dBus_rsp_valid;
   assign dBus_rsp_payload_data = dBusWishbone_DAT_MISO_regNext;
   assign dBus_rsp_payload_error = 1'b0;
@@ -5322,7 +5344,7 @@ module VexRiscv (
       IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
       IBusCachedPlugin_decodePc_pcReg <= externalResetVector;
-      _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+      _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= 1'b0;
       IBusCachedPlugin_decompressor_bufferValid <= 1'b0;
       IBusCachedPlugin_decompressor_throw2BytesReg <= 1'b0;
       _zz_IBusCachedPlugin_injector_decodeInput_valid <= 1'b0;
@@ -5330,22 +5352,20 @@ module VexRiscv (
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= 32'h0;
-      dataCache_1_io_mem_cmd_rValid <= 1'b0;
-      dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= 32'h0;
-      _zz_2 <= 1'b1;
+      IBusCachedPlugin_rspCounter <= 32'h00000000;
+      toplevel_dataCache_1_io_mem_cmd_rValidN <= 1'b1;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
+      DBusCachedPlugin_rspCounter <= 32'h00000000;
+      _zz_5 <= 1'b1;
       HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
-      CsrPlugin_misa_base <= 2'b01;
-      CsrPlugin_misa_extensions <= 26'h0000042;
       CsrPlugin_mstatus_MIE <= 1'b0;
       CsrPlugin_mstatus_MPIE <= 1'b0;
       CsrPlugin_mstatus_MPP <= 2'b11;
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
-      CsrPlugin_mcycle <= 64'h0;
-      CsrPlugin_minstret <= 64'h0;
+      CsrPlugin_mcycle <= 64'h0000000000000000;
+      CsrPlugin_minstret <= 64'h0000000000000000;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= 1'b0;
@@ -5357,15 +5377,15 @@ module VexRiscv (
       CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
-      memory_DivPlugin_div_counter_value <= 6'h0;
-      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h0;
+      memory_DivPlugin_div_counter_value <= 6'h00;
+      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h00000000;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
-      switch_Fetcher_l365 <= 3'b000;
+      IBusCachedPlugin_injector_port_state <= 3'b000;
       _zz_iBusWishbone_ADR <= 3'b000;
       _zz_iBus_rsp_valid <= 1'b0;
-      _zz_dBus_cmd_ready <= 3'b000;
+      _zz_dBusWishbone_ADR <= 3'b000;
       _zz_dBus_rsp_valid <= 1'b0;
     end else begin
       if(IBusCachedPlugin_fetchPc_correction) begin
@@ -5375,42 +5395,42 @@ module VexRiscv (
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusCachedPlugin_fetchPc_booted <= 1'b1;
-      if(when_Fetcher_l134) begin
+      if(when_Fetcher_l133) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_output_fire_1) begin
+      if(IBusCachedPlugin_fetchPc_output_fire) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b1;
       end
-      if(when_Fetcher_l134_1) begin
+      if(when_Fetcher_l133_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(when_Fetcher_l161) begin
+      if(when_Fetcher_l160) begin
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
-      if(when_Fetcher_l183) begin
+      if(when_Fetcher_l182) begin
         IBusCachedPlugin_decodePc_pcReg <= IBusCachedPlugin_decodePc_pcPlus;
       end
-      if(when_Fetcher_l195) begin
+      if(when_Fetcher_l194) begin
         IBusCachedPlugin_decodePc_pcReg <= IBusCachedPlugin_jump_pcLoad_payload;
       end
       if(IBusCachedPlugin_iBusRsp_flush) begin
-        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= 1'b0;
       end
       if(_zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready) begin
-        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
       if(IBusCachedPlugin_decompressor_output_fire) begin
         IBusCachedPlugin_decompressor_throw2BytesReg <= ((((! IBusCachedPlugin_decompressor_unaligned) && IBusCachedPlugin_decompressor_isInputLowRvc) && IBusCachedPlugin_decompressor_isInputHighRvc) || (IBusCachedPlugin_decompressor_bufferValid && IBusCachedPlugin_decompressor_isInputHighRvc));
       end
-      if(when_Fetcher_l286) begin
+      if(when_Fetcher_l285) begin
         IBusCachedPlugin_decompressor_bufferValid <= 1'b0;
       end
-      if(when_Fetcher_l289) begin
+      if(when_Fetcher_l288) begin
         if(IBusCachedPlugin_decompressor_bufferFill) begin
           IBusCachedPlugin_decompressor_bufferValid <= 1'b1;
         end
       end
-      if(when_Fetcher_l294) begin
+      if(when_Fetcher_l293) begin
         IBusCachedPlugin_decompressor_throw2BytesReg <= 1'b0;
         IBusCachedPlugin_decompressor_bufferValid <= 1'b0;
       end
@@ -5420,25 +5440,25 @@ module VexRiscv (
       if(IBusCachedPlugin_decompressor_output_ready) begin
         _zz_IBusCachedPlugin_injector_decodeInput_valid <= (IBusCachedPlugin_decompressor_output_valid && (! IBusCachedPlugin_externalFlush));
       end
-      if(when_Fetcher_l332) begin
+      if(when_Fetcher_l331) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
       if(IBusCachedPlugin_decodePc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if(when_Fetcher_l332_1) begin
+      if(when_Fetcher_l331_1) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= IBusCachedPlugin_injector_nextPcCalc_valids_0;
       end
       if(IBusCachedPlugin_decodePc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(when_Fetcher_l332_2) begin
+      if(when_Fetcher_l331_2) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= IBusCachedPlugin_injector_nextPcCalc_valids_1;
       end
       if(IBusCachedPlugin_decodePc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(when_Fetcher_l332_3) begin
+      if(when_Fetcher_l331_3) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
       end
       if(IBusCachedPlugin_decodePc_flushed) begin
@@ -5448,68 +5468,68 @@ module VexRiscv (
         IBusCachedPlugin_rspCounter <= (IBusCachedPlugin_rspCounter + 32'h00000001);
       end
       if(dataCache_1_io_mem_cmd_valid) begin
-        dataCache_1_io_mem_cmd_rValid <= 1'b1;
+        toplevel_dataCache_1_io_mem_cmd_rValidN <= 1'b0;
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
-        dataCache_1_io_mem_cmd_rValid <= 1'b0;
+      if(toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+        toplevel_dataCache_1_io_mem_cmd_rValidN <= 1'b1;
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
-        dataCache_1_io_mem_cmd_s2mPipe_rValid <= dataCache_1_io_mem_cmd_s2mPipe_valid;
+      if(toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+        toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_valid;
       end
       if(dBus_rsp_valid) begin
         DBusCachedPlugin_rspCounter <= (DBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      _zz_2 <= 1'b0;
+      _zz_5 <= 1'b0;
       HazardSimplePlugin_writeBackBuffer_valid <= HazardSimplePlugin_writeBackWrites_valid;
       CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
       if(writeBack_arbitration_isFiring) begin
         CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
       end
-      if(when_CsrPlugin_l922) begin
+      if(when_CsrPlugin_l1259) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if(when_CsrPlugin_l922_1) begin
+      if(when_CsrPlugin_l1259_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if(when_CsrPlugin_l922_2) begin
+      if(when_CsrPlugin_l1259_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if(when_CsrPlugin_l922_3) begin
+      if(when_CsrPlugin_l1259_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(when_CsrPlugin_l959) begin
-        if(when_CsrPlugin_l965) begin
+      if(when_CsrPlugin_l1296) begin
+        if(when_CsrPlugin_l1302) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_1) begin
+        if(when_CsrPlugin_l1302_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_2) begin
+        if(when_CsrPlugin_l1302_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
       CsrPlugin_lastStageWasWfi <= (writeBack_arbitration_isFiring && (writeBack_ENV_CTRL == EnvCtrlEnum_WFI));
       if(CsrPlugin_pipelineLiberator_active) begin
-        if(when_CsrPlugin_l993) begin
+        if(when_CsrPlugin_l1335) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if(when_CsrPlugin_l993_1) begin
+        if(when_CsrPlugin_l1335_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if(when_CsrPlugin_l993_2) begin
+        if(when_CsrPlugin_l1335_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(when_CsrPlugin_l998) begin
+      if(when_CsrPlugin_l1340) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
@@ -5518,19 +5538,21 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(when_CsrPlugin_l1032) begin
-        case(CsrPlugin_targetPrivilege)
-          2'b11 : begin
-            CsrPlugin_mstatus_MIE <= 1'b0;
-            CsrPlugin_mstatus_MPIE <= CsrPlugin_mstatus_MIE;
-            CsrPlugin_mstatus_MPP <= CsrPlugin_privilege;
-          end
-          default : begin
-          end
-        endcase
+      if(when_CsrPlugin_l1390) begin
+        if(when_CsrPlugin_l1398) begin
+          case(CsrPlugin_targetPrivilege)
+            2'b11 : begin
+              CsrPlugin_mstatus_MIE <= 1'b0;
+              CsrPlugin_mstatus_MPIE <= CsrPlugin_mstatus_MIE;
+              CsrPlugin_mstatus_MPP <= CsrPlugin_privilege;
+            end
+            default : begin
+            end
+          endcase
+        end
       end
-      if(when_CsrPlugin_l1077) begin
-        case(switch_CsrPlugin_l1081)
+      if(when_CsrPlugin_l1456) begin
+        case(switch_CsrPlugin_l1460)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -5540,7 +5562,7 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l965_2,{_zz_when_CsrPlugin_l965_1,_zz_when_CsrPlugin_l965}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l1302_2,{_zz_when_CsrPlugin_l1302_1,_zz_when_CsrPlugin_l1302}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
       if(when_Pipeline_l151) begin
         execute_arbitration_isValid <= 1'b0;
@@ -5560,40 +5582,34 @@ module VexRiscv (
       if(when_Pipeline_l154_2) begin
         writeBack_arbitration_isValid <= memory_arbitration_isValid;
       end
-      case(switch_Fetcher_l365)
+      case(IBusCachedPlugin_injector_port_state)
         3'b000 : begin
-          if(IBusCachedPlugin_injectionPort_valid) begin
-            switch_Fetcher_l365 <= 3'b001;
+          if(DebugPlugin_injectionPort_valid) begin
+            IBusCachedPlugin_injector_port_state <= 3'b001;
           end
         end
         3'b001 : begin
-          switch_Fetcher_l365 <= 3'b010;
+          IBusCachedPlugin_injector_port_state <= 3'b010;
         end
         3'b010 : begin
-          switch_Fetcher_l365 <= 3'b011;
+          IBusCachedPlugin_injector_port_state <= 3'b011;
         end
         3'b011 : begin
-          if(when_Fetcher_l381) begin
-            switch_Fetcher_l365 <= 3'b100;
+          if(when_Fetcher_l391) begin
+            IBusCachedPlugin_injector_port_state <= 3'b100;
           end
         end
         3'b100 : begin
-          switch_Fetcher_l365 <= 3'b000;
+          IBusCachedPlugin_injector_port_state <= 3'b000;
         end
         default : begin
         end
       endcase
-      if(execute_CsrPlugin_csr_769) begin
-        if(execute_CsrPlugin_writeEnable) begin
-          CsrPlugin_misa_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 30];
-          CsrPlugin_misa_extensions <= CsrPlugin_csrMapping_writeDataSignal[25 : 0];
-        end
-      end
       if(execute_CsrPlugin_csr_768) begin
         if(execute_CsrPlugin_writeEnable) begin
           CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
           CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
-          case(switch_CsrPlugin_l723)
+          case(switch_CsrPlugin_l1031)
             2'b11 : begin
               CsrPlugin_mstatus_MPP <= 2'b11;
             end
@@ -5640,13 +5656,13 @@ module VexRiscv (
         end
       end
       _zz_iBus_rsp_valid <= (iBusWishbone_CYC && iBusWishbone_ACK);
-      if((_zz_dBus_cmd_ready_1 && _zz_dBus_cmd_ready_2)) begin
-        _zz_dBus_cmd_ready <= (_zz_dBus_cmd_ready + 3'b001);
-        if(_zz_dBus_cmd_ready_4) begin
-          _zz_dBus_cmd_ready <= 3'b000;
+      if((_zz_dBusWishbone_CYC && _zz_dBus_cmd_ready)) begin
+        _zz_dBusWishbone_ADR <= (_zz_dBusWishbone_ADR + 3'b001);
+        if(_zz_dBus_cmd_ready_2) begin
+          _zz_dBusWishbone_ADR <= 3'b000;
         end
       end
-      _zz_dBus_rsp_valid <= ((_zz_dBus_cmd_ready_1 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
+      _zz_dBus_rsp_valid <= ((_zz_dBusWishbone_CYC && (! dBusWishbone_WE)) && dBusWishbone_ACK);
     end
   end
 
@@ -5657,7 +5673,7 @@ module VexRiscv (
     if(IBusCachedPlugin_decompressor_input_valid) begin
       IBusCachedPlugin_decompressor_throw2BytesLatch <= IBusCachedPlugin_decompressor_throw2Bytes;
     end
-    if(when_Fetcher_l289) begin
+    if(when_Fetcher_l288) begin
       IBusCachedPlugin_decompressor_bufferData <= IBusCachedPlugin_decompressor_input_payload_rsp_inst[31 : 16];
     end
     if(IBusCachedPlugin_decompressor_output_ready) begin
@@ -5672,23 +5688,23 @@ module VexRiscv (
     if(IBusCachedPlugin_iBusRsp_stages_1_input_ready) begin
       IBusCachedPlugin_s1_tightlyCoupledHit <= IBusCachedPlugin_s0_tightlyCoupledHit;
     end
-    if(dataCache_1_io_mem_cmd_ready) begin
-      dataCache_1_io_mem_cmd_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
-      dataCache_1_io_mem_cmd_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
-      dataCache_1_io_mem_cmd_rData_address <= dataCache_1_io_mem_cmd_payload_address;
-      dataCache_1_io_mem_cmd_rData_data <= dataCache_1_io_mem_cmd_payload_data;
-      dataCache_1_io_mem_cmd_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
-      dataCache_1_io_mem_cmd_rData_size <= dataCache_1_io_mem_cmd_payload_size;
-      dataCache_1_io_mem_cmd_rData_last <= dataCache_1_io_mem_cmd_payload_last;
+    if(toplevel_dataCache_1_io_mem_cmd_rValidN) begin
+      toplevel_dataCache_1_io_mem_cmd_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
+      toplevel_dataCache_1_io_mem_cmd_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
+      toplevel_dataCache_1_io_mem_cmd_rData_address <= dataCache_1_io_mem_cmd_payload_address;
+      toplevel_dataCache_1_io_mem_cmd_rData_data <= dataCache_1_io_mem_cmd_payload_data;
+      toplevel_dataCache_1_io_mem_cmd_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
+      toplevel_dataCache_1_io_mem_cmd_rData_size <= dataCache_1_io_mem_cmd_payload_size;
+      toplevel_dataCache_1_io_mem_cmd_rData_last <= dataCache_1_io_mem_cmd_payload_last;
     end
-    if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
-      dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_address <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_data <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_size <= dataCache_1_io_mem_cmd_s2mPipe_payload_size;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_last <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+    if(toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_address <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_data <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_size <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_size;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_last <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_last;
     end
     HazardSimplePlugin_writeBackBuffer_payload_address <= HazardSimplePlugin_writeBackWrites_payload_address;
     HazardSimplePlugin_writeBackBuffer_payload_data <= HazardSimplePlugin_writeBackWrites_payload_data;
@@ -5707,33 +5723,35 @@ module VexRiscv (
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(when_CsrPlugin_l959) begin
-      if(when_CsrPlugin_l965) begin
+    if(when_CsrPlugin_l1296) begin
+      if(when_CsrPlugin_l1302) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l965_1) begin
+      if(when_CsrPlugin_l1302_1) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l965_2) begin
+      if(when_CsrPlugin_l1302_2) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(when_CsrPlugin_l1032) begin
-      case(CsrPlugin_targetPrivilege)
-        2'b11 : begin
-          CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
-          CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
-          CsrPlugin_mepc <= writeBack_PC;
-          if(CsrPlugin_hadException) begin
-            CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
+    if(when_CsrPlugin_l1390) begin
+      if(when_CsrPlugin_l1398) begin
+        case(CsrPlugin_targetPrivilege)
+          2'b11 : begin
+            CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
+            CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
+            CsrPlugin_mepc <= writeBack_PC;
+            if(CsrPlugin_hadException) begin
+              CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
+            end
           end
-        end
-        default : begin
-        end
-      endcase
+          default : begin
+          end
+        endcase
+      end
     end
     if(when_MulDivIterativePlugin_l126) begin
       memory_DivPlugin_div_done <= 1'b1;
@@ -5751,17 +5769,17 @@ module VexRiscv (
       end
     end
     if(when_MulDivIterativePlugin_l162) begin
-      memory_DivPlugin_accumulator <= 65'h0;
+      memory_DivPlugin_accumulator <= 65'h00000000000000000;
       memory_DivPlugin_rs1 <= ((_zz_memory_DivPlugin_rs1 ? (~ _zz_memory_DivPlugin_rs1_1) : _zz_memory_DivPlugin_rs1_1) + _zz_memory_DivPlugin_rs1_2);
       memory_DivPlugin_rs2 <= ((_zz_memory_DivPlugin_rs2 ? (~ execute_RS2) : execute_RS2) + _zz_memory_DivPlugin_rs2_1);
-      memory_DivPlugin_div_needRevert <= ((_zz_memory_DivPlugin_rs1 ^ (_zz_memory_DivPlugin_rs2 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
+      memory_DivPlugin_div_needRevert <= ((_zz_memory_DivPlugin_rs1 ^ (_zz_memory_DivPlugin_rs2 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h00000000) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
     end
     externalInterruptArray_regNext <= externalInterruptArray;
     if(when_Pipeline_l124) begin
       decode_to_execute_PC <= decode_PC;
     end
     if(when_Pipeline_l124_1) begin
-      execute_to_memory_PC <= _zz_execute_SRC2;
+      execute_to_memory_PC <= _zz_execute_to_memory_PC;
     end
     if(when_Pipeline_l124_2) begin
       memory_to_writeBack_PC <= memory_PC;
@@ -5961,79 +5979,79 @@ module VexRiscv (
     if(when_Pipeline_l124_67) begin
       memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
     end
-    if(when_Fetcher_l401) begin
-      _zz_IBusCachedPlugin_injector_decodeInput_payload_rsp_inst <= IBusCachedPlugin_injectionPort_payload;
+    if(when_Fetcher_l411) begin
+      _zz_IBusCachedPlugin_injector_decodeInput_payload_rsp_inst <= DebugPlugin_injectionPort_payload;
     end
-    if(when_CsrPlugin_l1277) begin
+    if(when_CsrPlugin_l1669) begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
     end
-    if(when_CsrPlugin_l1277_1) begin
+    if(when_CsrPlugin_l1669_1) begin
       execute_CsrPlugin_csr_3857 <= (decode_INSTRUCTION[31 : 20] == 12'hf11);
     end
-    if(when_CsrPlugin_l1277_2) begin
+    if(when_CsrPlugin_l1669_2) begin
       execute_CsrPlugin_csr_3858 <= (decode_INSTRUCTION[31 : 20] == 12'hf12);
     end
-    if(when_CsrPlugin_l1277_3) begin
+    if(when_CsrPlugin_l1669_3) begin
       execute_CsrPlugin_csr_3859 <= (decode_INSTRUCTION[31 : 20] == 12'hf13);
     end
-    if(when_CsrPlugin_l1277_4) begin
+    if(when_CsrPlugin_l1669_4) begin
       execute_CsrPlugin_csr_3860 <= (decode_INSTRUCTION[31 : 20] == 12'hf14);
     end
-    if(when_CsrPlugin_l1277_5) begin
+    if(when_CsrPlugin_l1669_5) begin
       execute_CsrPlugin_csr_769 <= (decode_INSTRUCTION[31 : 20] == 12'h301);
     end
-    if(when_CsrPlugin_l1277_6) begin
+    if(when_CsrPlugin_l1669_6) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if(when_CsrPlugin_l1277_7) begin
+    if(when_CsrPlugin_l1669_7) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if(when_CsrPlugin_l1277_8) begin
+    if(when_CsrPlugin_l1669_8) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if(when_CsrPlugin_l1277_9) begin
+    if(when_CsrPlugin_l1669_9) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if(when_CsrPlugin_l1277_10) begin
+    if(when_CsrPlugin_l1669_10) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if(when_CsrPlugin_l1277_11) begin
+    if(when_CsrPlugin_l1669_11) begin
       execute_CsrPlugin_csr_832 <= (decode_INSTRUCTION[31 : 20] == 12'h340);
     end
-    if(when_CsrPlugin_l1277_12) begin
+    if(when_CsrPlugin_l1669_12) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if(when_CsrPlugin_l1277_13) begin
+    if(when_CsrPlugin_l1669_13) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if(when_CsrPlugin_l1277_14) begin
+    if(when_CsrPlugin_l1669_14) begin
       execute_CsrPlugin_csr_2816 <= (decode_INSTRUCTION[31 : 20] == 12'hb00);
     end
-    if(when_CsrPlugin_l1277_15) begin
+    if(when_CsrPlugin_l1669_15) begin
       execute_CsrPlugin_csr_2944 <= (decode_INSTRUCTION[31 : 20] == 12'hb80);
     end
-    if(when_CsrPlugin_l1277_16) begin
+    if(when_CsrPlugin_l1669_16) begin
       execute_CsrPlugin_csr_2818 <= (decode_INSTRUCTION[31 : 20] == 12'hb02);
     end
-    if(when_CsrPlugin_l1277_17) begin
+    if(when_CsrPlugin_l1669_17) begin
       execute_CsrPlugin_csr_2946 <= (decode_INSTRUCTION[31 : 20] == 12'hb82);
     end
-    if(when_CsrPlugin_l1277_18) begin
+    if(when_CsrPlugin_l1669_18) begin
       execute_CsrPlugin_csr_3072 <= (decode_INSTRUCTION[31 : 20] == 12'hc00);
     end
-    if(when_CsrPlugin_l1277_19) begin
+    if(when_CsrPlugin_l1669_19) begin
       execute_CsrPlugin_csr_3200 <= (decode_INSTRUCTION[31 : 20] == 12'hc80);
     end
-    if(when_CsrPlugin_l1277_20) begin
+    if(when_CsrPlugin_l1669_20) begin
       execute_CsrPlugin_csr_3074 <= (decode_INSTRUCTION[31 : 20] == 12'hc02);
     end
-    if(when_CsrPlugin_l1277_21) begin
+    if(when_CsrPlugin_l1669_21) begin
       execute_CsrPlugin_csr_3202 <= (decode_INSTRUCTION[31 : 20] == 12'hc82);
     end
-    if(when_CsrPlugin_l1277_22) begin
+    if(when_CsrPlugin_l1669_22) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if(when_CsrPlugin_l1277_23) begin
+    if(when_CsrPlugin_l1669_23) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
     if(execute_CsrPlugin_csr_836) begin
@@ -6044,7 +6062,6 @@ module VexRiscv (
     if(execute_CsrPlugin_csr_773) begin
       if(execute_CsrPlugin_writeEnable) begin
         CsrPlugin_mtvec_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 2];
-        CsrPlugin_mtvec_mode <= CsrPlugin_csrMapping_writeDataSignal[1 : 0];
       end
     end
     if(execute_CsrPlugin_csr_833) begin
@@ -6082,9 +6099,9 @@ module VexRiscv (
     if(writeBack_arbitration_isValid) begin
       DebugPlugin_busReadDataReg <= _zz_decode_RS2_2;
     end
-    _zz_when_DebugPlugin_l244 <= debug_bus_cmd_payload_address[2];
+    _zz_when_DebugPlugin_l257 <= debug_bus_cmd_payload_address[2];
     if(debug_bus_cmd_valid) begin
-      case(switch_DebugPlugin_l267)
+      case(switch_DebugPlugin_l280)
         6'h10 : begin
           if(debug_bus_cmd_payload_wr) begin
             DebugPlugin_hardwareBreakpoints_0_pc <= debug_bus_cmd_payload_data[31 : 1];
@@ -6099,7 +6116,7 @@ module VexRiscv (
         end
       endcase
     end
-    if(when_DebugPlugin_l295) begin
+    if(when_DebugPlugin_l308) begin
       DebugPlugin_busReadDataReg <= execute_PC;
     end
     DebugPlugin_resetIt_regNext <= DebugPlugin_resetIt;
@@ -6116,41 +6133,41 @@ module VexRiscv (
       DebugPlugin_disableEbreak <= 1'b0;
       DebugPlugin_hardwareBreakpoints_0_valid <= 1'b0;
       DebugPlugin_hardwareBreakpoints_1_valid <= 1'b0;
-      _zz_3 <= 1'b0;
+      _zz_6 <= 1'b0;
     end else begin
-      if(when_DebugPlugin_l225) begin
+      if(when_DebugPlugin_l238) begin
         DebugPlugin_godmode <= 1'b1;
       end
       if(debug_bus_cmd_valid) begin
         DebugPlugin_debugUsed <= 1'b1;
       end
       if(debug_bus_cmd_valid) begin
-        case(switch_DebugPlugin_l267)
-          6'h0 : begin
+        case(switch_DebugPlugin_l280)
+          6'h00 : begin
             if(debug_bus_cmd_payload_wr) begin
               DebugPlugin_stepIt <= debug_bus_cmd_payload_data[4];
-              if(when_DebugPlugin_l271) begin
+              if(when_DebugPlugin_l284) begin
                 DebugPlugin_resetIt <= 1'b1;
               end
-              if(when_DebugPlugin_l271_1) begin
+              if(when_DebugPlugin_l284_1) begin
                 DebugPlugin_resetIt <= 1'b0;
               end
-              if(when_DebugPlugin_l272) begin
+              if(when_DebugPlugin_l285) begin
                 DebugPlugin_haltIt <= 1'b1;
               end
-              if(when_DebugPlugin_l272_1) begin
+              if(when_DebugPlugin_l285_1) begin
                 DebugPlugin_haltIt <= 1'b0;
               end
-              if(when_DebugPlugin_l273) begin
+              if(when_DebugPlugin_l286) begin
                 DebugPlugin_haltedByBreak <= 1'b0;
               end
-              if(when_DebugPlugin_l274) begin
+              if(when_DebugPlugin_l287) begin
                 DebugPlugin_godmode <= 1'b0;
               end
-              if(when_DebugPlugin_l275) begin
+              if(when_DebugPlugin_l288) begin
                 DebugPlugin_disableEbreak <= 1'b1;
               end
-              if(when_DebugPlugin_l275_1) begin
+              if(when_DebugPlugin_l288_1) begin
                 DebugPlugin_disableEbreak <= 1'b0;
               end
             end
@@ -6169,18 +6186,18 @@ module VexRiscv (
           end
         endcase
       end
-      if(when_DebugPlugin_l295) begin
-        if(when_DebugPlugin_l298) begin
+      if(when_DebugPlugin_l308) begin
+        if(when_DebugPlugin_l311) begin
           DebugPlugin_haltIt <= 1'b1;
           DebugPlugin_haltedByBreak <= 1'b1;
         end
       end
-      if(when_DebugPlugin_l311) begin
+      if(when_DebugPlugin_l324) begin
         if(decode_arbitration_isValid) begin
           DebugPlugin_haltIt <= 1'b1;
         end
       end
-      _zz_3 <= (DebugPlugin_stepIt && decode_arbitration_isFiring);
+      _zz_6 <= (DebugPlugin_stepIt && decode_arbitration_isFiring);
     end
   end
 
@@ -6188,88 +6205,85 @@ module VexRiscv (
 endmodule
 
 module DataCache (
-  input               io_cpu_execute_isValid,
-  input      [31:0]   io_cpu_execute_address,
-  output reg          io_cpu_execute_haltIt,
-  input               io_cpu_execute_args_wr,
-  input      [1:0]    io_cpu_execute_args_size,
-  input               io_cpu_execute_args_isLrsc,
-  input               io_cpu_execute_args_isAmo,
-  input               io_cpu_execute_args_amoCtrl_swap,
-  input      [2:0]    io_cpu_execute_args_amoCtrl_alu,
-  input               io_cpu_execute_args_totalyConsistent,
-  output              io_cpu_execute_refilling,
-  input               io_cpu_memory_isValid,
-  input               io_cpu_memory_isStuck,
-  output              io_cpu_memory_isWrite,
-  input      [31:0]   io_cpu_memory_address,
-  input      [31:0]   io_cpu_memory_mmuRsp_physicalAddress,
-  input               io_cpu_memory_mmuRsp_isIoAccess,
-  input               io_cpu_memory_mmuRsp_isPaging,
-  input               io_cpu_memory_mmuRsp_allowRead,
-  input               io_cpu_memory_mmuRsp_allowWrite,
-  input               io_cpu_memory_mmuRsp_allowExecute,
-  input               io_cpu_memory_mmuRsp_exception,
-  input               io_cpu_memory_mmuRsp_refilling,
-  input               io_cpu_memory_mmuRsp_bypassTranslation,
-  input               io_cpu_writeBack_isValid,
-  input               io_cpu_writeBack_isStuck,
-  input               io_cpu_writeBack_isFiring,
-  input               io_cpu_writeBack_isUser,
-  output reg          io_cpu_writeBack_haltIt,
-  output              io_cpu_writeBack_isWrite,
-  input      [31:0]   io_cpu_writeBack_storeData,
-  output reg [31:0]   io_cpu_writeBack_data,
-  input      [31:0]   io_cpu_writeBack_address,
-  output              io_cpu_writeBack_mmuException,
-  output              io_cpu_writeBack_unalignedAccess,
-  output reg          io_cpu_writeBack_accessError,
-  output              io_cpu_writeBack_keepMemRspData,
-  input               io_cpu_writeBack_fence_SW,
-  input               io_cpu_writeBack_fence_SR,
-  input               io_cpu_writeBack_fence_SO,
-  input               io_cpu_writeBack_fence_SI,
-  input               io_cpu_writeBack_fence_PW,
-  input               io_cpu_writeBack_fence_PR,
-  input               io_cpu_writeBack_fence_PO,
-  input               io_cpu_writeBack_fence_PI,
-  input      [3:0]    io_cpu_writeBack_fence_FM,
-  output              io_cpu_writeBack_exclusiveOk,
-  output reg          io_cpu_redo,
-  input               io_cpu_flush_valid,
-  output              io_cpu_flush_ready,
-  input               io_cpu_flush_payload_singleLine,
-  input      [6:0]    io_cpu_flush_payload_lineId,
-  output reg          io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output reg          io_mem_cmd_payload_wr,
-  output              io_mem_cmd_payload_uncached,
-  output reg [31:0]   io_mem_cmd_payload_address,
-  output     [31:0]   io_mem_cmd_payload_data,
-  output     [3:0]    io_mem_cmd_payload_mask,
-  output reg [2:0]    io_mem_cmd_payload_size,
-  output              io_mem_cmd_payload_last,
-  input               io_mem_rsp_valid,
-  input               io_mem_rsp_payload_last,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input               clk,
-  input               reset
+  input  wire          io_cpu_execute_isValid,
+  input  wire [31:0]   io_cpu_execute_address,
+  output reg           io_cpu_execute_haltIt,
+  input  wire          io_cpu_execute_args_wr,
+  input  wire [1:0]    io_cpu_execute_args_size,
+  input  wire          io_cpu_execute_args_isLrsc,
+  input  wire          io_cpu_execute_args_isAmo,
+  input  wire          io_cpu_execute_args_amoCtrl_swap,
+  input  wire [2:0]    io_cpu_execute_args_amoCtrl_alu,
+  input  wire          io_cpu_execute_args_totalyConsistent,
+  output wire          io_cpu_execute_refilling,
+  input  wire          io_cpu_memory_isValid,
+  input  wire          io_cpu_memory_isStuck,
+  output wire          io_cpu_memory_isWrite,
+  input  wire [31:0]   io_cpu_memory_address,
+  input  wire [31:0]   io_cpu_memory_mmuRsp_physicalAddress,
+  input  wire          io_cpu_memory_mmuRsp_isIoAccess,
+  input  wire          io_cpu_memory_mmuRsp_isPaging,
+  input  wire          io_cpu_memory_mmuRsp_allowRead,
+  input  wire          io_cpu_memory_mmuRsp_allowWrite,
+  input  wire          io_cpu_memory_mmuRsp_allowExecute,
+  input  wire          io_cpu_memory_mmuRsp_exception,
+  input  wire          io_cpu_memory_mmuRsp_refilling,
+  input  wire          io_cpu_memory_mmuRsp_bypassTranslation,
+  input  wire          io_cpu_writeBack_isValid,
+  input  wire          io_cpu_writeBack_isStuck,
+  input  wire          io_cpu_writeBack_isFiring,
+  input  wire          io_cpu_writeBack_isUser,
+  output reg           io_cpu_writeBack_haltIt,
+  output wire          io_cpu_writeBack_isWrite,
+  input  wire [31:0]   io_cpu_writeBack_storeData,
+  output reg  [31:0]   io_cpu_writeBack_data,
+  input  wire [31:0]   io_cpu_writeBack_address,
+  output wire          io_cpu_writeBack_mmuException,
+  output wire          io_cpu_writeBack_unalignedAccess,
+  output reg           io_cpu_writeBack_accessError,
+  output wire          io_cpu_writeBack_keepMemRspData,
+  input  wire          io_cpu_writeBack_fence_SW,
+  input  wire          io_cpu_writeBack_fence_SR,
+  input  wire          io_cpu_writeBack_fence_SO,
+  input  wire          io_cpu_writeBack_fence_SI,
+  input  wire          io_cpu_writeBack_fence_PW,
+  input  wire          io_cpu_writeBack_fence_PR,
+  input  wire          io_cpu_writeBack_fence_PO,
+  input  wire          io_cpu_writeBack_fence_PI,
+  input  wire [3:0]    io_cpu_writeBack_fence_FM,
+  output wire          io_cpu_writeBack_exclusiveOk,
+  output reg           io_cpu_redo,
+  input  wire          io_cpu_flush_valid,
+  output wire          io_cpu_flush_ready,
+  input  wire          io_cpu_flush_payload_singleLine,
+  input  wire [6:0]    io_cpu_flush_payload_lineId,
+  output wire          io_cpu_writesPending,
+  output reg           io_mem_cmd_valid,
+  input  wire          io_mem_cmd_ready,
+  output reg           io_mem_cmd_payload_wr,
+  output wire          io_mem_cmd_payload_uncached,
+  output reg  [31:0]   io_mem_cmd_payload_address,
+  output wire [31:0]   io_mem_cmd_payload_data,
+  output wire [3:0]    io_mem_cmd_payload_mask,
+  output reg  [2:0]    io_mem_cmd_payload_size,
+  output wire          io_mem_cmd_payload_last,
+  input  wire          io_mem_rsp_valid,
+  input  wire          io_mem_rsp_payload_last,
+  input  wire [31:0]   io_mem_rsp_payload_data,
+  input  wire          io_mem_rsp_payload_error,
+  input  wire          clk,
+  input  wire          reset
 );
 
   reg        [21:0]   _zz_ways_0_tags_port0;
   reg        [31:0]   _zz_ways_0_data_port0;
   wire       [21:0]   _zz_ways_0_tags_port;
-  wire       [9:0]    _zz_stage0_dataColisions;
-  wire       [9:0]    _zz__zz_stageA_dataColisions;
   wire       [31:0]   _zz_stageB_amo_addSub;
   wire       [31:0]   _zz_stageB_amo_addSub_1;
   wire       [31:0]   _zz_stageB_amo_addSub_2;
   wire       [31:0]   _zz_stageB_amo_addSub_3;
   wire       [31:0]   _zz_stageB_amo_addSub_4;
   wire       [1:0]    _zz_stageB_amo_addSub_5;
-  wire       [1:0]    _zz_stageB_amo_addSub_6;
-  wire       [1:0]    _zz_stageB_amo_addSub_7;
   wire       [0:0]    _zz_when;
   wire       [2:0]    _zz_loader_counter_valueNext;
   wire       [0:0]    _zz_loader_counter_valueNext_1;
@@ -6306,19 +6320,19 @@ module DataCache (
   wire                _zz_ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRsp;
-  wire                when_DataCache_l642;
   wire                when_DataCache_l645;
-  wire                when_DataCache_l664;
+  wire                when_DataCache_l648;
+  wire                when_DataCache_l667;
   wire                rspSync;
   wire                rspLast;
   reg                 memCmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_DataCache_l686;
+  wire                when_DataCache_l689;
   reg        [3:0]    _zz_stage0_mask;
   wire       [3:0]    stage0_mask;
   wire       [0:0]    stage0_dataColisions;
   wire       [0:0]    stage0_wayInvalidate;
-  wire                when_DataCache_l771;
+  wire                when_DataCache_l776;
   reg                 stageA_request_wr;
   reg        [1:0]    stageA_request_size;
   reg                 stageA_request_isLrsc;
@@ -6326,16 +6340,16 @@ module DataCache (
   reg                 stageA_request_amoCtrl_swap;
   reg        [2:0]    stageA_request_amoCtrl_alu;
   reg                 stageA_request_totalyConsistent;
-  wire                when_DataCache_l771_1;
+  wire                when_DataCache_l776_1;
   reg        [3:0]    stageA_mask;
   wire       [0:0]    stageA_wayHits;
-  wire                when_DataCache_l771_2;
+  wire                when_DataCache_l776_2;
   reg        [0:0]    stageA_wayInvalidate;
-  wire                when_DataCache_l771_3;
+  wire                when_DataCache_l776_3;
   reg        [0:0]    stage0_dataColisions_regNextWhen;
   wire       [0:0]    _zz_stageA_dataColisions;
   wire       [0:0]    stageA_dataColisions;
-  wire                when_DataCache_l822;
+  wire                when_DataCache_l827;
   reg                 stageB_request_wr;
   reg        [1:0]    stageB_request_size;
   reg                 stageB_request_isLrsc;
@@ -6344,7 +6358,7 @@ module DataCache (
   reg        [2:0]    stageB_request_amoCtrl_alu;
   reg                 stageB_request_totalyConsistent;
   reg                 stageB_mmuRspFreeze;
-  wire                when_DataCache_l824;
+  wire                when_DataCache_l829;
   reg        [31:0]   stageB_mmuRsp_physicalAddress;
   reg                 stageB_mmuRsp_isIoAccess;
   reg                 stageB_mmuRsp_isPaging;
@@ -6354,36 +6368,38 @@ module DataCache (
   reg                 stageB_mmuRsp_exception;
   reg                 stageB_mmuRsp_refilling;
   reg                 stageB_mmuRsp_bypassTranslation;
-  wire                when_DataCache_l821;
+  wire                when_DataCache_l826;
   reg                 stageB_tagsReadRsp_0_valid;
   reg                 stageB_tagsReadRsp_0_error;
   reg        [19:0]   stageB_tagsReadRsp_0_address;
-  wire                when_DataCache_l821_1;
+  wire                when_DataCache_l826_1;
   reg        [31:0]   stageB_dataReadRsp_0;
-  wire                when_DataCache_l820;
+  wire                when_DataCache_l825;
   reg        [0:0]    stageB_wayInvalidate;
   wire                stageB_consistancyHazard;
-  wire                when_DataCache_l820_1;
+  wire                when_DataCache_l825_1;
   reg        [0:0]    stageB_dataColisions;
-  wire                when_DataCache_l820_2;
+  wire                when_DataCache_l825_2;
   reg                 stageB_unaligned;
-  wire                when_DataCache_l820_3;
+  wire                when_DataCache_l825_3;
   reg        [0:0]    stageB_waysHitsBeforeInvalidate;
   wire       [0:0]    stageB_waysHits;
   wire                stageB_waysHit;
   wire       [31:0]   stageB_dataMux;
-  wire                when_DataCache_l820_4;
+  wire                when_DataCache_l825_4;
   reg        [3:0]    stageB_mask;
   reg                 stageB_loaderValid;
   wire       [31:0]   stageB_ioMemRspMuxed;
   reg                 stageB_flusher_waitDone;
   wire                stageB_flusher_hold;
   reg        [7:0]    stageB_flusher_counter;
-  wire                when_DataCache_l850;
-  wire                when_DataCache_l856;
+  wire                when_DataCache_l855;
+  wire                when_DataCache_l861;
+  wire                when_DataCache_l863;
   reg                 stageB_flusher_start;
+  wire                when_DataCache_l877;
   reg                 stageB_lrSc_reserved;
-  wire                when_DataCache_l880;
+  wire                when_DataCache_l885;
   wire                stageB_isExternalLsrc;
   wire                stageB_isExternalAmo;
   reg        [31:0]   stageB_requestDataBypass;
@@ -6392,26 +6408,26 @@ module DataCache (
   wire       [31:0]   stageB_amo_addSub;
   wire                stageB_amo_less;
   wire                stageB_amo_selectRf;
-  wire       [2:0]    switch_Misc_l210;
+  wire       [2:0]    switch_Misc_l232;
   reg        [31:0]   stageB_amo_result;
   reg        [31:0]   stageB_amo_resultReg;
   reg                 stageB_amo_internal_resultRegValid;
   reg                 stageB_cpuWriteToCache;
-  wire                when_DataCache_l926;
+  wire                when_DataCache_l931;
   wire                stageB_badPermissions;
   wire                stageB_loadStoreFault;
   wire                stageB_bypassCache;
-  wire                when_DataCache_l995;
-  wire                when_DataCache_l999;
+  wire                when_DataCache_l1000;
   wire                when_DataCache_l1004;
   wire                when_DataCache_l1009;
-  wire                when_DataCache_l1012;
-  wire                when_DataCache_l1020;
+  wire                when_DataCache_l1014;
+  wire                when_DataCache_l1017;
   wire                when_DataCache_l1025;
-  wire                when_DataCache_l1032;
-  wire                when_DataCache_l991;
-  wire                when_DataCache_l1066;
-  wire                when_DataCache_l1075;
+  wire                when_DataCache_l1030;
+  wire                when_DataCache_l1037;
+  wire                when_DataCache_l996;
+  wire                when_DataCache_l1072;
+  wire                when_DataCache_l1081;
   reg                 loader_valid;
   reg                 loader_counter_willIncrement;
   wire                loader_counter_willClear;
@@ -6423,12 +6439,12 @@ module DataCache (
   reg                 loader_error;
   wire                loader_kill;
   reg                 loader_killReg;
-  wire                when_DataCache_l1090;
+  wire                when_DataCache_l1097;
   wire                loader_done;
-  wire                when_DataCache_l1118;
-  reg                 loader_valid_regNext;
-  wire                when_DataCache_l1122;
   wire                when_DataCache_l1125;
+  reg                 loader_valid_regNext;
+  wire                when_DataCache_l1129;
+  wire                when_DataCache_l1132;
   (* no_rw_check , ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
   (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
   (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
@@ -6439,16 +6455,12 @@ module DataCache (
   reg [7:0] _zz_ways_0_datasymbol_read_2;
   reg [7:0] _zz_ways_0_datasymbol_read_3;
 
-  assign _zz_stage0_dataColisions = (io_cpu_execute_address[11 : 2] >>> 0);
-  assign _zz__zz_stageA_dataColisions = (io_cpu_memory_address[11 : 2] >>> 0);
   assign _zz_stageB_amo_addSub = ($signed(_zz_stageB_amo_addSub_1) + $signed(_zz_stageB_amo_addSub_4));
   assign _zz_stageB_amo_addSub_1 = ($signed(_zz_stageB_amo_addSub_2) + $signed(_zz_stageB_amo_addSub_3));
   assign _zz_stageB_amo_addSub_2 = io_cpu_writeBack_storeData[31 : 0];
   assign _zz_stageB_amo_addSub_3 = (stageB_amo_compare ? (~ stageB_dataMux[31 : 0]) : stageB_dataMux[31 : 0]);
-  assign _zz_stageB_amo_addSub_5 = (stageB_amo_compare ? _zz_stageB_amo_addSub_6 : _zz_stageB_amo_addSub_7);
+  assign _zz_stageB_amo_addSub_5 = (stageB_amo_compare ? 2'b01 : 2'b00);
   assign _zz_stageB_amo_addSub_4 = {{30{_zz_stageB_amo_addSub_5[1]}}, _zz_stageB_amo_addSub_5};
-  assign _zz_stageB_amo_addSub_6 = 2'b01;
-  assign _zz_stageB_amo_addSub_7 = 2'b00;
   assign _zz_when = 1'b1;
   assign _zz_loader_counter_valueNext_1 = loader_counter_willIncrement;
   assign _zz_loader_counter_valueNext = {2'd0, _zz_loader_counter_valueNext_1};
@@ -6495,14 +6507,14 @@ module DataCache (
 
   always @(*) begin
     _zz_1 = 1'b0;
-    if(when_DataCache_l645) begin
+    if(when_DataCache_l648) begin
       _zz_1 = 1'b1;
     end
   end
 
   always @(*) begin
     _zz_2 = 1'b0;
-    if(when_DataCache_l642) begin
+    if(when_DataCache_l645) begin
       _zz_2 = 1'b1;
     end
   end
@@ -6516,43 +6528,45 @@ module DataCache (
   assign _zz_ways_0_dataReadRspMem = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
   assign ways_0_dataReadRspMem = _zz_ways_0_data_port0;
   assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
-  assign when_DataCache_l642 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
-  assign when_DataCache_l645 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
+  assign when_DataCache_l645 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
+  assign when_DataCache_l648 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
   always @(*) begin
     tagsReadCmd_valid = 1'b0;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       tagsReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     tagsReadCmd_payload = 7'bxxxxxxx;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
     end
   end
 
   always @(*) begin
     dataReadCmd_valid = 1'b0;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       dataReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     dataReadCmd_payload = 10'bxxxxxxxxxx;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       dataReadCmd_payload = io_cpu_execute_address[11 : 2];
     end
   end
 
   always @(*) begin
     tagsWriteCmd_valid = 1'b0;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_valid = 1'b1;
     end
-    if(when_DataCache_l1066) begin
-      tagsWriteCmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        tagsWriteCmd_valid = 1'b0;
+      end
     end
     if(loader_done) begin
       tagsWriteCmd_valid = 1'b1;
@@ -6561,7 +6575,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_way = 1'bx;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_payload_way = 1'b1;
     end
     if(loader_done) begin
@@ -6571,7 +6585,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_address = 7'bxxxxxxx;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_payload_address = stageB_flusher_counter[6:0];
     end
     if(loader_done) begin
@@ -6581,7 +6595,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_data_valid = 1'bx;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_payload_data_valid = 1'b0;
     end
     if(loader_done) begin
@@ -6606,30 +6620,32 @@ module DataCache (
   always @(*) begin
     dataWriteCmd_valid = 1'b0;
     if(stageB_cpuWriteToCache) begin
-      if(when_DataCache_l926) begin
+      if(when_DataCache_l931) begin
         dataWriteCmd_valid = 1'b1;
       end
     end
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(when_DataCache_l1009) begin
             if(stageB_request_isAmo) begin
-              if(when_DataCache_l1012) begin
+              if(when_DataCache_l1017) begin
                 dataWriteCmd_valid = 1'b0;
               end
             end
-            if(when_DataCache_l1025) begin
+            if(when_DataCache_l1030) begin
               dataWriteCmd_valid = 1'b0;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1066) begin
-      dataWriteCmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        dataWriteCmd_valid = 1'b0;
+      end
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_valid = 1'b1;
     end
   end
@@ -6639,7 +6655,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_way = stageB_waysHits;
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_way = loader_waysAllocator;
     end
   end
@@ -6649,7 +6665,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
     end
   end
@@ -6659,7 +6675,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_data = io_mem_rsp_payload_data;
     end
   end
@@ -6672,15 +6688,15 @@ module DataCache (
         dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
       end
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_mask = 4'b1111;
     end
   end
 
-  assign when_DataCache_l664 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  assign when_DataCache_l667 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
   always @(*) begin
     io_cpu_execute_haltIt = 1'b0;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       io_cpu_execute_haltIt = 1'b1;
     end
   end
@@ -6688,7 +6704,7 @@ module DataCache (
   assign rspSync = 1'b1;
   assign rspLast = 1'b1;
   assign io_mem_cmd_fire = (io_mem_cmd_valid && io_mem_cmd_ready);
-  assign when_DataCache_l686 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l689 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     _zz_stage0_mask = 4'bxxxx;
     case(io_cpu_execute_args_size)
@@ -6707,42 +6723,42 @@ module DataCache (
   end
 
   assign stage0_mask = (_zz_stage0_mask <<< io_cpu_execute_address[1 : 0]);
-  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_stage0_dataColisions)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_execute_address[11 : 2])) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stage0_wayInvalidate = 1'b0;
-  assign when_DataCache_l771 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l771_1 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l776 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l776_1 = (! io_cpu_memory_isStuck);
   assign io_cpu_memory_isWrite = stageA_request_wr;
   assign stageA_wayHits = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign when_DataCache_l771_2 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l771_3 = (! io_cpu_memory_isStuck);
-  assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz__zz_stageA_dataColisions)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign when_DataCache_l776_2 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l776_3 = (! io_cpu_memory_isStuck);
+  assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_memory_address[11 : 2])) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_stageA_dataColisions);
-  assign when_DataCache_l822 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l827 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_mmuRspFreeze = 1'b0;
-    if(when_DataCache_l1125) begin
+    if(when_DataCache_l1132) begin
       stageB_mmuRspFreeze = 1'b1;
     end
   end
 
-  assign when_DataCache_l824 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
-  assign when_DataCache_l821 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l821_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l820 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l829 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
+  assign when_DataCache_l826 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l826_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825 = (! io_cpu_writeBack_isStuck);
   assign stageB_consistancyHazard = 1'b0;
-  assign when_DataCache_l820_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l820_2 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l820_3 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_2 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_3 = (! io_cpu_writeBack_isStuck);
   assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
   assign stageB_waysHit = (|stageB_waysHits);
   assign stageB_dataMux = stageB_dataReadRsp_0;
-  assign when_DataCache_l820_4 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_4 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_loaderValid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
             if(io_mem_cmd_ready) begin
               stageB_loaderValid = 1'b1;
             end
@@ -6750,8 +6766,10 @@ module DataCache (
         end
       end
     end
-    if(when_DataCache_l1066) begin
-      stageB_loaderValid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        stageB_loaderValid = 1'b0;
+      end
     end
   end
 
@@ -6760,40 +6778,44 @@ module DataCache (
     io_cpu_writeBack_haltIt = 1'b1;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l991) begin
-          if(when_DataCache_l995) begin
+        if(when_DataCache_l996) begin
+          if(when_DataCache_l1000) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
-          if(when_DataCache_l999) begin
+          if(when_DataCache_l1004) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
         end else begin
-          if(when_DataCache_l1004) begin
-            if(when_DataCache_l1009) begin
+          if(when_DataCache_l1009) begin
+            if(when_DataCache_l1014) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
             if(stageB_request_isAmo) begin
-              if(when_DataCache_l1012) begin
+              if(when_DataCache_l1017) begin
                 io_cpu_writeBack_haltIt = 1'b1;
               end
             end
-            if(when_DataCache_l1025) begin
+            if(when_DataCache_l1030) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1066) begin
-      io_cpu_writeBack_haltIt = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        io_cpu_writeBack_haltIt = 1'b0;
+      end
     end
   end
 
   assign stageB_flusher_hold = 1'b0;
-  assign when_DataCache_l850 = (! stageB_flusher_counter[7]);
-  assign when_DataCache_l856 = (! stageB_flusher_hold);
+  assign when_DataCache_l855 = (! stageB_flusher_counter[7]);
+  assign when_DataCache_l861 = (! stageB_flusher_hold);
+  assign when_DataCache_l863 = (io_cpu_flush_valid && io_cpu_flush_payload_singleLine);
   assign io_cpu_flush_ready = (stageB_flusher_waitDone && stageB_flusher_counter[7]);
-  assign when_DataCache_l880 = (io_cpu_writeBack_isValid && io_cpu_writeBack_isFiring);
+  assign when_DataCache_l877 = (io_cpu_flush_valid && io_cpu_flush_payload_singleLine);
+  assign when_DataCache_l885 = (io_cpu_writeBack_isValid && io_cpu_writeBack_isFiring);
   assign stageB_isExternalLsrc = 1'b0;
   assign stageB_isExternalAmo = 1'b0;
   always @(*) begin
@@ -6808,9 +6830,9 @@ module DataCache (
   assign stageB_amo_addSub = _zz_stageB_amo_addSub;
   assign stageB_amo_less = ((io_cpu_writeBack_storeData[31] == stageB_dataMux[31]) ? stageB_amo_addSub[31] : (stageB_amo_unsigned ? stageB_dataMux[31] : io_cpu_writeBack_storeData[31]));
   assign stageB_amo_selectRf = (stageB_request_amoCtrl_swap ? 1'b1 : (stageB_request_amoCtrl_alu[0] ^ stageB_amo_less));
-  assign switch_Misc_l210 = (stageB_request_amoCtrl_alu | {stageB_request_amoCtrl_swap,2'b00});
+  assign switch_Misc_l232 = (stageB_request_amoCtrl_alu | {stageB_request_amoCtrl_swap,2'b00});
   always @(*) begin
-    case(switch_Misc_l210)
+    case(switch_Misc_l232)
       3'b000 : begin
         stageB_amo_result = stageB_amo_addSub;
       end
@@ -6833,8 +6855,8 @@ module DataCache (
     stageB_cpuWriteToCache = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(when_DataCache_l1009) begin
             stageB_cpuWriteToCache = 1'b1;
           end
         end
@@ -6842,26 +6864,28 @@ module DataCache (
     end
   end
 
-  assign when_DataCache_l926 = (stageB_request_wr && stageB_waysHit);
+  assign when_DataCache_l931 = (stageB_request_wr && stageB_waysHit);
   assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_request_isAmo)));
   assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
   always @(*) begin
     io_cpu_redo = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(when_DataCache_l1004) begin
-            if(when_DataCache_l1020) begin
+        if(!when_DataCache_l996) begin
+          if(when_DataCache_l1009) begin
+            if(when_DataCache_l1025) begin
               io_cpu_redo = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1075) begin
-      io_cpu_redo = 1'b1;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1081) begin
+        io_cpu_redo = 1'b1;
+      end
     end
-    if(when_DataCache_l1122) begin
+    if(when_DataCache_l1129) begin
       io_cpu_redo = 1'b1;
     end
   end
@@ -6882,37 +6906,39 @@ module DataCache (
     io_mem_cmd_valid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l991) begin
+        if(when_DataCache_l996) begin
           io_mem_cmd_valid = (! memCmdSent);
-          if(when_DataCache_l999) begin
+          if(when_DataCache_l1004) begin
             io_mem_cmd_valid = 1'b0;
           end
         end else begin
-          if(when_DataCache_l1004) begin
+          if(when_DataCache_l1009) begin
             if(stageB_request_wr) begin
               io_mem_cmd_valid = 1'b1;
             end
             if(stageB_request_isAmo) begin
-              if(when_DataCache_l1012) begin
+              if(when_DataCache_l1017) begin
                 io_mem_cmd_valid = 1'b0;
               end
-            end
-            if(when_DataCache_l1020) begin
-              io_mem_cmd_valid = 1'b0;
             end
             if(when_DataCache_l1025) begin
               io_mem_cmd_valid = 1'b0;
             end
+            if(when_DataCache_l1030) begin
+              io_mem_cmd_valid = 1'b0;
+            end
           end else begin
-            if(when_DataCache_l1032) begin
+            if(when_DataCache_l1037) begin
               io_mem_cmd_valid = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1066) begin
-      io_mem_cmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        io_mem_cmd_valid = 1'b0;
+      end
     end
   end
 
@@ -6920,9 +6946,9 @@ module DataCache (
     io_mem_cmd_payload_address = stageB_mmuRsp_physicalAddress;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
-            io_mem_cmd_payload_address[4 : 0] = 5'h0;
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
+            io_mem_cmd_payload_address[4 : 0] = 5'h00;
           end
         end
       end
@@ -6934,8 +6960,8 @@ module DataCache (
     io_mem_cmd_payload_wr = stageB_request_wr;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
             io_mem_cmd_payload_wr = 1'b0;
           end
         end
@@ -6950,8 +6976,8 @@ module DataCache (
     io_mem_cmd_payload_size = {1'd0, stageB_request_size};
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
             io_mem_cmd_payload_size = 3'b101;
           end
         end
@@ -6961,15 +6987,15 @@ module DataCache (
 
   assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
   assign io_cpu_writeBack_keepMemRspData = 1'b0;
-  assign when_DataCache_l995 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
-  assign when_DataCache_l999 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
-  assign when_DataCache_l1004 = (stageB_waysHit || (stageB_request_wr && (! stageB_request_isAmo)));
-  assign when_DataCache_l1009 = ((! stageB_request_wr) || io_mem_cmd_ready);
-  assign when_DataCache_l1012 = (! stageB_amo_internal_resultRegValid);
-  assign when_DataCache_l1020 = (((! stageB_request_wr) || stageB_request_isAmo) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
-  assign when_DataCache_l1025 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
-  assign when_DataCache_l1032 = (! memCmdSent);
-  assign when_DataCache_l991 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  assign when_DataCache_l1000 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
+  assign when_DataCache_l1004 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
+  assign when_DataCache_l1009 = (stageB_waysHit || (stageB_request_wr && (! stageB_request_isAmo)));
+  assign when_DataCache_l1014 = ((! stageB_request_wr) || io_mem_cmd_ready);
+  assign when_DataCache_l1017 = (! stageB_amo_internal_resultRegValid);
+  assign when_DataCache_l1025 = (((! stageB_request_wr) || stageB_request_isAmo) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
+  assign when_DataCache_l1030 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
+  assign when_DataCache_l1037 = (! memCmdSent);
+  assign when_DataCache_l996 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
   always @(*) begin
     if(stageB_bypassCache) begin
       io_cpu_writeBack_data = stageB_ioMemRspMuxed;
@@ -6979,11 +7005,11 @@ module DataCache (
   end
 
   assign io_cpu_writeBack_exclusiveOk = stageB_lrSc_reserved;
-  assign when_DataCache_l1066 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign when_DataCache_l1075 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
+  assign when_DataCache_l1072 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign when_DataCache_l1081 = (stageB_mmuRsp_refilling || stageB_consistancyHazard);
   always @(*) begin
     loader_counter_willIncrement = 1'b0;
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       loader_counter_willIncrement = 1'b1;
     end
   end
@@ -6999,12 +7025,12 @@ module DataCache (
   end
 
   assign loader_kill = 1'b0;
-  assign when_DataCache_l1090 = ((loader_valid && io_mem_rsp_valid) && rspLast);
+  assign when_DataCache_l1097 = ((loader_valid && io_mem_rsp_valid) && rspLast);
   assign loader_done = loader_counter_willOverflow;
-  assign when_DataCache_l1118 = (! loader_valid);
-  assign when_DataCache_l1122 = (loader_valid && (! loader_valid_regNext));
+  assign when_DataCache_l1125 = (! loader_valid);
+  assign when_DataCache_l1129 = (loader_valid && (! loader_valid_regNext));
   assign io_cpu_execute_refilling = loader_valid;
-  assign when_DataCache_l1125 = (stageB_loaderValid || loader_valid);
+  assign when_DataCache_l1132 = (stageB_loaderValid || loader_valid);
   always @(posedge clk) begin
     tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
     tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
@@ -7012,7 +7038,7 @@ module DataCache (
     tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
     tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
     tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if(when_DataCache_l771) begin
+    if(when_DataCache_l776) begin
       stageA_request_wr <= io_cpu_execute_args_wr;
       stageA_request_size <= io_cpu_execute_args_size;
       stageA_request_isLrsc <= io_cpu_execute_args_isLrsc;
@@ -7021,16 +7047,16 @@ module DataCache (
       stageA_request_amoCtrl_alu <= io_cpu_execute_args_amoCtrl_alu;
       stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
     end
-    if(when_DataCache_l771_1) begin
+    if(when_DataCache_l776_1) begin
       stageA_mask <= stage0_mask;
     end
-    if(when_DataCache_l771_2) begin
+    if(when_DataCache_l776_2) begin
       stageA_wayInvalidate <= stage0_wayInvalidate;
     end
-    if(when_DataCache_l771_3) begin
+    if(when_DataCache_l776_3) begin
       stage0_dataColisions_regNextWhen <= stage0_dataColisions;
     end
-    if(when_DataCache_l822) begin
+    if(when_DataCache_l827) begin
       stageB_request_wr <= stageA_request_wr;
       stageB_request_size <= stageA_request_size;
       stageB_request_isLrsc <= stageA_request_isLrsc;
@@ -7039,7 +7065,7 @@ module DataCache (
       stageB_request_amoCtrl_alu <= stageA_request_amoCtrl_alu;
       stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
     end
-    if(when_DataCache_l824) begin
+    if(when_DataCache_l829) begin
       stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
       stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
       stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
@@ -7050,27 +7076,27 @@ module DataCache (
       stageB_mmuRsp_refilling <= io_cpu_memory_mmuRsp_refilling;
       stageB_mmuRsp_bypassTranslation <= io_cpu_memory_mmuRsp_bypassTranslation;
     end
-    if(when_DataCache_l821) begin
+    if(when_DataCache_l826) begin
       stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
       stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
       stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
     end
-    if(when_DataCache_l821_1) begin
+    if(when_DataCache_l826_1) begin
       stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
     end
-    if(when_DataCache_l820) begin
+    if(when_DataCache_l825) begin
       stageB_wayInvalidate <= stageA_wayInvalidate;
     end
-    if(when_DataCache_l820_1) begin
+    if(when_DataCache_l825_1) begin
       stageB_dataColisions <= stageA_dataColisions;
     end
-    if(when_DataCache_l820_2) begin
+    if(when_DataCache_l825_2) begin
       stageB_unaligned <= ({((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)),((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0))} != 2'b00);
     end
-    if(when_DataCache_l820_3) begin
+    if(when_DataCache_l825_3) begin
       stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
     end
-    if(when_DataCache_l820_4) begin
+    if(when_DataCache_l825_4) begin
       stageB_mask <= stageA_mask;
     end
     stageB_amo_internal_resultRegValid <= io_cpu_writeBack_isStuck;
@@ -7082,7 +7108,7 @@ module DataCache (
     if(reset) begin
       memCmdSent <= 1'b0;
       stageB_flusher_waitDone <= 1'b0;
-      stageB_flusher_counter <= 8'h0;
+      stageB_flusher_counter <= 8'h00;
       stageB_flusher_start <= 1'b1;
       stageB_lrSc_reserved <= 1'b0;
       loader_valid <= 1'b0;
@@ -7094,16 +7120,16 @@ module DataCache (
       if(io_mem_cmd_fire) begin
         memCmdSent <= 1'b1;
       end
-      if(when_DataCache_l686) begin
+      if(when_DataCache_l689) begin
         memCmdSent <= 1'b0;
       end
       if(io_cpu_flush_ready) begin
         stageB_flusher_waitDone <= 1'b0;
       end
-      if(when_DataCache_l850) begin
-        if(when_DataCache_l856) begin
+      if(when_DataCache_l855) begin
+        if(when_DataCache_l861) begin
           stageB_flusher_counter <= (stageB_flusher_counter + 8'h01);
-          if(io_cpu_flush_payload_singleLine) begin
+          if(when_DataCache_l863) begin
             stageB_flusher_counter[7] <= 1'b1;
           end
         end
@@ -7111,12 +7137,12 @@ module DataCache (
       stageB_flusher_start <= (((((((! stageB_flusher_waitDone) && (! stageB_flusher_start)) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
       if(stageB_flusher_start) begin
         stageB_flusher_waitDone <= 1'b1;
-        stageB_flusher_counter <= 8'h0;
-        if(io_cpu_flush_payload_singleLine) begin
+        stageB_flusher_counter <= 8'h00;
+        if(when_DataCache_l877) begin
           stageB_flusher_counter <= {1'b0,io_cpu_flush_payload_lineId};
         end
       end
-      if(when_DataCache_l880) begin
+      if(when_DataCache_l885) begin
         if(stageB_request_isLrsc) begin
           stageB_lrSc_reserved <= 1'b1;
         end
@@ -7124,15 +7150,17 @@ module DataCache (
           stageB_lrSc_reserved <= 1'b0;
         end
       end
-      if(when_DataCache_l1066) begin
-        stageB_lrSc_reserved <= stageB_lrSc_reserved;
+      if(io_cpu_writeBack_isValid) begin
+        if(when_DataCache_l1072) begin
+          stageB_lrSc_reserved <= stageB_lrSc_reserved;
+        end
       end
       `ifndef SYNTHESIS
         `ifdef FORMAL
-          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))); // DataCache.scala:L1077
+          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))); // DataCache.scala:L1084
         `else
           if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-            $display("ERROR writeBack stuck by another plugin is not allowed"); // DataCache.scala:L1077
+            $display("ERROR writeBack stuck by another plugin is not allowed"); // DataCache.scala:L1084
           end
         `endif
       `endif
@@ -7143,7 +7171,7 @@ module DataCache (
       if(loader_kill) begin
         loader_killReg <= 1'b1;
       end
-      if(when_DataCache_l1090) begin
+      if(when_DataCache_l1097) begin
         loader_error <= (loader_error || io_mem_rsp_payload_error);
       end
       if(loader_done) begin
@@ -7151,7 +7179,7 @@ module DataCache (
         loader_error <= 1'b0;
         loader_killReg <= 1'b0;
       end
-      if(when_DataCache_l1118) begin
+      if(when_DataCache_l1125) begin
         loader_waysAllocator <= _zz_loader_waysAllocator[0:0];
       end
     end
@@ -7161,46 +7189,46 @@ module DataCache (
 endmodule
 
 module InstructionCache (
-  input               io_flush,
-  input               io_cpu_prefetch_isValid,
-  output reg          io_cpu_prefetch_haltIt,
-  input      [31:0]   io_cpu_prefetch_pc,
-  input               io_cpu_fetch_isValid,
-  input               io_cpu_fetch_isStuck,
-  input               io_cpu_fetch_isRemoved,
-  input      [31:0]   io_cpu_fetch_pc,
-  output     [31:0]   io_cpu_fetch_data,
-  input      [31:0]   io_cpu_fetch_mmuRsp_physicalAddress,
-  input               io_cpu_fetch_mmuRsp_isIoAccess,
-  input               io_cpu_fetch_mmuRsp_isPaging,
-  input               io_cpu_fetch_mmuRsp_allowRead,
-  input               io_cpu_fetch_mmuRsp_allowWrite,
-  input               io_cpu_fetch_mmuRsp_allowExecute,
-  input               io_cpu_fetch_mmuRsp_exception,
-  input               io_cpu_fetch_mmuRsp_refilling,
-  input               io_cpu_fetch_mmuRsp_bypassTranslation,
-  output     [31:0]   io_cpu_fetch_physicalAddress,
-  output              io_cpu_fetch_cacheMiss,
-  output              io_cpu_fetch_error,
-  output              io_cpu_fetch_mmuRefilling,
-  output              io_cpu_fetch_mmuException,
-  input               io_cpu_fetch_isUser,
-  input               io_cpu_decode_isValid,
-  input               io_cpu_decode_isStuck,
-  input      [31:0]   io_cpu_decode_pc,
-  output     [31:0]   io_cpu_decode_physicalAddress,
-  output     [31:0]   io_cpu_decode_data,
-  input               io_cpu_fill_valid,
-  input      [31:0]   io_cpu_fill_payload,
-  output              io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output     [31:0]   io_mem_cmd_payload_address,
-  output     [2:0]    io_mem_cmd_payload_size,
-  input               io_mem_rsp_valid,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input               clk,
-  input               reset
+  input  wire          io_flush,
+  input  wire          io_cpu_prefetch_isValid,
+  output reg           io_cpu_prefetch_haltIt,
+  input  wire [31:0]   io_cpu_prefetch_pc,
+  input  wire          io_cpu_fetch_isValid,
+  input  wire          io_cpu_fetch_isStuck,
+  input  wire          io_cpu_fetch_isRemoved,
+  input  wire [31:0]   io_cpu_fetch_pc,
+  output wire [31:0]   io_cpu_fetch_data,
+  input  wire [31:0]   io_cpu_fetch_mmuRsp_physicalAddress,
+  input  wire          io_cpu_fetch_mmuRsp_isIoAccess,
+  input  wire          io_cpu_fetch_mmuRsp_isPaging,
+  input  wire          io_cpu_fetch_mmuRsp_allowRead,
+  input  wire          io_cpu_fetch_mmuRsp_allowWrite,
+  input  wire          io_cpu_fetch_mmuRsp_allowExecute,
+  input  wire          io_cpu_fetch_mmuRsp_exception,
+  input  wire          io_cpu_fetch_mmuRsp_refilling,
+  input  wire          io_cpu_fetch_mmuRsp_bypassTranslation,
+  output wire [31:0]   io_cpu_fetch_physicalAddress,
+  output wire          io_cpu_fetch_cacheMiss,
+  output wire          io_cpu_fetch_error,
+  output wire          io_cpu_fetch_mmuRefilling,
+  output wire          io_cpu_fetch_mmuException,
+  input  wire          io_cpu_fetch_isUser,
+  input  wire          io_cpu_decode_isValid,
+  input  wire          io_cpu_decode_isStuck,
+  input  wire [31:0]   io_cpu_decode_pc,
+  output wire [31:0]   io_cpu_decode_physicalAddress,
+  output wire [31:0]   io_cpu_decode_data,
+  input  wire          io_cpu_fill_valid,
+  input  wire [31:0]   io_cpu_fill_payload,
+  output wire          io_mem_cmd_valid,
+  input  wire          io_mem_cmd_ready,
+  output wire [31:0]   io_mem_cmd_payload_address,
+  output wire [2:0]    io_mem_cmd_payload_size,
+  input  wire          io_mem_rsp_valid,
+  input  wire [31:0]   io_mem_rsp_payload_data,
+  input  wire          io_mem_rsp_payload_error,
+  input  wire          clk,
+  input  wire          reset
 );
 
   reg        [31:0]   _zz_banks_0_port1;
@@ -7220,7 +7248,7 @@ module InstructionCache (
   wire                when_InstructionCache_l351;
   reg                 lineLoader_cmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_Utils_l515;
+  wire                when_Utils_l560;
   reg                 lineLoader_wayToAllocate_willIncrement;
   wire                lineLoader_wayToAllocate_willClear;
   wire                lineLoader_wayToAllocate_willOverflowIfInc;
@@ -7319,12 +7347,12 @@ module InstructionCache (
   assign when_InstructionCache_l351 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
   assign io_mem_cmd_fire = (io_mem_cmd_valid && io_mem_cmd_ready);
   assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
-  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
+  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h00};
   assign io_mem_cmd_payload_size = 3'b101;
-  assign when_Utils_l515 = (! lineLoader_valid);
+  assign when_Utils_l560 = (! lineLoader_valid);
   always @(*) begin
     lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if(when_Utils_l515) begin
+    if(when_Utils_l560) begin
       lineLoader_wayToAllocate_willIncrement = 1'b1;
     end
   end
@@ -7409,7 +7437,7 @@ module InstructionCache (
     end
     _zz_when_InstructionCache_l342 <= lineLoader_flushCounter[7];
     if(when_InstructionCache_l351) begin
-      lineLoader_flushCounter <= 8'h0;
+      lineLoader_flushCounter <= 8'h00;
     end
   end
 

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_Linux.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_Linux.v
@@ -1,38 +1,38 @@
-// Generator : SpinalHDL v1.7.1    git head : 0444bb76ab1d6e19f0ec46bc03c4769776deb7d5
+// Generator : SpinalHDL v1.9.4    git head : 270018552577f3bb8e5339ee2583c9c22d324215
 // Component : VexRiscv
-// Git hash  : 581fcb065adf7ea8b626f939ff51679d4c95872f
+// Git hash  : 63430af99f84cc1d11d58b556debe1cc3f238c67
 
 `timescale 1ns/1ps
 
 module VexRiscv (
-  input      [31:0]   externalResetVector,
-  input               timerInterrupt,
-  input               softwareInterrupt,
-  input      [31:0]   externalInterruptArray,
-  output reg          iBusWishbone_CYC,
-  output reg          iBusWishbone_STB,
-  input               iBusWishbone_ACK,
-  output              iBusWishbone_WE,
-  output     [29:0]   iBusWishbone_ADR,
-  input      [31:0]   iBusWishbone_DAT_MISO,
-  output     [31:0]   iBusWishbone_DAT_MOSI,
-  output     [3:0]    iBusWishbone_SEL,
-  input               iBusWishbone_ERR,
-  output     [2:0]    iBusWishbone_CTI,
-  output     [1:0]    iBusWishbone_BTE,
-  output              dBusWishbone_CYC,
-  output              dBusWishbone_STB,
-  input               dBusWishbone_ACK,
-  output              dBusWishbone_WE,
-  output     [29:0]   dBusWishbone_ADR,
-  input      [31:0]   dBusWishbone_DAT_MISO,
-  output     [31:0]   dBusWishbone_DAT_MOSI,
-  output     [3:0]    dBusWishbone_SEL,
-  input               dBusWishbone_ERR,
-  output     [2:0]    dBusWishbone_CTI,
-  output     [1:0]    dBusWishbone_BTE,
-  input               clk,
-  input               reset
+  input  wire [31:0]   externalResetVector,
+  input  wire          timerInterrupt,
+  input  wire          softwareInterrupt,
+  input  wire [31:0]   externalInterruptArray,
+  output reg           iBusWishbone_CYC,
+  output reg           iBusWishbone_STB,
+  input  wire          iBusWishbone_ACK,
+  output wire          iBusWishbone_WE,
+  output wire [29:0]   iBusWishbone_ADR,
+  input  wire [31:0]   iBusWishbone_DAT_MISO,
+  output wire [31:0]   iBusWishbone_DAT_MOSI,
+  output wire [3:0]    iBusWishbone_SEL,
+  input  wire          iBusWishbone_ERR,
+  output wire [2:0]    iBusWishbone_CTI,
+  output wire [1:0]    iBusWishbone_BTE,
+  output wire          dBusWishbone_CYC,
+  output wire          dBusWishbone_STB,
+  input  wire          dBusWishbone_ACK,
+  output wire          dBusWishbone_WE,
+  output wire [29:0]   dBusWishbone_ADR,
+  input  wire [31:0]   dBusWishbone_DAT_MISO,
+  output wire [31:0]   dBusWishbone_DAT_MOSI,
+  output wire [3:0]    dBusWishbone_SEL,
+  input  wire          dBusWishbone_ERR,
+  output wire [2:0]    dBusWishbone_CTI,
+  output wire [1:0]    dBusWishbone_BTE,
+  input  wire          clk,
+  input  wire          reset
 );
   localparam ShiftCtrlEnum_DISABLE_1 = 2'd0;
   localparam ShiftCtrlEnum_SLL_1 = 2'd1;
@@ -101,7 +101,6 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_flush_valid;
   wire                dataCache_1_io_cpu_flush_payload_singleLine;
   wire       [6:0]    dataCache_1_io_cpu_flush_payload_lineId;
-  wire                dataCache_1_io_mem_cmd_ready;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
@@ -129,6 +128,7 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_writeBack_exclusiveOk;
   wire                dataCache_1_io_cpu_flush_ready;
   wire                dataCache_1_io_cpu_redo;
+  wire                dataCache_1_io_cpu_writesPending;
   wire                dataCache_1_io_mem_cmd_valid;
   wire                dataCache_1_io_mem_cmd_payload_wr;
   wire                dataCache_1_io_mem_cmd_payload_uncached;
@@ -140,12 +140,11 @@ module VexRiscv (
   wire       [51:0]   _zz_memory_MUL_LOW;
   wire       [51:0]   _zz_memory_MUL_LOW_1;
   wire       [51:0]   _zz_memory_MUL_LOW_2;
-  wire       [51:0]   _zz_memory_MUL_LOW_3;
-  wire       [32:0]   _zz_memory_MUL_LOW_4;
-  wire       [51:0]   _zz_memory_MUL_LOW_5;
-  wire       [49:0]   _zz_memory_MUL_LOW_6;
-  wire       [51:0]   _zz_memory_MUL_LOW_7;
-  wire       [49:0]   _zz_memory_MUL_LOW_8;
+  wire       [32:0]   _zz_memory_MUL_LOW_3;
+  wire       [51:0]   _zz_memory_MUL_LOW_4;
+  wire       [49:0]   _zz_memory_MUL_LOW_5;
+  wire       [51:0]   _zz_memory_MUL_LOW_6;
+  wire       [49:0]   _zz_memory_MUL_LOW_7;
   wire       [31:0]   _zz_execute_SHIFT_RIGHT;
   wire       [32:0]   _zz_execute_SHIFT_RIGHT_1;
   wire       [32:0]   _zz_execute_SHIFT_RIGHT_2;
@@ -154,24 +153,24 @@ module VexRiscv (
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_2;
   wire                _zz_decode_LEGAL_INSTRUCTION_3;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_4;
-  wire       [17:0]   _zz_decode_LEGAL_INSTRUCTION_5;
+  wire       [16:0]   _zz_decode_LEGAL_INSTRUCTION_5;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_6;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_7;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_8;
   wire                _zz_decode_LEGAL_INSTRUCTION_9;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_10;
-  wire       [11:0]   _zz_decode_LEGAL_INSTRUCTION_11;
+  wire       [10:0]   _zz_decode_LEGAL_INSTRUCTION_11;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_12;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_13;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_14;
   wire                _zz_decode_LEGAL_INSTRUCTION_15;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_16;
-  wire       [5:0]    _zz_decode_LEGAL_INSTRUCTION_17;
+  wire       [4:0]    _zz_decode_LEGAL_INSTRUCTION_17;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_18;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_19;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_20;
-  wire                _zz_decode_LEGAL_INSTRUCTION_21;
-  wire                _zz_decode_LEGAL_INSTRUCTION_22;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_21;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_22;
   wire       [4:0]    _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1;
   reg        [31:0]   _zz_IBusCachedPlugin_jump_pcLoad_payload_6;
   wire       [2:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_7;
@@ -252,157 +251,154 @@ module VexRiscv (
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_13;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_14;
   wire                _zz__zz_decode_IS_RS2_SIGNED_15;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_16;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_17;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_16;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_17;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_18;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_19;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_20;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_21;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_22;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_23;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_20;
+  wire       [24:0]   _zz__zz_decode_IS_RS2_SIGNED_21;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_22;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_23;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_24;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_25;
-  wire       [24:0]   _zz__zz_decode_IS_RS2_SIGNED_26;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_27;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_28;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_25;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_26;
+  wire       [21:0]   _zz__zz_decode_IS_RS2_SIGNED_27;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_28;
   wire                _zz__zz_decode_IS_RS2_SIGNED_29;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_30;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_31;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_32;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_31;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_32;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_33;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_34;
-  wire       [21:0]   _zz__zz_decode_IS_RS2_SIGNED_35;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_36;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_37;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_38;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_34;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_35;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_36;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_37;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_38;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_39;
-  wire       [18:0]   _zz__zz_decode_IS_RS2_SIGNED_40;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_41;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_42;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_43;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_44;
-  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_45;
+  wire       [17:0]   _zz__zz_decode_IS_RS2_SIGNED_40;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_41;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_42;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_43;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_44;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_45;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_46;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_47;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_48;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_49;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_50;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_51;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_52;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_53;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_54;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_55;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_56;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_57;
-  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_58;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_47;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_48;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_49;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_50;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_51;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_52;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_53;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_54;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_55;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_56;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_57;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_58;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_59;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_60;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_61;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_62;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_63;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_64;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_65;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_66;
-  wire       [13:0]   _zz__zz_decode_IS_RS2_SIGNED_67;
-  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_68;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_61;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_62;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_63;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_64;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_65;
+  wire       [13:0]   _zz__zz_decode_IS_RS2_SIGNED_66;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_67;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_68;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_69;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_70;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_71;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_70;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_71;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_72;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_73;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_74;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_75;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_76;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_73;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_74;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_75;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_76;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_77;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_78;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_79;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_80;
-  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_81;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_82;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_83;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_84;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_78;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_79;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_80;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_81;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_82;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_83;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_84;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_85;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_86;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_87;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_88;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_89;
-  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_90;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_88;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_89;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_90;
   wire                _zz__zz_decode_IS_RS2_SIGNED_91;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_92;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_93;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_94;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_95;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_96;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_97;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_98;
+  wire       [6:0]    _zz__zz_decode_IS_RS2_SIGNED_94;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_95;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_96;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_97;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_98;
   wire                _zz__zz_decode_IS_RS2_SIGNED_99;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_100;
-  wire       [10:0]   _zz__zz_decode_IS_RS2_SIGNED_101;
-  wire       [6:0]    _zz__zz_decode_IS_RS2_SIGNED_102;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_103;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_104;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_105;
-  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_106;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_107;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_101;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_102;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_103;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_104;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_105;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_106;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_107;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_108;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_109;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_110;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_111;
-  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_112;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_113;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_114;
+  wire       [10:0]   _zz__zz_decode_IS_RS2_SIGNED_109;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_110;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_111;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_112;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_113;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_114;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_115;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_116;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_116;
   wire                _zz__zz_decode_IS_RS2_SIGNED_117;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_118;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_119;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_120;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_121;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_122;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_123;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_124;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_118;
+  wire       [8:0]    _zz__zz_decode_IS_RS2_SIGNED_119;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_120;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_121;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_122;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_123;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_124;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_125;
-  wire       [7:0]    _zz__zz_decode_IS_RS2_SIGNED_126;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_127;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_126;
+  wire       [6:0]    _zz__zz_decode_IS_RS2_SIGNED_127;
   wire                _zz__zz_decode_IS_RS2_SIGNED_128;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_129;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_130;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_131;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_132;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_129;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_130;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_131;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_132;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_133;
-  wire       [5:0]    _zz__zz_decode_IS_RS2_SIGNED_134;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_135;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_136;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_137;
-  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_138;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_139;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_140;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_134;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_135;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_136;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_137;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_138;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_139;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_140;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_141;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_142;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_143;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_144;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_145;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_146;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_147;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_142;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_143;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_144;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_145;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_146;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_147;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_148;
-  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_149;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_150;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_151;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_152;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_153;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_149;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_150;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_151;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_152;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_153;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_154;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_155;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_156;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_157;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_155;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_156;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_157;
   wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_158;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_159;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_160;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_161;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_162;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_163;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_164;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_165;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_166;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_159;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_160;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_161;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_162;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_163;
   wire                _zz_RegFilePlugin_regFile_port;
   wire                _zz_decode_RegFilePlugin_rs1Data;
   wire                _zz_RegFilePlugin_regFile_port_1;
@@ -410,14 +406,12 @@ module VexRiscv (
   wire       [0:0]    _zz__zz_execute_REGFILE_WRITE_DATA;
   wire       [2:0]    _zz__zz_execute_SRC1;
   wire       [4:0]    _zz__zz_execute_SRC1_1;
-  wire       [11:0]   _zz__zz_execute_SRC2_3;
+  wire       [11:0]   _zz__zz_execute_SRC2_2;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_1;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_2;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_3;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_4;
-  wire       [31:0]   _zz_execute_SrcPlugin_addSub_5;
-  wire       [31:0]   _zz_execute_SrcPlugin_addSub_6;
   wire       [19:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_2;
   wire       [11:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_4;
   wire       [31:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_6;
@@ -451,7 +445,7 @@ module VexRiscv (
   wire       [0:0]    _zz_memory_DivPlugin_rs1_3;
   wire       [31:0]   _zz_memory_DivPlugin_rs2_1;
   wire       [0:0]    _zz_memory_DivPlugin_rs2_2;
-  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_28;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_26;
   wire       [26:0]   _zz_iBusWishbone_ADR_1;
   wire       [51:0]   memory_MUL_LOW;
   wire       [33:0]   memory_MUL_HH;
@@ -498,7 +492,6 @@ module VexRiscv (
   wire       [1:0]    _zz_decode_to_execute_ALU_BITWISE_CTRL;
   wire       [1:0]    _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   wire                decode_SRC_LESS_UNSIGNED;
-  wire                decode_IS_SFENCE_VMA;
   wire                decode_IS_SFENCE_VMA2;
   wire                decode_MEMORY_MANAGMENT;
   wire                memory_MEMORY_LRSC;
@@ -519,6 +512,7 @@ module VexRiscv (
   wire       [1:0]    _zz_decode_SRC1_CTRL;
   wire       [1:0]    _zz_decode_to_execute_SRC1_CTRL;
   wire       [1:0]    _zz_decode_to_execute_SRC1_CTRL_1;
+  wire                decode_RESCHEDULE_NEXT;
   wire                decode_MEMORY_FORCE_CONSTISTENCY;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
@@ -544,7 +538,7 @@ module VexRiscv (
   wire       [1:0]    _zz_execute_ENV_CTRL;
   wire       [1:0]    writeBack_ENV_CTRL;
   wire       [1:0]    _zz_writeBack_ENV_CTRL;
-  wire                execute_IS_SFENCE_VMA;
+  wire                execute_RESCHEDULE_NEXT;
   wire       [31:0]   memory_BRANCH_CALC;
   wire                memory_BRANCH_DO;
   wire       [31:0]   execute_PC;
@@ -572,7 +566,7 @@ module VexRiscv (
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_execute_SRC2;
+  wire       [31:0]   _zz_execute_to_memory_PC;
   wire       [1:0]    execute_SRC2_CTRL;
   wire       [1:0]    _zz_execute_SRC2_CTRL;
   wire       [1:0]    execute_SRC1_CTRL;
@@ -788,8 +782,9 @@ module VexRiscv (
   wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
   wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
   wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
-  wire                CsrPlugin_csrMapping_allowCsrSignal;
+  reg                 CsrPlugin_csrMapping_allowCsrSignal;
   wire                CsrPlugin_csrMapping_hazardFree;
+  wire                CsrPlugin_csrMapping_doForceFailCsr;
   reg                 CsrPlugin_inWfi /* verilator public */ ;
   wire                CsrPlugin_thirdPartyWake;
   reg                 CsrPlugin_jumpInterface_valid;
@@ -811,6 +806,7 @@ module VexRiscv (
   wire                CsrPlugin_allowInterrupts;
   wire                CsrPlugin_allowException;
   wire                CsrPlugin_allowEbreakException;
+  reg                 CsrPlugin_xretAwayFromMachine;
   wire                IBusCachedPlugin_externalFlush;
   wire                IBusCachedPlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
@@ -831,14 +827,13 @@ module VexRiscv (
   reg                 IBusCachedPlugin_fetchPc_pcRegPropagate;
   reg                 IBusCachedPlugin_fetchPc_booted;
   reg                 IBusCachedPlugin_fetchPc_inc;
-  wire                when_Fetcher_l134;
-  wire                IBusCachedPlugin_fetchPc_output_fire_1;
-  wire                when_Fetcher_l134_1;
+  wire                when_Fetcher_l133;
+  wire                when_Fetcher_l133_1;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pc;
   wire                IBusCachedPlugin_fetchPc_redo_valid;
   wire       [31:0]   IBusCachedPlugin_fetchPc_redo_payload;
   reg                 IBusCachedPlugin_fetchPc_flushed;
-  wire                when_Fetcher_l161;
+  wire                when_Fetcher_l160;
   reg                 IBusCachedPlugin_iBusRsp_redoFetch;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_ready;
@@ -866,8 +861,8 @@ module VexRiscv (
   wire                _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready;
   wire                IBusCachedPlugin_iBusRsp_flush;
   wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
-  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
-  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid;
+  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1;
   wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
@@ -880,18 +875,18 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_output_payload_rsp_error;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   wire                IBusCachedPlugin_iBusRsp_output_payload_isRvc;
-  wire                when_Fetcher_l243;
-  wire                when_Fetcher_l323;
+  wire                when_Fetcher_l242;
+  wire                when_Fetcher_l322;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
-  wire                when_Fetcher_l332;
+  wire                when_Fetcher_l331;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
-  wire                when_Fetcher_l332_1;
+  wire                when_Fetcher_l331_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
-  wire                when_Fetcher_l332_2;
+  wire                when_Fetcher_l331_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
-  wire                when_Fetcher_l332_3;
+  wire                when_Fetcher_l331_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                when_Fetcher_l332_4;
+  wire                when_Fetcher_l331_4;
   wire                _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   reg        [18:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1;
   wire                _zz_2;
@@ -917,81 +912,82 @@ module VexRiscv (
   wire                IBusCachedPlugin_rsp_iBusRspOutputHalt;
   wire                IBusCachedPlugin_rsp_issueDetected;
   reg                 IBusCachedPlugin_rsp_redoFetch;
-  wire                when_IBusCachedPlugin_l239;
-  wire                when_IBusCachedPlugin_l244;
+  wire                when_IBusCachedPlugin_l245;
   wire                when_IBusCachedPlugin_l250;
   wire                when_IBusCachedPlugin_l256;
-  wire                when_IBusCachedPlugin_l267;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_valid;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_ready;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_address;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_data;
-  wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_size;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_last;
-  reg                 dataCache_1_io_mem_cmd_rValid;
-  reg                 dataCache_1_io_mem_cmd_rData_wr;
-  reg                 dataCache_1_io_mem_cmd_rData_uncached;
-  reg        [31:0]   dataCache_1_io_mem_cmd_rData_address;
-  reg        [31:0]   dataCache_1_io_mem_cmd_rData_data;
-  reg        [3:0]    dataCache_1_io_mem_cmd_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_rData_size;
-  reg                 dataCache_1_io_mem_cmd_rData_last;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
-  wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data;
-  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
-  wire                when_Stream_l368;
+  wire                when_IBusCachedPlugin_l262;
+  wire                when_IBusCachedPlugin_l273;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_valid;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+  wire       [3:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+  wire       [2:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_size;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rValidN;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rData_wr;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rData_uncached;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_rData_address;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_rData_data;
+  reg        [3:0]    toplevel_dataCache_1_io_mem_cmd_rData_mask;
+  reg        [2:0]    toplevel_dataCache_1_io_mem_cmd_rData_size;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rData_last;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
+  wire       [3:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
+  wire       [2:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_address;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_data;
+  reg        [3:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
+  reg        [2:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_size;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  wire                when_Stream_l369;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
-  wire                when_DBusCachedPlugin_l308;
-  wire                when_DBusCachedPlugin_l316;
+  wire                when_DBusCachedPlugin_l352;
+  wire                when_DBusCachedPlugin_l360;
   wire       [1:0]    execute_DBusCachedPlugin_size;
   reg        [31:0]   _zz_execute_MEMORY_STORE_DATA_RF;
-  wire                dataCache_1_io_cpu_flush_isStall;
-  wire                when_DBusCachedPlugin_l350;
-  wire                when_DBusCachedPlugin_l366;
-  wire                when_DBusCachedPlugin_l393;
-  wire                when_DBusCachedPlugin_l446;
-  wire                when_DBusCachedPlugin_l466;
+  wire                toplevel_dataCache_1_io_cpu_flush_isStall;
+  wire                when_DBusCachedPlugin_l394;
+  wire                when_DBusCachedPlugin_l410;
+  wire                when_DBusCachedPlugin_l472;
+  wire                when_DBusCachedPlugin_l533;
+  wire                when_DBusCachedPlugin_l553;
+  wire       [31:0]   writeBack_DBusCachedPlugin_rspData;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_0;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_1;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_2;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspRf;
-  wire                when_DBusCachedPlugin_l482;
-  wire       [1:0]    switch_Misc_l210;
+  wire                when_DBusCachedPlugin_l570;
+  wire       [1:0]    switch_Misc_l232;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_1;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated_2;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
-  wire                when_DBusCachedPlugin_l492;
+  wire                when_DBusCachedPlugin_l580;
   reg                 DBusCachedPlugin_forceDatapath;
-  wire                when_DBusCachedPlugin_l506;
-  wire                when_DBusCachedPlugin_l507;
+  wire                when_DBusCachedPlugin_l604;
+  wire                when_DBusCachedPlugin_l605;
   wire                MmuPlugin_dBusAccess_cmd_fire;
   reg                 MmuPlugin_status_sum;
   reg                 MmuPlugin_status_mxr;
   reg                 MmuPlugin_status_mprv;
   reg                 MmuPlugin_satp_mode;
   reg        [8:0]    MmuPlugin_satp_asid;
-  reg        [19:0]   MmuPlugin_satp_ppn;
+  reg        [21:0]   MmuPlugin_satp_ppn;
   reg                 MmuPlugin_ports_0_cache_0_valid;
   reg                 MmuPlugin_ports_0_cache_0_exception;
   reg                 MmuPlugin_ports_0_cache_0_superPage;
@@ -1038,8 +1034,8 @@ module VexRiscv (
   reg                 MmuPlugin_ports_0_cache_3_allowUser;
   wire                MmuPlugin_ports_0_dirty;
   reg                 MmuPlugin_ports_0_requireMmuLockupCalc;
-  wire                when_MmuPlugin_l125;
-  wire                when_MmuPlugin_l126;
+  wire                when_MmuPlugin_l131;
+  wire                when_MmuPlugin_l132;
   wire       [3:0]    MmuPlugin_ports_0_cacheHitsCalc;
   wire                MmuPlugin_ports_0_cacheHit;
   wire                _zz_MmuPlugin_ports_0_cacheLine_valid;
@@ -1109,9 +1105,9 @@ module VexRiscv (
   reg                 MmuPlugin_ports_1_cache_3_allowUser;
   wire                MmuPlugin_ports_1_dirty;
   reg                 MmuPlugin_ports_1_requireMmuLockupCalc;
-  wire                when_MmuPlugin_l125_1;
-  wire                when_MmuPlugin_l126_1;
-  wire                when_MmuPlugin_l128;
+  wire                when_MmuPlugin_l131_1;
+  wire                when_MmuPlugin_l132_1;
+  wire                when_MmuPlugin_l134;
   wire       [3:0]    MmuPlugin_ports_1_cacheHitsCalc;
   wire                MmuPlugin_ports_1_cacheHit;
   wire                _zz_MmuPlugin_ports_1_cacheLine_valid;
@@ -1156,7 +1152,7 @@ module VexRiscv (
   wire       [11:0]   MmuPlugin_shared_dBusRsp_pte_PPN1;
   wire                MmuPlugin_shared_dBusRsp_exception;
   wire                MmuPlugin_shared_dBusRsp_leaf;
-  wire                when_MmuPlugin_l205;
+  wire                when_MmuPlugin_l211;
   reg                 MmuPlugin_shared_pteBuffer_V;
   reg                 MmuPlugin_shared_pteBuffer_R;
   reg                 MmuPlugin_shared_pteBuffer_W;
@@ -1173,21 +1169,21 @@ module VexRiscv (
   wire       [1:0]    MmuPlugin_shared_refills;
   wire       [1:0]    _zz_MmuPlugin_shared_refills_2;
   reg        [1:0]    _zz_MmuPlugin_shared_refills_3;
-  wire                when_MmuPlugin_l217;
+  wire                when_MmuPlugin_l223;
   wire       [31:0]   _zz_MmuPlugin_shared_vpn_0;
-  wire                when_MmuPlugin_l243;
-  wire                when_MmuPlugin_l272;
-  wire                when_MmuPlugin_l274;
-  wire                when_MmuPlugin_l280;
-  wire                when_MmuPlugin_l280_1;
-  wire                when_MmuPlugin_l280_2;
-  wire                when_MmuPlugin_l280_3;
-  wire                when_MmuPlugin_l274_1;
-  wire                when_MmuPlugin_l280_4;
-  wire                when_MmuPlugin_l280_5;
-  wire                when_MmuPlugin_l280_6;
-  wire                when_MmuPlugin_l280_7;
-  wire                when_MmuPlugin_l304;
+  wire                when_MmuPlugin_l250;
+  wire                when_MmuPlugin_l279;
+  wire                when_MmuPlugin_l281;
+  wire                when_MmuPlugin_l287;
+  wire                when_MmuPlugin_l287_1;
+  wire                when_MmuPlugin_l287_2;
+  wire                when_MmuPlugin_l287_3;
+  wire                when_MmuPlugin_l281_1;
+  wire                when_MmuPlugin_l287_4;
+  wire                when_MmuPlugin_l287_5;
+  wire                when_MmuPlugin_l287_6;
+  wire                when_MmuPlugin_l287_7;
+  wire                when_MmuPlugin_l311;
   wire       [35:0]   _zz_decode_IS_RS2_SIGNED;
   wire                _zz_decode_IS_RS2_SIGNED_1;
   wire                _zz_decode_IS_RS2_SIGNED_2;
@@ -1198,6 +1194,7 @@ module VexRiscv (
   wire                _zz_decode_IS_RS2_SIGNED_7;
   wire                _zz_decode_IS_RS2_SIGNED_8;
   wire                _zz_decode_IS_RS2_SIGNED_9;
+  wire                _zz_decode_IS_RS2_SIGNED_10;
   wire       [1:0]    _zz_decode_SRC1_CTRL_2;
   wire       [1:0]    _zz_decode_ALU_CTRL_2;
   wire       [1:0]    _zz_decode_SRC2_CTRL_2;
@@ -1213,15 +1210,15 @@ module VexRiscv (
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
   reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
   reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_7;
+  reg                 _zz_10;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
   reg        [31:0]   _zz_execute_REGFILE_WRITE_DATA;
   reg        [31:0]   _zz_execute_SRC1;
-  wire                _zz_execute_SRC2_1;
-  reg        [19:0]   _zz_execute_SRC2_2;
-  wire                _zz_execute_SRC2_3;
-  reg        [19:0]   _zz_execute_SRC2_4;
-  reg        [31:0]   _zz_execute_SRC2_5;
+  wire                _zz_execute_SRC2;
+  reg        [19:0]   _zz_execute_SRC2_1;
+  wire                _zz_execute_SRC2_2;
+  reg        [19:0]   _zz_execute_SRC2_3;
+  reg        [31:0]   _zz_execute_SRC2_4;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   wire       [4:0]    execute_FullBarrelShifterPlugin_amplitude;
@@ -1258,7 +1255,7 @@ module VexRiscv (
   wire                when_HazardSimplePlugin_l108;
   wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    switch_Misc_l210_1;
+  wire       [2:0]    switch_Misc_l232_1;
   reg                 _zz_execute_BRANCH_COND_RESULT;
   reg                 _zz_execute_BRANCH_COND_RESULT_1;
   wire                _zz_execute_BranchPlugin_missAlignedTarget;
@@ -1302,6 +1299,7 @@ module VexRiscv (
   reg                 CsrPlugin_medeleg_IAM;
   reg                 CsrPlugin_medeleg_IAF;
   reg                 CsrPlugin_medeleg_II;
+  reg                 CsrPlugin_medeleg_BP;
   reg                 CsrPlugin_medeleg_LAM;
   reg                 CsrPlugin_medeleg_LAF;
   reg                 CsrPlugin_medeleg_SAM;
@@ -1314,6 +1312,12 @@ module VexRiscv (
   reg                 CsrPlugin_mideleg_ST;
   reg                 CsrPlugin_mideleg_SE;
   reg                 CsrPlugin_mideleg_SS;
+  wire                CsrPlugin_mcounteren_IR;
+  wire                CsrPlugin_mcounteren_TM;
+  wire                CsrPlugin_mcounteren_CY;
+  wire                CsrPlugin_scounteren_IR;
+  wire                CsrPlugin_scounteren_TM;
+  wire                CsrPlugin_scounteren_CY;
   reg                 CsrPlugin_sstatus_SIE;
   reg                 CsrPlugin_sstatus_SPIE;
   reg        [0:0]    CsrPlugin_sstatus_SPP;
@@ -1336,13 +1340,13 @@ module VexRiscv (
   reg        [8:0]    CsrPlugin_satp_ASID;
   reg        [0:0]    CsrPlugin_satp_MODE;
   reg                 CsrPlugin_rescheduleLogic_rescheduleNext;
-  wire                when_CsrPlugin_l816;
-  wire                _zz_when_CsrPlugin_l965;
-  wire                _zz_when_CsrPlugin_l965_1;
-  wire                _zz_when_CsrPlugin_l965_2;
-  wire                _zz_when_CsrPlugin_l965_3;
-  wire                _zz_when_CsrPlugin_l965_4;
-  wire                _zz_when_CsrPlugin_l965_5;
+  wire                when_CsrPlugin_l1153;
+  wire                _zz_when_CsrPlugin_l1302;
+  wire                _zz_when_CsrPlugin_l1302_1;
+  wire                _zz_when_CsrPlugin_l1302_2;
+  wire                _zz_when_CsrPlugin_l1302_3;
+  wire                _zz_when_CsrPlugin_l1302_4;
+  wire                _zz_when_CsrPlugin_l1302_5;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -1354,81 +1358,86 @@ module VexRiscv (
   reg        [3:0]    CsrPlugin_exceptionPortCtrl_exceptionContext_code;
   reg        [31:0]   CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
   reg        [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped;
-  wire                when_CsrPlugin_l879;
-  wire                when_CsrPlugin_l879_1;
-  wire                when_CsrPlugin_l879_2;
-  wire                when_CsrPlugin_l879_3;
-  wire                when_CsrPlugin_l879_4;
-  wire                when_CsrPlugin_l879_5;
-  wire                when_CsrPlugin_l879_6;
-  wire                when_CsrPlugin_l879_7;
-  wire                when_CsrPlugin_l879_8;
-  wire                when_CsrPlugin_l879_9;
-  wire                when_CsrPlugin_l879_10;
-  wire                when_CsrPlugin_l879_11;
+  wire                when_CsrPlugin_l1216;
+  wire                when_CsrPlugin_l1216_1;
+  wire                when_CsrPlugin_l1216_2;
+  wire                when_CsrPlugin_l1216_3;
+  wire                when_CsrPlugin_l1216_4;
+  wire                when_CsrPlugin_l1216_5;
+  wire                when_CsrPlugin_l1216_6;
+  wire                when_CsrPlugin_l1216_7;
+  wire                when_CsrPlugin_l1216_8;
+  wire                when_CsrPlugin_l1216_9;
+  wire                when_CsrPlugin_l1216_10;
+  wire                when_CsrPlugin_l1216_11;
+  wire                when_CsrPlugin_l1216_12;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
   wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code;
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
-  wire                when_CsrPlugin_l922;
-  wire                when_CsrPlugin_l922_1;
-  wire                when_CsrPlugin_l922_2;
-  wire                when_CsrPlugin_l922_3;
-  wire                when_CsrPlugin_l935;
+  wire                when_CsrPlugin_l1259;
+  wire                when_CsrPlugin_l1259_1;
+  wire                when_CsrPlugin_l1259_2;
+  wire                when_CsrPlugin_l1259_3;
+  wire                when_CsrPlugin_l1272;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
-  wire                when_CsrPlugin_l959;
-  wire                when_CsrPlugin_l959_1;
-  wire                when_CsrPlugin_l965;
-  wire                when_CsrPlugin_l965_1;
-  wire                when_CsrPlugin_l965_2;
-  wire                when_CsrPlugin_l965_3;
-  wire                when_CsrPlugin_l965_4;
-  wire                when_CsrPlugin_l965_5;
-  wire                when_CsrPlugin_l965_6;
-  wire                when_CsrPlugin_l965_7;
-  wire                when_CsrPlugin_l965_8;
+  wire                when_CsrPlugin_l1296;
+  wire                when_CsrPlugin_l1296_1;
+  wire                when_CsrPlugin_l1302;
+  wire                when_CsrPlugin_l1302_1;
+  wire                when_CsrPlugin_l1302_2;
+  wire                when_CsrPlugin_l1302_3;
+  wire                when_CsrPlugin_l1302_4;
+  wire                when_CsrPlugin_l1302_5;
+  wire                when_CsrPlugin_l1302_6;
+  wire                when_CsrPlugin_l1302_7;
+  wire                when_CsrPlugin_l1302_8;
   wire                CsrPlugin_exception;
   reg                 CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
-  wire                when_CsrPlugin_l993;
-  wire                when_CsrPlugin_l993_1;
-  wire                when_CsrPlugin_l993_2;
-  wire                when_CsrPlugin_l998;
+  wire                when_CsrPlugin_l1335;
+  wire                when_CsrPlugin_l1335_1;
+  wire                when_CsrPlugin_l1335_2;
+  wire                when_CsrPlugin_l1340;
   reg                 CsrPlugin_pipelineLiberator_done;
-  wire                when_CsrPlugin_l1004;
+  wire                when_CsrPlugin_l1346;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
+  wire                CsrPlugin_trapCauseEbreakDebug;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
-  wire                when_CsrPlugin_l1032;
-  wire                when_CsrPlugin_l1077;
-  wire       [1:0]    switch_CsrPlugin_l1081;
+  wire                CsrPlugin_trapEnterDebug;
+  wire                when_CsrPlugin_l1390;
+  wire                when_CsrPlugin_l1398;
+  wire                when_CsrPlugin_l1456;
+  wire       [1:0]    switch_CsrPlugin_l1460;
+  wire                when_CsrPlugin_l1468;
   reg                 execute_CsrPlugin_wfiWake;
-  wire                when_CsrPlugin_l1121;
-  wire                when_CsrPlugin_l1123;
-  wire                when_CsrPlugin_l1129;
+  wire                when_CsrPlugin_l1519;
+  wire                when_CsrPlugin_l1521;
+  wire                when_CsrPlugin_l1527;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire                when_CsrPlugin_l1142;
-  wire                when_CsrPlugin_l1149;
-  wire                when_CsrPlugin_l1150;
-  wire                when_CsrPlugin_l1157;
+  wire                when_CsrPlugin_l1540;
+  wire                when_CsrPlugin_l1547;
+  wire                when_CsrPlugin_l1548;
+  wire                when_CsrPlugin_l1555;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   reg        [31:0]   execute_CsrPlugin_readToWriteData;
-  wire                switch_Misc_l210_2;
+  wire                switch_Misc_l232_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
-  wire                when_CsrPlugin_l1189;
-  wire                when_CsrPlugin_l1193;
+  wire                when_CsrPlugin_l1587;
+  wire                when_CsrPlugin_l1591;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg                 execute_MulPlugin_aSigned;
   reg                 execute_MulPlugin_bSigned;
@@ -1475,9 +1484,9 @@ module VexRiscv (
   reg        [32:0]   _zz_memory_DivPlugin_rs1_1;
   reg        [31:0]   externalInterruptArray_regNext;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit;
-  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
-  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
+  wire       [31:0]   _zz_externalInterrupt;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
+  wire       [31:0]   _zz_externalInterruptS;
   wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
   wire                when_Pipeline_l124_1;
@@ -1499,51 +1508,51 @@ module VexRiscv (
   wire                when_Pipeline_l124_9;
   reg                 decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
   wire                when_Pipeline_l124_10;
-  reg        [1:0]    decode_to_execute_SRC1_CTRL;
+  reg                 decode_to_execute_RESCHEDULE_NEXT;
   wire                when_Pipeline_l124_11;
-  reg                 decode_to_execute_SRC_USE_SUB_LESS;
+  reg        [1:0]    decode_to_execute_SRC1_CTRL;
   wire                when_Pipeline_l124_12;
-  reg                 decode_to_execute_MEMORY_ENABLE;
+  reg                 decode_to_execute_SRC_USE_SUB_LESS;
   wire                when_Pipeline_l124_13;
-  reg                 execute_to_memory_MEMORY_ENABLE;
+  reg                 decode_to_execute_MEMORY_ENABLE;
   wire                when_Pipeline_l124_14;
-  reg                 memory_to_writeBack_MEMORY_ENABLE;
+  reg                 execute_to_memory_MEMORY_ENABLE;
   wire                when_Pipeline_l124_15;
-  reg        [1:0]    decode_to_execute_ALU_CTRL;
+  reg                 memory_to_writeBack_MEMORY_ENABLE;
   wire                when_Pipeline_l124_16;
-  reg        [1:0]    decode_to_execute_SRC2_CTRL;
+  reg        [1:0]    decode_to_execute_ALU_CTRL;
   wire                when_Pipeline_l124_17;
-  reg                 decode_to_execute_REGFILE_WRITE_VALID;
+  reg        [1:0]    decode_to_execute_SRC2_CTRL;
   wire                when_Pipeline_l124_18;
-  reg                 execute_to_memory_REGFILE_WRITE_VALID;
+  reg                 decode_to_execute_REGFILE_WRITE_VALID;
   wire                when_Pipeline_l124_19;
-  reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
+  reg                 execute_to_memory_REGFILE_WRITE_VALID;
   wire                when_Pipeline_l124_20;
-  reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
+  reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
   wire                when_Pipeline_l124_21;
-  reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
   wire                when_Pipeline_l124_22;
-  reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
+  reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
   wire                when_Pipeline_l124_23;
-  reg                 decode_to_execute_MEMORY_WR;
+  reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
   wire                when_Pipeline_l124_24;
-  reg                 execute_to_memory_MEMORY_WR;
+  reg                 decode_to_execute_MEMORY_WR;
   wire                when_Pipeline_l124_25;
-  reg                 memory_to_writeBack_MEMORY_WR;
+  reg                 execute_to_memory_MEMORY_WR;
   wire                when_Pipeline_l124_26;
-  reg                 decode_to_execute_MEMORY_LRSC;
+  reg                 memory_to_writeBack_MEMORY_WR;
   wire                when_Pipeline_l124_27;
-  reg                 execute_to_memory_MEMORY_LRSC;
+  reg                 decode_to_execute_MEMORY_LRSC;
   wire                when_Pipeline_l124_28;
-  reg                 memory_to_writeBack_MEMORY_LRSC;
+  reg                 execute_to_memory_MEMORY_LRSC;
   wire                when_Pipeline_l124_29;
-  reg                 decode_to_execute_MEMORY_AMO;
+  reg                 memory_to_writeBack_MEMORY_LRSC;
   wire                when_Pipeline_l124_30;
-  reg                 decode_to_execute_MEMORY_MANAGMENT;
+  reg                 decode_to_execute_MEMORY_AMO;
   wire                when_Pipeline_l124_31;
-  reg                 decode_to_execute_IS_SFENCE_VMA2;
+  reg                 decode_to_execute_MEMORY_MANAGMENT;
   wire                when_Pipeline_l124_32;
-  reg                 decode_to_execute_IS_SFENCE_VMA;
+  reg                 decode_to_execute_IS_SFENCE_VMA2;
   wire                when_Pipeline_l124_33;
   reg                 decode_to_execute_SRC_LESS_UNSIGNED;
   wire                when_Pipeline_l124_34;
@@ -1624,64 +1633,66 @@ module VexRiscv (
   wire                when_Pipeline_l154_1;
   wire                when_Pipeline_l151_2;
   wire                when_Pipeline_l154_2;
-  wire                when_CsrPlugin_l1277;
+  wire                when_CsrPlugin_l1669;
   reg                 execute_CsrPlugin_csr_3264;
-  wire                when_CsrPlugin_l1277_1;
+  wire                when_CsrPlugin_l1669_1;
   reg                 execute_CsrPlugin_csr_768;
-  wire                when_CsrPlugin_l1277_2;
+  wire                when_CsrPlugin_l1669_2;
   reg                 execute_CsrPlugin_csr_256;
-  wire                when_CsrPlugin_l1277_3;
+  wire                when_CsrPlugin_l1669_3;
   reg                 execute_CsrPlugin_csr_384;
-  wire                when_CsrPlugin_l1277_4;
+  wire                when_CsrPlugin_l1669_4;
   reg                 execute_CsrPlugin_csr_3857;
-  wire                when_CsrPlugin_l1277_5;
+  wire                when_CsrPlugin_l1669_5;
   reg                 execute_CsrPlugin_csr_3858;
-  wire                when_CsrPlugin_l1277_6;
+  wire                when_CsrPlugin_l1669_6;
   reg                 execute_CsrPlugin_csr_3859;
-  wire                when_CsrPlugin_l1277_7;
+  wire                when_CsrPlugin_l1669_7;
   reg                 execute_CsrPlugin_csr_3860;
-  wire                when_CsrPlugin_l1277_8;
+  wire                when_CsrPlugin_l1669_8;
   reg                 execute_CsrPlugin_csr_836;
-  wire                when_CsrPlugin_l1277_9;
+  wire                when_CsrPlugin_l1669_9;
   reg                 execute_CsrPlugin_csr_772;
-  wire                when_CsrPlugin_l1277_10;
+  wire                when_CsrPlugin_l1669_10;
   reg                 execute_CsrPlugin_csr_773;
-  wire                when_CsrPlugin_l1277_11;
+  wire                when_CsrPlugin_l1669_11;
   reg                 execute_CsrPlugin_csr_833;
-  wire                when_CsrPlugin_l1277_12;
+  wire                when_CsrPlugin_l1669_12;
   reg                 execute_CsrPlugin_csr_832;
-  wire                when_CsrPlugin_l1277_13;
+  wire                when_CsrPlugin_l1669_13;
   reg                 execute_CsrPlugin_csr_834;
-  wire                when_CsrPlugin_l1277_14;
+  wire                when_CsrPlugin_l1669_14;
   reg                 execute_CsrPlugin_csr_835;
-  wire                when_CsrPlugin_l1277_15;
+  wire                when_CsrPlugin_l1669_15;
   reg                 execute_CsrPlugin_csr_770;
-  wire                when_CsrPlugin_l1277_16;
+  wire                when_CsrPlugin_l1669_16;
   reg                 execute_CsrPlugin_csr_771;
-  wire                when_CsrPlugin_l1277_17;
+  wire                when_CsrPlugin_l1669_17;
   reg                 execute_CsrPlugin_csr_324;
-  wire                when_CsrPlugin_l1277_18;
+  wire                when_CsrPlugin_l1669_18;
   reg                 execute_CsrPlugin_csr_260;
-  wire                when_CsrPlugin_l1277_19;
+  wire                when_CsrPlugin_l1669_19;
   reg                 execute_CsrPlugin_csr_261;
-  wire                when_CsrPlugin_l1277_20;
+  wire                when_CsrPlugin_l1669_20;
   reg                 execute_CsrPlugin_csr_321;
-  wire                when_CsrPlugin_l1277_21;
+  wire                when_CsrPlugin_l1669_21;
   reg                 execute_CsrPlugin_csr_320;
-  wire                when_CsrPlugin_l1277_22;
+  wire                when_CsrPlugin_l1669_22;
   reg                 execute_CsrPlugin_csr_322;
-  wire                when_CsrPlugin_l1277_23;
+  wire                when_CsrPlugin_l1669_23;
   reg                 execute_CsrPlugin_csr_323;
-  wire                when_CsrPlugin_l1277_24;
+  wire                when_CsrPlugin_l1669_24;
   reg                 execute_CsrPlugin_csr_3008;
-  wire                when_CsrPlugin_l1277_25;
+  wire                when_CsrPlugin_l1669_25;
   reg                 execute_CsrPlugin_csr_4032;
-  wire                when_CsrPlugin_l1277_26;
+  wire                when_CsrPlugin_l1669_26;
   reg                 execute_CsrPlugin_csr_2496;
-  wire                when_CsrPlugin_l1277_27;
+  wire                when_CsrPlugin_l1669_27;
   reg                 execute_CsrPlugin_csr_3520;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
+  wire       [1:0]    switch_CsrPlugin_l1031;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
-  wire       [1:0]    switch_CsrPlugin_l723;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_5;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_6;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
@@ -1703,20 +1714,22 @@ module VexRiscv (
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_23;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_24;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_25;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_26;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_27;
-  wire                when_CsrPlugin_l1310;
-  wire                when_CsrPlugin_l1315;
+  wire                when_CsrPlugin_l1702;
+  wire       [11:0]   _zz_when_CsrPlugin_l1709;
+  wire                when_CsrPlugin_l1709;
+  reg                 when_CsrPlugin_l1719;
+  wire                when_CsrPlugin_l1717;
+  wire                when_CsrPlugin_l1725;
   reg        [2:0]    _zz_iBusWishbone_ADR;
   wire                when_InstructionCache_l239;
   reg                 _zz_iBus_rsp_valid;
   reg        [31:0]   iBusWishbone_DAT_MISO_regNext;
-  reg        [2:0]    _zz_dBus_cmd_ready;
+  reg        [2:0]    _zz_dBusWishbone_ADR;
+  wire                _zz_dBusWishbone_CYC;
+  wire                _zz_dBus_cmd_ready;
   wire                _zz_dBus_cmd_ready_1;
   wire                _zz_dBus_cmd_ready_2;
-  wire                _zz_dBus_cmd_ready_3;
-  wire                _zz_dBus_cmd_ready_4;
-  wire                _zz_dBus_cmd_ready_5;
+  wire                _zz_dBusWishbone_ADR_1;
   reg                 _zz_dBus_rsp_valid;
   reg        [31:0]   dBusWishbone_DAT_MISO_regNext;
   `ifndef SYNTHESIS
@@ -1804,15 +1817,14 @@ module VexRiscv (
   (* no_rw_check , ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
   assign _zz_when = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
-  assign _zz_memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW_1) + $signed(_zz_memory_MUL_LOW_5));
-  assign _zz_memory_MUL_LOW_1 = ($signed(_zz_memory_MUL_LOW_2) + $signed(_zz_memory_MUL_LOW_3));
-  assign _zz_memory_MUL_LOW_2 = 52'h0;
-  assign _zz_memory_MUL_LOW_4 = {1'b0,memory_MUL_LL};
-  assign _zz_memory_MUL_LOW_3 = {{19{_zz_memory_MUL_LOW_4[32]}}, _zz_memory_MUL_LOW_4};
-  assign _zz_memory_MUL_LOW_6 = ({16'd0,memory_MUL_LH} <<< 16);
-  assign _zz_memory_MUL_LOW_5 = {{2{_zz_memory_MUL_LOW_6[49]}}, _zz_memory_MUL_LOW_6};
-  assign _zz_memory_MUL_LOW_8 = ({16'd0,memory_MUL_HL} <<< 16);
-  assign _zz_memory_MUL_LOW_7 = {{2{_zz_memory_MUL_LOW_8[49]}}, _zz_memory_MUL_LOW_8};
+  assign _zz_memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW_1) + $signed(_zz_memory_MUL_LOW_4));
+  assign _zz_memory_MUL_LOW_1 = ($signed(52'h0000000000000) + $signed(_zz_memory_MUL_LOW_2));
+  assign _zz_memory_MUL_LOW_3 = {1'b0,memory_MUL_LL};
+  assign _zz_memory_MUL_LOW_2 = {{19{_zz_memory_MUL_LOW_3[32]}}, _zz_memory_MUL_LOW_3};
+  assign _zz_memory_MUL_LOW_5 = ({16'd0,memory_MUL_LH} <<< 5'd16);
+  assign _zz_memory_MUL_LOW_4 = {{2{_zz_memory_MUL_LOW_5[49]}}, _zz_memory_MUL_LOW_5};
+  assign _zz_memory_MUL_LOW_7 = ({16'd0,memory_MUL_HL} <<< 5'd16);
+  assign _zz_memory_MUL_LOW_6 = {{2{_zz_memory_MUL_LOW_7[49]}}, _zz_memory_MUL_LOW_7};
   assign _zz_execute_SHIFT_RIGHT_1 = ($signed(_zz_execute_SHIFT_RIGHT_2) >>> execute_FullBarrelShifterPlugin_amplitude);
   assign _zz_execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT_1[31 : 0];
   assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == ShiftCtrlEnum_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
@@ -1828,7 +1840,7 @@ module VexRiscv (
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
   assign _zz_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId_1;
-  assign _zz_io_cpu_flush_payload_lineId_1 = (execute_RS1 >>> 5);
+  assign _zz_io_cpu_flush_payload_lineId_1 = (execute_RS1 >>> 3'd5);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code_1 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
   assign _zz_writeBack_DBusCachedPlugin_rspRf = (! dataCache_1_io_cpu_writeBack_exclusiveOk);
@@ -1840,14 +1852,12 @@ module VexRiscv (
   assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
   assign _zz__zz_execute_SRC1 = 3'b100;
   assign _zz__zz_execute_SRC1_1 = execute_INSTRUCTION[19 : 15];
-  assign _zz__zz_execute_SRC2_3 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz__zz_execute_SRC2_2 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
   assign _zz_execute_SrcPlugin_addSub = ($signed(_zz_execute_SrcPlugin_addSub_1) + $signed(_zz_execute_SrcPlugin_addSub_4));
   assign _zz_execute_SrcPlugin_addSub_1 = ($signed(_zz_execute_SrcPlugin_addSub_2) + $signed(_zz_execute_SrcPlugin_addSub_3));
   assign _zz_execute_SrcPlugin_addSub_2 = execute_SRC1;
   assign _zz_execute_SrcPlugin_addSub_3 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? _zz_execute_SrcPlugin_addSub_5 : _zz_execute_SrcPlugin_addSub_6);
-  assign _zz_execute_SrcPlugin_addSub_5 = 32'h00000001;
-  assign _zz_execute_SrcPlugin_addSub_6 = 32'h0;
+  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? 32'h00000001 : 32'h00000000);
   assign _zz__zz_execute_BranchPlugin_missAlignedTarget_2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
   assign _zz__zz_execute_BranchPlugin_missAlignedTarget_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
   assign _zz__zz_execute_BranchPlugin_missAlignedTarget_6 = {_zz_execute_BranchPlugin_missAlignedTarget_1,execute_INSTRUCTION[31 : 20]};
@@ -1859,7 +1869,7 @@ module VexRiscv (
   assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code & (~ _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1));
   assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code - 2'b01);
   assign _zz_writeBack_MulPlugin_result = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
-  assign _zz_writeBack_MulPlugin_result_1 = ({32'd0,writeBack_MUL_HH} <<< 32);
+  assign _zz_writeBack_MulPlugin_result_1 = ({32'd0,writeBack_MUL_HH} <<< 6'd32);
   assign _zz__zz_decode_RS2_2 = writeBack_MUL_LOW[31 : 0];
   assign _zz__zz_decode_RS2_2_1 = writeBack_MulPlugin_result[63 : 32];
   assign _zz_memory_DivPlugin_div_counter_valueNext_1 = memory_DivPlugin_div_counter_willIncrement;
@@ -1877,17 +1887,17 @@ module VexRiscv (
   assign _zz_memory_DivPlugin_rs1_2 = {32'd0, _zz_memory_DivPlugin_rs1_3};
   assign _zz_memory_DivPlugin_rs2_2 = _zz_memory_DivPlugin_rs2;
   assign _zz_memory_DivPlugin_rs2_1 = {31'd0, _zz_memory_DivPlugin_rs2_2};
-  assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 5);
+  assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 3'd5);
   assign _zz_decode_RegFilePlugin_rs1Data = 1'b1;
   assign _zz_decode_RegFilePlugin_rs2Data = 1'b1;
   assign _zz_IBusCachedPlugin_jump_pcLoad_payload_7 = {_zz_IBusCachedPlugin_jump_pcLoad_payload_3,{_zz_IBusCachedPlugin_jump_pcLoad_payload_5,_zz_IBusCachedPlugin_jump_pcLoad_payload_4}};
   assign _zz_writeBack_DBusCachedPlugin_rspShifted_1 = dataCache_1_io_cpu_writeBack_address[1 : 0];
   assign _zz_writeBack_DBusCachedPlugin_rspShifted_3 = dataCache_1_io_cpu_writeBack_address[1 : 1];
-  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000107f;
-  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00002073;
-  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000207f;
+  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000407f);
+  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00004063;
+  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000107f) == 32'h00000013);
   assign _zz_decode_LEGAL_INSTRUCTION_5 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_6) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_7 == _zz_decode_LEGAL_INSTRUCTION_8),{_zz_decode_LEGAL_INSTRUCTION_9,{_zz_decode_LEGAL_INSTRUCTION_10,_zz_decode_LEGAL_INSTRUCTION_11}}}}}};
   assign _zz_decode_LEGAL_INSTRUCTION_6 = 32'h0000505f;
   assign _zz_decode_LEGAL_INSTRUCTION_7 = (decode_INSTRUCTION & 32'h0000707b);
@@ -1896,16 +1906,16 @@ module VexRiscv (
   assign _zz_decode_LEGAL_INSTRUCTION_10 = ((decode_INSTRUCTION & 32'h1800707f) == 32'h0000202f);
   assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033),{((decode_INSTRUCTION & 32'he800707f) == 32'h0800202f),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h0000500f),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,{_zz_decode_LEGAL_INSTRUCTION_16,_zz_decode_LEGAL_INSTRUCTION_17}}}}}};
   assign _zz_decode_LEGAL_INSTRUCTION_12 = 32'h01f0707f;
-  assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'hbc00707f);
+  assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'hbe00705f);
   assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h00005013;
-  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hfc00307f) == 32'h00001013);
-  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00005033);
-  assign _zz_decode_LEGAL_INSTRUCTION_17 = {((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033),{((decode_INSTRUCTION & 32'hf9f0707f) == 32'h1000202f),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_18) == 32'h12000073),{(_zz_decode_LEGAL_INSTRUCTION_19 == _zz_decode_LEGAL_INSTRUCTION_20),{_zz_decode_LEGAL_INSTRUCTION_21,_zz_decode_LEGAL_INSTRUCTION_22}}}}};
-  assign _zz_decode_LEGAL_INSTRUCTION_18 = 32'hfe007fff;
-  assign _zz_decode_LEGAL_INSTRUCTION_19 = (decode_INSTRUCTION & 32'hdfffffff);
-  assign _zz_decode_LEGAL_INSTRUCTION_20 = 32'h10200073;
-  assign _zz_decode_LEGAL_INSTRUCTION_21 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073);
-  assign _zz_decode_LEGAL_INSTRUCTION_22 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073);
+  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hfe00305f) == 32'h00001013);
+  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
+  assign _zz_decode_LEGAL_INSTRUCTION_17 = {((decode_INSTRUCTION & 32'hf9f0707f) == 32'h1000202f),{((decode_INSTRUCTION & 32'hfe007fff) == 32'h12000073),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_18) == 32'h10200073),{(_zz_decode_LEGAL_INSTRUCTION_19 == _zz_decode_LEGAL_INSTRUCTION_20),(_zz_decode_LEGAL_INSTRUCTION_21 == _zz_decode_LEGAL_INSTRUCTION_22)}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_18 = 32'hdfffffff;
+  assign _zz_decode_LEGAL_INSTRUCTION_19 = (decode_INSTRUCTION & 32'hffffffff);
+  assign _zz_decode_LEGAL_INSTRUCTION_20 = 32'h10500073;
+  assign _zz_decode_LEGAL_INSTRUCTION_21 = (decode_INSTRUCTION & 32'hffffffff);
+  assign _zz_decode_LEGAL_INSTRUCTION_22 = 32'h00000073;
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_4 = decode_INSTRUCTION[31];
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_5 = decode_INSTRUCTION[31];
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_6 = decode_INSTRUCTION[7];
@@ -1927,171 +1937,168 @@ module VexRiscv (
   assign _zz__zz_decode_IS_RS2_SIGNED_3 = ((decode_INSTRUCTION & 32'h02203050) == 32'h00000050);
   assign _zz__zz_decode_IS_RS2_SIGNED_4 = (|((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_5) == 32'h00000050));
   assign _zz__zz_decode_IS_RS2_SIGNED_6 = (|{_zz__zz_decode_IS_RS2_SIGNED_7,_zz__zz_decode_IS_RS2_SIGNED_8});
-  assign _zz__zz_decode_IS_RS2_SIGNED_9 = {(|{_zz__zz_decode_IS_RS2_SIGNED_10,_zz__zz_decode_IS_RS2_SIGNED_11}),{(|_zz__zz_decode_IS_RS2_SIGNED_13),{_zz__zz_decode_IS_RS2_SIGNED_15,{_zz__zz_decode_IS_RS2_SIGNED_18,_zz__zz_decode_IS_RS2_SIGNED_26}}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_9 = {(|{_zz__zz_decode_IS_RS2_SIGNED_10,_zz__zz_decode_IS_RS2_SIGNED_11}),{(|_zz__zz_decode_IS_RS2_SIGNED_13),{_zz__zz_decode_IS_RS2_SIGNED_15,{_zz__zz_decode_IS_RS2_SIGNED_18,_zz__zz_decode_IS_RS2_SIGNED_21}}}};
   assign _zz__zz_decode_IS_RS2_SIGNED_5 = 32'h02403050;
   assign _zz__zz_decode_IS_RS2_SIGNED_7 = ((decode_INSTRUCTION & 32'h00001050) == 32'h00001050);
   assign _zz__zz_decode_IS_RS2_SIGNED_8 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002050);
-  assign _zz__zz_decode_IS_RS2_SIGNED_10 = _zz_decode_IS_RS2_SIGNED_2;
+  assign _zz__zz_decode_IS_RS2_SIGNED_10 = _zz_decode_IS_RS2_SIGNED_4;
   assign _zz__zz_decode_IS_RS2_SIGNED_11 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_12) == 32'h00000004);
   assign _zz__zz_decode_IS_RS2_SIGNED_13 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_14) == 32'h00000040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_15 = (|{_zz__zz_decode_IS_RS2_SIGNED_16,_zz__zz_decode_IS_RS2_SIGNED_17});
-  assign _zz__zz_decode_IS_RS2_SIGNED_18 = (|{_zz__zz_decode_IS_RS2_SIGNED_19,_zz__zz_decode_IS_RS2_SIGNED_21});
-  assign _zz__zz_decode_IS_RS2_SIGNED_26 = {(|_zz__zz_decode_IS_RS2_SIGNED_27),{_zz__zz_decode_IS_RS2_SIGNED_29,{_zz__zz_decode_IS_RS2_SIGNED_32,_zz__zz_decode_IS_RS2_SIGNED_35}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_15 = (|(_zz__zz_decode_IS_RS2_SIGNED_16 == _zz__zz_decode_IS_RS2_SIGNED_17));
+  assign _zz__zz_decode_IS_RS2_SIGNED_18 = (|{_zz__zz_decode_IS_RS2_SIGNED_19,_zz__zz_decode_IS_RS2_SIGNED_20});
+  assign _zz__zz_decode_IS_RS2_SIGNED_21 = {(|_zz__zz_decode_IS_RS2_SIGNED_22),{_zz__zz_decode_IS_RS2_SIGNED_23,{_zz__zz_decode_IS_RS2_SIGNED_25,_zz__zz_decode_IS_RS2_SIGNED_27}}};
   assign _zz__zz_decode_IS_RS2_SIGNED_12 = 32'h0000001c;
   assign _zz__zz_decode_IS_RS2_SIGNED_14 = 32'h00000058;
-  assign _zz__zz_decode_IS_RS2_SIGNED_16 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00005010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_17 = ((decode_INSTRUCTION & 32'h02007064) == 32'h00005020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_19 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_20) == 32'h40001010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_21 = {(_zz__zz_decode_IS_RS2_SIGNED_22 == _zz__zz_decode_IS_RS2_SIGNED_23),(_zz__zz_decode_IS_RS2_SIGNED_24 == _zz__zz_decode_IS_RS2_SIGNED_25)};
-  assign _zz__zz_decode_IS_RS2_SIGNED_27 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_28) == 32'h00001000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_29 = (|(_zz__zz_decode_IS_RS2_SIGNED_30 == _zz__zz_decode_IS_RS2_SIGNED_31));
-  assign _zz__zz_decode_IS_RS2_SIGNED_32 = (|{_zz__zz_decode_IS_RS2_SIGNED_33,_zz__zz_decode_IS_RS2_SIGNED_34});
-  assign _zz__zz_decode_IS_RS2_SIGNED_35 = {(|_zz__zz_decode_IS_RS2_SIGNED_36),{_zz__zz_decode_IS_RS2_SIGNED_37,{_zz__zz_decode_IS_RS2_SIGNED_38,_zz__zz_decode_IS_RS2_SIGNED_40}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_20 = 32'h40003054;
-  assign _zz__zz_decode_IS_RS2_SIGNED_22 = (decode_INSTRUCTION & 32'h00007034);
-  assign _zz__zz_decode_IS_RS2_SIGNED_23 = 32'h00001010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_24 = (decode_INSTRUCTION & 32'h02007054);
-  assign _zz__zz_decode_IS_RS2_SIGNED_25 = 32'h00001010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_28 = 32'h00001000;
-  assign _zz__zz_decode_IS_RS2_SIGNED_30 = (decode_INSTRUCTION & 32'h00003000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_31 = 32'h00002000;
-  assign _zz__zz_decode_IS_RS2_SIGNED_33 = _zz_decode_IS_RS2_SIGNED_7;
-  assign _zz__zz_decode_IS_RS2_SIGNED_34 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00001000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_36 = _zz_decode_IS_RS2_SIGNED_8;
-  assign _zz__zz_decode_IS_RS2_SIGNED_37 = (|_zz_decode_IS_RS2_SIGNED_8);
-  assign _zz__zz_decode_IS_RS2_SIGNED_38 = (|((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_39) == 32'h00004008));
-  assign _zz__zz_decode_IS_RS2_SIGNED_40 = {(|(_zz__zz_decode_IS_RS2_SIGNED_41 == _zz__zz_decode_IS_RS2_SIGNED_42)),{(|{_zz__zz_decode_IS_RS2_SIGNED_43,_zz__zz_decode_IS_RS2_SIGNED_45}),{(|_zz__zz_decode_IS_RS2_SIGNED_50),{_zz__zz_decode_IS_RS2_SIGNED_52,{_zz__zz_decode_IS_RS2_SIGNED_55,_zz__zz_decode_IS_RS2_SIGNED_67}}}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_39 = 32'h00004048;
-  assign _zz__zz_decode_IS_RS2_SIGNED_41 = (decode_INSTRUCTION & 32'h00000064);
-  assign _zz__zz_decode_IS_RS2_SIGNED_42 = 32'h00000024;
-  assign _zz__zz_decode_IS_RS2_SIGNED_43 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_44) == 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_45 = {(_zz__zz_decode_IS_RS2_SIGNED_46 == _zz__zz_decode_IS_RS2_SIGNED_47),{_zz__zz_decode_IS_RS2_SIGNED_48,_zz__zz_decode_IS_RS2_SIGNED_49}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_50 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_51) == 32'h00000008);
-  assign _zz__zz_decode_IS_RS2_SIGNED_52 = (|(_zz__zz_decode_IS_RS2_SIGNED_53 == _zz__zz_decode_IS_RS2_SIGNED_54));
-  assign _zz__zz_decode_IS_RS2_SIGNED_55 = (|{_zz__zz_decode_IS_RS2_SIGNED_56,_zz__zz_decode_IS_RS2_SIGNED_58});
-  assign _zz__zz_decode_IS_RS2_SIGNED_67 = {(|_zz__zz_decode_IS_RS2_SIGNED_68),{_zz__zz_decode_IS_RS2_SIGNED_75,{_zz__zz_decode_IS_RS2_SIGNED_88,_zz__zz_decode_IS_RS2_SIGNED_101}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_44 = 32'h00000034;
-  assign _zz__zz_decode_IS_RS2_SIGNED_46 = (decode_INSTRUCTION & 32'h00000064);
-  assign _zz__zz_decode_IS_RS2_SIGNED_47 = 32'h00000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_48 = ((decode_INSTRUCTION & 32'h08000070) == 32'h08000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_49 = ((decode_INSTRUCTION & 32'h10000070) == 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_51 = 32'h10000008;
-  assign _zz__zz_decode_IS_RS2_SIGNED_53 = (decode_INSTRUCTION & 32'h10000008);
-  assign _zz__zz_decode_IS_RS2_SIGNED_54 = 32'h10000008;
-  assign _zz__zz_decode_IS_RS2_SIGNED_56 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_57) == 32'h00002040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_58 = {(_zz__zz_decode_IS_RS2_SIGNED_59 == _zz__zz_decode_IS_RS2_SIGNED_60),{_zz__zz_decode_IS_RS2_SIGNED_61,{_zz__zz_decode_IS_RS2_SIGNED_63,_zz__zz_decode_IS_RS2_SIGNED_64}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_68 = {(_zz__zz_decode_IS_RS2_SIGNED_69 == _zz__zz_decode_IS_RS2_SIGNED_70),{_zz__zz_decode_IS_RS2_SIGNED_71,_zz__zz_decode_IS_RS2_SIGNED_73}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_75 = (|{_zz__zz_decode_IS_RS2_SIGNED_76,{_zz__zz_decode_IS_RS2_SIGNED_78,_zz__zz_decode_IS_RS2_SIGNED_81}});
-  assign _zz__zz_decode_IS_RS2_SIGNED_88 = (|{_zz__zz_decode_IS_RS2_SIGNED_89,_zz__zz_decode_IS_RS2_SIGNED_90});
-  assign _zz__zz_decode_IS_RS2_SIGNED_101 = {(|_zz__zz_decode_IS_RS2_SIGNED_102),{_zz__zz_decode_IS_RS2_SIGNED_117,{_zz__zz_decode_IS_RS2_SIGNED_122,_zz__zz_decode_IS_RS2_SIGNED_126}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_57 = 32'h00002040;
-  assign _zz__zz_decode_IS_RS2_SIGNED_59 = (decode_INSTRUCTION & 32'h00001040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_60 = 32'h00001040;
-  assign _zz__zz_decode_IS_RS2_SIGNED_61 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_62) == 32'h00000040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_63 = _zz_decode_IS_RS2_SIGNED_7;
-  assign _zz__zz_decode_IS_RS2_SIGNED_64 = {_zz_decode_IS_RS2_SIGNED_4,_zz__zz_decode_IS_RS2_SIGNED_65};
-  assign _zz__zz_decode_IS_RS2_SIGNED_69 = (decode_INSTRUCTION & 32'h08000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_70 = 32'h08000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_71 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_72) == 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_73 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_74) == 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_76 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_77) == 32'h00000040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_78 = (_zz__zz_decode_IS_RS2_SIGNED_79 == _zz__zz_decode_IS_RS2_SIGNED_80);
-  assign _zz__zz_decode_IS_RS2_SIGNED_81 = {_zz__zz_decode_IS_RS2_SIGNED_82,{_zz__zz_decode_IS_RS2_SIGNED_84,_zz__zz_decode_IS_RS2_SIGNED_85}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_89 = _zz_decode_IS_RS2_SIGNED_6;
-  assign _zz__zz_decode_IS_RS2_SIGNED_90 = {_zz__zz_decode_IS_RS2_SIGNED_91,{_zz__zz_decode_IS_RS2_SIGNED_93,_zz__zz_decode_IS_RS2_SIGNED_96}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_102 = {_zz_decode_IS_RS2_SIGNED_2,{_zz__zz_decode_IS_RS2_SIGNED_103,_zz__zz_decode_IS_RS2_SIGNED_106}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_117 = (|{_zz__zz_decode_IS_RS2_SIGNED_118,_zz__zz_decode_IS_RS2_SIGNED_119});
-  assign _zz__zz_decode_IS_RS2_SIGNED_122 = (|_zz__zz_decode_IS_RS2_SIGNED_123);
-  assign _zz__zz_decode_IS_RS2_SIGNED_126 = {_zz__zz_decode_IS_RS2_SIGNED_127,{_zz__zz_decode_IS_RS2_SIGNED_130,_zz__zz_decode_IS_RS2_SIGNED_134}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_62 = 32'h00000050;
-  assign _zz__zz_decode_IS_RS2_SIGNED_65 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_66) == 32'h00000040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_72 = 32'h10000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_74 = 32'h00000028;
-  assign _zz__zz_decode_IS_RS2_SIGNED_77 = 32'h00000040;
-  assign _zz__zz_decode_IS_RS2_SIGNED_79 = (decode_INSTRUCTION & 32'h00004020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_80 = 32'h00004020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_82 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_83) == 32'h00000010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_84 = _zz_decode_IS_RS2_SIGNED_6;
+  assign _zz__zz_decode_IS_RS2_SIGNED_16 = (decode_INSTRUCTION & 32'h02007054);
+  assign _zz__zz_decode_IS_RS2_SIGNED_17 = 32'h00005010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_19 = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_20 = ((decode_INSTRUCTION & 32'h02007054) == 32'h00001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_22 = ((decode_INSTRUCTION & 32'h00001000) == 32'h00001000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_23 = (|((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_24) == 32'h00002000));
+  assign _zz__zz_decode_IS_RS2_SIGNED_25 = (|{_zz_decode_IS_RS2_SIGNED_9,_zz__zz_decode_IS_RS2_SIGNED_26});
+  assign _zz__zz_decode_IS_RS2_SIGNED_27 = {(|_zz_decode_IS_RS2_SIGNED_2),{(|_zz__zz_decode_IS_RS2_SIGNED_28),{_zz__zz_decode_IS_RS2_SIGNED_29,{_zz__zz_decode_IS_RS2_SIGNED_31,_zz__zz_decode_IS_RS2_SIGNED_40}}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_24 = 32'h00003000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_26 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00001000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_28 = ((decode_INSTRUCTION & 32'h00004048) == 32'h00004008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_29 = (|((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_30) == 32'h00000024));
+  assign _zz__zz_decode_IS_RS2_SIGNED_31 = (|{_zz__zz_decode_IS_RS2_SIGNED_32,{_zz__zz_decode_IS_RS2_SIGNED_33,_zz__zz_decode_IS_RS2_SIGNED_35}});
+  assign _zz__zz_decode_IS_RS2_SIGNED_40 = {(|_zz__zz_decode_IS_RS2_SIGNED_41),{(|_zz__zz_decode_IS_RS2_SIGNED_42),{_zz__zz_decode_IS_RS2_SIGNED_44,{_zz__zz_decode_IS_RS2_SIGNED_57,_zz__zz_decode_IS_RS2_SIGNED_66}}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_30 = 32'h00000064;
+  assign _zz__zz_decode_IS_RS2_SIGNED_32 = ((decode_INSTRUCTION & 32'h00000034) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_33 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_34) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_35 = {(_zz__zz_decode_IS_RS2_SIGNED_36 == _zz__zz_decode_IS_RS2_SIGNED_37),(_zz__zz_decode_IS_RS2_SIGNED_38 == _zz__zz_decode_IS_RS2_SIGNED_39)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_41 = ((decode_INSTRUCTION & 32'h10000008) == 32'h00000008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_42 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_43) == 32'h10000008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_44 = (|{_zz__zz_decode_IS_RS2_SIGNED_45,{_zz__zz_decode_IS_RS2_SIGNED_47,_zz__zz_decode_IS_RS2_SIGNED_50}});
+  assign _zz__zz_decode_IS_RS2_SIGNED_57 = (|{_zz__zz_decode_IS_RS2_SIGNED_58,_zz__zz_decode_IS_RS2_SIGNED_61});
+  assign _zz__zz_decode_IS_RS2_SIGNED_66 = {(|_zz__zz_decode_IS_RS2_SIGNED_67),{_zz__zz_decode_IS_RS2_SIGNED_80,{_zz__zz_decode_IS_RS2_SIGNED_93,_zz__zz_decode_IS_RS2_SIGNED_109}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_34 = 32'h00000064;
+  assign _zz__zz_decode_IS_RS2_SIGNED_36 = (decode_INSTRUCTION & 32'h08000070);
+  assign _zz__zz_decode_IS_RS2_SIGNED_37 = 32'h08000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_38 = (decode_INSTRUCTION & 32'h10000070);
+  assign _zz__zz_decode_IS_RS2_SIGNED_39 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_43 = 32'h10000008;
+  assign _zz__zz_decode_IS_RS2_SIGNED_45 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_46) == 32'h00002040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_47 = (_zz__zz_decode_IS_RS2_SIGNED_48 == _zz__zz_decode_IS_RS2_SIGNED_49);
+  assign _zz__zz_decode_IS_RS2_SIGNED_50 = {_zz__zz_decode_IS_RS2_SIGNED_51,{_zz__zz_decode_IS_RS2_SIGNED_53,_zz__zz_decode_IS_RS2_SIGNED_54}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_58 = (_zz__zz_decode_IS_RS2_SIGNED_59 == _zz__zz_decode_IS_RS2_SIGNED_60);
+  assign _zz__zz_decode_IS_RS2_SIGNED_61 = {_zz__zz_decode_IS_RS2_SIGNED_62,_zz__zz_decode_IS_RS2_SIGNED_64};
+  assign _zz__zz_decode_IS_RS2_SIGNED_67 = {_zz__zz_decode_IS_RS2_SIGNED_68,{_zz__zz_decode_IS_RS2_SIGNED_70,_zz__zz_decode_IS_RS2_SIGNED_73}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_80 = (|{_zz__zz_decode_IS_RS2_SIGNED_81,_zz__zz_decode_IS_RS2_SIGNED_82});
+  assign _zz__zz_decode_IS_RS2_SIGNED_93 = (|_zz__zz_decode_IS_RS2_SIGNED_94);
+  assign _zz__zz_decode_IS_RS2_SIGNED_109 = {_zz__zz_decode_IS_RS2_SIGNED_110,{_zz__zz_decode_IS_RS2_SIGNED_115,_zz__zz_decode_IS_RS2_SIGNED_119}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_46 = 32'h00002040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_48 = (decode_INSTRUCTION & 32'h00001040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_49 = 32'h00001040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_51 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_52) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_53 = _zz_decode_IS_RS2_SIGNED_9;
+  assign _zz__zz_decode_IS_RS2_SIGNED_54 = {_zz_decode_IS_RS2_SIGNED_6,_zz__zz_decode_IS_RS2_SIGNED_55};
+  assign _zz__zz_decode_IS_RS2_SIGNED_59 = (decode_INSTRUCTION & 32'h08000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_60 = 32'h08000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_62 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_63) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_64 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_65) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_68 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_69) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_70 = (_zz__zz_decode_IS_RS2_SIGNED_71 == _zz__zz_decode_IS_RS2_SIGNED_72);
+  assign _zz__zz_decode_IS_RS2_SIGNED_73 = {_zz__zz_decode_IS_RS2_SIGNED_74,{_zz__zz_decode_IS_RS2_SIGNED_76,_zz__zz_decode_IS_RS2_SIGNED_79}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_81 = _zz_decode_IS_RS2_SIGNED_8;
+  assign _zz__zz_decode_IS_RS2_SIGNED_82 = {_zz__zz_decode_IS_RS2_SIGNED_83,{_zz__zz_decode_IS_RS2_SIGNED_85,_zz__zz_decode_IS_RS2_SIGNED_88}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_94 = {_zz_decode_IS_RS2_SIGNED_4,{_zz__zz_decode_IS_RS2_SIGNED_95,_zz__zz_decode_IS_RS2_SIGNED_98}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_110 = (|{_zz__zz_decode_IS_RS2_SIGNED_111,_zz__zz_decode_IS_RS2_SIGNED_112});
+  assign _zz__zz_decode_IS_RS2_SIGNED_115 = (|_zz__zz_decode_IS_RS2_SIGNED_116);
+  assign _zz__zz_decode_IS_RS2_SIGNED_119 = {_zz__zz_decode_IS_RS2_SIGNED_120,{_zz__zz_decode_IS_RS2_SIGNED_123,_zz__zz_decode_IS_RS2_SIGNED_127}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_52 = 32'h00000050;
+  assign _zz__zz_decode_IS_RS2_SIGNED_55 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_56) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_63 = 32'h10000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_65 = 32'h00000028;
+  assign _zz__zz_decode_IS_RS2_SIGNED_69 = 32'h00000040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_71 = (decode_INSTRUCTION & 32'h00004020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_72 = 32'h00004020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_74 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_75) == 32'h00000010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_76 = (_zz__zz_decode_IS_RS2_SIGNED_77 == _zz__zz_decode_IS_RS2_SIGNED_78);
+  assign _zz__zz_decode_IS_RS2_SIGNED_79 = _zz_decode_IS_RS2_SIGNED_8;
+  assign _zz__zz_decode_IS_RS2_SIGNED_83 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_84) == 32'h00002010);
   assign _zz__zz_decode_IS_RS2_SIGNED_85 = (_zz__zz_decode_IS_RS2_SIGNED_86 == _zz__zz_decode_IS_RS2_SIGNED_87);
-  assign _zz__zz_decode_IS_RS2_SIGNED_91 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_92) == 32'h00002010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_93 = (_zz__zz_decode_IS_RS2_SIGNED_94 == _zz__zz_decode_IS_RS2_SIGNED_95);
-  assign _zz__zz_decode_IS_RS2_SIGNED_96 = {_zz__zz_decode_IS_RS2_SIGNED_97,_zz__zz_decode_IS_RS2_SIGNED_99};
-  assign _zz__zz_decode_IS_RS2_SIGNED_103 = (_zz__zz_decode_IS_RS2_SIGNED_104 == _zz__zz_decode_IS_RS2_SIGNED_105);
-  assign _zz__zz_decode_IS_RS2_SIGNED_106 = {_zz__zz_decode_IS_RS2_SIGNED_107,{_zz__zz_decode_IS_RS2_SIGNED_109,_zz__zz_decode_IS_RS2_SIGNED_112}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_118 = _zz_decode_IS_RS2_SIGNED_5;
-  assign _zz__zz_decode_IS_RS2_SIGNED_119 = (_zz__zz_decode_IS_RS2_SIGNED_120 == _zz__zz_decode_IS_RS2_SIGNED_121);
-  assign _zz__zz_decode_IS_RS2_SIGNED_123 = {_zz_decode_IS_RS2_SIGNED_5,_zz__zz_decode_IS_RS2_SIGNED_124};
-  assign _zz__zz_decode_IS_RS2_SIGNED_127 = (|_zz__zz_decode_IS_RS2_SIGNED_128);
-  assign _zz__zz_decode_IS_RS2_SIGNED_130 = (|_zz__zz_decode_IS_RS2_SIGNED_131);
-  assign _zz__zz_decode_IS_RS2_SIGNED_134 = {_zz__zz_decode_IS_RS2_SIGNED_135,{_zz__zz_decode_IS_RS2_SIGNED_145,_zz__zz_decode_IS_RS2_SIGNED_149}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_66 = 32'h02400040;
-  assign _zz__zz_decode_IS_RS2_SIGNED_83 = 32'h00000030;
-  assign _zz__zz_decode_IS_RS2_SIGNED_86 = (decode_INSTRUCTION & 32'h02000028);
-  assign _zz__zz_decode_IS_RS2_SIGNED_87 = 32'h00000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_92 = 32'h00002030;
-  assign _zz__zz_decode_IS_RS2_SIGNED_94 = (decode_INSTRUCTION & 32'h00001030);
-  assign _zz__zz_decode_IS_RS2_SIGNED_95 = 32'h00000010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_97 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_98) == 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_99 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_100) == 32'h00002020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_104 = (decode_INSTRUCTION & 32'h00001010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_105 = 32'h00001010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_107 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_108) == 32'h00002010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_109 = (_zz__zz_decode_IS_RS2_SIGNED_110 == _zz__zz_decode_IS_RS2_SIGNED_111);
-  assign _zz__zz_decode_IS_RS2_SIGNED_112 = {_zz__zz_decode_IS_RS2_SIGNED_113,{_zz__zz_decode_IS_RS2_SIGNED_114,_zz__zz_decode_IS_RS2_SIGNED_115}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_120 = (decode_INSTRUCTION & 32'h00000070);
-  assign _zz__zz_decode_IS_RS2_SIGNED_121 = 32'h00000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_124 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_125) == 32'h0);
-  assign _zz__zz_decode_IS_RS2_SIGNED_128 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_129) == 32'h00004010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_131 = (_zz__zz_decode_IS_RS2_SIGNED_132 == _zz__zz_decode_IS_RS2_SIGNED_133);
-  assign _zz__zz_decode_IS_RS2_SIGNED_135 = (|{_zz__zz_decode_IS_RS2_SIGNED_136,_zz__zz_decode_IS_RS2_SIGNED_138});
-  assign _zz__zz_decode_IS_RS2_SIGNED_145 = (|_zz__zz_decode_IS_RS2_SIGNED_146);
-  assign _zz__zz_decode_IS_RS2_SIGNED_149 = {_zz__zz_decode_IS_RS2_SIGNED_150,{_zz__zz_decode_IS_RS2_SIGNED_156,_zz__zz_decode_IS_RS2_SIGNED_161}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_98 = 32'h02003020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_100 = 32'h02002068;
-  assign _zz__zz_decode_IS_RS2_SIGNED_108 = 32'h00002010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_110 = (decode_INSTRUCTION & 32'h00002008);
-  assign _zz__zz_decode_IS_RS2_SIGNED_111 = 32'h00002008;
-  assign _zz__zz_decode_IS_RS2_SIGNED_113 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_114 = _zz_decode_IS_RS2_SIGNED_6;
-  assign _zz__zz_decode_IS_RS2_SIGNED_115 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_116) == 32'h0);
-  assign _zz__zz_decode_IS_RS2_SIGNED_125 = 32'h00000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_129 = 32'h00004014;
-  assign _zz__zz_decode_IS_RS2_SIGNED_132 = (decode_INSTRUCTION & 32'h00006014);
-  assign _zz__zz_decode_IS_RS2_SIGNED_133 = 32'h00002010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_136 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_137) == 32'h0);
-  assign _zz__zz_decode_IS_RS2_SIGNED_138 = {_zz_decode_IS_RS2_SIGNED_4,{_zz__zz_decode_IS_RS2_SIGNED_139,{_zz__zz_decode_IS_RS2_SIGNED_140,_zz__zz_decode_IS_RS2_SIGNED_142}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_146 = {_zz_decode_IS_RS2_SIGNED_3,(_zz__zz_decode_IS_RS2_SIGNED_147 == _zz__zz_decode_IS_RS2_SIGNED_148)};
-  assign _zz__zz_decode_IS_RS2_SIGNED_150 = (|{_zz__zz_decode_IS_RS2_SIGNED_151,{_zz__zz_decode_IS_RS2_SIGNED_152,_zz__zz_decode_IS_RS2_SIGNED_154}});
-  assign _zz__zz_decode_IS_RS2_SIGNED_156 = (|{_zz__zz_decode_IS_RS2_SIGNED_157,_zz__zz_decode_IS_RS2_SIGNED_158});
-  assign _zz__zz_decode_IS_RS2_SIGNED_161 = {(|_zz__zz_decode_IS_RS2_SIGNED_162),(|_zz__zz_decode_IS_RS2_SIGNED_165)};
-  assign _zz__zz_decode_IS_RS2_SIGNED_116 = 32'h00000028;
-  assign _zz__zz_decode_IS_RS2_SIGNED_137 = 32'h00000044;
-  assign _zz__zz_decode_IS_RS2_SIGNED_139 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_140 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_141) == 32'h00001000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_142 = {(_zz__zz_decode_IS_RS2_SIGNED_143 == _zz__zz_decode_IS_RS2_SIGNED_144),_zz_decode_IS_RS2_SIGNED_3};
-  assign _zz__zz_decode_IS_RS2_SIGNED_147 = (decode_INSTRUCTION & 32'h00000058);
-  assign _zz__zz_decode_IS_RS2_SIGNED_148 = 32'h0;
-  assign _zz__zz_decode_IS_RS2_SIGNED_151 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_152 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_153) == 32'h00002010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_154 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_155) == 32'h40000030);
-  assign _zz__zz_decode_IS_RS2_SIGNED_157 = _zz_decode_IS_RS2_SIGNED_2;
-  assign _zz__zz_decode_IS_RS2_SIGNED_158 = {_zz_decode_IS_RS2_SIGNED_1,(_zz__zz_decode_IS_RS2_SIGNED_159 == _zz__zz_decode_IS_RS2_SIGNED_160)};
-  assign _zz__zz_decode_IS_RS2_SIGNED_162 = {_zz_decode_IS_RS2_SIGNED_1,(_zz__zz_decode_IS_RS2_SIGNED_163 == _zz__zz_decode_IS_RS2_SIGNED_164)};
-  assign _zz__zz_decode_IS_RS2_SIGNED_165 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_166) == 32'h00001008);
-  assign _zz__zz_decode_IS_RS2_SIGNED_141 = 32'h00005004;
-  assign _zz__zz_decode_IS_RS2_SIGNED_143 = (decode_INSTRUCTION & 32'h00004050);
-  assign _zz__zz_decode_IS_RS2_SIGNED_144 = 32'h00004000;
-  assign _zz__zz_decode_IS_RS2_SIGNED_153 = 32'h00002014;
-  assign _zz__zz_decode_IS_RS2_SIGNED_155 = 32'h40000034;
-  assign _zz__zz_decode_IS_RS2_SIGNED_159 = (decode_INSTRUCTION & 32'h00002014);
-  assign _zz__zz_decode_IS_RS2_SIGNED_160 = 32'h00000004;
-  assign _zz__zz_decode_IS_RS2_SIGNED_163 = (decode_INSTRUCTION & 32'h0000004c);
-  assign _zz__zz_decode_IS_RS2_SIGNED_164 = 32'h00000004;
-  assign _zz__zz_decode_IS_RS2_SIGNED_166 = 32'h00005048;
+  assign _zz__zz_decode_IS_RS2_SIGNED_88 = {_zz__zz_decode_IS_RS2_SIGNED_89,_zz__zz_decode_IS_RS2_SIGNED_91};
+  assign _zz__zz_decode_IS_RS2_SIGNED_95 = (_zz__zz_decode_IS_RS2_SIGNED_96 == _zz__zz_decode_IS_RS2_SIGNED_97);
+  assign _zz__zz_decode_IS_RS2_SIGNED_98 = {_zz__zz_decode_IS_RS2_SIGNED_99,{_zz__zz_decode_IS_RS2_SIGNED_101,_zz__zz_decode_IS_RS2_SIGNED_104}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_111 = _zz_decode_IS_RS2_SIGNED_7;
+  assign _zz__zz_decode_IS_RS2_SIGNED_112 = (_zz__zz_decode_IS_RS2_SIGNED_113 == _zz__zz_decode_IS_RS2_SIGNED_114);
+  assign _zz__zz_decode_IS_RS2_SIGNED_116 = {_zz_decode_IS_RS2_SIGNED_7,_zz__zz_decode_IS_RS2_SIGNED_117};
+  assign _zz__zz_decode_IS_RS2_SIGNED_120 = (|_zz__zz_decode_IS_RS2_SIGNED_121);
+  assign _zz__zz_decode_IS_RS2_SIGNED_123 = (|_zz__zz_decode_IS_RS2_SIGNED_124);
+  assign _zz__zz_decode_IS_RS2_SIGNED_127 = {_zz__zz_decode_IS_RS2_SIGNED_128,{_zz__zz_decode_IS_RS2_SIGNED_139,_zz__zz_decode_IS_RS2_SIGNED_143}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_56 = 32'h02400040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_75 = 32'h00000030;
+  assign _zz__zz_decode_IS_RS2_SIGNED_77 = (decode_INSTRUCTION & 32'h02000010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_78 = 32'h00000010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_84 = 32'h00002030;
+  assign _zz__zz_decode_IS_RS2_SIGNED_86 = (decode_INSTRUCTION & 32'h00001030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_87 = 32'h00000010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_89 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_90) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_91 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_92) == 32'h00002020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_96 = (decode_INSTRUCTION & 32'h00001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_97 = 32'h00001010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_99 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_100) == 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_101 = (_zz__zz_decode_IS_RS2_SIGNED_102 == _zz__zz_decode_IS_RS2_SIGNED_103);
+  assign _zz__zz_decode_IS_RS2_SIGNED_104 = {_zz__zz_decode_IS_RS2_SIGNED_105,{_zz__zz_decode_IS_RS2_SIGNED_106,_zz__zz_decode_IS_RS2_SIGNED_107}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_113 = (decode_INSTRUCTION & 32'h00000070);
+  assign _zz__zz_decode_IS_RS2_SIGNED_114 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_117 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_118) == 32'h00000000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_121 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_122) == 32'h00004010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_124 = (_zz__zz_decode_IS_RS2_SIGNED_125 == _zz__zz_decode_IS_RS2_SIGNED_126);
+  assign _zz__zz_decode_IS_RS2_SIGNED_128 = (|{_zz__zz_decode_IS_RS2_SIGNED_129,_zz__zz_decode_IS_RS2_SIGNED_131});
+  assign _zz__zz_decode_IS_RS2_SIGNED_139 = (|_zz__zz_decode_IS_RS2_SIGNED_140);
+  assign _zz__zz_decode_IS_RS2_SIGNED_143 = {_zz__zz_decode_IS_RS2_SIGNED_144,{_zz__zz_decode_IS_RS2_SIGNED_153,_zz__zz_decode_IS_RS2_SIGNED_157}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_90 = 32'h02003020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_92 = 32'h02002068;
+  assign _zz__zz_decode_IS_RS2_SIGNED_100 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_102 = (decode_INSTRUCTION & 32'h00002008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_103 = 32'h00002008;
+  assign _zz__zz_decode_IS_RS2_SIGNED_105 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_106 = _zz_decode_IS_RS2_SIGNED_8;
+  assign _zz__zz_decode_IS_RS2_SIGNED_107 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_108) == 32'h00000000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_118 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_122 = 32'h00004014;
+  assign _zz__zz_decode_IS_RS2_SIGNED_125 = (decode_INSTRUCTION & 32'h00006014);
+  assign _zz__zz_decode_IS_RS2_SIGNED_126 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_129 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_130) == 32'h00000000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_131 = {_zz_decode_IS_RS2_SIGNED_6,{_zz__zz_decode_IS_RS2_SIGNED_132,{_zz__zz_decode_IS_RS2_SIGNED_134,_zz__zz_decode_IS_RS2_SIGNED_137}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_140 = {_zz_decode_IS_RS2_SIGNED_5,(_zz__zz_decode_IS_RS2_SIGNED_141 == _zz__zz_decode_IS_RS2_SIGNED_142)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_144 = (|{_zz__zz_decode_IS_RS2_SIGNED_145,{_zz__zz_decode_IS_RS2_SIGNED_147,_zz__zz_decode_IS_RS2_SIGNED_150}});
+  assign _zz__zz_decode_IS_RS2_SIGNED_153 = (|{_zz__zz_decode_IS_RS2_SIGNED_154,_zz__zz_decode_IS_RS2_SIGNED_155});
+  assign _zz__zz_decode_IS_RS2_SIGNED_157 = {(|_zz__zz_decode_IS_RS2_SIGNED_158),{_zz__zz_decode_IS_RS2_SIGNED_160,_zz__zz_decode_IS_RS2_SIGNED_163}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_108 = 32'h00000028;
+  assign _zz__zz_decode_IS_RS2_SIGNED_130 = 32'h00000044;
+  assign _zz__zz_decode_IS_RS2_SIGNED_132 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_133) == 32'h00002000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_134 = (_zz__zz_decode_IS_RS2_SIGNED_135 == _zz__zz_decode_IS_RS2_SIGNED_136);
+  assign _zz__zz_decode_IS_RS2_SIGNED_137 = {_zz__zz_decode_IS_RS2_SIGNED_138,_zz_decode_IS_RS2_SIGNED_5};
+  assign _zz__zz_decode_IS_RS2_SIGNED_141 = (decode_INSTRUCTION & 32'h00000058);
+  assign _zz__zz_decode_IS_RS2_SIGNED_142 = 32'h00000000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_145 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_146) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_147 = (_zz__zz_decode_IS_RS2_SIGNED_148 == _zz__zz_decode_IS_RS2_SIGNED_149);
+  assign _zz__zz_decode_IS_RS2_SIGNED_150 = (_zz__zz_decode_IS_RS2_SIGNED_151 == _zz__zz_decode_IS_RS2_SIGNED_152);
+  assign _zz__zz_decode_IS_RS2_SIGNED_154 = _zz_decode_IS_RS2_SIGNED_4;
+  assign _zz__zz_decode_IS_RS2_SIGNED_155 = {_zz_decode_IS_RS2_SIGNED_3,_zz__zz_decode_IS_RS2_SIGNED_156};
+  assign _zz__zz_decode_IS_RS2_SIGNED_158 = {_zz_decode_IS_RS2_SIGNED_3,_zz__zz_decode_IS_RS2_SIGNED_159};
+  assign _zz__zz_decode_IS_RS2_SIGNED_160 = (|{_zz__zz_decode_IS_RS2_SIGNED_161,_zz__zz_decode_IS_RS2_SIGNED_162});
+  assign _zz__zz_decode_IS_RS2_SIGNED_163 = (|_zz_decode_IS_RS2_SIGNED_1);
+  assign _zz__zz_decode_IS_RS2_SIGNED_133 = 32'h00006004;
+  assign _zz__zz_decode_IS_RS2_SIGNED_135 = (decode_INSTRUCTION & 32'h00005004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_136 = 32'h00001000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_138 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_146 = 32'h00000044;
+  assign _zz__zz_decode_IS_RS2_SIGNED_148 = (decode_INSTRUCTION & 32'h00002014);
+  assign _zz__zz_decode_IS_RS2_SIGNED_149 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_151 = (decode_INSTRUCTION & 32'h40000034);
+  assign _zz__zz_decode_IS_RS2_SIGNED_152 = 32'h40000030;
+  assign _zz__zz_decode_IS_RS2_SIGNED_156 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00000004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_159 = ((decode_INSTRUCTION & 32'h0000004c) == 32'h00000004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_161 = _zz_decode_IS_RS2_SIGNED_1;
+  assign _zz__zz_decode_IS_RS2_SIGNED_162 = _zz_decode_IS_RS2_SIGNED_2;
   assign _zz_execute_BranchPlugin_branch_src2_6 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_7 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_8 = execute_INSTRUCTION[7];
-  assign _zz_CsrPlugin_csrMapping_readDataInit_28 = 32'h0;
+  assign _zz_CsrPlugin_csrMapping_readDataInit_26 = 32'h00000000;
   always @(posedge clk) begin
     if(_zz_decode_RegFilePlugin_rs1Data) begin
       _zz_RegFilePlugin_regFile_port0 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
@@ -2221,8 +2228,9 @@ module VexRiscv (
     .io_cpu_flush_ready                     (dataCache_1_io_cpu_flush_ready                   ), //o
     .io_cpu_flush_payload_singleLine        (dataCache_1_io_cpu_flush_payload_singleLine      ), //i
     .io_cpu_flush_payload_lineId            (dataCache_1_io_cpu_flush_payload_lineId[6:0]     ), //i
+    .io_cpu_writesPending                   (dataCache_1_io_cpu_writesPending                 ), //o
     .io_mem_cmd_valid                       (dataCache_1_io_mem_cmd_valid                     ), //o
-    .io_mem_cmd_ready                       (dataCache_1_io_mem_cmd_ready                     ), //i
+    .io_mem_cmd_ready                       (toplevel_dataCache_1_io_mem_cmd_rValidN          ), //i
     .io_mem_cmd_payload_wr                  (dataCache_1_io_mem_cmd_payload_wr                ), //o
     .io_mem_cmd_payload_uncached            (dataCache_1_io_mem_cmd_payload_uncached          ), //o
     .io_mem_cmd_payload_address             (dataCache_1_io_mem_cmd_payload_address[31:0]     ), //o
@@ -3074,7 +3082,7 @@ module VexRiscv (
   end
   `endif
 
-  assign memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW) + $signed(_zz_memory_MUL_LOW_7));
+  assign memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW) + $signed(_zz_memory_MUL_LOW_6));
   assign memory_MUL_HH = execute_to_memory_MUL_HH;
   assign execute_MUL_HH = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bHigh));
   assign execute_MUL_HL = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bSLow));
@@ -3088,7 +3096,7 @@ module VexRiscv (
   assign memory_MEMORY_STORE_DATA_RF = execute_to_memory_MEMORY_STORE_DATA_RF;
   assign execute_MEMORY_STORE_DATA_RF = _zz_execute_MEMORY_STORE_DATA_RF;
   assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
-  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
+  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h00)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h00))));
   assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
   assign decode_IS_RS2_SIGNED = _zz_decode_IS_RS2_SIGNED[35];
@@ -3109,21 +3117,21 @@ module VexRiscv (
   assign decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL;
   assign _zz_decode_to_execute_ALU_BITWISE_CTRL = _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   assign decode_SRC_LESS_UNSIGNED = _zz_decode_IS_RS2_SIGNED[22];
-  assign decode_IS_SFENCE_VMA = _zz_decode_IS_RS2_SIGNED[21];
-  assign decode_IS_SFENCE_VMA2 = _zz_decode_IS_RS2_SIGNED[20];
-  assign decode_MEMORY_MANAGMENT = _zz_decode_IS_RS2_SIGNED[19];
+  assign decode_IS_SFENCE_VMA2 = _zz_decode_IS_RS2_SIGNED[21];
+  assign decode_MEMORY_MANAGMENT = _zz_decode_IS_RS2_SIGNED[20];
   assign memory_MEMORY_LRSC = execute_to_memory_MEMORY_LRSC;
   assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
-  assign decode_MEMORY_WR = _zz_decode_IS_RS2_SIGNED[13];
+  assign decode_MEMORY_WR = _zz_decode_IS_RS2_SIGNED[14];
   assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_decode_IS_RS2_SIGNED[12];
-  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_decode_IS_RS2_SIGNED[11];
+  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_decode_IS_RS2_SIGNED[13];
+  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_decode_IS_RS2_SIGNED[12];
   assign decode_SRC2_CTRL = _zz_decode_SRC2_CTRL;
   assign _zz_decode_to_execute_SRC2_CTRL = _zz_decode_to_execute_SRC2_CTRL_1;
   assign decode_ALU_CTRL = _zz_decode_ALU_CTRL;
   assign _zz_decode_to_execute_ALU_CTRL = _zz_decode_to_execute_ALU_CTRL_1;
   assign decode_SRC1_CTRL = _zz_decode_SRC1_CTRL;
   assign _zz_decode_to_execute_SRC1_CTRL = _zz_decode_to_execute_SRC1_CTRL_1;
+  assign decode_RESCHEDULE_NEXT = _zz_decode_IS_RS2_SIGNED[1];
   assign decode_MEMORY_FORCE_CONSTISTENCY = _zz_decode_MEMORY_FORCE_CONSTISTENCY;
   assign writeBack_FORMAL_PC_NEXT = memory_to_writeBack_FORMAL_PC_NEXT;
   assign memory_FORMAL_PC_NEXT = execute_to_memory_FORMAL_PC_NEXT;
@@ -3146,18 +3154,18 @@ module VexRiscv (
   assign memory_ENV_CTRL = _zz_memory_ENV_CTRL;
   assign execute_ENV_CTRL = _zz_execute_ENV_CTRL;
   assign writeBack_ENV_CTRL = _zz_writeBack_ENV_CTRL;
-  assign execute_IS_SFENCE_VMA = decode_to_execute_IS_SFENCE_VMA;
+  assign execute_RESCHEDULE_NEXT = decode_to_execute_RESCHEDULE_NEXT;
   assign memory_BRANCH_CALC = execute_to_memory_BRANCH_CALC;
   assign memory_BRANCH_DO = execute_to_memory_BRANCH_DO;
   assign execute_PC = decode_to_execute_PC;
   assign execute_PREDICTION_HAD_BRANCHED2 = decode_to_execute_PREDICTION_HAD_BRANCHED2;
   assign execute_BRANCH_COND_RESULT = _zz_execute_BRANCH_COND_RESULT_1;
   assign execute_BRANCH_CTRL = _zz_execute_BRANCH_CTRL;
-  assign decode_RS2_USE = _zz_decode_IS_RS2_SIGNED[17];
-  assign decode_RS1_USE = _zz_decode_IS_RS2_SIGNED[5];
+  assign decode_RS2_USE = _zz_decode_IS_RS2_SIGNED[18];
+  assign decode_RS1_USE = _zz_decode_IS_RS2_SIGNED[6];
   always @(*) begin
     _zz_decode_RS2 = execute_REGFILE_WRITE_DATA;
-    if(when_CsrPlugin_l1189) begin
+    if(when_CsrPlugin_l1587) begin
       _zz_decode_RS2 = CsrPlugin_csrMapping_readDataSignal;
     end
     if(DBusCachedPlugin_forceDatapath) begin
@@ -3256,15 +3264,15 @@ module VexRiscv (
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_execute_SRC2 = execute_PC;
+  assign _zz_execute_to_memory_PC = execute_PC;
   assign execute_SRC2_CTRL = _zz_execute_SRC2_CTRL;
   assign execute_SRC1_CTRL = _zz_execute_SRC1_CTRL;
-  assign decode_SRC_USE_SUB_LESS = _zz_decode_IS_RS2_SIGNED[3];
-  assign decode_SRC_ADD_ZERO = _zz_decode_IS_RS2_SIGNED[18];
+  assign decode_SRC_USE_SUB_LESS = _zz_decode_IS_RS2_SIGNED[4];
+  assign decode_SRC_ADD_ZERO = _zz_decode_IS_RS2_SIGNED[19];
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
   assign execute_ALU_CTRL = _zz_execute_ALU_CTRL;
-  assign execute_SRC2 = _zz_execute_SRC2_5;
+  assign execute_SRC2 = _zz_execute_SRC2_4;
   assign execute_SRC1 = _zz_execute_SRC1;
   assign execute_ALU_BITWISE_CTRL = _zz_execute_ALU_BITWISE_CTRL;
   assign _zz_lastStageRegFileWrite_payload_address = writeBack_INSTRUCTION;
@@ -3278,19 +3286,19 @@ module VexRiscv (
 
   assign decode_INSTRUCTION_ANTICIPATED = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusCachedPlugin_cache_io_cpu_fetch_data);
   always @(*) begin
-    decode_REGFILE_WRITE_VALID = _zz_decode_IS_RS2_SIGNED[10];
+    decode_REGFILE_WRITE_VALID = _zz_decode_IS_RS2_SIGNED[11];
     if(when_RegFilePlugin_l63) begin
       decode_REGFILE_WRITE_VALID = 1'b0;
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00001073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
+  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000107f) == 32'h00001073),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00002073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
   assign execute_IS_SFENCE_VMA2 = decode_to_execute_IS_SFENCE_VMA2;
   assign writeBack_IS_DBUS_SHARING = memory_to_writeBack_IS_DBUS_SHARING;
   assign memory_IS_DBUS_SHARING = execute_to_memory_IS_DBUS_SHARING;
   always @(*) begin
     _zz_decode_RS2_2 = writeBack_REGFILE_WRITE_DATA;
-    if(when_DBusCachedPlugin_l492) begin
+    if(when_DBusCachedPlugin_l580) begin
       _zz_decode_RS2_2 = writeBack_DBusCachedPlugin_rspFormated;
     end
     if(when_MulPlugin_l147) begin
@@ -3315,7 +3323,7 @@ module VexRiscv (
   always @(*) begin
     execute_MEMORY_AMO = decode_to_execute_MEMORY_AMO;
     if(MmuPlugin_dBusAccess_cmd_valid) begin
-      if(when_DBusCachedPlugin_l506) begin
+      if(when_DBusCachedPlugin_l604) begin
         execute_MEMORY_AMO = 1'b0;
       end
     end
@@ -3324,7 +3332,7 @@ module VexRiscv (
   always @(*) begin
     execute_MEMORY_LRSC = decode_to_execute_MEMORY_LRSC;
     if(MmuPlugin_dBusAccess_cmd_valid) begin
-      if(when_DBusCachedPlugin_l506) begin
+      if(when_DBusCachedPlugin_l604) begin
         execute_MEMORY_LRSC = 1'b0;
       end
     end
@@ -3338,34 +3346,34 @@ module VexRiscv (
   assign execute_SRC_ADD = execute_SrcPlugin_addSub;
   assign execute_MEMORY_ENABLE = decode_to_execute_MEMORY_ENABLE;
   assign execute_INSTRUCTION = decode_to_execute_INSTRUCTION;
-  assign decode_MEMORY_AMO = _zz_decode_IS_RS2_SIGNED[16];
-  assign decode_MEMORY_LRSC = _zz_decode_IS_RS2_SIGNED[15];
-  assign decode_MEMORY_ENABLE = _zz_decode_IS_RS2_SIGNED[4];
+  assign decode_MEMORY_AMO = _zz_decode_IS_RS2_SIGNED[17];
+  assign decode_MEMORY_LRSC = _zz_decode_IS_RS2_SIGNED[16];
+  assign decode_MEMORY_ENABLE = _zz_decode_IS_RS2_SIGNED[5];
   assign decode_FLUSH_ALL = _zz_decode_IS_RS2_SIGNED[0];
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_4 = IBusCachedPlugin_rsp_issueDetected_3;
-    if(when_IBusCachedPlugin_l256) begin
+    if(when_IBusCachedPlugin_l262) begin
       IBusCachedPlugin_rsp_issueDetected_4 = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_3 = IBusCachedPlugin_rsp_issueDetected_2;
-    if(when_IBusCachedPlugin_l250) begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_rsp_issueDetected_3 = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
-    if(when_IBusCachedPlugin_l244) begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
-    if(when_IBusCachedPlugin_l239) begin
+    if(when_IBusCachedPlugin_l245) begin
       IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
@@ -3398,7 +3406,7 @@ module VexRiscv (
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
   always @(*) begin
     decode_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l308) begin
+    if(when_DBusCachedPlugin_l352) begin
       decode_arbitration_haltItself = 1'b1;
     end
   end
@@ -3417,7 +3425,7 @@ module VexRiscv (
     if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(when_CsrPlugin_l1129) begin
+    if(when_CsrPlugin_l1527) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
@@ -3445,15 +3453,15 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l350) begin
+    if(when_DBusCachedPlugin_l394) begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(when_CsrPlugin_l1121) begin
-      if(when_CsrPlugin_l1123) begin
+    if(when_CsrPlugin_l1519) begin
+      if(when_CsrPlugin_l1521) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(when_CsrPlugin_l1193) begin
+    if(when_CsrPlugin_l1591) begin
       if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
@@ -3462,7 +3470,7 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if(when_DBusCachedPlugin_l366) begin
+    if(when_DBusCachedPlugin_l410) begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
@@ -3521,7 +3529,7 @@ module VexRiscv (
 
   always @(*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l466) begin
+    if(when_DBusCachedPlugin_l553) begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
@@ -3552,10 +3560,10 @@ module VexRiscv (
     if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -3566,13 +3574,13 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @(*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(when_CsrPlugin_l935) begin
+    if(when_CsrPlugin_l1272) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
@@ -3580,17 +3588,27 @@ module VexRiscv (
   assign IBusCachedPlugin_forceNoDecodeCond = 1'b0;
   always @(*) begin
     IBusCachedPlugin_incomingInstruction = 1'b0;
-    if(when_Fetcher_l243) begin
+    if(when_Fetcher_l242) begin
       IBusCachedPlugin_incomingInstruction = 1'b1;
     end
   end
 
   assign BranchPlugin_inDebugNoFetchFlag = 1'b0;
-  assign CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+  always @(*) begin
+    CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+    if(when_CsrPlugin_l1702) begin
+      CsrPlugin_csrMapping_allowCsrSignal = 1'b1;
+    end
+    if(when_CsrPlugin_l1709) begin
+      CsrPlugin_csrMapping_allowCsrSignal = 1'b1;
+    end
+  end
+
+  assign CsrPlugin_csrMapping_doForceFailCsr = 1'b0;
   assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
   always @(*) begin
     CsrPlugin_inWfi = 1'b0;
-    if(when_CsrPlugin_l1121) begin
+    if(when_CsrPlugin_l1519) begin
       CsrPlugin_inWfi = 1'b1;
     end
   end
@@ -3598,21 +3616,21 @@ module VexRiscv (
   assign CsrPlugin_thirdPartyWake = 1'b0;
   always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(when_CsrPlugin_l1077) begin
-      case(switch_CsrPlugin_l1081)
+    if(when_CsrPlugin_l1456) begin
+      case(switch_CsrPlugin_l1460)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -3629,8 +3647,26 @@ module VexRiscv (
   assign CsrPlugin_allowInterrupts = 1'b1;
   assign CsrPlugin_allowException = 1'b1;
   assign CsrPlugin_allowEbreakException = 1'b1;
+  always @(*) begin
+    CsrPlugin_xretAwayFromMachine = 1'b0;
+    if(when_CsrPlugin_l1456) begin
+      case(switch_CsrPlugin_l1460)
+        2'b11 : begin
+          if(when_CsrPlugin_l1468) begin
+            CsrPlugin_xretAwayFromMachine = 1'b1;
+          end
+        end
+        2'b01 : begin
+          CsrPlugin_xretAwayFromMachine = 1'b1;
+        end
+        default : begin
+        end
+      endcase
+    end
+  end
+
   assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
-  assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_redoInterface_valid,{CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusCachedPlugin_redoBranch_valid,IBusCachedPlugin_predictionJumpInterface_valid}}}} != 5'h0);
+  assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_redoInterface_valid,{CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusCachedPlugin_redoBranch_valid,IBusCachedPlugin_predictionJumpInterface_valid}}}} != 5'h00);
   assign _zz_IBusCachedPlugin_jump_pcLoad_payload = {IBusCachedPlugin_predictionJumpInterface_valid,{CsrPlugin_redoInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}}};
   assign _zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload & (~ _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1));
   assign _zz_IBusCachedPlugin_jump_pcLoad_payload_2 = _zz_IBusCachedPlugin_jump_pcLoad_payload_1[3];
@@ -3657,9 +3693,8 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l134 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
-  assign IBusCachedPlugin_fetchPc_output_fire_1 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
-  assign when_Fetcher_l134_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
+  assign when_Fetcher_l133 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l133_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
   always @(*) begin
     IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_IBusCachedPlugin_fetchPc_pc);
     if(IBusCachedPlugin_fetchPc_redo_valid) begin
@@ -3682,7 +3717,7 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l161 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
+  assign when_Fetcher_l160 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
   assign IBusCachedPlugin_fetchPc_output_valid = ((! IBusCachedPlugin_fetcherHalt) && IBusCachedPlugin_fetchPc_booted);
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
   always @(*) begin
@@ -3719,7 +3754,7 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_1_output_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b0;
-    if(when_IBusCachedPlugin_l267) begin
+    if(when_IBusCachedPlugin_l273) begin
       IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b1;
     end
   end
@@ -3732,9 +3767,9 @@ module VexRiscv (
   assign IBusCachedPlugin_fetchPc_redo_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_iBusRsp_flush = ((decode_arbitration_removeIt || (decode_arbitration_flushNext && (! decode_arbitration_isStuck))) || IBusCachedPlugin_iBusRsp_redoFetch);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
-  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1 = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
   assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid)) || IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready);
   assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
@@ -3744,18 +3779,18 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
   always @(*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
-    if(when_Fetcher_l323) begin
+    if(when_Fetcher_l322) begin
       IBusCachedPlugin_iBusRsp_readyForError = 1'b0;
     end
   end
 
-  assign when_Fetcher_l243 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
-  assign when_Fetcher_l323 = (! IBusCachedPlugin_pcValids_0);
-  assign when_Fetcher_l332 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
-  assign when_Fetcher_l332_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
-  assign when_Fetcher_l332_2 = (! execute_arbitration_isStuck);
-  assign when_Fetcher_l332_3 = (! memory_arbitration_isStuck);
-  assign when_Fetcher_l332_4 = (! writeBack_arbitration_isStuck);
+  assign when_Fetcher_l242 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
+  assign when_Fetcher_l322 = (! IBusCachedPlugin_pcValids_0);
+  assign when_Fetcher_l331 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l331_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
+  assign when_Fetcher_l331_2 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l331_3 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l331_4 = (! writeBack_arbitration_isStuck);
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
@@ -3910,90 +3945,89 @@ module VexRiscv (
   assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
   always @(*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(when_IBusCachedPlugin_l239) begin
+    if(when_IBusCachedPlugin_l245) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(when_IBusCachedPlugin_l250) begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_cache_io_cpu_fill_valid = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
-    if(when_IBusCachedPlugin_l250) begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_cache_io_cpu_fill_valid = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_valid = 1'b0;
-    if(when_IBusCachedPlugin_l244) begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
-    if(when_IBusCachedPlugin_l256) begin
+    if(when_IBusCachedPlugin_l262) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_payload_code = 4'bxxxx;
-    if(when_IBusCachedPlugin_l244) begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b1100;
     end
-    if(when_IBusCachedPlugin_l256) begin
+    if(when_IBusCachedPlugin_l262) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b0001;
     end
   end
 
   assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_2_input_payload[31 : 2],2'b00};
-  assign when_IBusCachedPlugin_l239 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign when_IBusCachedPlugin_l244 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
-  assign when_IBusCachedPlugin_l250 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
-  assign when_IBusCachedPlugin_l256 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
-  assign when_IBusCachedPlugin_l267 = (IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt);
+  assign when_IBusCachedPlugin_l245 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign when_IBusCachedPlugin_l250 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign when_IBusCachedPlugin_l256 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
+  assign when_IBusCachedPlugin_l262 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
+  assign when_IBusCachedPlugin_l273 = (IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt);
   assign IBusCachedPlugin_iBusRsp_output_valid = IBusCachedPlugin_iBusRsp_stages_2_output_valid;
   assign IBusCachedPlugin_iBusRsp_stages_2_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
   assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_decode_data;
   assign IBusCachedPlugin_iBusRsp_output_payload_pc = IBusCachedPlugin_iBusRsp_stages_2_output_payload;
   assign IBusCachedPlugin_cache_io_flush = (decode_arbitration_isValid && decode_FLUSH_ALL);
-  assign dataCache_1_io_mem_cmd_ready = (! dataCache_1_io_mem_cmd_rValid);
-  assign dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || dataCache_1_io_mem_cmd_rValid);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_wr : dataCache_1_io_mem_cmd_payload_wr);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_uncached : dataCache_1_io_mem_cmd_payload_uncached);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_address = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_address : dataCache_1_io_mem_cmd_payload_address);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_data = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_data : dataCache_1_io_mem_cmd_payload_data);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_mask : dataCache_1_io_mem_cmd_payload_mask);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_size = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_size : dataCache_1_io_mem_cmd_payload_size);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_last : dataCache_1_io_mem_cmd_payload_last);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || (! toplevel_dataCache_1_io_mem_cmd_rValidN));
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_wr : toplevel_dataCache_1_io_mem_cmd_rData_wr);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_uncached : toplevel_dataCache_1_io_mem_cmd_rData_uncached);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_address = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_address : toplevel_dataCache_1_io_mem_cmd_rData_address);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_data = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_data : toplevel_dataCache_1_io_mem_cmd_rData_data);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_mask : toplevel_dataCache_1_io_mem_cmd_rData_mask);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_size = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_size : toplevel_dataCache_1_io_mem_cmd_rData_size);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_last = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_last : toplevel_dataCache_1_io_mem_cmd_rData_last);
   always @(*) begin
-    dataCache_1_io_mem_cmd_s2mPipe_ready = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
-    if(when_Stream_l368) begin
-      dataCache_1_io_mem_cmd_s2mPipe_ready = 1'b1;
+    toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
+    if(when_Stream_l369) begin
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l368 = (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_rValid;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_rData_address;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_rData_data;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size = dataCache_1_io_mem_cmd_s2mPipe_rData_size;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_rData_last;
-  assign dBus_cmd_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
-  assign dBus_cmd_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
-  assign dBus_cmd_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
-  assign dBus_cmd_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
-  assign dBus_cmd_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
-  assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  assign dBus_cmd_payload_size = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
-  assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  assign when_DBusCachedPlugin_l308 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
+  assign when_Stream_l369 = (! toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_address;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_data;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_size;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  assign dBus_cmd_valid = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
+  assign dBus_cmd_payload_wr = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
+  assign dBus_cmd_payload_uncached = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
+  assign dBus_cmd_payload_address = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
+  assign dBus_cmd_payload_data = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
+  assign dBus_cmd_payload_mask = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
+  assign dBus_cmd_payload_size = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
+  assign dBus_cmd_payload_last = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  assign when_DBusCachedPlugin_l352 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
   always @(*) begin
     _zz_decode_MEMORY_FORCE_CONSTISTENCY = 1'b0;
-    if(when_DBusCachedPlugin_l316) begin
+    if(when_DBusCachedPlugin_l360) begin
       if(decode_MEMORY_LRSC) begin
         _zz_decode_MEMORY_FORCE_CONSTISTENCY = 1'b1;
       end
@@ -4003,13 +4037,13 @@ module VexRiscv (
     end
   end
 
-  assign when_DBusCachedPlugin_l316 = decode_INSTRUCTION[25];
+  assign when_DBusCachedPlugin_l360 = decode_INSTRUCTION[25];
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
   always @(*) begin
     dataCache_1_io_cpu_execute_isValid = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
     if(MmuPlugin_dBusAccess_cmd_valid) begin
-      if(when_DBusCachedPlugin_l506) begin
-        if(when_DBusCachedPlugin_l507) begin
+      if(when_DBusCachedPlugin_l604) begin
+        if(when_DBusCachedPlugin_l605) begin
           dataCache_1_io_cpu_execute_isValid = 1'b1;
         end
       end
@@ -4019,7 +4053,7 @@ module VexRiscv (
   always @(*) begin
     dataCache_1_io_cpu_execute_address = execute_SRC_ADD;
     if(MmuPlugin_dBusAccess_cmd_valid) begin
-      if(when_DBusCachedPlugin_l506) begin
+      if(when_DBusCachedPlugin_l604) begin
         dataCache_1_io_cpu_execute_address = MmuPlugin_dBusAccess_cmd_payload_address;
       end
     end
@@ -4028,7 +4062,7 @@ module VexRiscv (
   always @(*) begin
     dataCache_1_io_cpu_execute_args_wr = execute_MEMORY_WR;
     if(MmuPlugin_dBusAccess_cmd_valid) begin
-      if(when_DBusCachedPlugin_l506) begin
+      if(when_DBusCachedPlugin_l604) begin
         dataCache_1_io_cpu_execute_args_wr = 1'b0;
       end
     end
@@ -4051,17 +4085,17 @@ module VexRiscv (
   always @(*) begin
     dataCache_1_io_cpu_execute_args_size = execute_DBusCachedPlugin_size;
     if(MmuPlugin_dBusAccess_cmd_valid) begin
-      if(when_DBusCachedPlugin_l506) begin
+      if(when_DBusCachedPlugin_l604) begin
         dataCache_1_io_cpu_execute_args_size = MmuPlugin_dBusAccess_cmd_payload_size;
       end
     end
   end
 
   assign dataCache_1_io_cpu_flush_valid = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
-  assign dataCache_1_io_cpu_flush_payload_singleLine = (execute_INSTRUCTION[19 : 15] != 5'h0);
+  assign dataCache_1_io_cpu_flush_payload_singleLine = (execute_INSTRUCTION[19 : 15] != 5'h00);
   assign dataCache_1_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId[6:0];
-  assign dataCache_1_io_cpu_flush_isStall = (dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready));
-  assign when_DBusCachedPlugin_l350 = (dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
+  assign toplevel_dataCache_1_io_cpu_flush_isStall = (dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready));
+  assign when_DBusCachedPlugin_l394 = (toplevel_dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
   always @(*) begin
     dataCache_1_io_cpu_execute_args_isLrsc = 1'b0;
     if(execute_MEMORY_LRSC) begin
@@ -4071,7 +4105,7 @@ module VexRiscv (
 
   assign dataCache_1_io_cpu_execute_args_amoCtrl_alu = execute_INSTRUCTION[31 : 29];
   assign dataCache_1_io_cpu_execute_args_amoCtrl_swap = execute_INSTRUCTION[27];
-  assign when_DBusCachedPlugin_l366 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
+  assign when_DBusCachedPlugin_l410 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
   always @(*) begin
     dataCache_1_io_cpu_memory_isValid = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
     if(memory_IS_DBUS_SHARING) begin
@@ -4093,12 +4127,12 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
   always @(*) begin
     dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if(when_DBusCachedPlugin_l393) begin
+    if(when_DBusCachedPlugin_l472) begin
       dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = 1'b1;
     end
   end
 
-  assign when_DBusCachedPlugin_l393 = (1'b0 && (! dataCache_1_io_cpu_memory_isWrite));
+  assign when_DBusCachedPlugin_l472 = (1'b0 && (! dataCache_1_io_cpu_memory_isWrite));
   always @(*) begin
     dataCache_1_io_cpu_writeBack_isValid = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
     if(writeBack_IS_DBUS_SHARING) begin
@@ -4114,7 +4148,7 @@ module VexRiscv (
   assign dataCache_1_io_cpu_writeBack_storeData[31 : 0] = writeBack_MEMORY_STORE_DATA_RF;
   always @(*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(when_DBusCachedPlugin_l446) begin
+    if(when_DBusCachedPlugin_l533) begin
       if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
@@ -4124,7 +4158,7 @@ module VexRiscv (
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(when_DBusCachedPlugin_l446) begin
+    if(when_DBusCachedPlugin_l533) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
@@ -4143,7 +4177,7 @@ module VexRiscv (
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
-    if(when_DBusCachedPlugin_l446) begin
+    if(when_DBusCachedPlugin_l533) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code};
       end
@@ -4156,12 +4190,13 @@ module VexRiscv (
     end
   end
 
-  assign when_DBusCachedPlugin_l446 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign when_DBusCachedPlugin_l466 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
-  assign writeBack_DBusCachedPlugin_rspSplits_0 = dataCache_1_io_cpu_writeBack_data[7 : 0];
-  assign writeBack_DBusCachedPlugin_rspSplits_1 = dataCache_1_io_cpu_writeBack_data[15 : 8];
-  assign writeBack_DBusCachedPlugin_rspSplits_2 = dataCache_1_io_cpu_writeBack_data[23 : 16];
-  assign writeBack_DBusCachedPlugin_rspSplits_3 = dataCache_1_io_cpu_writeBack_data[31 : 24];
+  assign when_DBusCachedPlugin_l533 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l553 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
+  assign writeBack_DBusCachedPlugin_rspData = dataCache_1_io_cpu_writeBack_data;
+  assign writeBack_DBusCachedPlugin_rspSplits_0 = writeBack_DBusCachedPlugin_rspData[7 : 0];
+  assign writeBack_DBusCachedPlugin_rspSplits_1 = writeBack_DBusCachedPlugin_rspData[15 : 8];
+  assign writeBack_DBusCachedPlugin_rspSplits_2 = writeBack_DBusCachedPlugin_rspData[23 : 16];
+  assign writeBack_DBusCachedPlugin_rspSplits_3 = writeBack_DBusCachedPlugin_rspData[31 : 24];
   always @(*) begin
     writeBack_DBusCachedPlugin_rspShifted[7 : 0] = _zz_writeBack_DBusCachedPlugin_rspShifted;
     writeBack_DBusCachedPlugin_rspShifted[15 : 8] = _zz_writeBack_DBusCachedPlugin_rspShifted_2;
@@ -4171,13 +4206,13 @@ module VexRiscv (
 
   always @(*) begin
     writeBack_DBusCachedPlugin_rspRf = writeBack_DBusCachedPlugin_rspShifted[31 : 0];
-    if(when_DBusCachedPlugin_l482) begin
+    if(when_DBusCachedPlugin_l570) begin
       writeBack_DBusCachedPlugin_rspRf = {31'd0, _zz_writeBack_DBusCachedPlugin_rspRf};
     end
   end
 
-  assign when_DBusCachedPlugin_l482 = (writeBack_MEMORY_LRSC && writeBack_MEMORY_WR);
-  assign switch_Misc_l210 = writeBack_INSTRUCTION[13 : 12];
+  assign when_DBusCachedPlugin_l570 = (writeBack_MEMORY_LRSC && writeBack_MEMORY_WR);
+  assign switch_Misc_l232 = writeBack_INSTRUCTION[13 : 12];
   assign _zz_writeBack_DBusCachedPlugin_rspFormated = (writeBack_DBusCachedPlugin_rspRf[7] && (! writeBack_INSTRUCTION[14]));
   always @(*) begin
     _zz_writeBack_DBusCachedPlugin_rspFormated_1[31] = _zz_writeBack_DBusCachedPlugin_rspFormated;
@@ -4229,7 +4264,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    case(switch_Misc_l210)
+    case(switch_Misc_l232)
       2'b00 : begin
         writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_1;
       end
@@ -4242,12 +4277,12 @@ module VexRiscv (
     endcase
   end
 
-  assign when_DBusCachedPlugin_l492 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l580 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
   always @(*) begin
     MmuPlugin_dBusAccess_cmd_ready = 1'b0;
     if(MmuPlugin_dBusAccess_cmd_valid) begin
-      if(when_DBusCachedPlugin_l506) begin
-        if(when_DBusCachedPlugin_l507) begin
+      if(when_DBusCachedPlugin_l604) begin
+        if(when_DBusCachedPlugin_l605) begin
           MmuPlugin_dBusAccess_cmd_ready = (! execute_arbitration_isStuck);
         end
       end
@@ -4257,14 +4292,14 @@ module VexRiscv (
   always @(*) begin
     DBusCachedPlugin_forceDatapath = 1'b0;
     if(MmuPlugin_dBusAccess_cmd_valid) begin
-      if(when_DBusCachedPlugin_l506) begin
+      if(when_DBusCachedPlugin_l604) begin
         DBusCachedPlugin_forceDatapath = 1'b1;
       end
     end
   end
 
-  assign when_DBusCachedPlugin_l506 = (! ({(writeBack_arbitration_isValid || CsrPlugin_exceptionPendings_3),{(memory_arbitration_isValid || CsrPlugin_exceptionPendings_2),(execute_arbitration_isValid || CsrPlugin_exceptionPendings_1)}} != 3'b000));
-  assign when_DBusCachedPlugin_l507 = (! dataCache_1_io_cpu_execute_refilling);
+  assign when_DBusCachedPlugin_l604 = (! ({(writeBack_arbitration_isValid || CsrPlugin_exceptionPendings_3),{(memory_arbitration_isValid || CsrPlugin_exceptionPendings_2),(execute_arbitration_isValid || CsrPlugin_exceptionPendings_1)}} != 3'b000));
+  assign when_DBusCachedPlugin_l605 = (! dataCache_1_io_cpu_execute_refilling);
   assign MmuPlugin_dBusAccess_cmd_fire = (MmuPlugin_dBusAccess_cmd_valid && MmuPlugin_dBusAccess_cmd_ready);
   assign MmuPlugin_dBusAccess_rsp_valid = ((writeBack_IS_DBUS_SHARING && (! dataCache_1_io_cpu_writeBack_isWrite)) && (dataCache_1_io_cpu_redo || (! dataCache_1_io_cpu_writeBack_haltIt)));
   assign MmuPlugin_dBusAccess_rsp_payload_data = writeBack_DBusCachedPlugin_rspRf;
@@ -4273,16 +4308,16 @@ module VexRiscv (
   assign MmuPlugin_ports_0_dirty = 1'b0;
   always @(*) begin
     MmuPlugin_ports_0_requireMmuLockupCalc = ((1'b1 && (! IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation)) && MmuPlugin_satp_mode);
-    if(when_MmuPlugin_l125) begin
+    if(when_MmuPlugin_l131) begin
       MmuPlugin_ports_0_requireMmuLockupCalc = 1'b0;
     end
-    if(when_MmuPlugin_l126) begin
+    if(when_MmuPlugin_l132) begin
       MmuPlugin_ports_0_requireMmuLockupCalc = 1'b0;
     end
   end
 
-  assign when_MmuPlugin_l125 = ((! MmuPlugin_status_mprv) && (CsrPlugin_privilege == 2'b11));
-  assign when_MmuPlugin_l126 = (CsrPlugin_privilege == 2'b11);
+  assign when_MmuPlugin_l131 = ((! MmuPlugin_status_mprv) && (CsrPlugin_privilege == 2'b11));
+  assign when_MmuPlugin_l132 = (CsrPlugin_privilege == 2'b11);
   assign MmuPlugin_ports_0_cacheHitsCalc = {((MmuPlugin_ports_0_cache_3_valid && (MmuPlugin_ports_0_cache_3_virtualAddress_1 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_0_cache_3_superPage || (MmuPlugin_ports_0_cache_3_virtualAddress_0 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12]))),{((MmuPlugin_ports_0_cache_2_valid && (MmuPlugin_ports_0_cache_2_virtualAddress_1 == _zz_MmuPlugin_ports_0_cacheHitsCalc)) && (MmuPlugin_ports_0_cache_2_superPage || (MmuPlugin_ports_0_cache_2_virtualAddress_0 == _zz_MmuPlugin_ports_0_cacheHitsCalc_1))),{((MmuPlugin_ports_0_cache_1_valid && _zz_MmuPlugin_ports_0_cacheHitsCalc_2) && (MmuPlugin_ports_0_cache_1_superPage || _zz_MmuPlugin_ports_0_cacheHitsCalc_3)),((MmuPlugin_ports_0_cache_0_valid && _zz_MmuPlugin_ports_0_cacheHitsCalc_4) && (MmuPlugin_ports_0_cache_0_superPage || _zz_MmuPlugin_ports_0_cacheHitsCalc_5))}}};
   assign MmuPlugin_ports_0_cacheHit = (|MmuPlugin_ports_0_cacheHitsCalc);
   assign _zz_MmuPlugin_ports_0_cacheLine_valid = MmuPlugin_ports_0_cacheHitsCalc[3];
@@ -4302,8 +4337,8 @@ module VexRiscv (
   assign MmuPlugin_ports_0_cacheLine_allowUser = _zz_MmuPlugin_ports_0_cacheLine_allowUser;
   always @(*) begin
     MmuPlugin_ports_0_entryToReplace_willIncrement = 1'b0;
-    if(when_MmuPlugin_l272) begin
-      if(when_MmuPlugin_l274) begin
+    if(when_MmuPlugin_l279) begin
+      if(when_MmuPlugin_l281) begin
         MmuPlugin_ports_0_entryToReplace_willIncrement = 1'b1;
       end
     end
@@ -4388,19 +4423,19 @@ module VexRiscv (
   assign MmuPlugin_ports_1_dirty = 1'b0;
   always @(*) begin
     MmuPlugin_ports_1_requireMmuLockupCalc = ((1'b1 && (! DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation)) && MmuPlugin_satp_mode);
-    if(when_MmuPlugin_l125_1) begin
+    if(when_MmuPlugin_l131_1) begin
       MmuPlugin_ports_1_requireMmuLockupCalc = 1'b0;
     end
-    if(when_MmuPlugin_l126_1) begin
-      if(when_MmuPlugin_l128) begin
+    if(when_MmuPlugin_l132_1) begin
+      if(when_MmuPlugin_l134) begin
         MmuPlugin_ports_1_requireMmuLockupCalc = 1'b0;
       end
     end
   end
 
-  assign when_MmuPlugin_l125_1 = ((! MmuPlugin_status_mprv) && (CsrPlugin_privilege == 2'b11));
-  assign when_MmuPlugin_l126_1 = (CsrPlugin_privilege == 2'b11);
-  assign when_MmuPlugin_l128 = ((! MmuPlugin_status_mprv) || (CsrPlugin_mstatus_MPP == 2'b11));
+  assign when_MmuPlugin_l131_1 = ((! MmuPlugin_status_mprv) && (CsrPlugin_privilege == 2'b11));
+  assign when_MmuPlugin_l132_1 = (CsrPlugin_privilege == 2'b11);
+  assign when_MmuPlugin_l134 = ((! MmuPlugin_status_mprv) || (CsrPlugin_mstatus_MPP == 2'b11));
   assign MmuPlugin_ports_1_cacheHitsCalc = {((MmuPlugin_ports_1_cache_3_valid && (MmuPlugin_ports_1_cache_3_virtualAddress_1 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_1_cache_3_superPage || (MmuPlugin_ports_1_cache_3_virtualAddress_0 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12]))),{((MmuPlugin_ports_1_cache_2_valid && (MmuPlugin_ports_1_cache_2_virtualAddress_1 == _zz_MmuPlugin_ports_1_cacheHitsCalc)) && (MmuPlugin_ports_1_cache_2_superPage || (MmuPlugin_ports_1_cache_2_virtualAddress_0 == _zz_MmuPlugin_ports_1_cacheHitsCalc_1))),{((MmuPlugin_ports_1_cache_1_valid && _zz_MmuPlugin_ports_1_cacheHitsCalc_2) && (MmuPlugin_ports_1_cache_1_superPage || _zz_MmuPlugin_ports_1_cacheHitsCalc_3)),((MmuPlugin_ports_1_cache_0_valid && _zz_MmuPlugin_ports_1_cacheHitsCalc_4) && (MmuPlugin_ports_1_cache_0_superPage || _zz_MmuPlugin_ports_1_cacheHitsCalc_5))}}};
   assign MmuPlugin_ports_1_cacheHit = (|MmuPlugin_ports_1_cacheHitsCalc);
   assign _zz_MmuPlugin_ports_1_cacheLine_valid = MmuPlugin_ports_1_cacheHitsCalc[3];
@@ -4420,8 +4455,8 @@ module VexRiscv (
   assign MmuPlugin_ports_1_cacheLine_allowUser = _zz_MmuPlugin_ports_1_cacheLine_allowUser;
   always @(*) begin
     MmuPlugin_ports_1_entryToReplace_willIncrement = 1'b0;
-    if(when_MmuPlugin_l272) begin
-      if(when_MmuPlugin_l274_1) begin
+    if(when_MmuPlugin_l279) begin
+      if(when_MmuPlugin_l281_1) begin
         MmuPlugin_ports_1_entryToReplace_willIncrement = 1'b1;
       end
     end
@@ -4516,7 +4551,7 @@ module VexRiscv (
   assign MmuPlugin_shared_dBusRsp_pte_PPN1 = MmuPlugin_shared_dBusRspStaged_payload_data[31 : 20];
   assign MmuPlugin_shared_dBusRsp_exception = (((! MmuPlugin_shared_dBusRsp_pte_V) || ((! MmuPlugin_shared_dBusRsp_pte_R) && MmuPlugin_shared_dBusRsp_pte_W)) || MmuPlugin_shared_dBusRspStaged_payload_error);
   assign MmuPlugin_shared_dBusRsp_leaf = (MmuPlugin_shared_dBusRsp_pte_R || MmuPlugin_shared_dBusRsp_pte_X);
-  assign when_MmuPlugin_l205 = (MmuPlugin_shared_dBusRspStaged_valid && (! MmuPlugin_shared_dBusRspStaged_payload_redo));
+  assign when_MmuPlugin_l211 = (MmuPlugin_shared_dBusRspStaged_valid && (! MmuPlugin_shared_dBusRspStaged_payload_redo));
   always @(*) begin
     MmuPlugin_dBusAccess_cmd_valid = 1'b0;
     case(MmuPlugin_shared_state_1)
@@ -4543,7 +4578,7 @@ module VexRiscv (
       MmuPlugin_shared_State_IDLE : begin
       end
       MmuPlugin_shared_State_L1_CMD : begin
-        MmuPlugin_dBusAccess_cmd_payload_address = {{MmuPlugin_satp_ppn,MmuPlugin_shared_vpn_1},2'b00};
+        MmuPlugin_dBusAccess_cmd_payload_address = {{MmuPlugin_satp_ppn[19 : 0],MmuPlugin_shared_vpn_1},2'b00};
       end
       MmuPlugin_shared_State_L1_RSP : begin
       end
@@ -4570,38 +4605,39 @@ module VexRiscv (
   end
 
   assign MmuPlugin_shared_refills = _zz_MmuPlugin_shared_refills_3;
-  assign when_MmuPlugin_l217 = (|MmuPlugin_shared_refills);
+  assign when_MmuPlugin_l223 = (|MmuPlugin_shared_refills);
   assign _zz_MmuPlugin_shared_vpn_0 = (MmuPlugin_shared_refills[0] ? IBusCachedPlugin_mmuBus_cmd_0_virtualAddress : DBusCachedPlugin_mmuBus_cmd_0_virtualAddress);
-  assign when_MmuPlugin_l243 = (MmuPlugin_shared_dBusRsp_leaf || MmuPlugin_shared_dBusRsp_exception);
+  assign when_MmuPlugin_l250 = (MmuPlugin_shared_dBusRsp_leaf || MmuPlugin_shared_dBusRsp_exception);
   assign IBusCachedPlugin_mmuBus_busy = ((MmuPlugin_shared_state_1 != MmuPlugin_shared_State_IDLE) && MmuPlugin_shared_portSortedOh[0]);
   assign DBusCachedPlugin_mmuBus_busy = ((MmuPlugin_shared_state_1 != MmuPlugin_shared_State_IDLE) && MmuPlugin_shared_portSortedOh[1]);
-  assign when_MmuPlugin_l272 = ((MmuPlugin_shared_dBusRspStaged_valid && (! MmuPlugin_shared_dBusRspStaged_payload_redo)) && (MmuPlugin_shared_dBusRsp_leaf || MmuPlugin_shared_dBusRsp_exception));
-  assign when_MmuPlugin_l274 = MmuPlugin_shared_portSortedOh[0];
-  assign when_MmuPlugin_l280 = (MmuPlugin_ports_0_entryToReplace_value == 2'b00);
-  assign when_MmuPlugin_l280_1 = (MmuPlugin_ports_0_entryToReplace_value == 2'b01);
-  assign when_MmuPlugin_l280_2 = (MmuPlugin_ports_0_entryToReplace_value == 2'b10);
-  assign when_MmuPlugin_l280_3 = (MmuPlugin_ports_0_entryToReplace_value == 2'b11);
-  assign when_MmuPlugin_l274_1 = MmuPlugin_shared_portSortedOh[1];
-  assign when_MmuPlugin_l280_4 = (MmuPlugin_ports_1_entryToReplace_value == 2'b00);
-  assign when_MmuPlugin_l280_5 = (MmuPlugin_ports_1_entryToReplace_value == 2'b01);
-  assign when_MmuPlugin_l280_6 = (MmuPlugin_ports_1_entryToReplace_value == 2'b10);
-  assign when_MmuPlugin_l280_7 = (MmuPlugin_ports_1_entryToReplace_value == 2'b11);
-  assign when_MmuPlugin_l304 = ((execute_arbitration_isValid && execute_arbitration_isFiring) && execute_IS_SFENCE_VMA2);
-  assign _zz_decode_IS_RS2_SIGNED_1 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_decode_IS_RS2_SIGNED_2 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_decode_IS_RS2_SIGNED_3 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002000);
-  assign _zz_decode_IS_RS2_SIGNED_4 = ((decode_INSTRUCTION & 32'h00000018) == 32'h0);
-  assign _zz_decode_IS_RS2_SIGNED_5 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_decode_IS_RS2_SIGNED_6 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
-  assign _zz_decode_IS_RS2_SIGNED_7 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
-  assign _zz_decode_IS_RS2_SIGNED_8 = ((decode_INSTRUCTION & 32'h02003050) == 32'h02000050);
-  assign _zz_decode_IS_RS2_SIGNED_9 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
-  assign _zz_decode_IS_RS2_SIGNED = {(|_zz_decode_IS_RS2_SIGNED_9),{(|_zz_decode_IS_RS2_SIGNED_9),{(|(_zz__zz_decode_IS_RS2_SIGNED == _zz__zz_decode_IS_RS2_SIGNED_1)),{(|_zz__zz_decode_IS_RS2_SIGNED_2),{(|_zz__zz_decode_IS_RS2_SIGNED_3),{_zz__zz_decode_IS_RS2_SIGNED_4,{_zz__zz_decode_IS_RS2_SIGNED_6,_zz__zz_decode_IS_RS2_SIGNED_9}}}}}}};
-  assign _zz_decode_SRC1_CTRL_2 = _zz_decode_IS_RS2_SIGNED[2 : 1];
+  assign when_MmuPlugin_l279 = ((MmuPlugin_shared_dBusRspStaged_valid && (! MmuPlugin_shared_dBusRspStaged_payload_redo)) && (MmuPlugin_shared_dBusRsp_leaf || MmuPlugin_shared_dBusRsp_exception));
+  assign when_MmuPlugin_l281 = MmuPlugin_shared_portSortedOh[0];
+  assign when_MmuPlugin_l287 = (MmuPlugin_ports_0_entryToReplace_value == 2'b00);
+  assign when_MmuPlugin_l287_1 = (MmuPlugin_ports_0_entryToReplace_value == 2'b01);
+  assign when_MmuPlugin_l287_2 = (MmuPlugin_ports_0_entryToReplace_value == 2'b10);
+  assign when_MmuPlugin_l287_3 = (MmuPlugin_ports_0_entryToReplace_value == 2'b11);
+  assign when_MmuPlugin_l281_1 = MmuPlugin_shared_portSortedOh[1];
+  assign when_MmuPlugin_l287_4 = (MmuPlugin_ports_1_entryToReplace_value == 2'b00);
+  assign when_MmuPlugin_l287_5 = (MmuPlugin_ports_1_entryToReplace_value == 2'b01);
+  assign when_MmuPlugin_l287_6 = (MmuPlugin_ports_1_entryToReplace_value == 2'b10);
+  assign when_MmuPlugin_l287_7 = (MmuPlugin_ports_1_entryToReplace_value == 2'b11);
+  assign when_MmuPlugin_l311 = ((execute_arbitration_isValid && execute_arbitration_isFiring) && execute_IS_SFENCE_VMA2);
+  assign _zz_decode_IS_RS2_SIGNED_1 = ((decode_INSTRUCTION & 32'h00005048) == 32'h00001008);
+  assign _zz_decode_IS_RS2_SIGNED_2 = ((decode_INSTRUCTION & 32'h02003050) == 32'h02000050);
+  assign _zz_decode_IS_RS2_SIGNED_3 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
+  assign _zz_decode_IS_RS2_SIGNED_4 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_decode_IS_RS2_SIGNED_5 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002000);
+  assign _zz_decode_IS_RS2_SIGNED_6 = ((decode_INSTRUCTION & 32'h00000018) == 32'h00000000);
+  assign _zz_decode_IS_RS2_SIGNED_7 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_decode_IS_RS2_SIGNED_8 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
+  assign _zz_decode_IS_RS2_SIGNED_9 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
+  assign _zz_decode_IS_RS2_SIGNED_10 = ((decode_INSTRUCTION & 32'h00001000) == 32'h00000000);
+  assign _zz_decode_IS_RS2_SIGNED = {(|_zz_decode_IS_RS2_SIGNED_10),{(|_zz_decode_IS_RS2_SIGNED_10),{(|(_zz__zz_decode_IS_RS2_SIGNED == _zz__zz_decode_IS_RS2_SIGNED_1)),{(|_zz__zz_decode_IS_RS2_SIGNED_2),{(|_zz__zz_decode_IS_RS2_SIGNED_3),{_zz__zz_decode_IS_RS2_SIGNED_4,{_zz__zz_decode_IS_RS2_SIGNED_6,_zz__zz_decode_IS_RS2_SIGNED_9}}}}}}};
+  assign _zz_decode_SRC1_CTRL_2 = _zz_decode_IS_RS2_SIGNED[3 : 2];
   assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
-  assign _zz_decode_ALU_CTRL_2 = _zz_decode_IS_RS2_SIGNED[7 : 6];
+  assign _zz_decode_ALU_CTRL_2 = _zz_decode_IS_RS2_SIGNED[8 : 7];
   assign _zz_decode_ALU_CTRL_1 = _zz_decode_ALU_CTRL_2;
-  assign _zz_decode_SRC2_CTRL_2 = _zz_decode_IS_RS2_SIGNED[9 : 8];
+  assign _zz_decode_SRC2_CTRL_2 = _zz_decode_IS_RS2_SIGNED[10 : 9];
   assign _zz_decode_SRC2_CTRL_1 = _zz_decode_SRC2_CTRL_2;
   assign _zz_decode_ALU_BITWISE_CTRL_2 = _zz_decode_IS_RS2_SIGNED[24 : 23];
   assign _zz_decode_ALU_BITWISE_CTRL_1 = _zz_decode_ALU_BITWISE_CTRL_2;
@@ -4614,29 +4650,29 @@ module VexRiscv (
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
-  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h0);
+  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h00);
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
   assign decode_RegFilePlugin_rs1Data = _zz_RegFilePlugin_regFile_port0;
   assign decode_RegFilePlugin_rs2Data = _zz_RegFilePlugin_regFile_port1;
   always @(*) begin
     lastStageRegFileWrite_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
-    if(_zz_7) begin
+    if(_zz_10) begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
   always @(*) begin
     lastStageRegFileWrite_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
-    if(_zz_7) begin
-      lastStageRegFileWrite_payload_address = 5'h0;
+    if(_zz_10) begin
+      lastStageRegFileWrite_payload_address = 5'h00;
     end
   end
 
   always @(*) begin
     lastStageRegFileWrite_payload_data = _zz_decode_RS2_2;
-    if(_zz_7) begin
-      lastStageRegFileWrite_payload_data = 32'h0;
+    if(_zz_10) begin
+      lastStageRegFileWrite_payload_data = 32'h00000000;
     end
   end
 
@@ -4677,7 +4713,7 @@ module VexRiscv (
         _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
       Src1CtrlEnum_IMU : begin
-        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h000};
       end
       default : begin
         _zz_execute_SRC1 = {27'd0, _zz__zz_execute_SRC1_1};
@@ -4685,67 +4721,67 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_execute_SRC2_1 = execute_INSTRUCTION[31];
+  assign _zz_execute_SRC2 = execute_INSTRUCTION[31];
   always @(*) begin
-    _zz_execute_SRC2_2[19] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[18] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[17] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[16] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[15] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[14] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[13] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[12] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[11] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[10] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[9] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[8] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[7] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[6] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[5] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[4] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[3] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[2] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[1] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[0] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_1[19] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[18] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[17] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[16] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[15] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[14] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[13] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[12] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[11] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[10] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[9] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[8] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[7] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[6] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[5] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[4] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[3] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[2] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[1] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[0] = _zz_execute_SRC2;
   end
 
-  assign _zz_execute_SRC2_3 = _zz__zz_execute_SRC2_3[11];
+  assign _zz_execute_SRC2_2 = _zz__zz_execute_SRC2_2[11];
   always @(*) begin
-    _zz_execute_SRC2_4[19] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[18] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[17] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[16] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[15] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[14] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[13] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[12] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[11] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[10] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[9] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[8] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[7] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[6] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[5] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[4] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[3] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[2] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[1] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[0] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_3[19] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[18] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[17] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[16] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[15] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[14] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[13] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[12] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[11] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[10] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[9] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[8] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[7] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[6] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[5] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[4] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[3] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[2] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[1] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[0] = _zz_execute_SRC2_2;
   end
 
   always @(*) begin
     case(execute_SRC2_CTRL)
       Src2CtrlEnum_RS : begin
-        _zz_execute_SRC2_5 = execute_RS2;
+        _zz_execute_SRC2_4 = execute_RS2;
       end
       Src2CtrlEnum_IMI : begin
-        _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
+        _zz_execute_SRC2_4 = {_zz_execute_SRC2_1,execute_INSTRUCTION[31 : 20]};
       end
       Src2CtrlEnum_IMS : begin
-        _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_execute_SRC2_4 = {_zz_execute_SRC2_3,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_execute_SRC2_5 = _zz_execute_SRC2;
+        _zz_execute_SRC2_4 = _zz_execute_to_memory_PC;
       end
     endcase
   end
@@ -4911,16 +4947,19 @@ module VexRiscv (
   assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
   assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign switch_Misc_l210_1 = execute_INSTRUCTION[14 : 12];
+  assign switch_Misc_l232_1 = execute_INSTRUCTION[14 : 12];
   always @(*) begin
-    casez(switch_Misc_l210_1)
+    case(switch_Misc_l232_1)
       3'b000 : begin
         _zz_execute_BRANCH_COND_RESULT = execute_BranchPlugin_eq;
       end
       3'b001 : begin
         _zz_execute_BRANCH_COND_RESULT = (! execute_BranchPlugin_eq);
       end
-      3'b1?1 : begin
+      3'b101 : begin
+        _zz_execute_BRANCH_COND_RESULT = (! execute_SRC_LESS);
+      end
+      3'b111 : begin
         _zz_execute_BRANCH_COND_RESULT = (! execute_SRC_LESS);
       end
       default : begin
@@ -5125,7 +5164,13 @@ module VexRiscv (
   end
 
   assign CsrPlugin_misa_base = 2'b01;
-  assign CsrPlugin_misa_extensions = 26'h0;
+  assign CsrPlugin_misa_extensions = 26'h0000000;
+  assign CsrPlugin_mcounteren_IR = 1'b1;
+  assign CsrPlugin_mcounteren_TM = 1'b1;
+  assign CsrPlugin_mcounteren_CY = 1'b1;
+  assign CsrPlugin_scounteren_IR = 1'b1;
+  assign CsrPlugin_scounteren_TM = 1'b1;
+  assign CsrPlugin_scounteren_CY = 1'b1;
   assign CsrPlugin_sip_SEIP_OR = (CsrPlugin_sip_SEIP_SOFT || CsrPlugin_sip_SEIP_INPUT);
   always @(*) begin
     CsrPlugin_redoInterface_valid = 1'b0;
@@ -5137,7 +5182,7 @@ module VexRiscv (
   assign CsrPlugin_redoInterface_payload = decode_PC;
   always @(*) begin
     CsrPlugin_rescheduleLogic_rescheduleNext = 1'b0;
-    if(when_CsrPlugin_l816) begin
+    if(when_CsrPlugin_l1153) begin
       CsrPlugin_rescheduleLogic_rescheduleNext = 1'b1;
     end
     if(execute_CsrPlugin_csr_384) begin
@@ -5147,73 +5192,78 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l816 = (execute_arbitration_isValid && execute_IS_SFENCE_VMA);
-  assign _zz_when_CsrPlugin_l965 = (CsrPlugin_sip_STIP && CsrPlugin_sie_STIE);
-  assign _zz_when_CsrPlugin_l965_1 = (CsrPlugin_sip_SSIP && CsrPlugin_sie_SSIE);
-  assign _zz_when_CsrPlugin_l965_2 = (CsrPlugin_sip_SEIP_OR && CsrPlugin_sie_SEIE);
-  assign _zz_when_CsrPlugin_l965_3 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_when_CsrPlugin_l965_4 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_when_CsrPlugin_l965_5 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign when_CsrPlugin_l1153 = (execute_arbitration_isValid && execute_RESCHEDULE_NEXT);
+  assign _zz_when_CsrPlugin_l1302 = (CsrPlugin_sip_STIP && CsrPlugin_sie_STIE);
+  assign _zz_when_CsrPlugin_l1302_1 = (CsrPlugin_sip_SSIP && CsrPlugin_sie_SSIE);
+  assign _zz_when_CsrPlugin_l1302_2 = (CsrPlugin_sip_SEIP_OR && CsrPlugin_sie_SEIE);
+  assign _zz_when_CsrPlugin_l1302_3 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l1302_4 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l1302_5 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
     case(CsrPlugin_exceptionPortCtrl_exceptionContext_code)
       4'b0000 : begin
-        if(when_CsrPlugin_l879) begin
+        if(when_CsrPlugin_l1216) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b0001 : begin
-        if(when_CsrPlugin_l879_1) begin
+        if(when_CsrPlugin_l1216_1) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b0010 : begin
-        if(when_CsrPlugin_l879_2) begin
+        if(when_CsrPlugin_l1216_2) begin
+          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
+        end
+      end
+      4'b0011 : begin
+        if(when_CsrPlugin_l1216_3) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b0100 : begin
-        if(when_CsrPlugin_l879_3) begin
+        if(when_CsrPlugin_l1216_4) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b0101 : begin
-        if(when_CsrPlugin_l879_4) begin
+        if(when_CsrPlugin_l1216_5) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b0110 : begin
-        if(when_CsrPlugin_l879_5) begin
+        if(when_CsrPlugin_l1216_6) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b0111 : begin
-        if(when_CsrPlugin_l879_6) begin
+        if(when_CsrPlugin_l1216_7) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b1000 : begin
-        if(when_CsrPlugin_l879_7) begin
+        if(when_CsrPlugin_l1216_8) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b1001 : begin
-        if(when_CsrPlugin_l879_8) begin
+        if(when_CsrPlugin_l1216_9) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b1100 : begin
-        if(when_CsrPlugin_l879_9) begin
+        if(when_CsrPlugin_l1216_10) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b1101 : begin
-        if(when_CsrPlugin_l879_10) begin
+        if(when_CsrPlugin_l1216_11) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b1111 : begin
-        if(when_CsrPlugin_l879_11) begin
+        if(when_CsrPlugin_l1216_12) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
@@ -5222,18 +5272,19 @@ module VexRiscv (
     endcase
   end
 
-  assign when_CsrPlugin_l879 = ((1'b1 && CsrPlugin_medeleg_IAM) && (! 1'b0));
-  assign when_CsrPlugin_l879_1 = ((1'b1 && CsrPlugin_medeleg_IAF) && (! 1'b0));
-  assign when_CsrPlugin_l879_2 = ((1'b1 && CsrPlugin_medeleg_II) && (! 1'b0));
-  assign when_CsrPlugin_l879_3 = ((1'b1 && CsrPlugin_medeleg_LAM) && (! 1'b0));
-  assign when_CsrPlugin_l879_4 = ((1'b1 && CsrPlugin_medeleg_LAF) && (! 1'b0));
-  assign when_CsrPlugin_l879_5 = ((1'b1 && CsrPlugin_medeleg_SAM) && (! 1'b0));
-  assign when_CsrPlugin_l879_6 = ((1'b1 && CsrPlugin_medeleg_SAF) && (! 1'b0));
-  assign when_CsrPlugin_l879_7 = ((1'b1 && CsrPlugin_medeleg_EU) && (! 1'b0));
-  assign when_CsrPlugin_l879_8 = ((1'b1 && CsrPlugin_medeleg_ES) && (! 1'b0));
-  assign when_CsrPlugin_l879_9 = ((1'b1 && CsrPlugin_medeleg_IPF) && (! 1'b0));
-  assign when_CsrPlugin_l879_10 = ((1'b1 && CsrPlugin_medeleg_LPF) && (! 1'b0));
-  assign when_CsrPlugin_l879_11 = ((1'b1 && CsrPlugin_medeleg_SPF) && (! 1'b0));
+  assign when_CsrPlugin_l1216 = ((1'b1 && CsrPlugin_medeleg_IAM) && (! 1'b0));
+  assign when_CsrPlugin_l1216_1 = ((1'b1 && CsrPlugin_medeleg_IAF) && (! 1'b0));
+  assign when_CsrPlugin_l1216_2 = ((1'b1 && CsrPlugin_medeleg_II) && (! 1'b0));
+  assign when_CsrPlugin_l1216_3 = ((1'b1 && CsrPlugin_medeleg_BP) && (! 1'b0));
+  assign when_CsrPlugin_l1216_4 = ((1'b1 && CsrPlugin_medeleg_LAM) && (! 1'b0));
+  assign when_CsrPlugin_l1216_5 = ((1'b1 && CsrPlugin_medeleg_LAF) && (! 1'b0));
+  assign when_CsrPlugin_l1216_6 = ((1'b1 && CsrPlugin_medeleg_SAM) && (! 1'b0));
+  assign when_CsrPlugin_l1216_7 = ((1'b1 && CsrPlugin_medeleg_SAF) && (! 1'b0));
+  assign when_CsrPlugin_l1216_8 = ((1'b1 && CsrPlugin_medeleg_EU) && (! 1'b0));
+  assign when_CsrPlugin_l1216_9 = ((1'b1 && CsrPlugin_medeleg_ES) && (! 1'b0));
+  assign when_CsrPlugin_l1216_10 = ((1'b1 && CsrPlugin_medeleg_IPF) && (! 1'b0));
+  assign when_CsrPlugin_l1216_11 = ((1'b1 && CsrPlugin_medeleg_LPF) && (! 1'b0));
+  assign when_CsrPlugin_l1216_12 = ((1'b1 && CsrPlugin_medeleg_SPF) && (! 1'b0));
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
   assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
   assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1[0];
@@ -5277,35 +5328,35 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l922 = (! decode_arbitration_isStuck);
-  assign when_CsrPlugin_l922_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l922_2 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l922_3 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l935 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
+  assign when_CsrPlugin_l1259 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l1272 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-  assign when_CsrPlugin_l959 = ((CsrPlugin_sstatus_SIE && (CsrPlugin_privilege == 2'b01)) || (CsrPlugin_privilege < 2'b01));
-  assign when_CsrPlugin_l959_1 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign when_CsrPlugin_l965 = ((_zz_when_CsrPlugin_l965 && (1'b1 && CsrPlugin_mideleg_ST)) && (! 1'b0));
-  assign when_CsrPlugin_l965_1 = ((_zz_when_CsrPlugin_l965_1 && (1'b1 && CsrPlugin_mideleg_SS)) && (! 1'b0));
-  assign when_CsrPlugin_l965_2 = ((_zz_when_CsrPlugin_l965_2 && (1'b1 && CsrPlugin_mideleg_SE)) && (! 1'b0));
-  assign when_CsrPlugin_l965_3 = ((_zz_when_CsrPlugin_l965 && 1'b1) && (! (CsrPlugin_mideleg_ST != 1'b0)));
-  assign when_CsrPlugin_l965_4 = ((_zz_when_CsrPlugin_l965_1 && 1'b1) && (! (CsrPlugin_mideleg_SS != 1'b0)));
-  assign when_CsrPlugin_l965_5 = ((_zz_when_CsrPlugin_l965_2 && 1'b1) && (! (CsrPlugin_mideleg_SE != 1'b0)));
-  assign when_CsrPlugin_l965_6 = ((_zz_when_CsrPlugin_l965_3 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l965_7 = ((_zz_when_CsrPlugin_l965_4 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l965_8 = ((_zz_when_CsrPlugin_l965_5 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1296 = ((CsrPlugin_sstatus_SIE && (CsrPlugin_privilege == 2'b01)) || (CsrPlugin_privilege < 2'b01));
+  assign when_CsrPlugin_l1296_1 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l1302 = ((_zz_when_CsrPlugin_l1302 && (1'b1 && CsrPlugin_mideleg_ST)) && (! 1'b0));
+  assign when_CsrPlugin_l1302_1 = ((_zz_when_CsrPlugin_l1302_1 && (1'b1 && CsrPlugin_mideleg_SS)) && (! 1'b0));
+  assign when_CsrPlugin_l1302_2 = ((_zz_when_CsrPlugin_l1302_2 && (1'b1 && CsrPlugin_mideleg_SE)) && (! 1'b0));
+  assign when_CsrPlugin_l1302_3 = ((_zz_when_CsrPlugin_l1302 && 1'b1) && (! (CsrPlugin_mideleg_ST != 1'b0)));
+  assign when_CsrPlugin_l1302_4 = ((_zz_when_CsrPlugin_l1302_1 && 1'b1) && (! (CsrPlugin_mideleg_SS != 1'b0)));
+  assign when_CsrPlugin_l1302_5 = ((_zz_when_CsrPlugin_l1302_2 && 1'b1) && (! (CsrPlugin_mideleg_SE != 1'b0)));
+  assign when_CsrPlugin_l1302_6 = ((_zz_when_CsrPlugin_l1302_3 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1302_7 = ((_zz_when_CsrPlugin_l1302_4 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1302_8 = ((_zz_when_CsrPlugin_l1302_5 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  assign when_CsrPlugin_l993 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l993_1 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l993_2 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l998 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  assign when_CsrPlugin_l1335 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1335_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l1335_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l1340 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
   always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(when_CsrPlugin_l1004) begin
+    if(when_CsrPlugin_l1346) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException) begin
@@ -5313,7 +5364,7 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l1004 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
+  assign when_CsrPlugin_l1346 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
   always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
@@ -5329,6 +5380,7 @@ module VexRiscv (
     end
   end
 
+  assign CsrPlugin_trapCauseEbreakDebug = 1'b0;
   always @(*) begin
     CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
@@ -5357,13 +5409,16 @@ module VexRiscv (
     endcase
   end
 
-  assign when_CsrPlugin_l1032 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign when_CsrPlugin_l1077 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
-  assign switch_CsrPlugin_l1081 = writeBack_INSTRUCTION[29 : 28];
+  assign CsrPlugin_trapEnterDebug = 1'b0;
+  assign when_CsrPlugin_l1390 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1398 = (! CsrPlugin_trapEnterDebug);
+  assign when_CsrPlugin_l1456 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign switch_CsrPlugin_l1460 = writeBack_INSTRUCTION[29 : 28];
+  assign when_CsrPlugin_l1468 = (CsrPlugin_mstatus_MPP < 2'b11);
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign when_CsrPlugin_l1121 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_WFI));
-  assign when_CsrPlugin_l1123 = (! execute_CsrPlugin_wfiWake);
-  assign when_CsrPlugin_l1129 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
+  assign when_CsrPlugin_l1519 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_WFI));
+  assign when_CsrPlugin_l1521 = (! execute_CsrPlugin_wfiWake);
+  assign when_CsrPlugin_l1527 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
   assign execute_CsrPlugin_blockedBySideEffects = ((|{writeBack_arbitration_isValid,memory_arbitration_isValid}) || 1'b0);
   always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
@@ -5478,18 +5533,18 @@ module VexRiscv (
     if(CsrPlugin_csrMapping_allowCsrSignal) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(when_CsrPlugin_l1315) begin
+    if(when_CsrPlugin_l1725) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if(when_CsrPlugin_l1149) begin
-      if(when_CsrPlugin_l1150) begin
+    if(when_CsrPlugin_l1547) begin
+      if(when_CsrPlugin_l1548) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
@@ -5497,20 +5552,20 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(when_CsrPlugin_l1142) begin
+    if(when_CsrPlugin_l1540) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1157) begin
+    if(when_CsrPlugin_l1555) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(when_CsrPlugin_l1142) begin
+    if(when_CsrPlugin_l1540) begin
       CsrPlugin_selfException_payload_code = 4'b0010;
     end
-    if(when_CsrPlugin_l1157) begin
+    if(when_CsrPlugin_l1555) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -5526,20 +5581,20 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  assign when_CsrPlugin_l1142 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
-  assign when_CsrPlugin_l1149 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
-  assign when_CsrPlugin_l1150 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
-  assign when_CsrPlugin_l1157 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
+  assign when_CsrPlugin_l1540 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
+  assign when_CsrPlugin_l1547 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign when_CsrPlugin_l1548 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1555 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
   always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -5557,9 +5612,9 @@ module VexRiscv (
     end
   end
 
-  assign switch_Misc_l210_2 = execute_INSTRUCTION[13];
+  assign switch_Misc_l232_2 = execute_INSTRUCTION[13];
   always @(*) begin
-    case(switch_Misc_l210_2)
+    case(switch_Misc_l232_2)
       1'b0 : begin
         _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
@@ -5570,8 +5625,8 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
-  assign when_CsrPlugin_l1189 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign when_CsrPlugin_l1193 = (execute_arbitration_isValid && (execute_IS_CSR || execute_IS_SFENCE_VMA));
+  assign when_CsrPlugin_l1587 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1591 = (execute_arbitration_isValid && (execute_IS_CSR || execute_RESCHEDULE_NEXT));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
@@ -5634,12 +5689,12 @@ module VexRiscv (
   assign memory_DivPlugin_div_counter_willOverflow = (memory_DivPlugin_div_counter_willOverflowIfInc && memory_DivPlugin_div_counter_willIncrement);
   always @(*) begin
     if(memory_DivPlugin_div_counter_willOverflow) begin
-      memory_DivPlugin_div_counter_valueNext = 6'h0;
+      memory_DivPlugin_div_counter_valueNext = 6'h00;
     end else begin
       memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_memory_DivPlugin_div_counter_valueNext);
     end
     if(memory_DivPlugin_div_counter_willClear) begin
-      memory_DivPlugin_div_counter_valueNext = 6'h0;
+      memory_DivPlugin_div_counter_valueNext = 6'h00;
     end
   end
 
@@ -5663,10 +5718,10 @@ module VexRiscv (
     _zz_memory_DivPlugin_rs1_1[31 : 0] = execute_RS1;
   end
 
-  assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
-  assign externalInterrupt = (|_zz_CsrPlugin_csrMapping_readDataInit_1);
-  assign _zz_CsrPlugin_csrMapping_readDataInit_3 = (_zz_CsrPlugin_csrMapping_readDataInit_2 & externalInterruptArray_regNext);
-  assign externalInterruptS = (|_zz_CsrPlugin_csrMapping_readDataInit_3);
+  assign _zz_externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
+  assign externalInterrupt = (|_zz_externalInterrupt);
+  assign _zz_externalInterruptS = (_zz_CsrPlugin_csrMapping_readDataInit_1 & externalInterruptArray_regNext);
+  assign externalInterruptS = (|_zz_externalInterruptS);
   assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
@@ -5677,35 +5732,35 @@ module VexRiscv (
   assign when_Pipeline_l124_7 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_8 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_9 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_10 = (! execute_arbitration_isStuck);
   assign _zz_decode_to_execute_SRC1_CTRL_1 = decode_SRC1_CTRL;
   assign _zz_decode_SRC1_CTRL = _zz_decode_SRC1_CTRL_1;
-  assign when_Pipeline_l124_10 = (! execute_arbitration_isStuck);
-  assign _zz_execute_SRC1_CTRL = decode_to_execute_SRC1_CTRL;
   assign when_Pipeline_l124_11 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SRC1_CTRL = decode_to_execute_SRC1_CTRL;
   assign when_Pipeline_l124_12 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_13 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_14 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_13 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_14 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_15 = (! writeBack_arbitration_isStuck);
   assign _zz_decode_to_execute_ALU_CTRL_1 = decode_ALU_CTRL;
   assign _zz_decode_ALU_CTRL = _zz_decode_ALU_CTRL_1;
-  assign when_Pipeline_l124_15 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_16 = (! execute_arbitration_isStuck);
   assign _zz_execute_ALU_CTRL = decode_to_execute_ALU_CTRL;
   assign _zz_decode_to_execute_SRC2_CTRL_1 = decode_SRC2_CTRL;
   assign _zz_decode_SRC2_CTRL = _zz_decode_SRC2_CTRL_1;
-  assign when_Pipeline_l124_16 = (! execute_arbitration_isStuck);
-  assign _zz_execute_SRC2_CTRL = decode_to_execute_SRC2_CTRL;
   assign when_Pipeline_l124_17 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_18 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_19 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_20 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SRC2_CTRL = decode_to_execute_SRC2_CTRL;
+  assign when_Pipeline_l124_18 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_19 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_20 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_21 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_22 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_23 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_24 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_25 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_26 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_27 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_28 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_22 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_23 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_24 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_25 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_26 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_27 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_28 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_29 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_30 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_31 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_32 = (! execute_arbitration_isStuck);
@@ -5790,239 +5845,248 @@ module VexRiscv (
   assign when_Pipeline_l154_1 = ((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt));
   assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
   assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
-  assign when_CsrPlugin_l1277 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_2 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_3 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_4 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_5 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_6 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_7 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_8 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_9 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_10 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_11 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_12 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_13 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_14 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_15 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_16 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_17 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_18 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_19 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_20 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_21 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_22 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_23 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_24 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_25 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_26 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_27 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_8 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_9 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_10 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_11 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_12 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_13 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_14 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_15 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_16 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_17 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_18 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_19 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_20 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_21 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_22 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_23 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_24 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_25 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_26 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_27 = (! execute_arbitration_isStuck);
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h00000000;
     if(execute_CsrPlugin_csr_3264) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_4[12 : 0] = 13'h1000;
-      _zz_CsrPlugin_csrMapping_readDataInit_4[25 : 20] = 6'h20;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[12 : 0] = 13'h1000;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[25 : 20] = 6'h20;
     end
   end
 
-  assign switch_CsrPlugin_l723 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
+  assign switch_CsrPlugin_l1031 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h00000000;
     if(execute_CsrPlugin_csr_768) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_5[19 : 19] = MmuPlugin_status_mxr;
-      _zz_CsrPlugin_csrMapping_readDataInit_5[18 : 18] = MmuPlugin_status_sum;
-      _zz_CsrPlugin_csrMapping_readDataInit_5[17 : 17] = MmuPlugin_status_mprv;
-      _zz_CsrPlugin_csrMapping_readDataInit_5[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_5[3 : 3] = CsrPlugin_mstatus_MIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_5[12 : 11] = CsrPlugin_mstatus_MPP;
-      _zz_CsrPlugin_csrMapping_readDataInit_5[8 : 8] = CsrPlugin_sstatus_SPP;
-      _zz_CsrPlugin_csrMapping_readDataInit_5[5 : 5] = CsrPlugin_sstatus_SPIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_5[1 : 1] = CsrPlugin_sstatus_SIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[19 : 19] = MmuPlugin_status_mxr;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[18 : 18] = MmuPlugin_status_sum;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[17 : 17] = MmuPlugin_status_mprv;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[8 : 8] = CsrPlugin_sstatus_SPP;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[5 : 5] = CsrPlugin_sstatus_SPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[1 : 1] = CsrPlugin_sstatus_SIE;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h00000000;
     if(execute_CsrPlugin_csr_256) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_6[19 : 19] = MmuPlugin_status_mxr;
-      _zz_CsrPlugin_csrMapping_readDataInit_6[18 : 18] = MmuPlugin_status_sum;
-      _zz_CsrPlugin_csrMapping_readDataInit_6[17 : 17] = MmuPlugin_status_mprv;
-      _zz_CsrPlugin_csrMapping_readDataInit_6[8 : 8] = CsrPlugin_sstatus_SPP;
-      _zz_CsrPlugin_csrMapping_readDataInit_6[5 : 5] = CsrPlugin_sstatus_SPIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_6[1 : 1] = CsrPlugin_sstatus_SIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[19 : 19] = MmuPlugin_status_mxr;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[18 : 18] = MmuPlugin_status_sum;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[17 : 17] = MmuPlugin_status_mprv;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[8 : 8] = CsrPlugin_sstatus_SPP;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[5 : 5] = CsrPlugin_sstatus_SPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[1 : 1] = CsrPlugin_sstatus_SIE;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h00000000;
     if(execute_CsrPlugin_csr_384) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_7[31 : 31] = MmuPlugin_satp_mode;
-      _zz_CsrPlugin_csrMapping_readDataInit_7[30 : 22] = MmuPlugin_satp_asid;
-      _zz_CsrPlugin_csrMapping_readDataInit_7[19 : 0] = MmuPlugin_satp_ppn;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[31 : 31] = MmuPlugin_satp_mode;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[30 : 22] = MmuPlugin_satp_asid;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[21 : 0] = MmuPlugin_satp_ppn;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h00000000;
     if(execute_CsrPlugin_csr_3857) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_8[0 : 0] = 1'b1;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[0 : 0] = 1'b1;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h00000000;
     if(execute_CsrPlugin_csr_3858) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_9[1 : 0] = 2'b10;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[1 : 0] = 2'b10;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_10 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h00000000;
     if(execute_CsrPlugin_csr_3859) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_10[1 : 0] = 2'b11;
+      _zz_CsrPlugin_csrMapping_readDataInit_8[1 : 0] = 2'b11;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_11 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h00000000;
     if(execute_CsrPlugin_csr_836) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_11[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_11[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_11[3 : 3] = CsrPlugin_mip_MSIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_11[5 : 5] = CsrPlugin_sip_STIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_11[1 : 1] = CsrPlugin_sip_SSIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_11[9 : 9] = CsrPlugin_sip_SEIP_OR;
+      _zz_CsrPlugin_csrMapping_readDataInit_9[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_9[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_9[3 : 3] = CsrPlugin_mip_MSIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_9[5 : 5] = CsrPlugin_sip_STIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_9[1 : 1] = CsrPlugin_sip_SSIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_9[9 : 9] = CsrPlugin_sip_SEIP_OR;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_12 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_10 = 32'h00000000;
     if(execute_CsrPlugin_csr_772) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_12[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_12[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_12[3 : 3] = CsrPlugin_mie_MSIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_12[9 : 9] = CsrPlugin_sie_SEIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_12[5 : 5] = CsrPlugin_sie_STIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_12[1 : 1] = CsrPlugin_sie_SSIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_10[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_10[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_10[3 : 3] = CsrPlugin_mie_MSIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_10[9 : 9] = CsrPlugin_sie_SEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_10[5 : 5] = CsrPlugin_sie_STIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_10[1 : 1] = CsrPlugin_sie_SSIE;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_13 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_11 = 32'h00000000;
     if(execute_CsrPlugin_csr_833) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_13[31 : 0] = CsrPlugin_mepc;
+      _zz_CsrPlugin_csrMapping_readDataInit_11[31 : 0] = CsrPlugin_mepc;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_14 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_12 = 32'h00000000;
     if(execute_CsrPlugin_csr_832) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_14[31 : 0] = CsrPlugin_mscratch;
+      _zz_CsrPlugin_csrMapping_readDataInit_12[31 : 0] = CsrPlugin_mscratch;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_15 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_13 = 32'h00000000;
     if(execute_CsrPlugin_csr_834) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_15[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_CsrPlugin_csrMapping_readDataInit_15[3 : 0] = CsrPlugin_mcause_exceptionCode;
+      _zz_CsrPlugin_csrMapping_readDataInit_13[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_CsrPlugin_csrMapping_readDataInit_13[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_16 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_14 = 32'h00000000;
     if(execute_CsrPlugin_csr_835) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_16[31 : 0] = CsrPlugin_mtval;
+      _zz_CsrPlugin_csrMapping_readDataInit_14[31 : 0] = CsrPlugin_mtval;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_17 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_15 = 32'h00000000;
     if(execute_CsrPlugin_csr_324) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_17[5 : 5] = CsrPlugin_sip_STIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_17[1 : 1] = CsrPlugin_sip_SSIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_17[9 : 9] = CsrPlugin_sip_SEIP_OR;
+      _zz_CsrPlugin_csrMapping_readDataInit_15[5 : 5] = CsrPlugin_sip_STIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_15[1 : 1] = CsrPlugin_sip_SSIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_15[9 : 9] = CsrPlugin_sip_SEIP_OR;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_18 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_16 = 32'h00000000;
     if(execute_CsrPlugin_csr_260) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_18[9 : 9] = CsrPlugin_sie_SEIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_18[5 : 5] = CsrPlugin_sie_STIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_18[1 : 1] = CsrPlugin_sie_SSIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_16[9 : 9] = CsrPlugin_sie_SEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_16[5 : 5] = CsrPlugin_sie_STIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_16[1 : 1] = CsrPlugin_sie_SSIE;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_19 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_17 = 32'h00000000;
     if(execute_CsrPlugin_csr_261) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_19[31 : 2] = CsrPlugin_stvec_base;
-      _zz_CsrPlugin_csrMapping_readDataInit_19[1 : 0] = CsrPlugin_stvec_mode;
+      _zz_CsrPlugin_csrMapping_readDataInit_17[31 : 2] = CsrPlugin_stvec_base;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_20 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_18 = 32'h00000000;
     if(execute_CsrPlugin_csr_321) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_20[31 : 0] = CsrPlugin_sepc;
+      _zz_CsrPlugin_csrMapping_readDataInit_18[31 : 0] = CsrPlugin_sepc;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_21 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_19 = 32'h00000000;
     if(execute_CsrPlugin_csr_320) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_21[31 : 0] = CsrPlugin_sscratch;
+      _zz_CsrPlugin_csrMapping_readDataInit_19[31 : 0] = CsrPlugin_sscratch;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_22 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_20 = 32'h00000000;
     if(execute_CsrPlugin_csr_322) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_22[31 : 31] = CsrPlugin_scause_interrupt;
-      _zz_CsrPlugin_csrMapping_readDataInit_22[3 : 0] = CsrPlugin_scause_exceptionCode;
+      _zz_CsrPlugin_csrMapping_readDataInit_20[31 : 31] = CsrPlugin_scause_interrupt;
+      _zz_CsrPlugin_csrMapping_readDataInit_20[3 : 0] = CsrPlugin_scause_exceptionCode;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_23 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_21 = 32'h00000000;
     if(execute_CsrPlugin_csr_323) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_23[31 : 0] = CsrPlugin_stval;
+      _zz_CsrPlugin_csrMapping_readDataInit_21[31 : 0] = CsrPlugin_stval;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_24 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_22 = 32'h00000000;
     if(execute_CsrPlugin_csr_3008) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_24[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
+      _zz_CsrPlugin_csrMapping_readDataInit_22[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_25 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_23 = 32'h00000000;
     if(execute_CsrPlugin_csr_4032) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_25[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_1;
+      _zz_CsrPlugin_csrMapping_readDataInit_23[31 : 0] = _zz_externalInterrupt;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_26 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_24 = 32'h00000000;
     if(execute_CsrPlugin_csr_2496) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_26[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_2;
+      _zz_CsrPlugin_csrMapping_readDataInit_24[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_1;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_27 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_25 = 32'h00000000;
     if(execute_CsrPlugin_csr_3520) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_27[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_3;
+      _zz_CsrPlugin_csrMapping_readDataInit_25[31 : 0] = _zz_externalInterruptS;
     end
   end
 
-  assign CsrPlugin_csrMapping_readDataInit = (((((_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5) | (_zz_CsrPlugin_csrMapping_readDataInit_6 | _zz_CsrPlugin_csrMapping_readDataInit_7)) | ((_zz_CsrPlugin_csrMapping_readDataInit_8 | _zz_CsrPlugin_csrMapping_readDataInit_9) | (_zz_CsrPlugin_csrMapping_readDataInit_10 | _zz_CsrPlugin_csrMapping_readDataInit_28))) | (((_zz_CsrPlugin_csrMapping_readDataInit_11 | _zz_CsrPlugin_csrMapping_readDataInit_12) | (_zz_CsrPlugin_csrMapping_readDataInit_13 | _zz_CsrPlugin_csrMapping_readDataInit_14)) | ((_zz_CsrPlugin_csrMapping_readDataInit_15 | _zz_CsrPlugin_csrMapping_readDataInit_16) | (_zz_CsrPlugin_csrMapping_readDataInit_17 | _zz_CsrPlugin_csrMapping_readDataInit_18)))) | ((((_zz_CsrPlugin_csrMapping_readDataInit_19 | _zz_CsrPlugin_csrMapping_readDataInit_20) | (_zz_CsrPlugin_csrMapping_readDataInit_21 | _zz_CsrPlugin_csrMapping_readDataInit_22)) | ((_zz_CsrPlugin_csrMapping_readDataInit_23 | _zz_CsrPlugin_csrMapping_readDataInit_24) | (_zz_CsrPlugin_csrMapping_readDataInit_25 | _zz_CsrPlugin_csrMapping_readDataInit_26))) | _zz_CsrPlugin_csrMapping_readDataInit_27));
-  assign when_CsrPlugin_l1310 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign when_CsrPlugin_l1315 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign CsrPlugin_csrMapping_readDataInit = (((((_zz_CsrPlugin_csrMapping_readDataInit_2 | _zz_CsrPlugin_csrMapping_readDataInit_3) | (_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5)) | ((_zz_CsrPlugin_csrMapping_readDataInit_6 | _zz_CsrPlugin_csrMapping_readDataInit_7) | (_zz_CsrPlugin_csrMapping_readDataInit_8 | _zz_CsrPlugin_csrMapping_readDataInit_26))) | (((_zz_CsrPlugin_csrMapping_readDataInit_9 | _zz_CsrPlugin_csrMapping_readDataInit_10) | (_zz_CsrPlugin_csrMapping_readDataInit_11 | _zz_CsrPlugin_csrMapping_readDataInit_12)) | ((_zz_CsrPlugin_csrMapping_readDataInit_13 | _zz_CsrPlugin_csrMapping_readDataInit_14) | (_zz_CsrPlugin_csrMapping_readDataInit_15 | _zz_CsrPlugin_csrMapping_readDataInit_16)))) | ((((_zz_CsrPlugin_csrMapping_readDataInit_17 | _zz_CsrPlugin_csrMapping_readDataInit_18) | (_zz_CsrPlugin_csrMapping_readDataInit_19 | _zz_CsrPlugin_csrMapping_readDataInit_20)) | ((_zz_CsrPlugin_csrMapping_readDataInit_21 | _zz_CsrPlugin_csrMapping_readDataInit_22) | (_zz_CsrPlugin_csrMapping_readDataInit_23 | _zz_CsrPlugin_csrMapping_readDataInit_24))) | _zz_CsrPlugin_csrMapping_readDataInit_25));
+  assign when_CsrPlugin_l1702 = ((execute_arbitration_isValid && execute_IS_CSR) && (({execute_CsrPlugin_csrAddress[11 : 2],2'b00} == 12'h3a0) || ({execute_CsrPlugin_csrAddress[11 : 4],4'b0000} == 12'h3b0)));
+  assign _zz_when_CsrPlugin_l1709 = (execute_CsrPlugin_csrAddress & 12'hf60);
+  assign when_CsrPlugin_l1709 = (((execute_arbitration_isValid && execute_IS_CSR) && (5'h03 <= execute_CsrPlugin_csrAddress[4 : 0])) && (((_zz_when_CsrPlugin_l1709 == 12'hb00) || (((_zz_when_CsrPlugin_l1709 == 12'hc00) && (! execute_CsrPlugin_writeInstruction)) && (CsrPlugin_privilege == 2'b11))) || ((execute_CsrPlugin_csrAddress & 12'hfe0) == 12'h320)));
+  always @(*) begin
+    when_CsrPlugin_l1719 = CsrPlugin_csrMapping_doForceFailCsr;
+    if(when_CsrPlugin_l1717) begin
+      when_CsrPlugin_l1719 = 1'b1;
+    end
+  end
+
+  assign when_CsrPlugin_l1717 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1725 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
   assign iBusWishbone_ADR = {_zz_iBusWishbone_ADR_1,_zz_iBusWishbone_ADR};
   assign iBusWishbone_CTI = ((_zz_iBusWishbone_ADR == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
@@ -6048,20 +6112,20 @@ module VexRiscv (
   assign iBus_rsp_valid = _zz_iBus_rsp_valid;
   assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
   assign iBus_rsp_payload_error = 1'b0;
-  assign _zz_dBus_cmd_ready_5 = (dBus_cmd_payload_size == 3'b101);
-  assign _zz_dBus_cmd_ready_1 = dBus_cmd_valid;
-  assign _zz_dBus_cmd_ready_3 = dBus_cmd_payload_wr;
-  assign _zz_dBus_cmd_ready_4 = ((! _zz_dBus_cmd_ready_5) || (_zz_dBus_cmd_ready == 3'b111));
-  assign dBus_cmd_ready = (_zz_dBus_cmd_ready_2 && (_zz_dBus_cmd_ready_3 || _zz_dBus_cmd_ready_4));
-  assign dBusWishbone_ADR = ((_zz_dBus_cmd_ready_5 ? {{dBus_cmd_payload_address[31 : 5],_zz_dBus_cmd_ready},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
-  assign dBusWishbone_CTI = (_zz_dBus_cmd_ready_5 ? (_zz_dBus_cmd_ready_4 ? 3'b111 : 3'b010) : 3'b000);
+  assign _zz_dBusWishbone_ADR_1 = (dBus_cmd_payload_size == 3'b101);
+  assign _zz_dBusWishbone_CYC = dBus_cmd_valid;
+  assign _zz_dBus_cmd_ready_1 = dBus_cmd_payload_wr;
+  assign _zz_dBus_cmd_ready_2 = ((! _zz_dBusWishbone_ADR_1) || (_zz_dBusWishbone_ADR == 3'b111));
+  assign dBus_cmd_ready = (_zz_dBus_cmd_ready && (_zz_dBus_cmd_ready_1 || _zz_dBus_cmd_ready_2));
+  assign dBusWishbone_ADR = ((_zz_dBusWishbone_ADR_1 ? {{dBus_cmd_payload_address[31 : 5],_zz_dBusWishbone_ADR},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2'd2);
+  assign dBusWishbone_CTI = (_zz_dBusWishbone_ADR_1 ? (_zz_dBus_cmd_ready_2 ? 3'b111 : 3'b010) : 3'b000);
   assign dBusWishbone_BTE = 2'b00;
-  assign dBusWishbone_SEL = (_zz_dBus_cmd_ready_3 ? dBus_cmd_payload_mask : 4'b1111);
-  assign dBusWishbone_WE = _zz_dBus_cmd_ready_3;
+  assign dBusWishbone_SEL = (_zz_dBus_cmd_ready_1 ? dBus_cmd_payload_mask : 4'b1111);
+  assign dBusWishbone_WE = _zz_dBus_cmd_ready_1;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_payload_data;
-  assign _zz_dBus_cmd_ready_2 = (_zz_dBus_cmd_ready_1 && dBusWishbone_ACK);
-  assign dBusWishbone_CYC = _zz_dBus_cmd_ready_1;
-  assign dBusWishbone_STB = _zz_dBus_cmd_ready_1;
+  assign _zz_dBus_cmd_ready = (_zz_dBusWishbone_CYC && dBusWishbone_ACK);
+  assign dBusWishbone_CYC = _zz_dBusWishbone_CYC;
+  assign dBusWishbone_STB = _zz_dBusWishbone_CYC;
   assign dBus_rsp_valid = _zz_dBus_rsp_valid;
   assign dBus_rsp_payload_data = dBusWishbone_DAT_MISO_regNext;
   assign dBus_rsp_payload_error = 1'b0;
@@ -6071,17 +6135,17 @@ module VexRiscv (
       IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
-      _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+      _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= 1'b0;
       _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= 32'h0;
-      dataCache_1_io_mem_cmd_rValid <= 1'b0;
-      dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= 32'h0;
+      IBusCachedPlugin_rspCounter <= 32'h00000000;
+      toplevel_dataCache_1_io_mem_cmd_rValidN <= 1'b1;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
+      DBusCachedPlugin_rspCounter <= 32'h00000000;
       MmuPlugin_status_sum <= 1'b0;
       MmuPlugin_status_mxr <= 1'b0;
       MmuPlugin_status_mprv <= 1'b0;
@@ -6098,7 +6162,7 @@ module VexRiscv (
       MmuPlugin_ports_1_entryToReplace_value <= 2'b00;
       MmuPlugin_shared_state_1 <= MmuPlugin_shared_State_IDLE;
       MmuPlugin_shared_dBusRspStaged_valid <= 1'b0;
-      _zz_7 <= 1'b1;
+      _zz_10 <= 1'b1;
       HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
       _zz_CsrPlugin_privilege <= 2'b11;
       CsrPlugin_mstatus_MIE <= 1'b0;
@@ -6107,11 +6171,12 @@ module VexRiscv (
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
-      CsrPlugin_mcycle <= 64'h0;
-      CsrPlugin_minstret <= 64'h0;
+      CsrPlugin_mcycle <= 64'h0000000000000000;
+      CsrPlugin_minstret <= 64'h0000000000000000;
       CsrPlugin_medeleg_IAM <= 1'b0;
       CsrPlugin_medeleg_IAF <= 1'b0;
       CsrPlugin_medeleg_II <= 1'b0;
+      CsrPlugin_medeleg_BP <= 1'b0;
       CsrPlugin_medeleg_LAM <= 1'b0;
       CsrPlugin_medeleg_LAF <= 1'b0;
       CsrPlugin_medeleg_SAM <= 1'b0;
@@ -6144,9 +6209,9 @@ module VexRiscv (
       CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
-      memory_DivPlugin_div_counter_value <= 6'h0;
-      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h0;
-      _zz_CsrPlugin_csrMapping_readDataInit_2 <= 32'h0;
+      memory_DivPlugin_div_counter_value <= 6'h00;
+      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h00000000;
+      _zz_CsrPlugin_csrMapping_readDataInit_1 <= 32'h00000000;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
@@ -6154,7 +6219,7 @@ module VexRiscv (
       memory_to_writeBack_IS_DBUS_SHARING <= 1'b0;
       _zz_iBusWishbone_ADR <= 3'b000;
       _zz_iBus_rsp_valid <= 1'b0;
-      _zz_dBus_cmd_ready <= 3'b000;
+      _zz_dBusWishbone_ADR <= 3'b000;
       _zz_dBus_rsp_valid <= 1'b0;
     end else begin
       if(IBusCachedPlugin_fetchPc_correction) begin
@@ -6164,23 +6229,23 @@ module VexRiscv (
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusCachedPlugin_fetchPc_booted <= 1'b1;
-      if(when_Fetcher_l134) begin
+      if(when_Fetcher_l133) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_output_fire_1) begin
+      if(IBusCachedPlugin_fetchPc_output_fire) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b1;
       end
-      if(when_Fetcher_l134_1) begin
+      if(when_Fetcher_l133_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(when_Fetcher_l161) begin
+      if(when_Fetcher_l160) begin
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
       if(IBusCachedPlugin_iBusRsp_flush) begin
-        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= 1'b0;
       end
       if(_zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready) begin
-        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
       if(IBusCachedPlugin_iBusRsp_flush) begin
         _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
@@ -6191,13 +6256,13 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if(when_Fetcher_l332) begin
+      if(when_Fetcher_l331) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(when_Fetcher_l332_1) begin
+      if(when_Fetcher_l331_1) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= IBusCachedPlugin_injector_nextPcCalc_valids_0;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -6206,7 +6271,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(when_Fetcher_l332_2) begin
+      if(when_Fetcher_l331_2) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= IBusCachedPlugin_injector_nextPcCalc_valids_1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -6215,7 +6280,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(when_Fetcher_l332_3) begin
+      if(when_Fetcher_l331_3) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -6224,7 +6289,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if(when_Fetcher_l332_4) begin
+      if(when_Fetcher_l331_4) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= IBusCachedPlugin_injector_nextPcCalc_valids_3;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -6234,16 +6299,19 @@ module VexRiscv (
         IBusCachedPlugin_rspCounter <= (IBusCachedPlugin_rspCounter + 32'h00000001);
       end
       if(dataCache_1_io_mem_cmd_valid) begin
-        dataCache_1_io_mem_cmd_rValid <= 1'b1;
+        toplevel_dataCache_1_io_mem_cmd_rValidN <= 1'b0;
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
-        dataCache_1_io_mem_cmd_rValid <= 1'b0;
+      if(toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+        toplevel_dataCache_1_io_mem_cmd_rValidN <= 1'b1;
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
-        dataCache_1_io_mem_cmd_s2mPipe_rValid <= dataCache_1_io_mem_cmd_s2mPipe_valid;
+      if(toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+        toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_valid;
       end
       if(dBus_rsp_valid) begin
         DBusCachedPlugin_rspCounter <= (DBusCachedPlugin_rspCounter + 32'h00000001);
+      end
+      if(CsrPlugin_xretAwayFromMachine) begin
+        MmuPlugin_status_mprv <= 1'b0;
       end
       MmuPlugin_ports_0_entryToReplace_value <= MmuPlugin_ports_0_entryToReplace_valueNext;
       if(contextSwitching) begin
@@ -6278,7 +6346,7 @@ module VexRiscv (
       MmuPlugin_shared_dBusRspStaged_valid <= MmuPlugin_dBusAccess_rsp_valid;
       case(MmuPlugin_shared_state_1)
         MmuPlugin_shared_State_IDLE : begin
-          if(when_MmuPlugin_l217) begin
+          if(when_MmuPlugin_l223) begin
             MmuPlugin_shared_state_1 <= MmuPlugin_shared_State_L1_CMD;
           end
         end
@@ -6290,7 +6358,7 @@ module VexRiscv (
         MmuPlugin_shared_State_L1_RSP : begin
           if(MmuPlugin_shared_dBusRspStaged_valid) begin
             MmuPlugin_shared_state_1 <= MmuPlugin_shared_State_L0_CMD;
-            if(when_MmuPlugin_l243) begin
+            if(when_MmuPlugin_l250) begin
               MmuPlugin_shared_state_1 <= MmuPlugin_shared_State_IDLE;
             end
             if(MmuPlugin_shared_dBusRspStaged_payload_redo) begin
@@ -6312,37 +6380,37 @@ module VexRiscv (
           end
         end
       endcase
-      if(when_MmuPlugin_l272) begin
-        if(when_MmuPlugin_l274) begin
-          if(when_MmuPlugin_l280) begin
+      if(when_MmuPlugin_l279) begin
+        if(when_MmuPlugin_l281) begin
+          if(when_MmuPlugin_l287) begin
             MmuPlugin_ports_0_cache_0_valid <= 1'b1;
           end
-          if(when_MmuPlugin_l280_1) begin
+          if(when_MmuPlugin_l287_1) begin
             MmuPlugin_ports_0_cache_1_valid <= 1'b1;
           end
-          if(when_MmuPlugin_l280_2) begin
+          if(when_MmuPlugin_l287_2) begin
             MmuPlugin_ports_0_cache_2_valid <= 1'b1;
           end
-          if(when_MmuPlugin_l280_3) begin
+          if(when_MmuPlugin_l287_3) begin
             MmuPlugin_ports_0_cache_3_valid <= 1'b1;
           end
         end
-        if(when_MmuPlugin_l274_1) begin
-          if(when_MmuPlugin_l280_4) begin
+        if(when_MmuPlugin_l281_1) begin
+          if(when_MmuPlugin_l287_4) begin
             MmuPlugin_ports_1_cache_0_valid <= 1'b1;
           end
-          if(when_MmuPlugin_l280_5) begin
+          if(when_MmuPlugin_l287_5) begin
             MmuPlugin_ports_1_cache_1_valid <= 1'b1;
           end
-          if(when_MmuPlugin_l280_6) begin
+          if(when_MmuPlugin_l287_6) begin
             MmuPlugin_ports_1_cache_2_valid <= 1'b1;
           end
-          if(when_MmuPlugin_l280_7) begin
+          if(when_MmuPlugin_l287_7) begin
             MmuPlugin_ports_1_cache_3_valid <= 1'b1;
           end
         end
       end
-      if(when_MmuPlugin_l304) begin
+      if(when_MmuPlugin_l311) begin
         MmuPlugin_ports_0_cache_0_valid <= 1'b0;
         MmuPlugin_ports_0_cache_1_valid <= 1'b0;
         MmuPlugin_ports_0_cache_2_valid <= 1'b0;
@@ -6352,77 +6420,77 @@ module VexRiscv (
         MmuPlugin_ports_1_cache_2_valid <= 1'b0;
         MmuPlugin_ports_1_cache_3_valid <= 1'b0;
       end
-      _zz_7 <= 1'b0;
+      _zz_10 <= 1'b0;
       HazardSimplePlugin_writeBackBuffer_valid <= HazardSimplePlugin_writeBackWrites_valid;
       CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
       if(writeBack_arbitration_isFiring) begin
         CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
       end
-      if(when_CsrPlugin_l922) begin
+      if(when_CsrPlugin_l1259) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if(when_CsrPlugin_l922_1) begin
+      if(when_CsrPlugin_l1259_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if(when_CsrPlugin_l922_2) begin
+      if(when_CsrPlugin_l1259_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if(when_CsrPlugin_l922_3) begin
+      if(when_CsrPlugin_l1259_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(when_CsrPlugin_l959) begin
-        if(when_CsrPlugin_l965) begin
+      if(when_CsrPlugin_l1296) begin
+        if(when_CsrPlugin_l1302) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_1) begin
+        if(when_CsrPlugin_l1302_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_2) begin
+        if(when_CsrPlugin_l1302_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
-      if(when_CsrPlugin_l959_1) begin
-        if(when_CsrPlugin_l965_3) begin
+      if(when_CsrPlugin_l1296_1) begin
+        if(when_CsrPlugin_l1302_3) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_4) begin
+        if(when_CsrPlugin_l1302_4) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_5) begin
+        if(when_CsrPlugin_l1302_5) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_6) begin
+        if(when_CsrPlugin_l1302_6) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_7) begin
+        if(when_CsrPlugin_l1302_7) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_8) begin
+        if(when_CsrPlugin_l1302_8) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
       CsrPlugin_lastStageWasWfi <= (writeBack_arbitration_isFiring && (writeBack_ENV_CTRL == EnvCtrlEnum_WFI));
       if(CsrPlugin_pipelineLiberator_active) begin
-        if(when_CsrPlugin_l993) begin
+        if(when_CsrPlugin_l1335) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if(when_CsrPlugin_l993_1) begin
+        if(when_CsrPlugin_l1335_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if(when_CsrPlugin_l993_2) begin
+        if(when_CsrPlugin_l1335_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(when_CsrPlugin_l998) begin
+      if(when_CsrPlugin_l1340) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
@@ -6431,25 +6499,27 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(when_CsrPlugin_l1032) begin
-        _zz_CsrPlugin_privilege <= CsrPlugin_targetPrivilege;
-        case(CsrPlugin_targetPrivilege)
-          2'b01 : begin
-            CsrPlugin_sstatus_SIE <= 1'b0;
-            CsrPlugin_sstatus_SPIE <= CsrPlugin_sstatus_SIE;
-            CsrPlugin_sstatus_SPP <= CsrPlugin_privilege[0 : 0];
-          end
-          2'b11 : begin
-            CsrPlugin_mstatus_MIE <= 1'b0;
-            CsrPlugin_mstatus_MPIE <= CsrPlugin_mstatus_MIE;
-            CsrPlugin_mstatus_MPP <= CsrPlugin_privilege;
-          end
-          default : begin
-          end
-        endcase
+      if(when_CsrPlugin_l1390) begin
+        if(when_CsrPlugin_l1398) begin
+          _zz_CsrPlugin_privilege <= CsrPlugin_targetPrivilege;
+          case(CsrPlugin_targetPrivilege)
+            2'b01 : begin
+              CsrPlugin_sstatus_SIE <= 1'b0;
+              CsrPlugin_sstatus_SPIE <= CsrPlugin_sstatus_SIE;
+              CsrPlugin_sstatus_SPP <= CsrPlugin_privilege[0 : 0];
+            end
+            2'b11 : begin
+              CsrPlugin_mstatus_MIE <= 1'b0;
+              CsrPlugin_mstatus_MPIE <= CsrPlugin_mstatus_MIE;
+              CsrPlugin_mstatus_MPP <= CsrPlugin_privilege;
+            end
+            default : begin
+            end
+          endcase
+        end
       end
-      if(when_CsrPlugin_l1077) begin
-        case(switch_CsrPlugin_l1081)
+      if(when_CsrPlugin_l1456) begin
+        case(switch_CsrPlugin_l1460)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -6466,7 +6536,7 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l965_5,{_zz_when_CsrPlugin_l965_4,{_zz_when_CsrPlugin_l965_3,{_zz_when_CsrPlugin_l965_2,{_zz_when_CsrPlugin_l965_1,_zz_when_CsrPlugin_l965}}}}} != 6'h0) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l1302_5,{_zz_when_CsrPlugin_l1302_4,{_zz_when_CsrPlugin_l1302_3,{_zz_when_CsrPlugin_l1302_2,{_zz_when_CsrPlugin_l1302_1,_zz_when_CsrPlugin_l1302}}}}} != 6'h00) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
       if(when_Pipeline_l124_57) begin
         execute_to_memory_IS_DBUS_SHARING <= execute_IS_DBUS_SHARING;
@@ -6505,7 +6575,7 @@ module VexRiscv (
           MmuPlugin_status_mprv <= CsrPlugin_csrMapping_writeDataSignal[17];
           CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
           CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
-          case(switch_CsrPlugin_l723)
+          case(switch_CsrPlugin_l1031)
             2'b11 : begin
               CsrPlugin_mstatus_MPP <= 2'b11;
             end
@@ -6568,6 +6638,7 @@ module VexRiscv (
           CsrPlugin_medeleg_IAM <= CsrPlugin_csrMapping_writeDataSignal[0];
           CsrPlugin_medeleg_IAF <= CsrPlugin_csrMapping_writeDataSignal[1];
           CsrPlugin_medeleg_II <= CsrPlugin_csrMapping_writeDataSignal[2];
+          CsrPlugin_medeleg_BP <= CsrPlugin_csrMapping_writeDataSignal[3];
           CsrPlugin_medeleg_LAM <= CsrPlugin_csrMapping_writeDataSignal[4];
           CsrPlugin_medeleg_LAF <= CsrPlugin_csrMapping_writeDataSignal[5];
           CsrPlugin_medeleg_SAM <= CsrPlugin_csrMapping_writeDataSignal[6];
@@ -6607,7 +6678,7 @@ module VexRiscv (
       end
       if(execute_CsrPlugin_csr_2496) begin
         if(execute_CsrPlugin_writeEnable) begin
-          _zz_CsrPlugin_csrMapping_readDataInit_2 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+          _zz_CsrPlugin_csrMapping_readDataInit_1 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
         end
       end
       if(when_InstructionCache_l239) begin
@@ -6616,13 +6687,13 @@ module VexRiscv (
         end
       end
       _zz_iBus_rsp_valid <= (iBusWishbone_CYC && iBusWishbone_ACK);
-      if((_zz_dBus_cmd_ready_1 && _zz_dBus_cmd_ready_2)) begin
-        _zz_dBus_cmd_ready <= (_zz_dBus_cmd_ready + 3'b001);
-        if(_zz_dBus_cmd_ready_4) begin
-          _zz_dBus_cmd_ready <= 3'b000;
+      if((_zz_dBusWishbone_CYC && _zz_dBus_cmd_ready)) begin
+        _zz_dBusWishbone_ADR <= (_zz_dBusWishbone_ADR + 3'b001);
+        if(_zz_dBus_cmd_ready_2) begin
+          _zz_dBusWishbone_ADR <= 3'b000;
         end
       end
-      _zz_dBus_rsp_valid <= ((_zz_dBus_cmd_ready_1 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
+      _zz_dBus_rsp_valid <= ((_zz_dBusWishbone_CYC && (! dBusWishbone_WE)) && dBusWishbone_ACK);
     end
   end
 
@@ -6636,28 +6707,28 @@ module VexRiscv (
     if(IBusCachedPlugin_iBusRsp_stages_2_input_ready) begin
       IBusCachedPlugin_s2_tightlyCoupledHit <= IBusCachedPlugin_s1_tightlyCoupledHit;
     end
-    if(dataCache_1_io_mem_cmd_ready) begin
-      dataCache_1_io_mem_cmd_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
-      dataCache_1_io_mem_cmd_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
-      dataCache_1_io_mem_cmd_rData_address <= dataCache_1_io_mem_cmd_payload_address;
-      dataCache_1_io_mem_cmd_rData_data <= dataCache_1_io_mem_cmd_payload_data;
-      dataCache_1_io_mem_cmd_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
-      dataCache_1_io_mem_cmd_rData_size <= dataCache_1_io_mem_cmd_payload_size;
-      dataCache_1_io_mem_cmd_rData_last <= dataCache_1_io_mem_cmd_payload_last;
+    if(toplevel_dataCache_1_io_mem_cmd_rValidN) begin
+      toplevel_dataCache_1_io_mem_cmd_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
+      toplevel_dataCache_1_io_mem_cmd_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
+      toplevel_dataCache_1_io_mem_cmd_rData_address <= dataCache_1_io_mem_cmd_payload_address;
+      toplevel_dataCache_1_io_mem_cmd_rData_data <= dataCache_1_io_mem_cmd_payload_data;
+      toplevel_dataCache_1_io_mem_cmd_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
+      toplevel_dataCache_1_io_mem_cmd_rData_size <= dataCache_1_io_mem_cmd_payload_size;
+      toplevel_dataCache_1_io_mem_cmd_rData_last <= dataCache_1_io_mem_cmd_payload_last;
     end
-    if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
-      dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_address <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_data <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_size <= dataCache_1_io_mem_cmd_s2mPipe_payload_size;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_last <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+    if(toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_address <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_data <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_size <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_size;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_last <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_last;
     end
     MmuPlugin_shared_dBusRspStaged_payload_data <= MmuPlugin_dBusAccess_rsp_payload_data;
     MmuPlugin_shared_dBusRspStaged_payload_error <= MmuPlugin_dBusAccess_rsp_payload_error;
     MmuPlugin_shared_dBusRspStaged_payload_redo <= MmuPlugin_dBusAccess_rsp_payload_redo;
-    if(when_MmuPlugin_l205) begin
+    if(when_MmuPlugin_l211) begin
       MmuPlugin_shared_pteBuffer_V <= MmuPlugin_shared_dBusRsp_pte_V;
       MmuPlugin_shared_pteBuffer_R <= MmuPlugin_shared_dBusRsp_pte_R;
       MmuPlugin_shared_pteBuffer_W <= MmuPlugin_shared_dBusRsp_pte_W;
@@ -6672,7 +6743,7 @@ module VexRiscv (
     end
     case(MmuPlugin_shared_state_1)
       MmuPlugin_shared_State_IDLE : begin
-        if(when_MmuPlugin_l217) begin
+        if(when_MmuPlugin_l223) begin
           MmuPlugin_shared_portSortedOh <= MmuPlugin_shared_refills;
           MmuPlugin_shared_vpn_1 <= _zz_MmuPlugin_shared_vpn_0[31 : 22];
           MmuPlugin_shared_vpn_0 <= _zz_MmuPlugin_shared_vpn_0[21 : 12];
@@ -6687,102 +6758,102 @@ module VexRiscv (
       default : begin
       end
     endcase
-    if(when_MmuPlugin_l272) begin
-      if(when_MmuPlugin_l274) begin
-        if(when_MmuPlugin_l280) begin
-          MmuPlugin_ports_0_cache_0_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
+    if(when_MmuPlugin_l279) begin
+      if(when_MmuPlugin_l281) begin
+        if(when_MmuPlugin_l287) begin
+          MmuPlugin_ports_0_cache_0_exception <= ((MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h000))) || (! MmuPlugin_shared_dBusRsp_pte_A));
           MmuPlugin_ports_0_cache_0_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_0_cache_0_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
           MmuPlugin_ports_0_cache_0_physicalAddress_0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
           MmuPlugin_ports_0_cache_0_physicalAddress_1 <= MmuPlugin_shared_dBusRsp_pte_PPN1[9 : 0];
           MmuPlugin_ports_0_cache_0_allowRead <= MmuPlugin_shared_dBusRsp_pte_R;
-          MmuPlugin_ports_0_cache_0_allowWrite <= MmuPlugin_shared_dBusRsp_pte_W;
+          MmuPlugin_ports_0_cache_0_allowWrite <= (MmuPlugin_shared_dBusRsp_pte_W && MmuPlugin_shared_dBusRsp_pte_D);
           MmuPlugin_ports_0_cache_0_allowExecute <= MmuPlugin_shared_dBusRsp_pte_X;
           MmuPlugin_ports_0_cache_0_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
           MmuPlugin_ports_0_cache_0_superPage <= (MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP);
         end
-        if(when_MmuPlugin_l280_1) begin
-          MmuPlugin_ports_0_cache_1_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
+        if(when_MmuPlugin_l287_1) begin
+          MmuPlugin_ports_0_cache_1_exception <= ((MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h000))) || (! MmuPlugin_shared_dBusRsp_pte_A));
           MmuPlugin_ports_0_cache_1_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_0_cache_1_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
           MmuPlugin_ports_0_cache_1_physicalAddress_0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
           MmuPlugin_ports_0_cache_1_physicalAddress_1 <= MmuPlugin_shared_dBusRsp_pte_PPN1[9 : 0];
           MmuPlugin_ports_0_cache_1_allowRead <= MmuPlugin_shared_dBusRsp_pte_R;
-          MmuPlugin_ports_0_cache_1_allowWrite <= MmuPlugin_shared_dBusRsp_pte_W;
+          MmuPlugin_ports_0_cache_1_allowWrite <= (MmuPlugin_shared_dBusRsp_pte_W && MmuPlugin_shared_dBusRsp_pte_D);
           MmuPlugin_ports_0_cache_1_allowExecute <= MmuPlugin_shared_dBusRsp_pte_X;
           MmuPlugin_ports_0_cache_1_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
           MmuPlugin_ports_0_cache_1_superPage <= (MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP);
         end
-        if(when_MmuPlugin_l280_2) begin
-          MmuPlugin_ports_0_cache_2_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
+        if(when_MmuPlugin_l287_2) begin
+          MmuPlugin_ports_0_cache_2_exception <= ((MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h000))) || (! MmuPlugin_shared_dBusRsp_pte_A));
           MmuPlugin_ports_0_cache_2_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_0_cache_2_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
           MmuPlugin_ports_0_cache_2_physicalAddress_0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
           MmuPlugin_ports_0_cache_2_physicalAddress_1 <= MmuPlugin_shared_dBusRsp_pte_PPN1[9 : 0];
           MmuPlugin_ports_0_cache_2_allowRead <= MmuPlugin_shared_dBusRsp_pte_R;
-          MmuPlugin_ports_0_cache_2_allowWrite <= MmuPlugin_shared_dBusRsp_pte_W;
+          MmuPlugin_ports_0_cache_2_allowWrite <= (MmuPlugin_shared_dBusRsp_pte_W && MmuPlugin_shared_dBusRsp_pte_D);
           MmuPlugin_ports_0_cache_2_allowExecute <= MmuPlugin_shared_dBusRsp_pte_X;
           MmuPlugin_ports_0_cache_2_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
           MmuPlugin_ports_0_cache_2_superPage <= (MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP);
         end
-        if(when_MmuPlugin_l280_3) begin
-          MmuPlugin_ports_0_cache_3_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
+        if(when_MmuPlugin_l287_3) begin
+          MmuPlugin_ports_0_cache_3_exception <= ((MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h000))) || (! MmuPlugin_shared_dBusRsp_pte_A));
           MmuPlugin_ports_0_cache_3_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_0_cache_3_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
           MmuPlugin_ports_0_cache_3_physicalAddress_0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
           MmuPlugin_ports_0_cache_3_physicalAddress_1 <= MmuPlugin_shared_dBusRsp_pte_PPN1[9 : 0];
           MmuPlugin_ports_0_cache_3_allowRead <= MmuPlugin_shared_dBusRsp_pte_R;
-          MmuPlugin_ports_0_cache_3_allowWrite <= MmuPlugin_shared_dBusRsp_pte_W;
+          MmuPlugin_ports_0_cache_3_allowWrite <= (MmuPlugin_shared_dBusRsp_pte_W && MmuPlugin_shared_dBusRsp_pte_D);
           MmuPlugin_ports_0_cache_3_allowExecute <= MmuPlugin_shared_dBusRsp_pte_X;
           MmuPlugin_ports_0_cache_3_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
           MmuPlugin_ports_0_cache_3_superPage <= (MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP);
         end
       end
-      if(when_MmuPlugin_l274_1) begin
-        if(when_MmuPlugin_l280_4) begin
-          MmuPlugin_ports_1_cache_0_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
+      if(when_MmuPlugin_l281_1) begin
+        if(when_MmuPlugin_l287_4) begin
+          MmuPlugin_ports_1_cache_0_exception <= ((MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h000))) || (! MmuPlugin_shared_dBusRsp_pte_A));
           MmuPlugin_ports_1_cache_0_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_1_cache_0_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
           MmuPlugin_ports_1_cache_0_physicalAddress_0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
           MmuPlugin_ports_1_cache_0_physicalAddress_1 <= MmuPlugin_shared_dBusRsp_pte_PPN1[9 : 0];
           MmuPlugin_ports_1_cache_0_allowRead <= MmuPlugin_shared_dBusRsp_pte_R;
-          MmuPlugin_ports_1_cache_0_allowWrite <= MmuPlugin_shared_dBusRsp_pte_W;
+          MmuPlugin_ports_1_cache_0_allowWrite <= (MmuPlugin_shared_dBusRsp_pte_W && MmuPlugin_shared_dBusRsp_pte_D);
           MmuPlugin_ports_1_cache_0_allowExecute <= MmuPlugin_shared_dBusRsp_pte_X;
           MmuPlugin_ports_1_cache_0_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
           MmuPlugin_ports_1_cache_0_superPage <= (MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP);
         end
-        if(when_MmuPlugin_l280_5) begin
-          MmuPlugin_ports_1_cache_1_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
+        if(when_MmuPlugin_l287_5) begin
+          MmuPlugin_ports_1_cache_1_exception <= ((MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h000))) || (! MmuPlugin_shared_dBusRsp_pte_A));
           MmuPlugin_ports_1_cache_1_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_1_cache_1_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
           MmuPlugin_ports_1_cache_1_physicalAddress_0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
           MmuPlugin_ports_1_cache_1_physicalAddress_1 <= MmuPlugin_shared_dBusRsp_pte_PPN1[9 : 0];
           MmuPlugin_ports_1_cache_1_allowRead <= MmuPlugin_shared_dBusRsp_pte_R;
-          MmuPlugin_ports_1_cache_1_allowWrite <= MmuPlugin_shared_dBusRsp_pte_W;
+          MmuPlugin_ports_1_cache_1_allowWrite <= (MmuPlugin_shared_dBusRsp_pte_W && MmuPlugin_shared_dBusRsp_pte_D);
           MmuPlugin_ports_1_cache_1_allowExecute <= MmuPlugin_shared_dBusRsp_pte_X;
           MmuPlugin_ports_1_cache_1_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
           MmuPlugin_ports_1_cache_1_superPage <= (MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP);
         end
-        if(when_MmuPlugin_l280_6) begin
-          MmuPlugin_ports_1_cache_2_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
+        if(when_MmuPlugin_l287_6) begin
+          MmuPlugin_ports_1_cache_2_exception <= ((MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h000))) || (! MmuPlugin_shared_dBusRsp_pte_A));
           MmuPlugin_ports_1_cache_2_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_1_cache_2_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
           MmuPlugin_ports_1_cache_2_physicalAddress_0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
           MmuPlugin_ports_1_cache_2_physicalAddress_1 <= MmuPlugin_shared_dBusRsp_pte_PPN1[9 : 0];
           MmuPlugin_ports_1_cache_2_allowRead <= MmuPlugin_shared_dBusRsp_pte_R;
-          MmuPlugin_ports_1_cache_2_allowWrite <= MmuPlugin_shared_dBusRsp_pte_W;
+          MmuPlugin_ports_1_cache_2_allowWrite <= (MmuPlugin_shared_dBusRsp_pte_W && MmuPlugin_shared_dBusRsp_pte_D);
           MmuPlugin_ports_1_cache_2_allowExecute <= MmuPlugin_shared_dBusRsp_pte_X;
           MmuPlugin_ports_1_cache_2_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
           MmuPlugin_ports_1_cache_2_superPage <= (MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP);
         end
-        if(when_MmuPlugin_l280_7) begin
-          MmuPlugin_ports_1_cache_3_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
+        if(when_MmuPlugin_l287_7) begin
+          MmuPlugin_ports_1_cache_3_exception <= ((MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h000))) || (! MmuPlugin_shared_dBusRsp_pte_A));
           MmuPlugin_ports_1_cache_3_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_1_cache_3_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
           MmuPlugin_ports_1_cache_3_physicalAddress_0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
           MmuPlugin_ports_1_cache_3_physicalAddress_1 <= MmuPlugin_shared_dBusRsp_pte_PPN1[9 : 0];
           MmuPlugin_ports_1_cache_3_allowRead <= MmuPlugin_shared_dBusRsp_pte_R;
-          MmuPlugin_ports_1_cache_3_allowWrite <= MmuPlugin_shared_dBusRsp_pte_W;
+          MmuPlugin_ports_1_cache_3_allowWrite <= (MmuPlugin_shared_dBusRsp_pte_W && MmuPlugin_shared_dBusRsp_pte_D);
           MmuPlugin_ports_1_cache_3_allowExecute <= MmuPlugin_shared_dBusRsp_pte_X;
           MmuPlugin_ports_1_cache_3_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
           MmuPlugin_ports_1_cache_3_superPage <= (MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP);
@@ -6811,67 +6882,69 @@ module VexRiscv (
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(when_CsrPlugin_l959) begin
-      if(when_CsrPlugin_l965) begin
+    if(when_CsrPlugin_l1296) begin
+      if(when_CsrPlugin_l1302) begin
         CsrPlugin_interrupt_code <= 4'b0101;
         CsrPlugin_interrupt_targetPrivilege <= 2'b01;
       end
-      if(when_CsrPlugin_l965_1) begin
+      if(when_CsrPlugin_l1302_1) begin
         CsrPlugin_interrupt_code <= 4'b0001;
         CsrPlugin_interrupt_targetPrivilege <= 2'b01;
       end
-      if(when_CsrPlugin_l965_2) begin
+      if(when_CsrPlugin_l1302_2) begin
         CsrPlugin_interrupt_code <= 4'b1001;
         CsrPlugin_interrupt_targetPrivilege <= 2'b01;
       end
     end
-    if(when_CsrPlugin_l959_1) begin
-      if(when_CsrPlugin_l965_3) begin
+    if(when_CsrPlugin_l1296_1) begin
+      if(when_CsrPlugin_l1302_3) begin
         CsrPlugin_interrupt_code <= 4'b0101;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l965_4) begin
+      if(when_CsrPlugin_l1302_4) begin
         CsrPlugin_interrupt_code <= 4'b0001;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l965_5) begin
+      if(when_CsrPlugin_l1302_5) begin
         CsrPlugin_interrupt_code <= 4'b1001;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l965_6) begin
+      if(when_CsrPlugin_l1302_6) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l965_7) begin
+      if(when_CsrPlugin_l1302_7) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l965_8) begin
+      if(when_CsrPlugin_l1302_8) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(when_CsrPlugin_l1032) begin
-      case(CsrPlugin_targetPrivilege)
-        2'b01 : begin
-          CsrPlugin_scause_interrupt <= (! CsrPlugin_hadException);
-          CsrPlugin_scause_exceptionCode <= CsrPlugin_trapCause;
-          CsrPlugin_sepc <= writeBack_PC;
-          if(CsrPlugin_hadException) begin
-            CsrPlugin_stval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
+    if(when_CsrPlugin_l1390) begin
+      if(when_CsrPlugin_l1398) begin
+        case(CsrPlugin_targetPrivilege)
+          2'b01 : begin
+            CsrPlugin_scause_interrupt <= (! CsrPlugin_hadException);
+            CsrPlugin_scause_exceptionCode <= CsrPlugin_trapCause;
+            CsrPlugin_sepc <= writeBack_PC;
+            if(CsrPlugin_hadException) begin
+              CsrPlugin_stval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
+            end
           end
-        end
-        2'b11 : begin
-          CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
-          CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
-          CsrPlugin_mepc <= writeBack_PC;
-          if(CsrPlugin_hadException) begin
-            CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
+          2'b11 : begin
+            CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
+            CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
+            CsrPlugin_mepc <= writeBack_PC;
+            if(CsrPlugin_hadException) begin
+              CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
+            end
           end
-        end
-        default : begin
-        end
-      endcase
+          default : begin
+          end
+        endcase
+      end
     end
     if(when_MulDivIterativePlugin_l126) begin
       memory_DivPlugin_div_done <= 1'b1;
@@ -6889,17 +6962,17 @@ module VexRiscv (
       end
     end
     if(when_MulDivIterativePlugin_l162) begin
-      memory_DivPlugin_accumulator <= 65'h0;
+      memory_DivPlugin_accumulator <= 65'h00000000000000000;
       memory_DivPlugin_rs1 <= ((_zz_memory_DivPlugin_rs1 ? (~ _zz_memory_DivPlugin_rs1_1) : _zz_memory_DivPlugin_rs1_1) + _zz_memory_DivPlugin_rs1_2);
       memory_DivPlugin_rs2 <= ((_zz_memory_DivPlugin_rs2 ? (~ execute_RS2) : execute_RS2) + _zz_memory_DivPlugin_rs2_1);
-      memory_DivPlugin_div_needRevert <= ((_zz_memory_DivPlugin_rs1 ^ (_zz_memory_DivPlugin_rs2 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
+      memory_DivPlugin_div_needRevert <= ((_zz_memory_DivPlugin_rs1 ^ (_zz_memory_DivPlugin_rs2 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h00000000) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
     end
     externalInterruptArray_regNext <= externalInterruptArray;
     if(when_Pipeline_l124) begin
       decode_to_execute_PC <= decode_PC;
     end
     if(when_Pipeline_l124_1) begin
-      execute_to_memory_PC <= _zz_execute_SRC2;
+      execute_to_memory_PC <= _zz_execute_to_memory_PC;
     end
     if(when_Pipeline_l124_2) begin
       memory_to_writeBack_PC <= memory_PC;
@@ -6926,73 +6999,73 @@ module VexRiscv (
       decode_to_execute_MEMORY_FORCE_CONSTISTENCY <= decode_MEMORY_FORCE_CONSTISTENCY;
     end
     if(when_Pipeline_l124_10) begin
-      decode_to_execute_SRC1_CTRL <= _zz_decode_to_execute_SRC1_CTRL;
+      decode_to_execute_RESCHEDULE_NEXT <= decode_RESCHEDULE_NEXT;
     end
     if(when_Pipeline_l124_11) begin
-      decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
+      decode_to_execute_SRC1_CTRL <= _zz_decode_to_execute_SRC1_CTRL;
     end
     if(when_Pipeline_l124_12) begin
-      decode_to_execute_MEMORY_ENABLE <= decode_MEMORY_ENABLE;
+      decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
     end
     if(when_Pipeline_l124_13) begin
-      execute_to_memory_MEMORY_ENABLE <= execute_MEMORY_ENABLE;
+      decode_to_execute_MEMORY_ENABLE <= decode_MEMORY_ENABLE;
     end
     if(when_Pipeline_l124_14) begin
-      memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
+      execute_to_memory_MEMORY_ENABLE <= execute_MEMORY_ENABLE;
     end
     if(when_Pipeline_l124_15) begin
-      decode_to_execute_ALU_CTRL <= _zz_decode_to_execute_ALU_CTRL;
+      memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
     end
     if(when_Pipeline_l124_16) begin
-      decode_to_execute_SRC2_CTRL <= _zz_decode_to_execute_SRC2_CTRL;
+      decode_to_execute_ALU_CTRL <= _zz_decode_to_execute_ALU_CTRL;
     end
     if(when_Pipeline_l124_17) begin
-      decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
+      decode_to_execute_SRC2_CTRL <= _zz_decode_to_execute_SRC2_CTRL;
     end
     if(when_Pipeline_l124_18) begin
-      execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
+      decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
     end
     if(when_Pipeline_l124_19) begin
-      memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
+      execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
     end
     if(when_Pipeline_l124_20) begin
-      decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
+      memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
     end
     if(when_Pipeline_l124_21) begin
-      decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
+      decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
     end
     if(when_Pipeline_l124_22) begin
-      execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
+      decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
     end
     if(when_Pipeline_l124_23) begin
-      decode_to_execute_MEMORY_WR <= decode_MEMORY_WR;
+      execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
     end
     if(when_Pipeline_l124_24) begin
-      execute_to_memory_MEMORY_WR <= execute_MEMORY_WR;
+      decode_to_execute_MEMORY_WR <= decode_MEMORY_WR;
     end
     if(when_Pipeline_l124_25) begin
-      memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
+      execute_to_memory_MEMORY_WR <= execute_MEMORY_WR;
     end
     if(when_Pipeline_l124_26) begin
-      decode_to_execute_MEMORY_LRSC <= decode_MEMORY_LRSC;
+      memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
     end
     if(when_Pipeline_l124_27) begin
-      execute_to_memory_MEMORY_LRSC <= execute_MEMORY_LRSC;
+      decode_to_execute_MEMORY_LRSC <= decode_MEMORY_LRSC;
     end
     if(when_Pipeline_l124_28) begin
-      memory_to_writeBack_MEMORY_LRSC <= memory_MEMORY_LRSC;
+      execute_to_memory_MEMORY_LRSC <= execute_MEMORY_LRSC;
     end
     if(when_Pipeline_l124_29) begin
-      decode_to_execute_MEMORY_AMO <= decode_MEMORY_AMO;
+      memory_to_writeBack_MEMORY_LRSC <= memory_MEMORY_LRSC;
     end
     if(when_Pipeline_l124_30) begin
-      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
+      decode_to_execute_MEMORY_AMO <= decode_MEMORY_AMO;
     end
     if(when_Pipeline_l124_31) begin
-      decode_to_execute_IS_SFENCE_VMA2 <= decode_IS_SFENCE_VMA2;
+      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
     end
     if(when_Pipeline_l124_32) begin
-      decode_to_execute_IS_SFENCE_VMA <= decode_IS_SFENCE_VMA;
+      decode_to_execute_IS_SFENCE_VMA2 <= decode_IS_SFENCE_VMA2;
     end
     if(when_Pipeline_l124_33) begin
       decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
@@ -7099,94 +7172,94 @@ module VexRiscv (
     if(when_Pipeline_l124_69) begin
       memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
     end
-    if(when_CsrPlugin_l1277) begin
+    if(when_CsrPlugin_l1669) begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
     end
-    if(when_CsrPlugin_l1277_1) begin
+    if(when_CsrPlugin_l1669_1) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if(when_CsrPlugin_l1277_2) begin
+    if(when_CsrPlugin_l1669_2) begin
       execute_CsrPlugin_csr_256 <= (decode_INSTRUCTION[31 : 20] == 12'h100);
     end
-    if(when_CsrPlugin_l1277_3) begin
+    if(when_CsrPlugin_l1669_3) begin
       execute_CsrPlugin_csr_384 <= (decode_INSTRUCTION[31 : 20] == 12'h180);
     end
-    if(when_CsrPlugin_l1277_4) begin
+    if(when_CsrPlugin_l1669_4) begin
       execute_CsrPlugin_csr_3857 <= (decode_INSTRUCTION[31 : 20] == 12'hf11);
     end
-    if(when_CsrPlugin_l1277_5) begin
+    if(when_CsrPlugin_l1669_5) begin
       execute_CsrPlugin_csr_3858 <= (decode_INSTRUCTION[31 : 20] == 12'hf12);
     end
-    if(when_CsrPlugin_l1277_6) begin
+    if(when_CsrPlugin_l1669_6) begin
       execute_CsrPlugin_csr_3859 <= (decode_INSTRUCTION[31 : 20] == 12'hf13);
     end
-    if(when_CsrPlugin_l1277_7) begin
+    if(when_CsrPlugin_l1669_7) begin
       execute_CsrPlugin_csr_3860 <= (decode_INSTRUCTION[31 : 20] == 12'hf14);
     end
-    if(when_CsrPlugin_l1277_8) begin
+    if(when_CsrPlugin_l1669_8) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if(when_CsrPlugin_l1277_9) begin
+    if(when_CsrPlugin_l1669_9) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if(when_CsrPlugin_l1277_10) begin
+    if(when_CsrPlugin_l1669_10) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if(when_CsrPlugin_l1277_11) begin
+    if(when_CsrPlugin_l1669_11) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if(when_CsrPlugin_l1277_12) begin
+    if(when_CsrPlugin_l1669_12) begin
       execute_CsrPlugin_csr_832 <= (decode_INSTRUCTION[31 : 20] == 12'h340);
     end
-    if(when_CsrPlugin_l1277_13) begin
+    if(when_CsrPlugin_l1669_13) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if(when_CsrPlugin_l1277_14) begin
+    if(when_CsrPlugin_l1669_14) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if(when_CsrPlugin_l1277_15) begin
+    if(when_CsrPlugin_l1669_15) begin
       execute_CsrPlugin_csr_770 <= (decode_INSTRUCTION[31 : 20] == 12'h302);
     end
-    if(when_CsrPlugin_l1277_16) begin
+    if(when_CsrPlugin_l1669_16) begin
       execute_CsrPlugin_csr_771 <= (decode_INSTRUCTION[31 : 20] == 12'h303);
     end
-    if(when_CsrPlugin_l1277_17) begin
+    if(when_CsrPlugin_l1669_17) begin
       execute_CsrPlugin_csr_324 <= (decode_INSTRUCTION[31 : 20] == 12'h144);
     end
-    if(when_CsrPlugin_l1277_18) begin
+    if(when_CsrPlugin_l1669_18) begin
       execute_CsrPlugin_csr_260 <= (decode_INSTRUCTION[31 : 20] == 12'h104);
     end
-    if(when_CsrPlugin_l1277_19) begin
+    if(when_CsrPlugin_l1669_19) begin
       execute_CsrPlugin_csr_261 <= (decode_INSTRUCTION[31 : 20] == 12'h105);
     end
-    if(when_CsrPlugin_l1277_20) begin
+    if(when_CsrPlugin_l1669_20) begin
       execute_CsrPlugin_csr_321 <= (decode_INSTRUCTION[31 : 20] == 12'h141);
     end
-    if(when_CsrPlugin_l1277_21) begin
+    if(when_CsrPlugin_l1669_21) begin
       execute_CsrPlugin_csr_320 <= (decode_INSTRUCTION[31 : 20] == 12'h140);
     end
-    if(when_CsrPlugin_l1277_22) begin
+    if(when_CsrPlugin_l1669_22) begin
       execute_CsrPlugin_csr_322 <= (decode_INSTRUCTION[31 : 20] == 12'h142);
     end
-    if(when_CsrPlugin_l1277_23) begin
+    if(when_CsrPlugin_l1669_23) begin
       execute_CsrPlugin_csr_323 <= (decode_INSTRUCTION[31 : 20] == 12'h143);
     end
-    if(when_CsrPlugin_l1277_24) begin
+    if(when_CsrPlugin_l1669_24) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if(when_CsrPlugin_l1277_25) begin
+    if(when_CsrPlugin_l1669_25) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
-    if(when_CsrPlugin_l1277_26) begin
+    if(when_CsrPlugin_l1669_26) begin
       execute_CsrPlugin_csr_2496 <= (decode_INSTRUCTION[31 : 20] == 12'h9c0);
     end
-    if(when_CsrPlugin_l1277_27) begin
+    if(when_CsrPlugin_l1669_27) begin
       execute_CsrPlugin_csr_3520 <= (decode_INSTRUCTION[31 : 20] == 12'hdc0);
     end
     if(execute_CsrPlugin_csr_384) begin
       if(execute_CsrPlugin_writeEnable) begin
         MmuPlugin_satp_asid <= CsrPlugin_csrMapping_writeDataSignal[30 : 22];
-        MmuPlugin_satp_ppn <= CsrPlugin_csrMapping_writeDataSignal[19 : 0];
+        MmuPlugin_satp_ppn <= CsrPlugin_csrMapping_writeDataSignal[21 : 0];
       end
     end
     if(execute_CsrPlugin_csr_836) begin
@@ -7197,7 +7270,6 @@ module VexRiscv (
     if(execute_CsrPlugin_csr_773) begin
       if(execute_CsrPlugin_writeEnable) begin
         CsrPlugin_mtvec_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 2];
-        CsrPlugin_mtvec_mode <= CsrPlugin_csrMapping_writeDataSignal[1 : 0];
       end
     end
     if(execute_CsrPlugin_csr_833) begin
@@ -7213,7 +7285,6 @@ module VexRiscv (
     if(execute_CsrPlugin_csr_261) begin
       if(execute_CsrPlugin_writeEnable) begin
         CsrPlugin_stvec_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 2];
-        CsrPlugin_stvec_mode <= CsrPlugin_csrMapping_writeDataSignal[1 : 0];
       end
     end
     if(execute_CsrPlugin_csr_321) begin
@@ -7245,96 +7316,93 @@ module VexRiscv (
 endmodule
 
 module DataCache (
-  input               io_cpu_execute_isValid,
-  input      [31:0]   io_cpu_execute_address,
-  output reg          io_cpu_execute_haltIt,
-  input               io_cpu_execute_args_wr,
-  input      [1:0]    io_cpu_execute_args_size,
-  input               io_cpu_execute_args_isLrsc,
-  input               io_cpu_execute_args_isAmo,
-  input               io_cpu_execute_args_amoCtrl_swap,
-  input      [2:0]    io_cpu_execute_args_amoCtrl_alu,
-  input               io_cpu_execute_args_totalyConsistent,
-  output              io_cpu_execute_refilling,
-  input               io_cpu_memory_isValid,
-  input               io_cpu_memory_isStuck,
-  output              io_cpu_memory_isWrite,
-  input      [31:0]   io_cpu_memory_address,
-  input      [31:0]   io_cpu_memory_mmuRsp_physicalAddress,
-  input               io_cpu_memory_mmuRsp_isIoAccess,
-  input               io_cpu_memory_mmuRsp_isPaging,
-  input               io_cpu_memory_mmuRsp_allowRead,
-  input               io_cpu_memory_mmuRsp_allowWrite,
-  input               io_cpu_memory_mmuRsp_allowExecute,
-  input               io_cpu_memory_mmuRsp_exception,
-  input               io_cpu_memory_mmuRsp_refilling,
-  input               io_cpu_memory_mmuRsp_bypassTranslation,
-  input               io_cpu_memory_mmuRsp_ways_0_sel,
-  input      [31:0]   io_cpu_memory_mmuRsp_ways_0_physical,
-  input               io_cpu_memory_mmuRsp_ways_1_sel,
-  input      [31:0]   io_cpu_memory_mmuRsp_ways_1_physical,
-  input               io_cpu_memory_mmuRsp_ways_2_sel,
-  input      [31:0]   io_cpu_memory_mmuRsp_ways_2_physical,
-  input               io_cpu_memory_mmuRsp_ways_3_sel,
-  input      [31:0]   io_cpu_memory_mmuRsp_ways_3_physical,
-  input               io_cpu_writeBack_isValid,
-  input               io_cpu_writeBack_isStuck,
-  input               io_cpu_writeBack_isFiring,
-  input               io_cpu_writeBack_isUser,
-  output reg          io_cpu_writeBack_haltIt,
-  output              io_cpu_writeBack_isWrite,
-  input      [31:0]   io_cpu_writeBack_storeData,
-  output reg [31:0]   io_cpu_writeBack_data,
-  input      [31:0]   io_cpu_writeBack_address,
-  output              io_cpu_writeBack_mmuException,
-  output              io_cpu_writeBack_unalignedAccess,
-  output reg          io_cpu_writeBack_accessError,
-  output              io_cpu_writeBack_keepMemRspData,
-  input               io_cpu_writeBack_fence_SW,
-  input               io_cpu_writeBack_fence_SR,
-  input               io_cpu_writeBack_fence_SO,
-  input               io_cpu_writeBack_fence_SI,
-  input               io_cpu_writeBack_fence_PW,
-  input               io_cpu_writeBack_fence_PR,
-  input               io_cpu_writeBack_fence_PO,
-  input               io_cpu_writeBack_fence_PI,
-  input      [3:0]    io_cpu_writeBack_fence_FM,
-  output              io_cpu_writeBack_exclusiveOk,
-  output reg          io_cpu_redo,
-  input               io_cpu_flush_valid,
-  output              io_cpu_flush_ready,
-  input               io_cpu_flush_payload_singleLine,
-  input      [6:0]    io_cpu_flush_payload_lineId,
-  output reg          io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output reg          io_mem_cmd_payload_wr,
-  output              io_mem_cmd_payload_uncached,
-  output reg [31:0]   io_mem_cmd_payload_address,
-  output     [31:0]   io_mem_cmd_payload_data,
-  output     [3:0]    io_mem_cmd_payload_mask,
-  output reg [2:0]    io_mem_cmd_payload_size,
-  output              io_mem_cmd_payload_last,
-  input               io_mem_rsp_valid,
-  input               io_mem_rsp_payload_last,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input               clk,
-  input               reset
+  input  wire          io_cpu_execute_isValid,
+  input  wire [31:0]   io_cpu_execute_address,
+  output reg           io_cpu_execute_haltIt,
+  input  wire          io_cpu_execute_args_wr,
+  input  wire [1:0]    io_cpu_execute_args_size,
+  input  wire          io_cpu_execute_args_isLrsc,
+  input  wire          io_cpu_execute_args_isAmo,
+  input  wire          io_cpu_execute_args_amoCtrl_swap,
+  input  wire [2:0]    io_cpu_execute_args_amoCtrl_alu,
+  input  wire          io_cpu_execute_args_totalyConsistent,
+  output wire          io_cpu_execute_refilling,
+  input  wire          io_cpu_memory_isValid,
+  input  wire          io_cpu_memory_isStuck,
+  output wire          io_cpu_memory_isWrite,
+  input  wire [31:0]   io_cpu_memory_address,
+  input  wire [31:0]   io_cpu_memory_mmuRsp_physicalAddress,
+  input  wire          io_cpu_memory_mmuRsp_isIoAccess,
+  input  wire          io_cpu_memory_mmuRsp_isPaging,
+  input  wire          io_cpu_memory_mmuRsp_allowRead,
+  input  wire          io_cpu_memory_mmuRsp_allowWrite,
+  input  wire          io_cpu_memory_mmuRsp_allowExecute,
+  input  wire          io_cpu_memory_mmuRsp_exception,
+  input  wire          io_cpu_memory_mmuRsp_refilling,
+  input  wire          io_cpu_memory_mmuRsp_bypassTranslation,
+  input  wire          io_cpu_memory_mmuRsp_ways_0_sel,
+  input  wire [31:0]   io_cpu_memory_mmuRsp_ways_0_physical,
+  input  wire          io_cpu_memory_mmuRsp_ways_1_sel,
+  input  wire [31:0]   io_cpu_memory_mmuRsp_ways_1_physical,
+  input  wire          io_cpu_memory_mmuRsp_ways_2_sel,
+  input  wire [31:0]   io_cpu_memory_mmuRsp_ways_2_physical,
+  input  wire          io_cpu_memory_mmuRsp_ways_3_sel,
+  input  wire [31:0]   io_cpu_memory_mmuRsp_ways_3_physical,
+  input  wire          io_cpu_writeBack_isValid,
+  input  wire          io_cpu_writeBack_isStuck,
+  input  wire          io_cpu_writeBack_isFiring,
+  input  wire          io_cpu_writeBack_isUser,
+  output reg           io_cpu_writeBack_haltIt,
+  output wire          io_cpu_writeBack_isWrite,
+  input  wire [31:0]   io_cpu_writeBack_storeData,
+  output reg  [31:0]   io_cpu_writeBack_data,
+  input  wire [31:0]   io_cpu_writeBack_address,
+  output wire          io_cpu_writeBack_mmuException,
+  output wire          io_cpu_writeBack_unalignedAccess,
+  output reg           io_cpu_writeBack_accessError,
+  output wire          io_cpu_writeBack_keepMemRspData,
+  input  wire          io_cpu_writeBack_fence_SW,
+  input  wire          io_cpu_writeBack_fence_SR,
+  input  wire          io_cpu_writeBack_fence_SO,
+  input  wire          io_cpu_writeBack_fence_SI,
+  input  wire          io_cpu_writeBack_fence_PW,
+  input  wire          io_cpu_writeBack_fence_PR,
+  input  wire          io_cpu_writeBack_fence_PO,
+  input  wire          io_cpu_writeBack_fence_PI,
+  input  wire [3:0]    io_cpu_writeBack_fence_FM,
+  output wire          io_cpu_writeBack_exclusiveOk,
+  output reg           io_cpu_redo,
+  input  wire          io_cpu_flush_valid,
+  output wire          io_cpu_flush_ready,
+  input  wire          io_cpu_flush_payload_singleLine,
+  input  wire [6:0]    io_cpu_flush_payload_lineId,
+  output wire          io_cpu_writesPending,
+  output reg           io_mem_cmd_valid,
+  input  wire          io_mem_cmd_ready,
+  output reg           io_mem_cmd_payload_wr,
+  output wire          io_mem_cmd_payload_uncached,
+  output reg  [31:0]   io_mem_cmd_payload_address,
+  output wire [31:0]   io_mem_cmd_payload_data,
+  output wire [3:0]    io_mem_cmd_payload_mask,
+  output reg  [2:0]    io_mem_cmd_payload_size,
+  output wire          io_mem_cmd_payload_last,
+  input  wire          io_mem_rsp_valid,
+  input  wire          io_mem_rsp_payload_last,
+  input  wire [31:0]   io_mem_rsp_payload_data,
+  input  wire          io_mem_rsp_payload_error,
+  input  wire          clk,
+  input  wire          reset
 );
 
   reg        [21:0]   _zz_ways_0_tags_port0;
   reg        [31:0]   _zz_ways_0_data_port0;
   wire       [21:0]   _zz_ways_0_tags_port;
-  wire       [9:0]    _zz_stage0_dataColisions;
-  wire       [9:0]    _zz__zz_stageA_dataColisions;
   wire       [31:0]   _zz_stageB_amo_addSub;
   wire       [31:0]   _zz_stageB_amo_addSub_1;
   wire       [31:0]   _zz_stageB_amo_addSub_2;
   wire       [31:0]   _zz_stageB_amo_addSub_3;
   wire       [31:0]   _zz_stageB_amo_addSub_4;
   wire       [1:0]    _zz_stageB_amo_addSub_5;
-  wire       [1:0]    _zz_stageB_amo_addSub_6;
-  wire       [1:0]    _zz_stageB_amo_addSub_7;
   wire       [0:0]    _zz_when;
   wire       [2:0]    _zz_loader_counter_valueNext;
   wire       [0:0]    _zz_loader_counter_valueNext_1;
@@ -7371,19 +7439,19 @@ module DataCache (
   wire                _zz_ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRsp;
-  wire                when_DataCache_l642;
   wire                when_DataCache_l645;
-  wire                when_DataCache_l664;
+  wire                when_DataCache_l648;
+  wire                when_DataCache_l667;
   wire                rspSync;
   wire                rspLast;
   reg                 memCmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_DataCache_l686;
+  wire                when_DataCache_l689;
   reg        [3:0]    _zz_stage0_mask;
   wire       [3:0]    stage0_mask;
   wire       [0:0]    stage0_dataColisions;
   wire       [0:0]    stage0_wayInvalidate;
-  wire                when_DataCache_l771;
+  wire                when_DataCache_l776;
   reg                 stageA_request_wr;
   reg        [1:0]    stageA_request_size;
   reg                 stageA_request_isLrsc;
@@ -7391,16 +7459,16 @@ module DataCache (
   reg                 stageA_request_amoCtrl_swap;
   reg        [2:0]    stageA_request_amoCtrl_alu;
   reg                 stageA_request_totalyConsistent;
-  wire                when_DataCache_l771_1;
+  wire                when_DataCache_l776_1;
   reg        [3:0]    stageA_mask;
   wire       [0:0]    stageA_wayHits;
-  wire                when_DataCache_l771_2;
+  wire                when_DataCache_l776_2;
   reg        [0:0]    stageA_wayInvalidate;
-  wire                when_DataCache_l771_3;
+  wire                when_DataCache_l776_3;
   reg        [0:0]    stage0_dataColisions_regNextWhen;
   wire       [0:0]    _zz_stageA_dataColisions;
   wire       [0:0]    stageA_dataColisions;
-  wire                when_DataCache_l822;
+  wire                when_DataCache_l827;
   reg                 stageB_request_wr;
   reg        [1:0]    stageB_request_size;
   reg                 stageB_request_isLrsc;
@@ -7409,7 +7477,7 @@ module DataCache (
   reg        [2:0]    stageB_request_amoCtrl_alu;
   reg                 stageB_request_totalyConsistent;
   reg                 stageB_mmuRspFreeze;
-  wire                when_DataCache_l824;
+  wire                when_DataCache_l829;
   reg        [31:0]   stageB_mmuRsp_physicalAddress;
   reg                 stageB_mmuRsp_isIoAccess;
   reg                 stageB_mmuRsp_isPaging;
@@ -7427,36 +7495,38 @@ module DataCache (
   reg        [31:0]   stageB_mmuRsp_ways_2_physical;
   reg                 stageB_mmuRsp_ways_3_sel;
   reg        [31:0]   stageB_mmuRsp_ways_3_physical;
-  wire                when_DataCache_l821;
+  wire                when_DataCache_l826;
   reg                 stageB_tagsReadRsp_0_valid;
   reg                 stageB_tagsReadRsp_0_error;
   reg        [19:0]   stageB_tagsReadRsp_0_address;
-  wire                when_DataCache_l821_1;
+  wire                when_DataCache_l826_1;
   reg        [31:0]   stageB_dataReadRsp_0;
-  wire                when_DataCache_l820;
+  wire                when_DataCache_l825;
   reg        [0:0]    stageB_wayInvalidate;
   wire                stageB_consistancyHazard;
-  wire                when_DataCache_l820_1;
+  wire                when_DataCache_l825_1;
   reg        [0:0]    stageB_dataColisions;
-  wire                when_DataCache_l820_2;
+  wire                when_DataCache_l825_2;
   reg                 stageB_unaligned;
-  wire                when_DataCache_l820_3;
+  wire                when_DataCache_l825_3;
   reg        [0:0]    stageB_waysHitsBeforeInvalidate;
   wire       [0:0]    stageB_waysHits;
   wire                stageB_waysHit;
   wire       [31:0]   stageB_dataMux;
-  wire                when_DataCache_l820_4;
+  wire                when_DataCache_l825_4;
   reg        [3:0]    stageB_mask;
   reg                 stageB_loaderValid;
   wire       [31:0]   stageB_ioMemRspMuxed;
   reg                 stageB_flusher_waitDone;
   wire                stageB_flusher_hold;
   reg        [7:0]    stageB_flusher_counter;
-  wire                when_DataCache_l850;
-  wire                when_DataCache_l856;
+  wire                when_DataCache_l855;
+  wire                when_DataCache_l861;
+  wire                when_DataCache_l863;
   reg                 stageB_flusher_start;
+  wire                when_DataCache_l877;
   reg                 stageB_lrSc_reserved;
-  wire                when_DataCache_l880;
+  wire                when_DataCache_l885;
   wire                stageB_isExternalLsrc;
   wire                stageB_isExternalAmo;
   reg        [31:0]   stageB_requestDataBypass;
@@ -7465,26 +7535,26 @@ module DataCache (
   wire       [31:0]   stageB_amo_addSub;
   wire                stageB_amo_less;
   wire                stageB_amo_selectRf;
-  wire       [2:0]    switch_Misc_l210;
+  wire       [2:0]    switch_Misc_l232;
   reg        [31:0]   stageB_amo_result;
   reg        [31:0]   stageB_amo_resultReg;
   reg                 stageB_amo_internal_resultRegValid;
   reg                 stageB_cpuWriteToCache;
-  wire                when_DataCache_l926;
+  wire                when_DataCache_l931;
   wire                stageB_badPermissions;
   wire                stageB_loadStoreFault;
   wire                stageB_bypassCache;
-  wire                when_DataCache_l995;
-  wire                when_DataCache_l999;
+  wire                when_DataCache_l1000;
   wire                when_DataCache_l1004;
   wire                when_DataCache_l1009;
-  wire                when_DataCache_l1012;
-  wire                when_DataCache_l1020;
+  wire                when_DataCache_l1014;
+  wire                when_DataCache_l1017;
   wire                when_DataCache_l1025;
-  wire                when_DataCache_l1032;
-  wire                when_DataCache_l991;
-  wire                when_DataCache_l1066;
-  wire                when_DataCache_l1075;
+  wire                when_DataCache_l1030;
+  wire                when_DataCache_l1037;
+  wire                when_DataCache_l996;
+  wire                when_DataCache_l1072;
+  wire                when_DataCache_l1081;
   reg                 loader_valid;
   reg                 loader_counter_willIncrement;
   wire                loader_counter_willClear;
@@ -7496,12 +7566,12 @@ module DataCache (
   reg                 loader_error;
   wire                loader_kill;
   reg                 loader_killReg;
-  wire                when_DataCache_l1090;
+  wire                when_DataCache_l1097;
   wire                loader_done;
-  wire                when_DataCache_l1118;
-  reg                 loader_valid_regNext;
-  wire                when_DataCache_l1122;
   wire                when_DataCache_l1125;
+  reg                 loader_valid_regNext;
+  wire                when_DataCache_l1129;
+  wire                when_DataCache_l1132;
   (* no_rw_check , ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
   (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
   (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
@@ -7512,16 +7582,12 @@ module DataCache (
   reg [7:0] _zz_ways_0_datasymbol_read_2;
   reg [7:0] _zz_ways_0_datasymbol_read_3;
 
-  assign _zz_stage0_dataColisions = (io_cpu_execute_address[11 : 2] >>> 0);
-  assign _zz__zz_stageA_dataColisions = (io_cpu_memory_address[11 : 2] >>> 0);
   assign _zz_stageB_amo_addSub = ($signed(_zz_stageB_amo_addSub_1) + $signed(_zz_stageB_amo_addSub_4));
   assign _zz_stageB_amo_addSub_1 = ($signed(_zz_stageB_amo_addSub_2) + $signed(_zz_stageB_amo_addSub_3));
   assign _zz_stageB_amo_addSub_2 = io_cpu_writeBack_storeData[31 : 0];
   assign _zz_stageB_amo_addSub_3 = (stageB_amo_compare ? (~ stageB_dataMux[31 : 0]) : stageB_dataMux[31 : 0]);
-  assign _zz_stageB_amo_addSub_5 = (stageB_amo_compare ? _zz_stageB_amo_addSub_6 : _zz_stageB_amo_addSub_7);
+  assign _zz_stageB_amo_addSub_5 = (stageB_amo_compare ? 2'b01 : 2'b00);
   assign _zz_stageB_amo_addSub_4 = {{30{_zz_stageB_amo_addSub_5[1]}}, _zz_stageB_amo_addSub_5};
-  assign _zz_stageB_amo_addSub_6 = 2'b01;
-  assign _zz_stageB_amo_addSub_7 = 2'b00;
   assign _zz_when = 1'b1;
   assign _zz_loader_counter_valueNext_1 = loader_counter_willIncrement;
   assign _zz_loader_counter_valueNext = {2'd0, _zz_loader_counter_valueNext_1};
@@ -7568,14 +7634,14 @@ module DataCache (
 
   always @(*) begin
     _zz_1 = 1'b0;
-    if(when_DataCache_l645) begin
+    if(when_DataCache_l648) begin
       _zz_1 = 1'b1;
     end
   end
 
   always @(*) begin
     _zz_2 = 1'b0;
-    if(when_DataCache_l642) begin
+    if(when_DataCache_l645) begin
       _zz_2 = 1'b1;
     end
   end
@@ -7589,43 +7655,45 @@ module DataCache (
   assign _zz_ways_0_dataReadRspMem = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
   assign ways_0_dataReadRspMem = _zz_ways_0_data_port0;
   assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
-  assign when_DataCache_l642 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
-  assign when_DataCache_l645 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
+  assign when_DataCache_l645 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
+  assign when_DataCache_l648 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
   always @(*) begin
     tagsReadCmd_valid = 1'b0;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       tagsReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     tagsReadCmd_payload = 7'bxxxxxxx;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
     end
   end
 
   always @(*) begin
     dataReadCmd_valid = 1'b0;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       dataReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     dataReadCmd_payload = 10'bxxxxxxxxxx;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       dataReadCmd_payload = io_cpu_execute_address[11 : 2];
     end
   end
 
   always @(*) begin
     tagsWriteCmd_valid = 1'b0;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_valid = 1'b1;
     end
-    if(when_DataCache_l1066) begin
-      tagsWriteCmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        tagsWriteCmd_valid = 1'b0;
+      end
     end
     if(loader_done) begin
       tagsWriteCmd_valid = 1'b1;
@@ -7634,7 +7702,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_way = 1'bx;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_payload_way = 1'b1;
     end
     if(loader_done) begin
@@ -7644,7 +7712,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_address = 7'bxxxxxxx;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_payload_address = stageB_flusher_counter[6:0];
     end
     if(loader_done) begin
@@ -7654,7 +7722,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_data_valid = 1'bx;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_payload_data_valid = 1'b0;
     end
     if(loader_done) begin
@@ -7679,30 +7747,32 @@ module DataCache (
   always @(*) begin
     dataWriteCmd_valid = 1'b0;
     if(stageB_cpuWriteToCache) begin
-      if(when_DataCache_l926) begin
+      if(when_DataCache_l931) begin
         dataWriteCmd_valid = 1'b1;
       end
     end
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(when_DataCache_l1009) begin
             if(stageB_request_isAmo) begin
-              if(when_DataCache_l1012) begin
+              if(when_DataCache_l1017) begin
                 dataWriteCmd_valid = 1'b0;
               end
             end
-            if(when_DataCache_l1025) begin
+            if(when_DataCache_l1030) begin
               dataWriteCmd_valid = 1'b0;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1066) begin
-      dataWriteCmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        dataWriteCmd_valid = 1'b0;
+      end
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_valid = 1'b1;
     end
   end
@@ -7712,7 +7782,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_way = stageB_waysHits;
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_way = loader_waysAllocator;
     end
   end
@@ -7722,7 +7792,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
     end
   end
@@ -7732,7 +7802,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_data = io_mem_rsp_payload_data;
     end
   end
@@ -7745,15 +7815,15 @@ module DataCache (
         dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
       end
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_mask = 4'b1111;
     end
   end
 
-  assign when_DataCache_l664 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  assign when_DataCache_l667 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
   always @(*) begin
     io_cpu_execute_haltIt = 1'b0;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       io_cpu_execute_haltIt = 1'b1;
     end
   end
@@ -7761,7 +7831,7 @@ module DataCache (
   assign rspSync = 1'b1;
   assign rspLast = 1'b1;
   assign io_mem_cmd_fire = (io_mem_cmd_valid && io_mem_cmd_ready);
-  assign when_DataCache_l686 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l689 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     _zz_stage0_mask = 4'bxxxx;
     case(io_cpu_execute_args_size)
@@ -7780,42 +7850,42 @@ module DataCache (
   end
 
   assign stage0_mask = (_zz_stage0_mask <<< io_cpu_execute_address[1 : 0]);
-  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_stage0_dataColisions)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_execute_address[11 : 2])) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stage0_wayInvalidate = 1'b0;
-  assign when_DataCache_l771 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l771_1 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l776 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l776_1 = (! io_cpu_memory_isStuck);
   assign io_cpu_memory_isWrite = stageA_request_wr;
   assign stageA_wayHits = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign when_DataCache_l771_2 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l771_3 = (! io_cpu_memory_isStuck);
-  assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz__zz_stageA_dataColisions)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign when_DataCache_l776_2 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l776_3 = (! io_cpu_memory_isStuck);
+  assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_memory_address[11 : 2])) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_stageA_dataColisions);
-  assign when_DataCache_l822 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l827 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_mmuRspFreeze = 1'b0;
-    if(when_DataCache_l1125) begin
+    if(when_DataCache_l1132) begin
       stageB_mmuRspFreeze = 1'b1;
     end
   end
 
-  assign when_DataCache_l824 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
-  assign when_DataCache_l821 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l821_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l820 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l829 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
+  assign when_DataCache_l826 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l826_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825 = (! io_cpu_writeBack_isStuck);
   assign stageB_consistancyHazard = 1'b0;
-  assign when_DataCache_l820_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l820_2 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l820_3 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_2 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_3 = (! io_cpu_writeBack_isStuck);
   assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
   assign stageB_waysHit = (|stageB_waysHits);
   assign stageB_dataMux = stageB_dataReadRsp_0;
-  assign when_DataCache_l820_4 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_4 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_loaderValid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
             if(io_mem_cmd_ready) begin
               stageB_loaderValid = 1'b1;
             end
@@ -7823,8 +7893,10 @@ module DataCache (
         end
       end
     end
-    if(when_DataCache_l1066) begin
-      stageB_loaderValid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        stageB_loaderValid = 1'b0;
+      end
     end
   end
 
@@ -7833,40 +7905,44 @@ module DataCache (
     io_cpu_writeBack_haltIt = 1'b1;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l991) begin
-          if(when_DataCache_l995) begin
+        if(when_DataCache_l996) begin
+          if(when_DataCache_l1000) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
-          if(when_DataCache_l999) begin
+          if(when_DataCache_l1004) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
         end else begin
-          if(when_DataCache_l1004) begin
-            if(when_DataCache_l1009) begin
+          if(when_DataCache_l1009) begin
+            if(when_DataCache_l1014) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
             if(stageB_request_isAmo) begin
-              if(when_DataCache_l1012) begin
+              if(when_DataCache_l1017) begin
                 io_cpu_writeBack_haltIt = 1'b1;
               end
             end
-            if(when_DataCache_l1025) begin
+            if(when_DataCache_l1030) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1066) begin
-      io_cpu_writeBack_haltIt = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        io_cpu_writeBack_haltIt = 1'b0;
+      end
     end
   end
 
   assign stageB_flusher_hold = 1'b0;
-  assign when_DataCache_l850 = (! stageB_flusher_counter[7]);
-  assign when_DataCache_l856 = (! stageB_flusher_hold);
+  assign when_DataCache_l855 = (! stageB_flusher_counter[7]);
+  assign when_DataCache_l861 = (! stageB_flusher_hold);
+  assign when_DataCache_l863 = (io_cpu_flush_valid && io_cpu_flush_payload_singleLine);
   assign io_cpu_flush_ready = (stageB_flusher_waitDone && stageB_flusher_counter[7]);
-  assign when_DataCache_l880 = (io_cpu_writeBack_isValid && io_cpu_writeBack_isFiring);
+  assign when_DataCache_l877 = (io_cpu_flush_valid && io_cpu_flush_payload_singleLine);
+  assign when_DataCache_l885 = (io_cpu_writeBack_isValid && io_cpu_writeBack_isFiring);
   assign stageB_isExternalLsrc = 1'b0;
   assign stageB_isExternalAmo = 1'b0;
   always @(*) begin
@@ -7881,9 +7957,9 @@ module DataCache (
   assign stageB_amo_addSub = _zz_stageB_amo_addSub;
   assign stageB_amo_less = ((io_cpu_writeBack_storeData[31] == stageB_dataMux[31]) ? stageB_amo_addSub[31] : (stageB_amo_unsigned ? stageB_dataMux[31] : io_cpu_writeBack_storeData[31]));
   assign stageB_amo_selectRf = (stageB_request_amoCtrl_swap ? 1'b1 : (stageB_request_amoCtrl_alu[0] ^ stageB_amo_less));
-  assign switch_Misc_l210 = (stageB_request_amoCtrl_alu | {stageB_request_amoCtrl_swap,2'b00});
+  assign switch_Misc_l232 = (stageB_request_amoCtrl_alu | {stageB_request_amoCtrl_swap,2'b00});
   always @(*) begin
-    case(switch_Misc_l210)
+    case(switch_Misc_l232)
       3'b000 : begin
         stageB_amo_result = stageB_amo_addSub;
       end
@@ -7906,8 +7982,8 @@ module DataCache (
     stageB_cpuWriteToCache = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(when_DataCache_l1009) begin
             stageB_cpuWriteToCache = 1'b1;
           end
         end
@@ -7915,26 +7991,28 @@ module DataCache (
     end
   end
 
-  assign when_DataCache_l926 = (stageB_request_wr && stageB_waysHit);
+  assign when_DataCache_l931 = (stageB_request_wr && stageB_waysHit);
   assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_request_isAmo)));
   assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
   always @(*) begin
     io_cpu_redo = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(when_DataCache_l1004) begin
-            if(when_DataCache_l1020) begin
+        if(!when_DataCache_l996) begin
+          if(when_DataCache_l1009) begin
+            if(when_DataCache_l1025) begin
               io_cpu_redo = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1075) begin
-      io_cpu_redo = 1'b1;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1081) begin
+        io_cpu_redo = 1'b1;
+      end
     end
-    if(when_DataCache_l1122) begin
+    if(when_DataCache_l1129) begin
       io_cpu_redo = 1'b1;
     end
   end
@@ -7955,37 +8033,39 @@ module DataCache (
     io_mem_cmd_valid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l991) begin
+        if(when_DataCache_l996) begin
           io_mem_cmd_valid = (! memCmdSent);
-          if(when_DataCache_l999) begin
+          if(when_DataCache_l1004) begin
             io_mem_cmd_valid = 1'b0;
           end
         end else begin
-          if(when_DataCache_l1004) begin
+          if(when_DataCache_l1009) begin
             if(stageB_request_wr) begin
               io_mem_cmd_valid = 1'b1;
             end
             if(stageB_request_isAmo) begin
-              if(when_DataCache_l1012) begin
+              if(when_DataCache_l1017) begin
                 io_mem_cmd_valid = 1'b0;
               end
-            end
-            if(when_DataCache_l1020) begin
-              io_mem_cmd_valid = 1'b0;
             end
             if(when_DataCache_l1025) begin
               io_mem_cmd_valid = 1'b0;
             end
+            if(when_DataCache_l1030) begin
+              io_mem_cmd_valid = 1'b0;
+            end
           end else begin
-            if(when_DataCache_l1032) begin
+            if(when_DataCache_l1037) begin
               io_mem_cmd_valid = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1066) begin
-      io_mem_cmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        io_mem_cmd_valid = 1'b0;
+      end
     end
   end
 
@@ -7993,9 +8073,9 @@ module DataCache (
     io_mem_cmd_payload_address = stageB_mmuRsp_physicalAddress;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
-            io_mem_cmd_payload_address[4 : 0] = 5'h0;
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
+            io_mem_cmd_payload_address[4 : 0] = 5'h00;
           end
         end
       end
@@ -8007,8 +8087,8 @@ module DataCache (
     io_mem_cmd_payload_wr = stageB_request_wr;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
             io_mem_cmd_payload_wr = 1'b0;
           end
         end
@@ -8023,8 +8103,8 @@ module DataCache (
     io_mem_cmd_payload_size = {1'd0, stageB_request_size};
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
             io_mem_cmd_payload_size = 3'b101;
           end
         end
@@ -8034,15 +8114,15 @@ module DataCache (
 
   assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
   assign io_cpu_writeBack_keepMemRspData = 1'b0;
-  assign when_DataCache_l995 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
-  assign when_DataCache_l999 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
-  assign when_DataCache_l1004 = (stageB_waysHit || (stageB_request_wr && (! stageB_request_isAmo)));
-  assign when_DataCache_l1009 = ((! stageB_request_wr) || io_mem_cmd_ready);
-  assign when_DataCache_l1012 = (! stageB_amo_internal_resultRegValid);
-  assign when_DataCache_l1020 = (((! stageB_request_wr) || stageB_request_isAmo) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
-  assign when_DataCache_l1025 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
-  assign when_DataCache_l1032 = (! memCmdSent);
-  assign when_DataCache_l991 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  assign when_DataCache_l1000 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
+  assign when_DataCache_l1004 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
+  assign when_DataCache_l1009 = (stageB_waysHit || (stageB_request_wr && (! stageB_request_isAmo)));
+  assign when_DataCache_l1014 = ((! stageB_request_wr) || io_mem_cmd_ready);
+  assign when_DataCache_l1017 = (! stageB_amo_internal_resultRegValid);
+  assign when_DataCache_l1025 = (((! stageB_request_wr) || stageB_request_isAmo) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
+  assign when_DataCache_l1030 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
+  assign when_DataCache_l1037 = (! memCmdSent);
+  assign when_DataCache_l996 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
   always @(*) begin
     if(stageB_bypassCache) begin
       io_cpu_writeBack_data = stageB_ioMemRspMuxed;
@@ -8052,11 +8132,11 @@ module DataCache (
   end
 
   assign io_cpu_writeBack_exclusiveOk = stageB_lrSc_reserved;
-  assign when_DataCache_l1066 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign when_DataCache_l1075 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
+  assign when_DataCache_l1072 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign when_DataCache_l1081 = (stageB_mmuRsp_refilling || stageB_consistancyHazard);
   always @(*) begin
     loader_counter_willIncrement = 1'b0;
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       loader_counter_willIncrement = 1'b1;
     end
   end
@@ -8072,12 +8152,12 @@ module DataCache (
   end
 
   assign loader_kill = 1'b0;
-  assign when_DataCache_l1090 = ((loader_valid && io_mem_rsp_valid) && rspLast);
+  assign when_DataCache_l1097 = ((loader_valid && io_mem_rsp_valid) && rspLast);
   assign loader_done = loader_counter_willOverflow;
-  assign when_DataCache_l1118 = (! loader_valid);
-  assign when_DataCache_l1122 = (loader_valid && (! loader_valid_regNext));
+  assign when_DataCache_l1125 = (! loader_valid);
+  assign when_DataCache_l1129 = (loader_valid && (! loader_valid_regNext));
   assign io_cpu_execute_refilling = loader_valid;
-  assign when_DataCache_l1125 = (stageB_loaderValid || loader_valid);
+  assign when_DataCache_l1132 = (stageB_loaderValid || loader_valid);
   always @(posedge clk) begin
     tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
     tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
@@ -8085,7 +8165,7 @@ module DataCache (
     tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
     tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
     tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if(when_DataCache_l771) begin
+    if(when_DataCache_l776) begin
       stageA_request_wr <= io_cpu_execute_args_wr;
       stageA_request_size <= io_cpu_execute_args_size;
       stageA_request_isLrsc <= io_cpu_execute_args_isLrsc;
@@ -8094,16 +8174,16 @@ module DataCache (
       stageA_request_amoCtrl_alu <= io_cpu_execute_args_amoCtrl_alu;
       stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
     end
-    if(when_DataCache_l771_1) begin
+    if(when_DataCache_l776_1) begin
       stageA_mask <= stage0_mask;
     end
-    if(when_DataCache_l771_2) begin
+    if(when_DataCache_l776_2) begin
       stageA_wayInvalidate <= stage0_wayInvalidate;
     end
-    if(when_DataCache_l771_3) begin
+    if(when_DataCache_l776_3) begin
       stage0_dataColisions_regNextWhen <= stage0_dataColisions;
     end
-    if(when_DataCache_l822) begin
+    if(when_DataCache_l827) begin
       stageB_request_wr <= stageA_request_wr;
       stageB_request_size <= stageA_request_size;
       stageB_request_isLrsc <= stageA_request_isLrsc;
@@ -8112,7 +8192,7 @@ module DataCache (
       stageB_request_amoCtrl_alu <= stageA_request_amoCtrl_alu;
       stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
     end
-    if(when_DataCache_l824) begin
+    if(when_DataCache_l829) begin
       stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
       stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
       stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
@@ -8131,27 +8211,27 @@ module DataCache (
       stageB_mmuRsp_ways_3_sel <= io_cpu_memory_mmuRsp_ways_3_sel;
       stageB_mmuRsp_ways_3_physical <= io_cpu_memory_mmuRsp_ways_3_physical;
     end
-    if(when_DataCache_l821) begin
+    if(when_DataCache_l826) begin
       stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
       stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
       stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
     end
-    if(when_DataCache_l821_1) begin
+    if(when_DataCache_l826_1) begin
       stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
     end
-    if(when_DataCache_l820) begin
+    if(when_DataCache_l825) begin
       stageB_wayInvalidate <= stageA_wayInvalidate;
     end
-    if(when_DataCache_l820_1) begin
+    if(when_DataCache_l825_1) begin
       stageB_dataColisions <= stageA_dataColisions;
     end
-    if(when_DataCache_l820_2) begin
+    if(when_DataCache_l825_2) begin
       stageB_unaligned <= ({((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)),((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0))} != 2'b00);
     end
-    if(when_DataCache_l820_3) begin
+    if(when_DataCache_l825_3) begin
       stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
     end
-    if(when_DataCache_l820_4) begin
+    if(when_DataCache_l825_4) begin
       stageB_mask <= stageA_mask;
     end
     stageB_amo_internal_resultRegValid <= io_cpu_writeBack_isStuck;
@@ -8163,7 +8243,7 @@ module DataCache (
     if(reset) begin
       memCmdSent <= 1'b0;
       stageB_flusher_waitDone <= 1'b0;
-      stageB_flusher_counter <= 8'h0;
+      stageB_flusher_counter <= 8'h00;
       stageB_flusher_start <= 1'b1;
       stageB_lrSc_reserved <= 1'b0;
       loader_valid <= 1'b0;
@@ -8175,16 +8255,16 @@ module DataCache (
       if(io_mem_cmd_fire) begin
         memCmdSent <= 1'b1;
       end
-      if(when_DataCache_l686) begin
+      if(when_DataCache_l689) begin
         memCmdSent <= 1'b0;
       end
       if(io_cpu_flush_ready) begin
         stageB_flusher_waitDone <= 1'b0;
       end
-      if(when_DataCache_l850) begin
-        if(when_DataCache_l856) begin
+      if(when_DataCache_l855) begin
+        if(when_DataCache_l861) begin
           stageB_flusher_counter <= (stageB_flusher_counter + 8'h01);
-          if(io_cpu_flush_payload_singleLine) begin
+          if(when_DataCache_l863) begin
             stageB_flusher_counter[7] <= 1'b1;
           end
         end
@@ -8192,12 +8272,12 @@ module DataCache (
       stageB_flusher_start <= (((((((! stageB_flusher_waitDone) && (! stageB_flusher_start)) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
       if(stageB_flusher_start) begin
         stageB_flusher_waitDone <= 1'b1;
-        stageB_flusher_counter <= 8'h0;
-        if(io_cpu_flush_payload_singleLine) begin
+        stageB_flusher_counter <= 8'h00;
+        if(when_DataCache_l877) begin
           stageB_flusher_counter <= {1'b0,io_cpu_flush_payload_lineId};
         end
       end
-      if(when_DataCache_l880) begin
+      if(when_DataCache_l885) begin
         if(stageB_request_isLrsc) begin
           stageB_lrSc_reserved <= 1'b1;
         end
@@ -8205,15 +8285,17 @@ module DataCache (
           stageB_lrSc_reserved <= 1'b0;
         end
       end
-      if(when_DataCache_l1066) begin
-        stageB_lrSc_reserved <= stageB_lrSc_reserved;
+      if(io_cpu_writeBack_isValid) begin
+        if(when_DataCache_l1072) begin
+          stageB_lrSc_reserved <= stageB_lrSc_reserved;
+        end
       end
       `ifndef SYNTHESIS
         `ifdef FORMAL
-          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))); // DataCache.scala:L1077
+          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))); // DataCache.scala:L1084
         `else
           if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-            $display("ERROR writeBack stuck by another plugin is not allowed"); // DataCache.scala:L1077
+            $display("ERROR writeBack stuck by another plugin is not allowed"); // DataCache.scala:L1084
           end
         `endif
       `endif
@@ -8224,7 +8306,7 @@ module DataCache (
       if(loader_kill) begin
         loader_killReg <= 1'b1;
       end
-      if(when_DataCache_l1090) begin
+      if(when_DataCache_l1097) begin
         loader_error <= (loader_error || io_mem_rsp_payload_error);
       end
       if(loader_done) begin
@@ -8232,7 +8314,7 @@ module DataCache (
         loader_error <= 1'b0;
         loader_killReg <= 1'b0;
       end
-      if(when_DataCache_l1118) begin
+      if(when_DataCache_l1125) begin
         loader_waysAllocator <= _zz_loader_waysAllocator[0:0];
       end
     end
@@ -8242,54 +8324,54 @@ module DataCache (
 endmodule
 
 module InstructionCache (
-  input               io_flush,
-  input               io_cpu_prefetch_isValid,
-  output reg          io_cpu_prefetch_haltIt,
-  input      [31:0]   io_cpu_prefetch_pc,
-  input               io_cpu_fetch_isValid,
-  input               io_cpu_fetch_isStuck,
-  input               io_cpu_fetch_isRemoved,
-  input      [31:0]   io_cpu_fetch_pc,
-  output     [31:0]   io_cpu_fetch_data,
-  input      [31:0]   io_cpu_fetch_mmuRsp_physicalAddress,
-  input               io_cpu_fetch_mmuRsp_isIoAccess,
-  input               io_cpu_fetch_mmuRsp_isPaging,
-  input               io_cpu_fetch_mmuRsp_allowRead,
-  input               io_cpu_fetch_mmuRsp_allowWrite,
-  input               io_cpu_fetch_mmuRsp_allowExecute,
-  input               io_cpu_fetch_mmuRsp_exception,
-  input               io_cpu_fetch_mmuRsp_refilling,
-  input               io_cpu_fetch_mmuRsp_bypassTranslation,
-  input               io_cpu_fetch_mmuRsp_ways_0_sel,
-  input      [31:0]   io_cpu_fetch_mmuRsp_ways_0_physical,
-  input               io_cpu_fetch_mmuRsp_ways_1_sel,
-  input      [31:0]   io_cpu_fetch_mmuRsp_ways_1_physical,
-  input               io_cpu_fetch_mmuRsp_ways_2_sel,
-  input      [31:0]   io_cpu_fetch_mmuRsp_ways_2_physical,
-  input               io_cpu_fetch_mmuRsp_ways_3_sel,
-  input      [31:0]   io_cpu_fetch_mmuRsp_ways_3_physical,
-  output     [31:0]   io_cpu_fetch_physicalAddress,
-  input               io_cpu_decode_isValid,
-  input               io_cpu_decode_isStuck,
-  input      [31:0]   io_cpu_decode_pc,
-  output     [31:0]   io_cpu_decode_physicalAddress,
-  output     [31:0]   io_cpu_decode_data,
-  output              io_cpu_decode_cacheMiss,
-  output              io_cpu_decode_error,
-  output              io_cpu_decode_mmuRefilling,
-  output              io_cpu_decode_mmuException,
-  input               io_cpu_decode_isUser,
-  input               io_cpu_fill_valid,
-  input      [31:0]   io_cpu_fill_payload,
-  output              io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output     [31:0]   io_mem_cmd_payload_address,
-  output     [2:0]    io_mem_cmd_payload_size,
-  input               io_mem_rsp_valid,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input               clk,
-  input               reset
+  input  wire          io_flush,
+  input  wire          io_cpu_prefetch_isValid,
+  output reg           io_cpu_prefetch_haltIt,
+  input  wire [31:0]   io_cpu_prefetch_pc,
+  input  wire          io_cpu_fetch_isValid,
+  input  wire          io_cpu_fetch_isStuck,
+  input  wire          io_cpu_fetch_isRemoved,
+  input  wire [31:0]   io_cpu_fetch_pc,
+  output wire [31:0]   io_cpu_fetch_data,
+  input  wire [31:0]   io_cpu_fetch_mmuRsp_physicalAddress,
+  input  wire          io_cpu_fetch_mmuRsp_isIoAccess,
+  input  wire          io_cpu_fetch_mmuRsp_isPaging,
+  input  wire          io_cpu_fetch_mmuRsp_allowRead,
+  input  wire          io_cpu_fetch_mmuRsp_allowWrite,
+  input  wire          io_cpu_fetch_mmuRsp_allowExecute,
+  input  wire          io_cpu_fetch_mmuRsp_exception,
+  input  wire          io_cpu_fetch_mmuRsp_refilling,
+  input  wire          io_cpu_fetch_mmuRsp_bypassTranslation,
+  input  wire          io_cpu_fetch_mmuRsp_ways_0_sel,
+  input  wire [31:0]   io_cpu_fetch_mmuRsp_ways_0_physical,
+  input  wire          io_cpu_fetch_mmuRsp_ways_1_sel,
+  input  wire [31:0]   io_cpu_fetch_mmuRsp_ways_1_physical,
+  input  wire          io_cpu_fetch_mmuRsp_ways_2_sel,
+  input  wire [31:0]   io_cpu_fetch_mmuRsp_ways_2_physical,
+  input  wire          io_cpu_fetch_mmuRsp_ways_3_sel,
+  input  wire [31:0]   io_cpu_fetch_mmuRsp_ways_3_physical,
+  output wire [31:0]   io_cpu_fetch_physicalAddress,
+  input  wire          io_cpu_decode_isValid,
+  input  wire          io_cpu_decode_isStuck,
+  input  wire [31:0]   io_cpu_decode_pc,
+  output wire [31:0]   io_cpu_decode_physicalAddress,
+  output wire [31:0]   io_cpu_decode_data,
+  output wire          io_cpu_decode_cacheMiss,
+  output wire          io_cpu_decode_error,
+  output wire          io_cpu_decode_mmuRefilling,
+  output wire          io_cpu_decode_mmuException,
+  input  wire          io_cpu_decode_isUser,
+  input  wire          io_cpu_fill_valid,
+  input  wire [31:0]   io_cpu_fill_payload,
+  output wire          io_mem_cmd_valid,
+  input  wire          io_mem_cmd_ready,
+  output wire [31:0]   io_mem_cmd_payload_address,
+  output wire [2:0]    io_mem_cmd_payload_size,
+  input  wire          io_mem_rsp_valid,
+  input  wire [31:0]   io_mem_rsp_payload_data,
+  input  wire          io_mem_rsp_payload_error,
+  input  wire          clk,
+  input  wire          reset
 );
 
   reg        [31:0]   _zz_banks_0_port1;
@@ -8309,7 +8391,7 @@ module InstructionCache (
   wire                when_InstructionCache_l351;
   reg                 lineLoader_cmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_Utils_l515;
+  wire                when_Utils_l560;
   reg                 lineLoader_wayToAllocate_willIncrement;
   wire                lineLoader_wayToAllocate_willClear;
   wire                lineLoader_wayToAllocate_willOverflowIfInc;
@@ -8432,12 +8514,12 @@ module InstructionCache (
   assign when_InstructionCache_l351 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
   assign io_mem_cmd_fire = (io_mem_cmd_valid && io_mem_cmd_ready);
   assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
-  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
+  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h00};
   assign io_mem_cmd_payload_size = 3'b101;
-  assign when_Utils_l515 = (! lineLoader_valid);
+  assign when_Utils_l560 = (! lineLoader_valid);
   always @(*) begin
     lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if(when_Utils_l515) begin
+    if(when_Utils_l560) begin
       lineLoader_wayToAllocate_willIncrement = 1'b1;
     end
   end
@@ -8528,7 +8610,7 @@ module InstructionCache (
     end
     _zz_when_InstructionCache_l342 <= lineLoader_flushCounter[7];
     if(when_InstructionCache_l351) begin
-      lineLoader_flushCounter <= 8'h0;
+      lineLoader_flushCounter <= 8'h00;
     end
     if(when_InstructionCache_l435) begin
       io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_LinuxDebug.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_LinuxDebug.v
@@ -1,46 +1,46 @@
-// Generator : SpinalHDL v1.7.1    git head : 0444bb76ab1d6e19f0ec46bc03c4769776deb7d5
+// Generator : SpinalHDL v1.9.4    git head : 270018552577f3bb8e5339ee2583c9c22d324215
 // Component : VexRiscv
-// Git hash  : 581fcb065adf7ea8b626f939ff51679d4c95872f
+// Git hash  : 63430af99f84cc1d11d58b556debe1cc3f238c67
 
 `timescale 1ns/1ps
 
 module VexRiscv (
-  input      [31:0]   externalResetVector,
-  input               timerInterrupt,
-  input               softwareInterrupt,
-  input      [31:0]   externalInterruptArray,
-  input               debug_bus_cmd_valid,
-  output reg          debug_bus_cmd_ready,
-  input               debug_bus_cmd_payload_wr,
-  input      [7:0]    debug_bus_cmd_payload_address,
-  input      [31:0]   debug_bus_cmd_payload_data,
-  output reg [31:0]   debug_bus_rsp_data,
-  output              debug_resetOut,
-  output reg          iBusWishbone_CYC,
-  output reg          iBusWishbone_STB,
-  input               iBusWishbone_ACK,
-  output              iBusWishbone_WE,
-  output     [29:0]   iBusWishbone_ADR,
-  input      [31:0]   iBusWishbone_DAT_MISO,
-  output     [31:0]   iBusWishbone_DAT_MOSI,
-  output     [3:0]    iBusWishbone_SEL,
-  input               iBusWishbone_ERR,
-  output     [2:0]    iBusWishbone_CTI,
-  output     [1:0]    iBusWishbone_BTE,
-  output              dBusWishbone_CYC,
-  output              dBusWishbone_STB,
-  input               dBusWishbone_ACK,
-  output              dBusWishbone_WE,
-  output     [29:0]   dBusWishbone_ADR,
-  input      [31:0]   dBusWishbone_DAT_MISO,
-  output     [31:0]   dBusWishbone_DAT_MOSI,
-  output     [3:0]    dBusWishbone_SEL,
-  input               dBusWishbone_ERR,
-  output     [2:0]    dBusWishbone_CTI,
-  output     [1:0]    dBusWishbone_BTE,
-  input               clk,
-  input               reset,
-  input               debugReset
+  input  wire [31:0]   externalResetVector,
+  input  wire          timerInterrupt,
+  input  wire          softwareInterrupt,
+  input  wire [31:0]   externalInterruptArray,
+  input  wire          debug_bus_cmd_valid,
+  output reg           debug_bus_cmd_ready,
+  input  wire          debug_bus_cmd_payload_wr,
+  input  wire [7:0]    debug_bus_cmd_payload_address,
+  input  wire [31:0]   debug_bus_cmd_payload_data,
+  output reg  [31:0]   debug_bus_rsp_data,
+  output wire          debug_resetOut,
+  output reg           iBusWishbone_CYC,
+  output reg           iBusWishbone_STB,
+  input  wire          iBusWishbone_ACK,
+  output wire          iBusWishbone_WE,
+  output wire [29:0]   iBusWishbone_ADR,
+  input  wire [31:0]   iBusWishbone_DAT_MISO,
+  output wire [31:0]   iBusWishbone_DAT_MOSI,
+  output wire [3:0]    iBusWishbone_SEL,
+  input  wire          iBusWishbone_ERR,
+  output wire [2:0]    iBusWishbone_CTI,
+  output wire [1:0]    iBusWishbone_BTE,
+  output wire          dBusWishbone_CYC,
+  output wire          dBusWishbone_STB,
+  input  wire          dBusWishbone_ACK,
+  output wire          dBusWishbone_WE,
+  output wire [29:0]   dBusWishbone_ADR,
+  input  wire [31:0]   dBusWishbone_DAT_MISO,
+  output wire [31:0]   dBusWishbone_DAT_MOSI,
+  output wire [3:0]    dBusWishbone_SEL,
+  input  wire          dBusWishbone_ERR,
+  output wire [2:0]    dBusWishbone_CTI,
+  output wire [1:0]    dBusWishbone_BTE,
+  input  wire          clk,
+  input  wire          reset,
+  input  wire          debugReset
 );
   localparam ShiftCtrlEnum_DISABLE_1 = 2'd0;
   localparam ShiftCtrlEnum_SLL_1 = 2'd1;
@@ -109,7 +109,6 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_flush_valid;
   wire                dataCache_1_io_cpu_flush_payload_singleLine;
   wire       [6:0]    dataCache_1_io_cpu_flush_payload_lineId;
-  wire                dataCache_1_io_mem_cmd_ready;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
@@ -137,6 +136,7 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_writeBack_exclusiveOk;
   wire                dataCache_1_io_cpu_flush_ready;
   wire                dataCache_1_io_cpu_redo;
+  wire                dataCache_1_io_cpu_writesPending;
   wire                dataCache_1_io_mem_cmd_valid;
   wire                dataCache_1_io_mem_cmd_payload_wr;
   wire                dataCache_1_io_mem_cmd_payload_uncached;
@@ -148,12 +148,11 @@ module VexRiscv (
   wire       [51:0]   _zz_memory_MUL_LOW;
   wire       [51:0]   _zz_memory_MUL_LOW_1;
   wire       [51:0]   _zz_memory_MUL_LOW_2;
-  wire       [51:0]   _zz_memory_MUL_LOW_3;
-  wire       [32:0]   _zz_memory_MUL_LOW_4;
-  wire       [51:0]   _zz_memory_MUL_LOW_5;
-  wire       [49:0]   _zz_memory_MUL_LOW_6;
-  wire       [51:0]   _zz_memory_MUL_LOW_7;
-  wire       [49:0]   _zz_memory_MUL_LOW_8;
+  wire       [32:0]   _zz_memory_MUL_LOW_3;
+  wire       [51:0]   _zz_memory_MUL_LOW_4;
+  wire       [49:0]   _zz_memory_MUL_LOW_5;
+  wire       [51:0]   _zz_memory_MUL_LOW_6;
+  wire       [49:0]   _zz_memory_MUL_LOW_7;
   wire       [31:0]   _zz_execute_SHIFT_RIGHT;
   wire       [32:0]   _zz_execute_SHIFT_RIGHT_1;
   wire       [32:0]   _zz_execute_SHIFT_RIGHT_2;
@@ -164,24 +163,24 @@ module VexRiscv (
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_2;
   wire                _zz_decode_LEGAL_INSTRUCTION_3;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_4;
-  wire       [17:0]   _zz_decode_LEGAL_INSTRUCTION_5;
+  wire       [16:0]   _zz_decode_LEGAL_INSTRUCTION_5;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_6;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_7;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_8;
   wire                _zz_decode_LEGAL_INSTRUCTION_9;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_10;
-  wire       [11:0]   _zz_decode_LEGAL_INSTRUCTION_11;
+  wire       [10:0]   _zz_decode_LEGAL_INSTRUCTION_11;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_12;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_13;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_14;
   wire                _zz_decode_LEGAL_INSTRUCTION_15;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_16;
-  wire       [5:0]    _zz_decode_LEGAL_INSTRUCTION_17;
+  wire       [4:0]    _zz_decode_LEGAL_INSTRUCTION_17;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_18;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_19;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_20;
-  wire                _zz_decode_LEGAL_INSTRUCTION_21;
-  wire                _zz_decode_LEGAL_INSTRUCTION_22;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_21;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_22;
   wire       [4:0]    _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1;
   reg        [31:0]   _zz_IBusCachedPlugin_jump_pcLoad_payload_6;
   wire       [2:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_7;
@@ -268,155 +267,154 @@ module VexRiscv (
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_19;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_20;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_21;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_22;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_23;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_24;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_22;
+  wire       [25:0]   _zz__zz_decode_IS_RS2_SIGNED_23;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_24;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_25;
-  wire       [25:0]   _zz__zz_decode_IS_RS2_SIGNED_26;
-  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_27;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_26;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_27;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_28;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_29;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_30;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_31;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_32;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_33;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_34;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_29;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_30;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_31;
+  wire       [22:0]   _zz__zz_decode_IS_RS2_SIGNED_32;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_33;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_34;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_35;
   wire                _zz__zz_decode_IS_RS2_SIGNED_36;
-  wire       [22:0]   _zz__zz_decode_IS_RS2_SIGNED_37;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_38;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_37;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_38;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_39;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_40;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_41;
-  wire       [19:0]   _zz__zz_decode_IS_RS2_SIGNED_42;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_43;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_44;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_45;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_40;
+  wire       [18:0]   _zz__zz_decode_IS_RS2_SIGNED_41;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_42;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_43;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_44;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_45;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_46;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_47;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_47;
   wire                _zz__zz_decode_IS_RS2_SIGNED_48;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_49;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_50;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_51;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_51;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_52;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_53;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_54;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_55;
-  wire       [15:0]   _zz__zz_decode_IS_RS2_SIGNED_56;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_57;
-  wire       [5:0]    _zz__zz_decode_IS_RS2_SIGNED_58;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_53;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_54;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_55;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_56;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_57;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_58;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_59;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_60;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_61;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_62;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_63;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_64;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_60;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_61;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_62;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_63;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_64;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_65;
-  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_66;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_67;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_68;
+  wire       [14:0]   _zz__zz_decode_IS_RS2_SIGNED_66;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_67;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_68;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_69;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_70;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_71;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_70;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_71;
   wire                _zz__zz_decode_IS_RS2_SIGNED_72;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_73;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_74;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_75;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_74;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_75;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_76;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_77;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_78;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_79;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_80;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_81;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_80;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_81;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_82;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_83;
-  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_84;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_85;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_86;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_83;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_84;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_85;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_86;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_87;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_88;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_89;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_90;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_91;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_92;
-  wire       [11:0]   _zz__zz_decode_IS_RS2_SIGNED_93;
-  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_94;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_95;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_96;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_88;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_89;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_90;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_91;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_92;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_93;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_94;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_95;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_96;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_97;
-  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_98;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_99;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_100;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_101;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_102;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_98;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_99;
+  wire       [11:0]   _zz__zz_decode_IS_RS2_SIGNED_100;
+  wire       [6:0]    _zz__zz_decode_IS_RS2_SIGNED_101;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_102;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_103;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_104;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_105;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_106;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_107;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_104;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_105;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_106;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_107;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_108;
-  wire       [5:0]    _zz__zz_decode_IS_RS2_SIGNED_109;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_110;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_111;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_112;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_113;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_114;
-  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_115;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_109;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_110;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_111;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_112;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_113;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_114;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_115;
   wire                _zz__zz_decode_IS_RS2_SIGNED_116;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_117;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_117;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_118;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_119;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_120;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_121;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_122;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_123;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_124;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_125;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_126;
-  wire       [8:0]    _zz__zz_decode_IS_RS2_SIGNED_127;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_128;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_121;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_122;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_123;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_124;
+  wire       [8:0]    _zz__zz_decode_IS_RS2_SIGNED_125;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_126;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_127;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_128;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_129;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_130;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_131;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_132;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_133;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_134;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_135;
+  wire       [6:0]    _zz__zz_decode_IS_RS2_SIGNED_133;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_134;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_135;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_136;
-  wire       [6:0]    _zz__zz_decode_IS_RS2_SIGNED_137;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_137;
   wire                _zz__zz_decode_IS_RS2_SIGNED_138;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_139;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_140;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_141;
-  wire       [5:0]    _zz__zz_decode_IS_RS2_SIGNED_142;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_143;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_144;
-  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_145;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_146;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_139;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_140;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_141;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_142;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_143;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_144;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_145;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_146;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_147;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_148;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_149;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_150;
-  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_151;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_152;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_148;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_149;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_150;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_151;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_152;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_153;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_154;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_154;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_155;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_156;
-  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_157;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_157;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_158;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_159;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_160;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_161;
-  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_162;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_163;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_164;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_165;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_166;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_159;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_160;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_161;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_162;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_163;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_164;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_165;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_166;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_167;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_168;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_169;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_170;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_169;
   wire                _zz_RegFilePlugin_regFile_port;
   wire                _zz_decode_RegFilePlugin_rs1Data;
   wire                _zz_RegFilePlugin_regFile_port_1;
@@ -424,14 +422,12 @@ module VexRiscv (
   wire       [0:0]    _zz__zz_execute_REGFILE_WRITE_DATA;
   wire       [2:0]    _zz__zz_execute_SRC1;
   wire       [4:0]    _zz__zz_execute_SRC1_1;
-  wire       [11:0]   _zz__zz_execute_SRC2_3;
+  wire       [11:0]   _zz__zz_execute_SRC2_2;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_1;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_2;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_3;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_4;
-  wire       [31:0]   _zz_execute_SrcPlugin_addSub_5;
-  wire       [31:0]   _zz_execute_SrcPlugin_addSub_6;
   wire       [19:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_2;
   wire       [11:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_4;
   wire       [31:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_6;
@@ -465,7 +461,7 @@ module VexRiscv (
   wire       [0:0]    _zz_memory_DivPlugin_rs1_3;
   wire       [31:0]   _zz_memory_DivPlugin_rs2_1;
   wire       [0:0]    _zz_memory_DivPlugin_rs2_2;
-  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_28;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_26;
   wire       [26:0]   _zz_iBusWishbone_ADR_1;
   wire       [51:0]   memory_MUL_LOW;
   wire       [33:0]   memory_MUL_HH;
@@ -513,7 +509,6 @@ module VexRiscv (
   wire       [1:0]    _zz_decode_to_execute_ALU_BITWISE_CTRL;
   wire       [1:0]    _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   wire                decode_SRC_LESS_UNSIGNED;
-  wire                decode_IS_SFENCE_VMA;
   wire                decode_IS_SFENCE_VMA2;
   wire                decode_MEMORY_MANAGMENT;
   wire                memory_MEMORY_LRSC;
@@ -534,6 +529,7 @@ module VexRiscv (
   wire       [1:0]    _zz_decode_SRC1_CTRL;
   wire       [1:0]    _zz_decode_to_execute_SRC1_CTRL;
   wire       [1:0]    _zz_decode_to_execute_SRC1_CTRL_1;
+  wire                decode_RESCHEDULE_NEXT;
   wire                decode_MEMORY_FORCE_CONSTISTENCY;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
@@ -561,7 +557,7 @@ module VexRiscv (
   wire       [1:0]    _zz_execute_ENV_CTRL;
   wire       [1:0]    writeBack_ENV_CTRL;
   wire       [1:0]    _zz_writeBack_ENV_CTRL;
-  wire                execute_IS_SFENCE_VMA;
+  wire                execute_RESCHEDULE_NEXT;
   wire       [31:0]   memory_BRANCH_CALC;
   wire                memory_BRANCH_DO;
   wire       [31:0]   execute_PC;
@@ -589,7 +585,7 @@ module VexRiscv (
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_execute_SRC2;
+  wire       [31:0]   _zz_execute_to_memory_PC;
   wire       [1:0]    execute_SRC2_CTRL;
   wire       [1:0]    _zz_execute_SRC2_CTRL;
   wire       [1:0]    execute_SRC1_CTRL;
@@ -782,7 +778,7 @@ module VexRiscv (
   reg                 DBusCachedPlugin_exceptionBus_valid;
   reg        [3:0]    DBusCachedPlugin_exceptionBus_payload_code;
   wire       [31:0]   DBusCachedPlugin_exceptionBus_payload_badAddr;
-  reg                 _zz_when_DBusCachedPlugin_l393;
+  reg                 _zz_when_DBusCachedPlugin_l472;
   reg                 MmuPlugin_dBusAccess_cmd_valid;
   reg                 MmuPlugin_dBusAccess_cmd_ready;
   reg        [31:0]   MmuPlugin_dBusAccess_cmd_payload_address;
@@ -806,8 +802,9 @@ module VexRiscv (
   wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
   wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
   wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
-  wire                CsrPlugin_csrMapping_allowCsrSignal;
+  reg                 CsrPlugin_csrMapping_allowCsrSignal;
   wire                CsrPlugin_csrMapping_hazardFree;
+  wire                CsrPlugin_csrMapping_doForceFailCsr;
   reg                 CsrPlugin_inWfi /* verilator public */ ;
   reg                 CsrPlugin_thirdPartyWake;
   reg                 CsrPlugin_jumpInterface_valid;
@@ -829,9 +826,10 @@ module VexRiscv (
   reg                 CsrPlugin_allowInterrupts;
   reg                 CsrPlugin_allowException;
   reg                 CsrPlugin_allowEbreakException;
-  reg                 IBusCachedPlugin_injectionPort_valid;
-  reg                 IBusCachedPlugin_injectionPort_ready;
-  wire       [31:0]   IBusCachedPlugin_injectionPort_payload;
+  reg                 CsrPlugin_xretAwayFromMachine;
+  reg                 DebugPlugin_injectionPort_valid;
+  reg                 DebugPlugin_injectionPort_ready;
+  wire       [31:0]   DebugPlugin_injectionPort_payload;
   wire                IBusCachedPlugin_externalFlush;
   wire                IBusCachedPlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
@@ -852,14 +850,13 @@ module VexRiscv (
   reg                 IBusCachedPlugin_fetchPc_pcRegPropagate;
   reg                 IBusCachedPlugin_fetchPc_booted;
   reg                 IBusCachedPlugin_fetchPc_inc;
-  wire                when_Fetcher_l134;
-  wire                IBusCachedPlugin_fetchPc_output_fire_1;
-  wire                when_Fetcher_l134_1;
+  wire                when_Fetcher_l133;
+  wire                when_Fetcher_l133_1;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pc;
   wire                IBusCachedPlugin_fetchPc_redo_valid;
   wire       [31:0]   IBusCachedPlugin_fetchPc_redo_payload;
   reg                 IBusCachedPlugin_fetchPc_flushed;
-  wire                when_Fetcher_l161;
+  wire                when_Fetcher_l160;
   reg                 IBusCachedPlugin_iBusRsp_redoFetch;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_ready;
@@ -887,8 +884,8 @@ module VexRiscv (
   wire                _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready;
   wire                IBusCachedPlugin_iBusRsp_flush;
   wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
-  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
-  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid;
+  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1;
   wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
@@ -901,18 +898,18 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_output_payload_rsp_error;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   wire                IBusCachedPlugin_iBusRsp_output_payload_isRvc;
-  wire                when_Fetcher_l243;
-  wire                when_Fetcher_l323;
+  wire                when_Fetcher_l242;
+  wire                when_Fetcher_l322;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
-  wire                when_Fetcher_l332;
+  wire                when_Fetcher_l331;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
-  wire                when_Fetcher_l332_1;
+  wire                when_Fetcher_l331_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
-  wire                when_Fetcher_l332_2;
+  wire                when_Fetcher_l331_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
-  wire                when_Fetcher_l332_3;
+  wire                when_Fetcher_l331_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                when_Fetcher_l332_4;
+  wire                when_Fetcher_l331_4;
   wire                _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   reg        [18:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1;
   wire                _zz_2;
@@ -938,81 +935,82 @@ module VexRiscv (
   wire                IBusCachedPlugin_rsp_iBusRspOutputHalt;
   wire                IBusCachedPlugin_rsp_issueDetected;
   reg                 IBusCachedPlugin_rsp_redoFetch;
-  wire                when_IBusCachedPlugin_l239;
-  wire                when_IBusCachedPlugin_l244;
+  wire                when_IBusCachedPlugin_l245;
   wire                when_IBusCachedPlugin_l250;
   wire                when_IBusCachedPlugin_l256;
-  wire                when_IBusCachedPlugin_l267;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_valid;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_ready;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_address;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_data;
-  wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_size;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_last;
-  reg                 dataCache_1_io_mem_cmd_rValid;
-  reg                 dataCache_1_io_mem_cmd_rData_wr;
-  reg                 dataCache_1_io_mem_cmd_rData_uncached;
-  reg        [31:0]   dataCache_1_io_mem_cmd_rData_address;
-  reg        [31:0]   dataCache_1_io_mem_cmd_rData_data;
-  reg        [3:0]    dataCache_1_io_mem_cmd_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_rData_size;
-  reg                 dataCache_1_io_mem_cmd_rData_last;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
-  wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data;
-  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
-  wire                when_Stream_l368;
+  wire                when_IBusCachedPlugin_l262;
+  wire                when_IBusCachedPlugin_l273;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_valid;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+  wire       [3:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+  wire       [2:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_size;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rValidN;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rData_wr;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rData_uncached;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_rData_address;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_rData_data;
+  reg        [3:0]    toplevel_dataCache_1_io_mem_cmd_rData_mask;
+  reg        [2:0]    toplevel_dataCache_1_io_mem_cmd_rData_size;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rData_last;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
+  wire       [3:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
+  wire       [2:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_address;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_data;
+  reg        [3:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
+  reg        [2:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_size;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  wire                when_Stream_l369;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
-  wire                when_DBusCachedPlugin_l308;
-  wire                when_DBusCachedPlugin_l316;
+  wire                when_DBusCachedPlugin_l352;
+  wire                when_DBusCachedPlugin_l360;
   wire       [1:0]    execute_DBusCachedPlugin_size;
   reg        [31:0]   _zz_execute_MEMORY_STORE_DATA_RF;
-  wire                dataCache_1_io_cpu_flush_isStall;
-  wire                when_DBusCachedPlugin_l350;
-  wire                when_DBusCachedPlugin_l366;
-  wire                when_DBusCachedPlugin_l393;
-  wire                when_DBusCachedPlugin_l446;
-  wire                when_DBusCachedPlugin_l466;
+  wire                toplevel_dataCache_1_io_cpu_flush_isStall;
+  wire                when_DBusCachedPlugin_l394;
+  wire                when_DBusCachedPlugin_l410;
+  wire                when_DBusCachedPlugin_l472;
+  wire                when_DBusCachedPlugin_l533;
+  wire                when_DBusCachedPlugin_l553;
+  wire       [31:0]   writeBack_DBusCachedPlugin_rspData;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_0;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_1;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_2;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspRf;
-  wire                when_DBusCachedPlugin_l482;
-  wire       [1:0]    switch_Misc_l210;
+  wire                when_DBusCachedPlugin_l570;
+  wire       [1:0]    switch_Misc_l232;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_1;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated_2;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
-  wire                when_DBusCachedPlugin_l492;
+  wire                when_DBusCachedPlugin_l580;
   reg                 DBusCachedPlugin_forceDatapath;
-  wire                when_DBusCachedPlugin_l506;
-  wire                when_DBusCachedPlugin_l507;
+  wire                when_DBusCachedPlugin_l604;
+  wire                when_DBusCachedPlugin_l605;
   wire                MmuPlugin_dBusAccess_cmd_fire;
   reg                 MmuPlugin_status_sum;
   reg                 MmuPlugin_status_mxr;
   reg                 MmuPlugin_status_mprv;
   reg                 MmuPlugin_satp_mode;
   reg        [8:0]    MmuPlugin_satp_asid;
-  reg        [19:0]   MmuPlugin_satp_ppn;
+  reg        [21:0]   MmuPlugin_satp_ppn;
   reg                 MmuPlugin_ports_0_cache_0_valid;
   reg                 MmuPlugin_ports_0_cache_0_exception;
   reg                 MmuPlugin_ports_0_cache_0_superPage;
@@ -1059,8 +1057,8 @@ module VexRiscv (
   reg                 MmuPlugin_ports_0_cache_3_allowUser;
   wire                MmuPlugin_ports_0_dirty;
   reg                 MmuPlugin_ports_0_requireMmuLockupCalc;
-  wire                when_MmuPlugin_l125;
-  wire                when_MmuPlugin_l126;
+  wire                when_MmuPlugin_l131;
+  wire                when_MmuPlugin_l132;
   wire       [3:0]    MmuPlugin_ports_0_cacheHitsCalc;
   wire                MmuPlugin_ports_0_cacheHit;
   wire                _zz_MmuPlugin_ports_0_cacheLine_valid;
@@ -1130,9 +1128,9 @@ module VexRiscv (
   reg                 MmuPlugin_ports_1_cache_3_allowUser;
   wire                MmuPlugin_ports_1_dirty;
   reg                 MmuPlugin_ports_1_requireMmuLockupCalc;
-  wire                when_MmuPlugin_l125_1;
-  wire                when_MmuPlugin_l126_1;
-  wire                when_MmuPlugin_l128;
+  wire                when_MmuPlugin_l131_1;
+  wire                when_MmuPlugin_l132_1;
+  wire                when_MmuPlugin_l134;
   wire       [3:0]    MmuPlugin_ports_1_cacheHitsCalc;
   wire                MmuPlugin_ports_1_cacheHit;
   wire                _zz_MmuPlugin_ports_1_cacheLine_valid;
@@ -1177,7 +1175,7 @@ module VexRiscv (
   wire       [11:0]   MmuPlugin_shared_dBusRsp_pte_PPN1;
   wire                MmuPlugin_shared_dBusRsp_exception;
   wire                MmuPlugin_shared_dBusRsp_leaf;
-  wire                when_MmuPlugin_l205;
+  wire                when_MmuPlugin_l211;
   reg                 MmuPlugin_shared_pteBuffer_V;
   reg                 MmuPlugin_shared_pteBuffer_R;
   reg                 MmuPlugin_shared_pteBuffer_W;
@@ -1194,21 +1192,21 @@ module VexRiscv (
   wire       [1:0]    MmuPlugin_shared_refills;
   wire       [1:0]    _zz_MmuPlugin_shared_refills_2;
   reg        [1:0]    _zz_MmuPlugin_shared_refills_3;
-  wire                when_MmuPlugin_l217;
+  wire                when_MmuPlugin_l223;
   wire       [31:0]   _zz_MmuPlugin_shared_vpn_0;
-  wire                when_MmuPlugin_l243;
-  wire                when_MmuPlugin_l272;
-  wire                when_MmuPlugin_l274;
-  wire                when_MmuPlugin_l280;
-  wire                when_MmuPlugin_l280_1;
-  wire                when_MmuPlugin_l280_2;
-  wire                when_MmuPlugin_l280_3;
-  wire                when_MmuPlugin_l274_1;
-  wire                when_MmuPlugin_l280_4;
-  wire                when_MmuPlugin_l280_5;
-  wire                when_MmuPlugin_l280_6;
-  wire                when_MmuPlugin_l280_7;
-  wire                when_MmuPlugin_l304;
+  wire                when_MmuPlugin_l250;
+  wire                when_MmuPlugin_l279;
+  wire                when_MmuPlugin_l281;
+  wire                when_MmuPlugin_l287;
+  wire                when_MmuPlugin_l287_1;
+  wire                when_MmuPlugin_l287_2;
+  wire                when_MmuPlugin_l287_3;
+  wire                when_MmuPlugin_l281_1;
+  wire                when_MmuPlugin_l287_4;
+  wire                when_MmuPlugin_l287_5;
+  wire                when_MmuPlugin_l287_6;
+  wire                when_MmuPlugin_l287_7;
+  wire                when_MmuPlugin_l311;
   wire       [36:0]   _zz_decode_IS_RS2_SIGNED;
   wire                _zz_decode_IS_RS2_SIGNED_1;
   wire                _zz_decode_IS_RS2_SIGNED_2;
@@ -1219,6 +1217,7 @@ module VexRiscv (
   wire                _zz_decode_IS_RS2_SIGNED_7;
   wire                _zz_decode_IS_RS2_SIGNED_8;
   wire                _zz_decode_IS_RS2_SIGNED_9;
+  wire                _zz_decode_IS_RS2_SIGNED_10;
   wire       [1:0]    _zz_decode_SRC1_CTRL_2;
   wire       [1:0]    _zz_decode_ALU_CTRL_2;
   wire       [1:0]    _zz_decode_SRC2_CTRL_2;
@@ -1234,15 +1233,15 @@ module VexRiscv (
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
   reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
   reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_7;
+  reg                 _zz_10;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
   reg        [31:0]   _zz_execute_REGFILE_WRITE_DATA;
   reg        [31:0]   _zz_execute_SRC1;
-  wire                _zz_execute_SRC2_1;
-  reg        [19:0]   _zz_execute_SRC2_2;
-  wire                _zz_execute_SRC2_3;
-  reg        [19:0]   _zz_execute_SRC2_4;
-  reg        [31:0]   _zz_execute_SRC2_5;
+  wire                _zz_execute_SRC2;
+  reg        [19:0]   _zz_execute_SRC2_1;
+  wire                _zz_execute_SRC2_2;
+  reg        [19:0]   _zz_execute_SRC2_3;
+  reg        [31:0]   _zz_execute_SRC2_4;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   wire       [4:0]    execute_FullBarrelShifterPlugin_amplitude;
@@ -1279,7 +1278,7 @@ module VexRiscv (
   wire                when_HazardSimplePlugin_l108;
   wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    switch_Misc_l210_1;
+  wire       [2:0]    switch_Misc_l232_1;
   reg                 _zz_execute_BRANCH_COND_RESULT;
   reg                 _zz_execute_BRANCH_COND_RESULT_1;
   wire                _zz_execute_BranchPlugin_missAlignedTarget;
@@ -1323,6 +1322,7 @@ module VexRiscv (
   reg                 CsrPlugin_medeleg_IAM;
   reg                 CsrPlugin_medeleg_IAF;
   reg                 CsrPlugin_medeleg_II;
+  reg                 CsrPlugin_medeleg_BP;
   reg                 CsrPlugin_medeleg_LAM;
   reg                 CsrPlugin_medeleg_LAF;
   reg                 CsrPlugin_medeleg_SAM;
@@ -1335,6 +1335,12 @@ module VexRiscv (
   reg                 CsrPlugin_mideleg_ST;
   reg                 CsrPlugin_mideleg_SE;
   reg                 CsrPlugin_mideleg_SS;
+  wire                CsrPlugin_mcounteren_IR;
+  wire                CsrPlugin_mcounteren_TM;
+  wire                CsrPlugin_mcounteren_CY;
+  wire                CsrPlugin_scounteren_IR;
+  wire                CsrPlugin_scounteren_TM;
+  wire                CsrPlugin_scounteren_CY;
   reg                 CsrPlugin_sstatus_SIE;
   reg                 CsrPlugin_sstatus_SPIE;
   reg        [0:0]    CsrPlugin_sstatus_SPP;
@@ -1357,13 +1363,13 @@ module VexRiscv (
   reg        [8:0]    CsrPlugin_satp_ASID;
   reg        [0:0]    CsrPlugin_satp_MODE;
   reg                 CsrPlugin_rescheduleLogic_rescheduleNext;
-  wire                when_CsrPlugin_l816;
-  wire                _zz_when_CsrPlugin_l965;
-  wire                _zz_when_CsrPlugin_l965_1;
-  wire                _zz_when_CsrPlugin_l965_2;
-  wire                _zz_when_CsrPlugin_l965_3;
-  wire                _zz_when_CsrPlugin_l965_4;
-  wire                _zz_when_CsrPlugin_l965_5;
+  wire                when_CsrPlugin_l1153;
+  wire                _zz_when_CsrPlugin_l1302;
+  wire                _zz_when_CsrPlugin_l1302_1;
+  wire                _zz_when_CsrPlugin_l1302_2;
+  wire                _zz_when_CsrPlugin_l1302_3;
+  wire                _zz_when_CsrPlugin_l1302_4;
+  wire                _zz_when_CsrPlugin_l1302_5;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -1375,81 +1381,86 @@ module VexRiscv (
   reg        [3:0]    CsrPlugin_exceptionPortCtrl_exceptionContext_code;
   reg        [31:0]   CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
   reg        [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped;
-  wire                when_CsrPlugin_l879;
-  wire                when_CsrPlugin_l879_1;
-  wire                when_CsrPlugin_l879_2;
-  wire                when_CsrPlugin_l879_3;
-  wire                when_CsrPlugin_l879_4;
-  wire                when_CsrPlugin_l879_5;
-  wire                when_CsrPlugin_l879_6;
-  wire                when_CsrPlugin_l879_7;
-  wire                when_CsrPlugin_l879_8;
-  wire                when_CsrPlugin_l879_9;
-  wire                when_CsrPlugin_l879_10;
-  wire                when_CsrPlugin_l879_11;
+  wire                when_CsrPlugin_l1216;
+  wire                when_CsrPlugin_l1216_1;
+  wire                when_CsrPlugin_l1216_2;
+  wire                when_CsrPlugin_l1216_3;
+  wire                when_CsrPlugin_l1216_4;
+  wire                when_CsrPlugin_l1216_5;
+  wire                when_CsrPlugin_l1216_6;
+  wire                when_CsrPlugin_l1216_7;
+  wire                when_CsrPlugin_l1216_8;
+  wire                when_CsrPlugin_l1216_9;
+  wire                when_CsrPlugin_l1216_10;
+  wire                when_CsrPlugin_l1216_11;
+  wire                when_CsrPlugin_l1216_12;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
   wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code;
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
-  wire                when_CsrPlugin_l922;
-  wire                when_CsrPlugin_l922_1;
-  wire                when_CsrPlugin_l922_2;
-  wire                when_CsrPlugin_l922_3;
-  wire                when_CsrPlugin_l935;
+  wire                when_CsrPlugin_l1259;
+  wire                when_CsrPlugin_l1259_1;
+  wire                when_CsrPlugin_l1259_2;
+  wire                when_CsrPlugin_l1259_3;
+  wire                when_CsrPlugin_l1272;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
-  wire                when_CsrPlugin_l959;
-  wire                when_CsrPlugin_l959_1;
-  wire                when_CsrPlugin_l965;
-  wire                when_CsrPlugin_l965_1;
-  wire                when_CsrPlugin_l965_2;
-  wire                when_CsrPlugin_l965_3;
-  wire                when_CsrPlugin_l965_4;
-  wire                when_CsrPlugin_l965_5;
-  wire                when_CsrPlugin_l965_6;
-  wire                when_CsrPlugin_l965_7;
-  wire                when_CsrPlugin_l965_8;
+  wire                when_CsrPlugin_l1296;
+  wire                when_CsrPlugin_l1296_1;
+  wire                when_CsrPlugin_l1302;
+  wire                when_CsrPlugin_l1302_1;
+  wire                when_CsrPlugin_l1302_2;
+  wire                when_CsrPlugin_l1302_3;
+  wire                when_CsrPlugin_l1302_4;
+  wire                when_CsrPlugin_l1302_5;
+  wire                when_CsrPlugin_l1302_6;
+  wire                when_CsrPlugin_l1302_7;
+  wire                when_CsrPlugin_l1302_8;
   wire                CsrPlugin_exception;
   reg                 CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
-  wire                when_CsrPlugin_l993;
-  wire                when_CsrPlugin_l993_1;
-  wire                when_CsrPlugin_l993_2;
-  wire                when_CsrPlugin_l998;
+  wire                when_CsrPlugin_l1335;
+  wire                when_CsrPlugin_l1335_1;
+  wire                when_CsrPlugin_l1335_2;
+  wire                when_CsrPlugin_l1340;
   reg                 CsrPlugin_pipelineLiberator_done;
-  wire                when_CsrPlugin_l1004;
+  wire                when_CsrPlugin_l1346;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
+  wire                CsrPlugin_trapCauseEbreakDebug;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
-  wire                when_CsrPlugin_l1032;
-  wire                when_CsrPlugin_l1077;
-  wire       [1:0]    switch_CsrPlugin_l1081;
+  wire                CsrPlugin_trapEnterDebug;
+  wire                when_CsrPlugin_l1390;
+  wire                when_CsrPlugin_l1398;
+  wire                when_CsrPlugin_l1456;
+  wire       [1:0]    switch_CsrPlugin_l1460;
+  wire                when_CsrPlugin_l1468;
   reg                 execute_CsrPlugin_wfiWake;
-  wire                when_CsrPlugin_l1121;
-  wire                when_CsrPlugin_l1123;
-  wire                when_CsrPlugin_l1129;
+  wire                when_CsrPlugin_l1519;
+  wire                when_CsrPlugin_l1521;
+  wire                when_CsrPlugin_l1527;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire                when_CsrPlugin_l1142;
-  wire                when_CsrPlugin_l1149;
-  wire                when_CsrPlugin_l1150;
-  wire                when_CsrPlugin_l1157;
+  wire                when_CsrPlugin_l1540;
+  wire                when_CsrPlugin_l1547;
+  wire                when_CsrPlugin_l1548;
+  wire                when_CsrPlugin_l1555;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   reg        [31:0]   execute_CsrPlugin_readToWriteData;
-  wire                switch_Misc_l210_2;
+  wire                switch_Misc_l232_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
-  wire                when_CsrPlugin_l1189;
-  wire                when_CsrPlugin_l1193;
+  wire                when_CsrPlugin_l1587;
+  wire                when_CsrPlugin_l1591;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg                 execute_MulPlugin_aSigned;
   reg                 execute_MulPlugin_bSigned;
@@ -1496,9 +1507,9 @@ module VexRiscv (
   reg        [32:0]   _zz_memory_DivPlugin_rs1_1;
   reg        [31:0]   externalInterruptArray_regNext;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit;
-  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
-  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
+  wire       [31:0]   _zz_externalInterrupt;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
+  wire       [31:0]   _zz_externalInterruptS;
   reg                 DebugPlugin_firstCycle;
   reg                 DebugPlugin_secondCycle;
   reg                 DebugPlugin_resetIt;
@@ -1506,7 +1517,7 @@ module VexRiscv (
   reg                 DebugPlugin_stepIt;
   reg                 DebugPlugin_isPipBusy;
   reg                 DebugPlugin_godmode;
-  wire                when_DebugPlugin_l225;
+  wire                when_DebugPlugin_l238;
   reg                 DebugPlugin_haltedByBreak;
   reg                 DebugPlugin_debugUsed /* verilator public */ ;
   reg                 DebugPlugin_disableEbreak;
@@ -1516,22 +1527,22 @@ module VexRiscv (
   reg                 DebugPlugin_hardwareBreakpoints_1_valid;
   reg        [30:0]   DebugPlugin_hardwareBreakpoints_1_pc;
   reg        [31:0]   DebugPlugin_busReadDataReg;
-  reg                 _zz_when_DebugPlugin_l244;
-  wire                when_DebugPlugin_l244;
-  wire       [5:0]    switch_DebugPlugin_l267;
-  wire                when_DebugPlugin_l271;
-  wire                when_DebugPlugin_l271_1;
-  wire                when_DebugPlugin_l272;
-  wire                when_DebugPlugin_l272_1;
-  wire                when_DebugPlugin_l273;
-  wire                when_DebugPlugin_l274;
-  wire                when_DebugPlugin_l275;
-  wire                when_DebugPlugin_l275_1;
-  wire                when_DebugPlugin_l295;
-  wire                when_DebugPlugin_l298;
+  reg                 _zz_when_DebugPlugin_l257;
+  wire                when_DebugPlugin_l257;
+  wire       [5:0]    switch_DebugPlugin_l280;
+  wire                when_DebugPlugin_l284;
+  wire                when_DebugPlugin_l284_1;
+  wire                when_DebugPlugin_l285;
+  wire                when_DebugPlugin_l285_1;
+  wire                when_DebugPlugin_l286;
+  wire                when_DebugPlugin_l287;
+  wire                when_DebugPlugin_l288;
+  wire                when_DebugPlugin_l288_1;
+  wire                when_DebugPlugin_l308;
   wire                when_DebugPlugin_l311;
+  wire                when_DebugPlugin_l324;
   reg                 DebugPlugin_resetIt_regNext;
-  wire                when_DebugPlugin_l331;
+  wire                when_DebugPlugin_l344;
   wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
   wire                when_Pipeline_l124_1;
@@ -1553,51 +1564,51 @@ module VexRiscv (
   wire                when_Pipeline_l124_9;
   reg                 decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
   wire                when_Pipeline_l124_10;
-  reg        [1:0]    decode_to_execute_SRC1_CTRL;
+  reg                 decode_to_execute_RESCHEDULE_NEXT;
   wire                when_Pipeline_l124_11;
-  reg                 decode_to_execute_SRC_USE_SUB_LESS;
+  reg        [1:0]    decode_to_execute_SRC1_CTRL;
   wire                when_Pipeline_l124_12;
-  reg                 decode_to_execute_MEMORY_ENABLE;
+  reg                 decode_to_execute_SRC_USE_SUB_LESS;
   wire                when_Pipeline_l124_13;
-  reg                 execute_to_memory_MEMORY_ENABLE;
+  reg                 decode_to_execute_MEMORY_ENABLE;
   wire                when_Pipeline_l124_14;
-  reg                 memory_to_writeBack_MEMORY_ENABLE;
+  reg                 execute_to_memory_MEMORY_ENABLE;
   wire                when_Pipeline_l124_15;
-  reg        [1:0]    decode_to_execute_ALU_CTRL;
+  reg                 memory_to_writeBack_MEMORY_ENABLE;
   wire                when_Pipeline_l124_16;
-  reg        [1:0]    decode_to_execute_SRC2_CTRL;
+  reg        [1:0]    decode_to_execute_ALU_CTRL;
   wire                when_Pipeline_l124_17;
-  reg                 decode_to_execute_REGFILE_WRITE_VALID;
+  reg        [1:0]    decode_to_execute_SRC2_CTRL;
   wire                when_Pipeline_l124_18;
-  reg                 execute_to_memory_REGFILE_WRITE_VALID;
+  reg                 decode_to_execute_REGFILE_WRITE_VALID;
   wire                when_Pipeline_l124_19;
-  reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
+  reg                 execute_to_memory_REGFILE_WRITE_VALID;
   wire                when_Pipeline_l124_20;
-  reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
+  reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
   wire                when_Pipeline_l124_21;
-  reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
   wire                when_Pipeline_l124_22;
-  reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
+  reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
   wire                when_Pipeline_l124_23;
-  reg                 decode_to_execute_MEMORY_WR;
+  reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
   wire                when_Pipeline_l124_24;
-  reg                 execute_to_memory_MEMORY_WR;
+  reg                 decode_to_execute_MEMORY_WR;
   wire                when_Pipeline_l124_25;
-  reg                 memory_to_writeBack_MEMORY_WR;
+  reg                 execute_to_memory_MEMORY_WR;
   wire                when_Pipeline_l124_26;
-  reg                 decode_to_execute_MEMORY_LRSC;
+  reg                 memory_to_writeBack_MEMORY_WR;
   wire                when_Pipeline_l124_27;
-  reg                 execute_to_memory_MEMORY_LRSC;
+  reg                 decode_to_execute_MEMORY_LRSC;
   wire                when_Pipeline_l124_28;
-  reg                 memory_to_writeBack_MEMORY_LRSC;
+  reg                 execute_to_memory_MEMORY_LRSC;
   wire                when_Pipeline_l124_29;
-  reg                 decode_to_execute_MEMORY_AMO;
+  reg                 memory_to_writeBack_MEMORY_LRSC;
   wire                when_Pipeline_l124_30;
-  reg                 decode_to_execute_MEMORY_MANAGMENT;
+  reg                 decode_to_execute_MEMORY_AMO;
   wire                when_Pipeline_l124_31;
-  reg                 decode_to_execute_IS_SFENCE_VMA2;
+  reg                 decode_to_execute_MEMORY_MANAGMENT;
   wire                when_Pipeline_l124_32;
-  reg                 decode_to_execute_IS_SFENCE_VMA;
+  reg                 decode_to_execute_IS_SFENCE_VMA2;
   wire                when_Pipeline_l124_33;
   reg                 decode_to_execute_SRC_LESS_UNSIGNED;
   wire                when_Pipeline_l124_34;
@@ -1680,66 +1691,68 @@ module VexRiscv (
   wire                when_Pipeline_l154_1;
   wire                when_Pipeline_l151_2;
   wire                when_Pipeline_l154_2;
-  reg        [2:0]    switch_Fetcher_l365;
-  wire                when_Fetcher_l381;
-  wire                when_CsrPlugin_l1277;
+  reg        [2:0]    IBusCachedPlugin_injector_port_state;
+  wire                when_Fetcher_l391;
+  wire                when_CsrPlugin_l1669;
   reg                 execute_CsrPlugin_csr_3264;
-  wire                when_CsrPlugin_l1277_1;
+  wire                when_CsrPlugin_l1669_1;
   reg                 execute_CsrPlugin_csr_768;
-  wire                when_CsrPlugin_l1277_2;
+  wire                when_CsrPlugin_l1669_2;
   reg                 execute_CsrPlugin_csr_256;
-  wire                when_CsrPlugin_l1277_3;
+  wire                when_CsrPlugin_l1669_3;
   reg                 execute_CsrPlugin_csr_384;
-  wire                when_CsrPlugin_l1277_4;
+  wire                when_CsrPlugin_l1669_4;
   reg                 execute_CsrPlugin_csr_3857;
-  wire                when_CsrPlugin_l1277_5;
+  wire                when_CsrPlugin_l1669_5;
   reg                 execute_CsrPlugin_csr_3858;
-  wire                when_CsrPlugin_l1277_6;
+  wire                when_CsrPlugin_l1669_6;
   reg                 execute_CsrPlugin_csr_3859;
-  wire                when_CsrPlugin_l1277_7;
+  wire                when_CsrPlugin_l1669_7;
   reg                 execute_CsrPlugin_csr_3860;
-  wire                when_CsrPlugin_l1277_8;
+  wire                when_CsrPlugin_l1669_8;
   reg                 execute_CsrPlugin_csr_836;
-  wire                when_CsrPlugin_l1277_9;
+  wire                when_CsrPlugin_l1669_9;
   reg                 execute_CsrPlugin_csr_772;
-  wire                when_CsrPlugin_l1277_10;
+  wire                when_CsrPlugin_l1669_10;
   reg                 execute_CsrPlugin_csr_773;
-  wire                when_CsrPlugin_l1277_11;
+  wire                when_CsrPlugin_l1669_11;
   reg                 execute_CsrPlugin_csr_833;
-  wire                when_CsrPlugin_l1277_12;
+  wire                when_CsrPlugin_l1669_12;
   reg                 execute_CsrPlugin_csr_832;
-  wire                when_CsrPlugin_l1277_13;
+  wire                when_CsrPlugin_l1669_13;
   reg                 execute_CsrPlugin_csr_834;
-  wire                when_CsrPlugin_l1277_14;
+  wire                when_CsrPlugin_l1669_14;
   reg                 execute_CsrPlugin_csr_835;
-  wire                when_CsrPlugin_l1277_15;
+  wire                when_CsrPlugin_l1669_15;
   reg                 execute_CsrPlugin_csr_770;
-  wire                when_CsrPlugin_l1277_16;
+  wire                when_CsrPlugin_l1669_16;
   reg                 execute_CsrPlugin_csr_771;
-  wire                when_CsrPlugin_l1277_17;
+  wire                when_CsrPlugin_l1669_17;
   reg                 execute_CsrPlugin_csr_324;
-  wire                when_CsrPlugin_l1277_18;
+  wire                when_CsrPlugin_l1669_18;
   reg                 execute_CsrPlugin_csr_260;
-  wire                when_CsrPlugin_l1277_19;
+  wire                when_CsrPlugin_l1669_19;
   reg                 execute_CsrPlugin_csr_261;
-  wire                when_CsrPlugin_l1277_20;
+  wire                when_CsrPlugin_l1669_20;
   reg                 execute_CsrPlugin_csr_321;
-  wire                when_CsrPlugin_l1277_21;
+  wire                when_CsrPlugin_l1669_21;
   reg                 execute_CsrPlugin_csr_320;
-  wire                when_CsrPlugin_l1277_22;
+  wire                when_CsrPlugin_l1669_22;
   reg                 execute_CsrPlugin_csr_322;
-  wire                when_CsrPlugin_l1277_23;
+  wire                when_CsrPlugin_l1669_23;
   reg                 execute_CsrPlugin_csr_323;
-  wire                when_CsrPlugin_l1277_24;
+  wire                when_CsrPlugin_l1669_24;
   reg                 execute_CsrPlugin_csr_3008;
-  wire                when_CsrPlugin_l1277_25;
+  wire                when_CsrPlugin_l1669_25;
   reg                 execute_CsrPlugin_csr_4032;
-  wire                when_CsrPlugin_l1277_26;
+  wire                when_CsrPlugin_l1669_26;
   reg                 execute_CsrPlugin_csr_2496;
-  wire                when_CsrPlugin_l1277_27;
+  wire                when_CsrPlugin_l1669_27;
   reg                 execute_CsrPlugin_csr_3520;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
+  wire       [1:0]    switch_CsrPlugin_l1031;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
-  wire       [1:0]    switch_CsrPlugin_l723;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_5;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_6;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
@@ -1761,20 +1774,22 @@ module VexRiscv (
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_23;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_24;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_25;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_26;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_27;
-  wire                when_CsrPlugin_l1310;
-  wire                when_CsrPlugin_l1315;
+  wire                when_CsrPlugin_l1702;
+  wire       [11:0]   _zz_when_CsrPlugin_l1709;
+  wire                when_CsrPlugin_l1709;
+  reg                 when_CsrPlugin_l1719;
+  wire                when_CsrPlugin_l1717;
+  wire                when_CsrPlugin_l1725;
   reg        [2:0]    _zz_iBusWishbone_ADR;
   wire                when_InstructionCache_l239;
   reg                 _zz_iBus_rsp_valid;
   reg        [31:0]   iBusWishbone_DAT_MISO_regNext;
-  reg        [2:0]    _zz_dBus_cmd_ready;
+  reg        [2:0]    _zz_dBusWishbone_ADR;
+  wire                _zz_dBusWishbone_CYC;
+  wire                _zz_dBus_cmd_ready;
   wire                _zz_dBus_cmd_ready_1;
   wire                _zz_dBus_cmd_ready_2;
-  wire                _zz_dBus_cmd_ready_3;
-  wire                _zz_dBus_cmd_ready_4;
-  wire                _zz_dBus_cmd_ready_5;
+  wire                _zz_dBusWishbone_ADR_1;
   reg                 _zz_dBus_rsp_valid;
   reg        [31:0]   dBusWishbone_DAT_MISO_regNext;
   `ifndef SYNTHESIS
@@ -1862,20 +1877,19 @@ module VexRiscv (
   (* no_rw_check , ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
   assign _zz_when = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
-  assign _zz_memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW_1) + $signed(_zz_memory_MUL_LOW_5));
-  assign _zz_memory_MUL_LOW_1 = ($signed(_zz_memory_MUL_LOW_2) + $signed(_zz_memory_MUL_LOW_3));
-  assign _zz_memory_MUL_LOW_2 = 52'h0;
-  assign _zz_memory_MUL_LOW_4 = {1'b0,memory_MUL_LL};
-  assign _zz_memory_MUL_LOW_3 = {{19{_zz_memory_MUL_LOW_4[32]}}, _zz_memory_MUL_LOW_4};
-  assign _zz_memory_MUL_LOW_6 = ({16'd0,memory_MUL_LH} <<< 16);
-  assign _zz_memory_MUL_LOW_5 = {{2{_zz_memory_MUL_LOW_6[49]}}, _zz_memory_MUL_LOW_6};
-  assign _zz_memory_MUL_LOW_8 = ({16'd0,memory_MUL_HL} <<< 16);
-  assign _zz_memory_MUL_LOW_7 = {{2{_zz_memory_MUL_LOW_8[49]}}, _zz_memory_MUL_LOW_8};
+  assign _zz_memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW_1) + $signed(_zz_memory_MUL_LOW_4));
+  assign _zz_memory_MUL_LOW_1 = ($signed(52'h0000000000000) + $signed(_zz_memory_MUL_LOW_2));
+  assign _zz_memory_MUL_LOW_3 = {1'b0,memory_MUL_LL};
+  assign _zz_memory_MUL_LOW_2 = {{19{_zz_memory_MUL_LOW_3[32]}}, _zz_memory_MUL_LOW_3};
+  assign _zz_memory_MUL_LOW_5 = ({16'd0,memory_MUL_LH} <<< 5'd16);
+  assign _zz_memory_MUL_LOW_4 = {{2{_zz_memory_MUL_LOW_5[49]}}, _zz_memory_MUL_LOW_5};
+  assign _zz_memory_MUL_LOW_7 = ({16'd0,memory_MUL_HL} <<< 5'd16);
+  assign _zz_memory_MUL_LOW_6 = {{2{_zz_memory_MUL_LOW_7[49]}}, _zz_memory_MUL_LOW_7};
   assign _zz_execute_SHIFT_RIGHT_1 = ($signed(_zz_execute_SHIFT_RIGHT_2) >>> execute_FullBarrelShifterPlugin_amplitude);
   assign _zz_execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT_1[31 : 0];
   assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == ShiftCtrlEnum_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
-  assign _zz_decode_DO_EBREAK = (decode_PC >>> 1);
-  assign _zz_decode_DO_EBREAK_1 = (decode_PC >>> 1);
+  assign _zz_decode_DO_EBREAK = (decode_PC >>> 1'd1);
+  assign _zz_decode_DO_EBREAK_1 = (decode_PC >>> 1'd1);
   assign _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload - 5'h01);
   assign _zz_IBusCachedPlugin_fetchPc_pc_1 = {IBusCachedPlugin_fetchPc_inc,2'b00};
   assign _zz_IBusCachedPlugin_fetchPc_pc = {29'd0, _zz_IBusCachedPlugin_fetchPc_pc_1};
@@ -1888,7 +1902,7 @@ module VexRiscv (
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
   assign _zz_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId_1;
-  assign _zz_io_cpu_flush_payload_lineId_1 = (execute_RS1 >>> 5);
+  assign _zz_io_cpu_flush_payload_lineId_1 = (execute_RS1 >>> 3'd5);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code_1 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
   assign _zz_writeBack_DBusCachedPlugin_rspRf = (! dataCache_1_io_cpu_writeBack_exclusiveOk);
@@ -1900,14 +1914,12 @@ module VexRiscv (
   assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
   assign _zz__zz_execute_SRC1 = 3'b100;
   assign _zz__zz_execute_SRC1_1 = execute_INSTRUCTION[19 : 15];
-  assign _zz__zz_execute_SRC2_3 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz__zz_execute_SRC2_2 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
   assign _zz_execute_SrcPlugin_addSub = ($signed(_zz_execute_SrcPlugin_addSub_1) + $signed(_zz_execute_SrcPlugin_addSub_4));
   assign _zz_execute_SrcPlugin_addSub_1 = ($signed(_zz_execute_SrcPlugin_addSub_2) + $signed(_zz_execute_SrcPlugin_addSub_3));
   assign _zz_execute_SrcPlugin_addSub_2 = execute_SRC1;
   assign _zz_execute_SrcPlugin_addSub_3 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? _zz_execute_SrcPlugin_addSub_5 : _zz_execute_SrcPlugin_addSub_6);
-  assign _zz_execute_SrcPlugin_addSub_5 = 32'h00000001;
-  assign _zz_execute_SrcPlugin_addSub_6 = 32'h0;
+  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? 32'h00000001 : 32'h00000000);
   assign _zz__zz_execute_BranchPlugin_missAlignedTarget_2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
   assign _zz__zz_execute_BranchPlugin_missAlignedTarget_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
   assign _zz__zz_execute_BranchPlugin_missAlignedTarget_6 = {_zz_execute_BranchPlugin_missAlignedTarget_1,execute_INSTRUCTION[31 : 20]};
@@ -1919,7 +1931,7 @@ module VexRiscv (
   assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code & (~ _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1));
   assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code - 2'b01);
   assign _zz_writeBack_MulPlugin_result = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
-  assign _zz_writeBack_MulPlugin_result_1 = ({32'd0,writeBack_MUL_HH} <<< 32);
+  assign _zz_writeBack_MulPlugin_result_1 = ({32'd0,writeBack_MUL_HH} <<< 6'd32);
   assign _zz__zz_decode_RS2_2 = writeBack_MUL_LOW[31 : 0];
   assign _zz__zz_decode_RS2_2_1 = writeBack_MulPlugin_result[63 : 32];
   assign _zz_memory_DivPlugin_div_counter_valueNext_1 = memory_DivPlugin_div_counter_willIncrement;
@@ -1937,17 +1949,17 @@ module VexRiscv (
   assign _zz_memory_DivPlugin_rs1_2 = {32'd0, _zz_memory_DivPlugin_rs1_3};
   assign _zz_memory_DivPlugin_rs2_2 = _zz_memory_DivPlugin_rs2;
   assign _zz_memory_DivPlugin_rs2_1 = {31'd0, _zz_memory_DivPlugin_rs2_2};
-  assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 5);
+  assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 3'd5);
   assign _zz_decode_RegFilePlugin_rs1Data = 1'b1;
   assign _zz_decode_RegFilePlugin_rs2Data = 1'b1;
   assign _zz_IBusCachedPlugin_jump_pcLoad_payload_7 = {_zz_IBusCachedPlugin_jump_pcLoad_payload_3,{_zz_IBusCachedPlugin_jump_pcLoad_payload_5,_zz_IBusCachedPlugin_jump_pcLoad_payload_4}};
   assign _zz_writeBack_DBusCachedPlugin_rspShifted_1 = dataCache_1_io_cpu_writeBack_address[1 : 0];
   assign _zz_writeBack_DBusCachedPlugin_rspShifted_3 = dataCache_1_io_cpu_writeBack_address[1 : 1];
-  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000107f;
-  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00002073;
-  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000207f;
+  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000407f);
+  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00004063;
+  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000107f) == 32'h00000013);
   assign _zz_decode_LEGAL_INSTRUCTION_5 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_6) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_7 == _zz_decode_LEGAL_INSTRUCTION_8),{_zz_decode_LEGAL_INSTRUCTION_9,{_zz_decode_LEGAL_INSTRUCTION_10,_zz_decode_LEGAL_INSTRUCTION_11}}}}}};
   assign _zz_decode_LEGAL_INSTRUCTION_6 = 32'h0000505f;
   assign _zz_decode_LEGAL_INSTRUCTION_7 = (decode_INSTRUCTION & 32'h0000707b);
@@ -1956,16 +1968,16 @@ module VexRiscv (
   assign _zz_decode_LEGAL_INSTRUCTION_10 = ((decode_INSTRUCTION & 32'h1800707f) == 32'h0000202f);
   assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033),{((decode_INSTRUCTION & 32'he800707f) == 32'h0800202f),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h0000500f),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,{_zz_decode_LEGAL_INSTRUCTION_16,_zz_decode_LEGAL_INSTRUCTION_17}}}}}};
   assign _zz_decode_LEGAL_INSTRUCTION_12 = 32'h01f0707f;
-  assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'hbc00707f);
+  assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'hbe00705f);
   assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h00005013;
-  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hfc00307f) == 32'h00001013);
-  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00005033);
-  assign _zz_decode_LEGAL_INSTRUCTION_17 = {((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033),{((decode_INSTRUCTION & 32'hf9f0707f) == 32'h1000202f),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_18) == 32'h12000073),{(_zz_decode_LEGAL_INSTRUCTION_19 == _zz_decode_LEGAL_INSTRUCTION_20),{_zz_decode_LEGAL_INSTRUCTION_21,_zz_decode_LEGAL_INSTRUCTION_22}}}}};
-  assign _zz_decode_LEGAL_INSTRUCTION_18 = 32'hfe007fff;
-  assign _zz_decode_LEGAL_INSTRUCTION_19 = (decode_INSTRUCTION & 32'hdfffffff);
-  assign _zz_decode_LEGAL_INSTRUCTION_20 = 32'h10200073;
-  assign _zz_decode_LEGAL_INSTRUCTION_21 = ((decode_INSTRUCTION & 32'hffefffff) == 32'h00000073);
-  assign _zz_decode_LEGAL_INSTRUCTION_22 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073);
+  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hfe00305f) == 32'h00001013);
+  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
+  assign _zz_decode_LEGAL_INSTRUCTION_17 = {((decode_INSTRUCTION & 32'hf9f0707f) == 32'h1000202f),{((decode_INSTRUCTION & 32'hfe007fff) == 32'h12000073),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_18) == 32'h10200073),{(_zz_decode_LEGAL_INSTRUCTION_19 == _zz_decode_LEGAL_INSTRUCTION_20),(_zz_decode_LEGAL_INSTRUCTION_21 == _zz_decode_LEGAL_INSTRUCTION_22)}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_18 = 32'hdfffffff;
+  assign _zz_decode_LEGAL_INSTRUCTION_19 = (decode_INSTRUCTION & 32'hffefffff);
+  assign _zz_decode_LEGAL_INSTRUCTION_20 = 32'h00000073;
+  assign _zz_decode_LEGAL_INSTRUCTION_21 = (decode_INSTRUCTION & 32'hffffffff);
+  assign _zz_decode_LEGAL_INSTRUCTION_22 = 32'h10500073;
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_4 = decode_INSTRUCTION[31];
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_5 = decode_INSTRUCTION[31];
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_6 = decode_INSTRUCTION[7];
@@ -1985,7 +1997,7 @@ module VexRiscv (
   assign _zz__zz_decode_IS_RS2_SIGNED_1 = ((decode_INSTRUCTION & 32'h02004074) == 32'h02000030);
   assign _zz__zz_decode_IS_RS2_SIGNED_2 = (|{(_zz__zz_decode_IS_RS2_SIGNED_3 == _zz__zz_decode_IS_RS2_SIGNED_4),(_zz__zz_decode_IS_RS2_SIGNED_5 == _zz__zz_decode_IS_RS2_SIGNED_6)});
   assign _zz__zz_decode_IS_RS2_SIGNED_7 = (|(_zz__zz_decode_IS_RS2_SIGNED_8 == _zz__zz_decode_IS_RS2_SIGNED_9));
-  assign _zz__zz_decode_IS_RS2_SIGNED_10 = {(|{_zz__zz_decode_IS_RS2_SIGNED_11,_zz__zz_decode_IS_RS2_SIGNED_13}),{(|_zz__zz_decode_IS_RS2_SIGNED_15),{_zz__zz_decode_IS_RS2_SIGNED_18,{_zz__zz_decode_IS_RS2_SIGNED_21,_zz__zz_decode_IS_RS2_SIGNED_26}}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_10 = {(|{_zz__zz_decode_IS_RS2_SIGNED_11,_zz__zz_decode_IS_RS2_SIGNED_13}),{(|_zz__zz_decode_IS_RS2_SIGNED_15),{_zz__zz_decode_IS_RS2_SIGNED_18,{_zz__zz_decode_IS_RS2_SIGNED_21,_zz__zz_decode_IS_RS2_SIGNED_23}}}};
   assign _zz__zz_decode_IS_RS2_SIGNED_3 = (decode_INSTRUCTION & 32'h10103050);
   assign _zz__zz_decode_IS_RS2_SIGNED_4 = 32'h00000050;
   assign _zz__zz_decode_IS_RS2_SIGNED_5 = (decode_INSTRUCTION & 32'h12203050);
@@ -1994,168 +2006,167 @@ module VexRiscv (
   assign _zz__zz_decode_IS_RS2_SIGNED_9 = 32'h00000050;
   assign _zz__zz_decode_IS_RS2_SIGNED_11 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_12) == 32'h00001050);
   assign _zz__zz_decode_IS_RS2_SIGNED_13 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_14) == 32'h00002050);
-  assign _zz__zz_decode_IS_RS2_SIGNED_15 = {_zz_decode_IS_RS2_SIGNED_2,(_zz__zz_decode_IS_RS2_SIGNED_16 == _zz__zz_decode_IS_RS2_SIGNED_17)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_15 = {_zz_decode_IS_RS2_SIGNED_4,(_zz__zz_decode_IS_RS2_SIGNED_16 == _zz__zz_decode_IS_RS2_SIGNED_17)};
   assign _zz__zz_decode_IS_RS2_SIGNED_18 = (|(_zz__zz_decode_IS_RS2_SIGNED_19 == _zz__zz_decode_IS_RS2_SIGNED_20));
-  assign _zz__zz_decode_IS_RS2_SIGNED_21 = (|{_zz__zz_decode_IS_RS2_SIGNED_22,_zz__zz_decode_IS_RS2_SIGNED_24});
-  assign _zz__zz_decode_IS_RS2_SIGNED_26 = {(|_zz__zz_decode_IS_RS2_SIGNED_27),{_zz__zz_decode_IS_RS2_SIGNED_32,{_zz__zz_decode_IS_RS2_SIGNED_35,_zz__zz_decode_IS_RS2_SIGNED_37}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_21 = (|_zz__zz_decode_IS_RS2_SIGNED_22);
+  assign _zz__zz_decode_IS_RS2_SIGNED_23 = {(|_zz__zz_decode_IS_RS2_SIGNED_24),{_zz__zz_decode_IS_RS2_SIGNED_27,{_zz__zz_decode_IS_RS2_SIGNED_29,_zz__zz_decode_IS_RS2_SIGNED_32}}};
   assign _zz__zz_decode_IS_RS2_SIGNED_12 = 32'h00001050;
   assign _zz__zz_decode_IS_RS2_SIGNED_14 = 32'h00002050;
   assign _zz__zz_decode_IS_RS2_SIGNED_16 = (decode_INSTRUCTION & 32'h0000001c);
   assign _zz__zz_decode_IS_RS2_SIGNED_17 = 32'h00000004;
   assign _zz__zz_decode_IS_RS2_SIGNED_19 = (decode_INSTRUCTION & 32'h00000058);
   assign _zz__zz_decode_IS_RS2_SIGNED_20 = 32'h00000040;
-  assign _zz__zz_decode_IS_RS2_SIGNED_22 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_23) == 32'h00005010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_24 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_25) == 32'h00005020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_27 = {(_zz__zz_decode_IS_RS2_SIGNED_28 == _zz__zz_decode_IS_RS2_SIGNED_29),{_zz__zz_decode_IS_RS2_SIGNED_30,_zz__zz_decode_IS_RS2_SIGNED_31}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_32 = (|(_zz__zz_decode_IS_RS2_SIGNED_33 == _zz__zz_decode_IS_RS2_SIGNED_34));
-  assign _zz__zz_decode_IS_RS2_SIGNED_35 = (|_zz__zz_decode_IS_RS2_SIGNED_36);
-  assign _zz__zz_decode_IS_RS2_SIGNED_37 = {(|_zz__zz_decode_IS_RS2_SIGNED_38),{_zz__zz_decode_IS_RS2_SIGNED_40,{_zz__zz_decode_IS_RS2_SIGNED_41,_zz__zz_decode_IS_RS2_SIGNED_42}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_23 = 32'h00007034;
-  assign _zz__zz_decode_IS_RS2_SIGNED_25 = 32'h02007064;
-  assign _zz__zz_decode_IS_RS2_SIGNED_28 = (decode_INSTRUCTION & 32'h40003054);
-  assign _zz__zz_decode_IS_RS2_SIGNED_29 = 32'h40001010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_30 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00001010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_31 = ((decode_INSTRUCTION & 32'h02007054) == 32'h00001010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_33 = (decode_INSTRUCTION & 32'h00001000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_34 = 32'h00001000;
-  assign _zz__zz_decode_IS_RS2_SIGNED_36 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_38 = {_zz_decode_IS_RS2_SIGNED_7,((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_39) == 32'h00001000)};
-  assign _zz__zz_decode_IS_RS2_SIGNED_40 = (|_zz_decode_IS_RS2_SIGNED_8);
-  assign _zz__zz_decode_IS_RS2_SIGNED_41 = (|_zz_decode_IS_RS2_SIGNED_8);
-  assign _zz__zz_decode_IS_RS2_SIGNED_42 = {(|_zz__zz_decode_IS_RS2_SIGNED_43),{(|_zz__zz_decode_IS_RS2_SIGNED_44),{_zz__zz_decode_IS_RS2_SIGNED_45,{_zz__zz_decode_IS_RS2_SIGNED_53,_zz__zz_decode_IS_RS2_SIGNED_56}}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_39 = 32'h00005000;
-  assign _zz__zz_decode_IS_RS2_SIGNED_43 = ((decode_INSTRUCTION & 32'h00004048) == 32'h00004008);
-  assign _zz__zz_decode_IS_RS2_SIGNED_44 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
-  assign _zz__zz_decode_IS_RS2_SIGNED_45 = (|{(_zz__zz_decode_IS_RS2_SIGNED_46 == _zz__zz_decode_IS_RS2_SIGNED_47),{_zz__zz_decode_IS_RS2_SIGNED_48,{_zz__zz_decode_IS_RS2_SIGNED_49,_zz__zz_decode_IS_RS2_SIGNED_51}}});
-  assign _zz__zz_decode_IS_RS2_SIGNED_53 = (|(_zz__zz_decode_IS_RS2_SIGNED_54 == _zz__zz_decode_IS_RS2_SIGNED_55));
-  assign _zz__zz_decode_IS_RS2_SIGNED_56 = {(|_zz__zz_decode_IS_RS2_SIGNED_57),{(|_zz__zz_decode_IS_RS2_SIGNED_58),{_zz__zz_decode_IS_RS2_SIGNED_71,{_zz__zz_decode_IS_RS2_SIGNED_80,_zz__zz_decode_IS_RS2_SIGNED_93}}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_46 = (decode_INSTRUCTION & 32'h00000034);
-  assign _zz__zz_decode_IS_RS2_SIGNED_47 = 32'h00000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_48 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_49 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_50) == 32'h08000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_51 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_52) == 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_54 = (decode_INSTRUCTION & 32'h10000008);
-  assign _zz__zz_decode_IS_RS2_SIGNED_55 = 32'h00000008;
-  assign _zz__zz_decode_IS_RS2_SIGNED_57 = ((decode_INSTRUCTION & 32'h10000008) == 32'h10000008);
-  assign _zz__zz_decode_IS_RS2_SIGNED_58 = {(_zz__zz_decode_IS_RS2_SIGNED_59 == _zz__zz_decode_IS_RS2_SIGNED_60),{_zz__zz_decode_IS_RS2_SIGNED_61,{_zz__zz_decode_IS_RS2_SIGNED_63,_zz__zz_decode_IS_RS2_SIGNED_66}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_71 = (|{_zz__zz_decode_IS_RS2_SIGNED_72,{_zz__zz_decode_IS_RS2_SIGNED_74,_zz__zz_decode_IS_RS2_SIGNED_77}});
-  assign _zz__zz_decode_IS_RS2_SIGNED_80 = (|{_zz__zz_decode_IS_RS2_SIGNED_81,_zz__zz_decode_IS_RS2_SIGNED_84});
-  assign _zz__zz_decode_IS_RS2_SIGNED_93 = {(|_zz__zz_decode_IS_RS2_SIGNED_94),{_zz__zz_decode_IS_RS2_SIGNED_107,{_zz__zz_decode_IS_RS2_SIGNED_123,_zz__zz_decode_IS_RS2_SIGNED_127}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_50 = 32'h08000070;
-  assign _zz__zz_decode_IS_RS2_SIGNED_52 = 32'h10000070;
-  assign _zz__zz_decode_IS_RS2_SIGNED_59 = (decode_INSTRUCTION & 32'h00002040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_60 = 32'h00002040;
-  assign _zz__zz_decode_IS_RS2_SIGNED_61 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_62) == 32'h00001040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_63 = (_zz__zz_decode_IS_RS2_SIGNED_64 == _zz__zz_decode_IS_RS2_SIGNED_65);
-  assign _zz__zz_decode_IS_RS2_SIGNED_66 = {_zz_decode_IS_RS2_SIGNED_7,{_zz__zz_decode_IS_RS2_SIGNED_67,_zz__zz_decode_IS_RS2_SIGNED_68}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_72 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_73) == 32'h08000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_74 = (_zz__zz_decode_IS_RS2_SIGNED_75 == _zz__zz_decode_IS_RS2_SIGNED_76);
+  assign _zz__zz_decode_IS_RS2_SIGNED_22 = ((decode_INSTRUCTION & 32'h02007054) == 32'h00005010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_24 = {((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_25) == 32'h40001010),((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_26) == 32'h00001010)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_27 = (|((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_28) == 32'h00001000));
+  assign _zz__zz_decode_IS_RS2_SIGNED_29 = (|(_zz__zz_decode_IS_RS2_SIGNED_30 == _zz__zz_decode_IS_RS2_SIGNED_31));
+  assign _zz__zz_decode_IS_RS2_SIGNED_32 = {(|{_zz__zz_decode_IS_RS2_SIGNED_33,_zz__zz_decode_IS_RS2_SIGNED_34}),{(|_zz__zz_decode_IS_RS2_SIGNED_35),{_zz__zz_decode_IS_RS2_SIGNED_36,{_zz__zz_decode_IS_RS2_SIGNED_38,_zz__zz_decode_IS_RS2_SIGNED_41}}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_25 = 32'h40003054;
+  assign _zz__zz_decode_IS_RS2_SIGNED_26 = 32'h02007054;
+  assign _zz__zz_decode_IS_RS2_SIGNED_28 = 32'h00001000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_30 = (decode_INSTRUCTION & 32'h00003000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_31 = 32'h00002000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_33 = _zz_decode_IS_RS2_SIGNED_9;
+  assign _zz__zz_decode_IS_RS2_SIGNED_34 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00001000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_35 = _zz_decode_IS_RS2_SIGNED_2;
+  assign _zz__zz_decode_IS_RS2_SIGNED_36 = (|((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_37) == 32'h00004008));
+  assign _zz__zz_decode_IS_RS2_SIGNED_38 = (|(_zz__zz_decode_IS_RS2_SIGNED_39 == _zz__zz_decode_IS_RS2_SIGNED_40));
+  assign _zz__zz_decode_IS_RS2_SIGNED_41 = {(|{_zz__zz_decode_IS_RS2_SIGNED_42,_zz__zz_decode_IS_RS2_SIGNED_44}),{(|_zz__zz_decode_IS_RS2_SIGNED_49),{_zz__zz_decode_IS_RS2_SIGNED_51,{_zz__zz_decode_IS_RS2_SIGNED_54,_zz__zz_decode_IS_RS2_SIGNED_66}}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_37 = 32'h00004048;
+  assign _zz__zz_decode_IS_RS2_SIGNED_39 = (decode_INSTRUCTION & 32'h00000064);
+  assign _zz__zz_decode_IS_RS2_SIGNED_40 = 32'h00000024;
+  assign _zz__zz_decode_IS_RS2_SIGNED_42 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_43) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_44 = {(_zz__zz_decode_IS_RS2_SIGNED_45 == _zz__zz_decode_IS_RS2_SIGNED_46),{_zz__zz_decode_IS_RS2_SIGNED_47,_zz__zz_decode_IS_RS2_SIGNED_48}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_49 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_50) == 32'h00000008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_51 = (|(_zz__zz_decode_IS_RS2_SIGNED_52 == _zz__zz_decode_IS_RS2_SIGNED_53));
+  assign _zz__zz_decode_IS_RS2_SIGNED_54 = (|{_zz__zz_decode_IS_RS2_SIGNED_55,_zz__zz_decode_IS_RS2_SIGNED_57});
+  assign _zz__zz_decode_IS_RS2_SIGNED_66 = {(|_zz__zz_decode_IS_RS2_SIGNED_67),{_zz__zz_decode_IS_RS2_SIGNED_74,{_zz__zz_decode_IS_RS2_SIGNED_87,_zz__zz_decode_IS_RS2_SIGNED_100}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_43 = 32'h00000034;
+  assign _zz__zz_decode_IS_RS2_SIGNED_45 = (decode_INSTRUCTION & 32'h00000064);
+  assign _zz__zz_decode_IS_RS2_SIGNED_46 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_47 = ((decode_INSTRUCTION & 32'h08000070) == 32'h08000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_48 = ((decode_INSTRUCTION & 32'h10000070) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_50 = 32'h10000008;
+  assign _zz__zz_decode_IS_RS2_SIGNED_52 = (decode_INSTRUCTION & 32'h10000008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_53 = 32'h10000008;
+  assign _zz__zz_decode_IS_RS2_SIGNED_55 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_56) == 32'h00002040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_57 = {(_zz__zz_decode_IS_RS2_SIGNED_58 == _zz__zz_decode_IS_RS2_SIGNED_59),{_zz__zz_decode_IS_RS2_SIGNED_60,{_zz__zz_decode_IS_RS2_SIGNED_62,_zz__zz_decode_IS_RS2_SIGNED_63}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_67 = {(_zz__zz_decode_IS_RS2_SIGNED_68 == _zz__zz_decode_IS_RS2_SIGNED_69),{_zz__zz_decode_IS_RS2_SIGNED_70,_zz__zz_decode_IS_RS2_SIGNED_72}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_74 = (|{_zz__zz_decode_IS_RS2_SIGNED_75,{_zz__zz_decode_IS_RS2_SIGNED_77,_zz__zz_decode_IS_RS2_SIGNED_80}});
+  assign _zz__zz_decode_IS_RS2_SIGNED_87 = (|{_zz__zz_decode_IS_RS2_SIGNED_88,_zz__zz_decode_IS_RS2_SIGNED_89});
+  assign _zz__zz_decode_IS_RS2_SIGNED_100 = {(|_zz__zz_decode_IS_RS2_SIGNED_101),{_zz__zz_decode_IS_RS2_SIGNED_116,{_zz__zz_decode_IS_RS2_SIGNED_121,_zz__zz_decode_IS_RS2_SIGNED_125}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_56 = 32'h00002040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_58 = (decode_INSTRUCTION & 32'h00001040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_59 = 32'h00001040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_60 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_61) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_62 = _zz_decode_IS_RS2_SIGNED_9;
+  assign _zz__zz_decode_IS_RS2_SIGNED_63 = {_zz_decode_IS_RS2_SIGNED_6,_zz__zz_decode_IS_RS2_SIGNED_64};
+  assign _zz__zz_decode_IS_RS2_SIGNED_68 = (decode_INSTRUCTION & 32'h08000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_69 = 32'h08000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_70 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_71) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_72 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_73) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_75 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_76) == 32'h00000040);
   assign _zz__zz_decode_IS_RS2_SIGNED_77 = (_zz__zz_decode_IS_RS2_SIGNED_78 == _zz__zz_decode_IS_RS2_SIGNED_79);
-  assign _zz__zz_decode_IS_RS2_SIGNED_81 = (_zz__zz_decode_IS_RS2_SIGNED_82 == _zz__zz_decode_IS_RS2_SIGNED_83);
-  assign _zz__zz_decode_IS_RS2_SIGNED_84 = {_zz__zz_decode_IS_RS2_SIGNED_85,{_zz__zz_decode_IS_RS2_SIGNED_87,_zz__zz_decode_IS_RS2_SIGNED_90}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_94 = {_zz_decode_IS_RS2_SIGNED_6,{_zz__zz_decode_IS_RS2_SIGNED_95,_zz__zz_decode_IS_RS2_SIGNED_98}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_107 = (|{_zz__zz_decode_IS_RS2_SIGNED_108,_zz__zz_decode_IS_RS2_SIGNED_109});
-  assign _zz__zz_decode_IS_RS2_SIGNED_123 = (|_zz__zz_decode_IS_RS2_SIGNED_124);
-  assign _zz__zz_decode_IS_RS2_SIGNED_127 = {_zz__zz_decode_IS_RS2_SIGNED_128,{_zz__zz_decode_IS_RS2_SIGNED_133,_zz__zz_decode_IS_RS2_SIGNED_137}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_62 = 32'h00001040;
-  assign _zz__zz_decode_IS_RS2_SIGNED_64 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz__zz_decode_IS_RS2_SIGNED_65 = 32'h00000040;
-  assign _zz__zz_decode_IS_RS2_SIGNED_67 = _zz_decode_IS_RS2_SIGNED_4;
-  assign _zz__zz_decode_IS_RS2_SIGNED_68 = (_zz__zz_decode_IS_RS2_SIGNED_69 == _zz__zz_decode_IS_RS2_SIGNED_70);
-  assign _zz__zz_decode_IS_RS2_SIGNED_73 = 32'h08000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_75 = (decode_INSTRUCTION & 32'h10000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_76 = 32'h00000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_78 = (decode_INSTRUCTION & 32'h00000028);
-  assign _zz__zz_decode_IS_RS2_SIGNED_79 = 32'h00000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_82 = (decode_INSTRUCTION & 32'h00000040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_83 = 32'h00000040;
-  assign _zz__zz_decode_IS_RS2_SIGNED_85 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_86) == 32'h00004020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_87 = (_zz__zz_decode_IS_RS2_SIGNED_88 == _zz__zz_decode_IS_RS2_SIGNED_89);
-  assign _zz__zz_decode_IS_RS2_SIGNED_90 = {_zz_decode_IS_RS2_SIGNED_6,_zz__zz_decode_IS_RS2_SIGNED_91};
-  assign _zz__zz_decode_IS_RS2_SIGNED_95 = (_zz__zz_decode_IS_RS2_SIGNED_96 == _zz__zz_decode_IS_RS2_SIGNED_97);
-  assign _zz__zz_decode_IS_RS2_SIGNED_98 = {_zz__zz_decode_IS_RS2_SIGNED_99,{_zz__zz_decode_IS_RS2_SIGNED_101,_zz__zz_decode_IS_RS2_SIGNED_104}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_108 = _zz_decode_IS_RS2_SIGNED_2;
-  assign _zz__zz_decode_IS_RS2_SIGNED_109 = {_zz__zz_decode_IS_RS2_SIGNED_110,{_zz__zz_decode_IS_RS2_SIGNED_112,_zz__zz_decode_IS_RS2_SIGNED_115}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_124 = {_zz_decode_IS_RS2_SIGNED_5,_zz__zz_decode_IS_RS2_SIGNED_125};
-  assign _zz__zz_decode_IS_RS2_SIGNED_128 = (|{_zz__zz_decode_IS_RS2_SIGNED_129,_zz__zz_decode_IS_RS2_SIGNED_130});
-  assign _zz__zz_decode_IS_RS2_SIGNED_133 = (|_zz__zz_decode_IS_RS2_SIGNED_134);
-  assign _zz__zz_decode_IS_RS2_SIGNED_137 = {_zz__zz_decode_IS_RS2_SIGNED_138,{_zz__zz_decode_IS_RS2_SIGNED_141,_zz__zz_decode_IS_RS2_SIGNED_151}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_69 = (decode_INSTRUCTION & 32'h02100040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_70 = 32'h00000040;
-  assign _zz__zz_decode_IS_RS2_SIGNED_86 = 32'h00004020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_88 = (decode_INSTRUCTION & 32'h00000030);
-  assign _zz__zz_decode_IS_RS2_SIGNED_89 = 32'h00000010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_91 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_92) == 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_96 = (decode_INSTRUCTION & 32'h00002030);
-  assign _zz__zz_decode_IS_RS2_SIGNED_97 = 32'h00002010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_99 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_100) == 32'h00000010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_101 = (_zz__zz_decode_IS_RS2_SIGNED_102 == _zz__zz_decode_IS_RS2_SIGNED_103);
-  assign _zz__zz_decode_IS_RS2_SIGNED_104 = (_zz__zz_decode_IS_RS2_SIGNED_105 == _zz__zz_decode_IS_RS2_SIGNED_106);
-  assign _zz__zz_decode_IS_RS2_SIGNED_110 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_111) == 32'h00001010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_112 = (_zz__zz_decode_IS_RS2_SIGNED_113 == _zz__zz_decode_IS_RS2_SIGNED_114);
-  assign _zz__zz_decode_IS_RS2_SIGNED_115 = {_zz__zz_decode_IS_RS2_SIGNED_116,{_zz__zz_decode_IS_RS2_SIGNED_118,_zz__zz_decode_IS_RS2_SIGNED_121}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_125 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_126) == 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_129 = _zz_decode_IS_RS2_SIGNED_5;
-  assign _zz__zz_decode_IS_RS2_SIGNED_130 = (_zz__zz_decode_IS_RS2_SIGNED_131 == _zz__zz_decode_IS_RS2_SIGNED_132);
-  assign _zz__zz_decode_IS_RS2_SIGNED_134 = (_zz__zz_decode_IS_RS2_SIGNED_135 == _zz__zz_decode_IS_RS2_SIGNED_136);
-  assign _zz__zz_decode_IS_RS2_SIGNED_138 = (|_zz__zz_decode_IS_RS2_SIGNED_139);
-  assign _zz__zz_decode_IS_RS2_SIGNED_141 = (|_zz__zz_decode_IS_RS2_SIGNED_142);
-  assign _zz__zz_decode_IS_RS2_SIGNED_151 = {_zz__zz_decode_IS_RS2_SIGNED_152,{_zz__zz_decode_IS_RS2_SIGNED_156,_zz__zz_decode_IS_RS2_SIGNED_162}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_92 = 32'h02000028;
-  assign _zz__zz_decode_IS_RS2_SIGNED_100 = 32'h00001030;
-  assign _zz__zz_decode_IS_RS2_SIGNED_102 = (decode_INSTRUCTION & 32'h02003020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_103 = 32'h00000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_105 = (decode_INSTRUCTION & 32'h02002068);
-  assign _zz__zz_decode_IS_RS2_SIGNED_106 = 32'h00002020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_111 = 32'h00001010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_113 = (decode_INSTRUCTION & 32'h00002010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_114 = 32'h00002010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_116 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_117) == 32'h00002008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_80 = {_zz__zz_decode_IS_RS2_SIGNED_81,{_zz__zz_decode_IS_RS2_SIGNED_83,_zz__zz_decode_IS_RS2_SIGNED_86}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_88 = _zz_decode_IS_RS2_SIGNED_8;
+  assign _zz__zz_decode_IS_RS2_SIGNED_89 = {_zz__zz_decode_IS_RS2_SIGNED_90,{_zz__zz_decode_IS_RS2_SIGNED_92,_zz__zz_decode_IS_RS2_SIGNED_95}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_101 = {_zz_decode_IS_RS2_SIGNED_4,{_zz__zz_decode_IS_RS2_SIGNED_102,_zz__zz_decode_IS_RS2_SIGNED_105}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_116 = (|{_zz__zz_decode_IS_RS2_SIGNED_117,_zz__zz_decode_IS_RS2_SIGNED_118});
+  assign _zz__zz_decode_IS_RS2_SIGNED_121 = (|_zz__zz_decode_IS_RS2_SIGNED_122);
+  assign _zz__zz_decode_IS_RS2_SIGNED_125 = {_zz__zz_decode_IS_RS2_SIGNED_126,{_zz__zz_decode_IS_RS2_SIGNED_129,_zz__zz_decode_IS_RS2_SIGNED_133}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_61 = 32'h00000050;
+  assign _zz__zz_decode_IS_RS2_SIGNED_64 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_65) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_71 = 32'h10000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_73 = 32'h00000028;
+  assign _zz__zz_decode_IS_RS2_SIGNED_76 = 32'h00000040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_78 = (decode_INSTRUCTION & 32'h00004020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_79 = 32'h00004020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_81 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_82) == 32'h00000010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_83 = (_zz__zz_decode_IS_RS2_SIGNED_84 == _zz__zz_decode_IS_RS2_SIGNED_85);
+  assign _zz__zz_decode_IS_RS2_SIGNED_86 = _zz_decode_IS_RS2_SIGNED_8;
+  assign _zz__zz_decode_IS_RS2_SIGNED_90 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_91) == 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_92 = (_zz__zz_decode_IS_RS2_SIGNED_93 == _zz__zz_decode_IS_RS2_SIGNED_94);
+  assign _zz__zz_decode_IS_RS2_SIGNED_95 = {_zz__zz_decode_IS_RS2_SIGNED_96,_zz__zz_decode_IS_RS2_SIGNED_98};
+  assign _zz__zz_decode_IS_RS2_SIGNED_102 = (_zz__zz_decode_IS_RS2_SIGNED_103 == _zz__zz_decode_IS_RS2_SIGNED_104);
+  assign _zz__zz_decode_IS_RS2_SIGNED_105 = {_zz__zz_decode_IS_RS2_SIGNED_106,{_zz__zz_decode_IS_RS2_SIGNED_108,_zz__zz_decode_IS_RS2_SIGNED_111}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_117 = _zz_decode_IS_RS2_SIGNED_7;
   assign _zz__zz_decode_IS_RS2_SIGNED_118 = (_zz__zz_decode_IS_RS2_SIGNED_119 == _zz__zz_decode_IS_RS2_SIGNED_120);
-  assign _zz__zz_decode_IS_RS2_SIGNED_121 = {_zz_decode_IS_RS2_SIGNED_6,_zz__zz_decode_IS_RS2_SIGNED_122};
-  assign _zz__zz_decode_IS_RS2_SIGNED_126 = 32'h00000070;
-  assign _zz__zz_decode_IS_RS2_SIGNED_131 = (decode_INSTRUCTION & 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_132 = 32'h0;
-  assign _zz__zz_decode_IS_RS2_SIGNED_135 = (decode_INSTRUCTION & 32'h00004014);
-  assign _zz__zz_decode_IS_RS2_SIGNED_136 = 32'h00004010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_139 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_140) == 32'h00002010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_142 = {_zz__zz_decode_IS_RS2_SIGNED_143,{_zz__zz_decode_IS_RS2_SIGNED_144,_zz__zz_decode_IS_RS2_SIGNED_145}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_152 = (|{_zz__zz_decode_IS_RS2_SIGNED_153,_zz__zz_decode_IS_RS2_SIGNED_154});
-  assign _zz__zz_decode_IS_RS2_SIGNED_156 = (|_zz__zz_decode_IS_RS2_SIGNED_157);
-  assign _zz__zz_decode_IS_RS2_SIGNED_162 = {_zz__zz_decode_IS_RS2_SIGNED_163,{_zz__zz_decode_IS_RS2_SIGNED_166,_zz__zz_decode_IS_RS2_SIGNED_169}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_117 = 32'h00002008;
-  assign _zz__zz_decode_IS_RS2_SIGNED_119 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz__zz_decode_IS_RS2_SIGNED_120 = 32'h00000010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_122 = ((decode_INSTRUCTION & 32'h00000028) == 32'h0);
-  assign _zz__zz_decode_IS_RS2_SIGNED_140 = 32'h00006014;
-  assign _zz__zz_decode_IS_RS2_SIGNED_143 = ((decode_INSTRUCTION & 32'h00000044) == 32'h0);
-  assign _zz__zz_decode_IS_RS2_SIGNED_144 = _zz_decode_IS_RS2_SIGNED_4;
-  assign _zz__zz_decode_IS_RS2_SIGNED_145 = {(_zz__zz_decode_IS_RS2_SIGNED_146 == _zz__zz_decode_IS_RS2_SIGNED_147),{_zz__zz_decode_IS_RS2_SIGNED_148,{_zz__zz_decode_IS_RS2_SIGNED_149,_zz__zz_decode_IS_RS2_SIGNED_150}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_153 = _zz_decode_IS_RS2_SIGNED_3;
-  assign _zz__zz_decode_IS_RS2_SIGNED_154 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_155) == 32'h0);
-  assign _zz__zz_decode_IS_RS2_SIGNED_157 = {(_zz__zz_decode_IS_RS2_SIGNED_158 == _zz__zz_decode_IS_RS2_SIGNED_159),{_zz__zz_decode_IS_RS2_SIGNED_160,_zz__zz_decode_IS_RS2_SIGNED_161}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_163 = (|{_zz_decode_IS_RS2_SIGNED_2,{_zz__zz_decode_IS_RS2_SIGNED_164,_zz__zz_decode_IS_RS2_SIGNED_165}});
+  assign _zz__zz_decode_IS_RS2_SIGNED_122 = {_zz_decode_IS_RS2_SIGNED_7,_zz__zz_decode_IS_RS2_SIGNED_123};
+  assign _zz__zz_decode_IS_RS2_SIGNED_126 = (|_zz__zz_decode_IS_RS2_SIGNED_127);
+  assign _zz__zz_decode_IS_RS2_SIGNED_129 = (|_zz__zz_decode_IS_RS2_SIGNED_130);
+  assign _zz__zz_decode_IS_RS2_SIGNED_133 = {_zz__zz_decode_IS_RS2_SIGNED_134,{_zz__zz_decode_IS_RS2_SIGNED_145,_zz__zz_decode_IS_RS2_SIGNED_149}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_65 = 32'h02100040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_82 = 32'h00000030;
+  assign _zz__zz_decode_IS_RS2_SIGNED_84 = (decode_INSTRUCTION & 32'h02000010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_85 = 32'h00000010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_91 = 32'h00002030;
+  assign _zz__zz_decode_IS_RS2_SIGNED_93 = (decode_INSTRUCTION & 32'h00001030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_94 = 32'h00000010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_96 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_97) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_98 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_99) == 32'h00002020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_103 = (decode_INSTRUCTION & 32'h00001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_104 = 32'h00001010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_106 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_107) == 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_108 = (_zz__zz_decode_IS_RS2_SIGNED_109 == _zz__zz_decode_IS_RS2_SIGNED_110);
+  assign _zz__zz_decode_IS_RS2_SIGNED_111 = {_zz__zz_decode_IS_RS2_SIGNED_112,{_zz__zz_decode_IS_RS2_SIGNED_113,_zz__zz_decode_IS_RS2_SIGNED_114}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_119 = (decode_INSTRUCTION & 32'h00000070);
+  assign _zz__zz_decode_IS_RS2_SIGNED_120 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_123 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_124) == 32'h00000000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_127 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_128) == 32'h00004010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_130 = (_zz__zz_decode_IS_RS2_SIGNED_131 == _zz__zz_decode_IS_RS2_SIGNED_132);
+  assign _zz__zz_decode_IS_RS2_SIGNED_134 = (|{_zz__zz_decode_IS_RS2_SIGNED_135,_zz__zz_decode_IS_RS2_SIGNED_137});
+  assign _zz__zz_decode_IS_RS2_SIGNED_145 = (|_zz__zz_decode_IS_RS2_SIGNED_146);
+  assign _zz__zz_decode_IS_RS2_SIGNED_149 = {_zz__zz_decode_IS_RS2_SIGNED_150,{_zz__zz_decode_IS_RS2_SIGNED_159,_zz__zz_decode_IS_RS2_SIGNED_163}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_97 = 32'h02003020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_99 = 32'h02002068;
+  assign _zz__zz_decode_IS_RS2_SIGNED_107 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_109 = (decode_INSTRUCTION & 32'h00002008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_110 = 32'h00002008;
+  assign _zz__zz_decode_IS_RS2_SIGNED_112 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_113 = _zz_decode_IS_RS2_SIGNED_8;
+  assign _zz__zz_decode_IS_RS2_SIGNED_114 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_115) == 32'h00000000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_124 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_128 = 32'h00004014;
+  assign _zz__zz_decode_IS_RS2_SIGNED_131 = (decode_INSTRUCTION & 32'h00006014);
+  assign _zz__zz_decode_IS_RS2_SIGNED_132 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_135 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_136) == 32'h00000000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_137 = {_zz_decode_IS_RS2_SIGNED_6,{_zz__zz_decode_IS_RS2_SIGNED_138,{_zz__zz_decode_IS_RS2_SIGNED_140,_zz__zz_decode_IS_RS2_SIGNED_143}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_146 = {_zz_decode_IS_RS2_SIGNED_5,(_zz__zz_decode_IS_RS2_SIGNED_147 == _zz__zz_decode_IS_RS2_SIGNED_148)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_150 = (|{_zz__zz_decode_IS_RS2_SIGNED_151,{_zz__zz_decode_IS_RS2_SIGNED_153,_zz__zz_decode_IS_RS2_SIGNED_156}});
+  assign _zz__zz_decode_IS_RS2_SIGNED_159 = (|{_zz__zz_decode_IS_RS2_SIGNED_160,_zz__zz_decode_IS_RS2_SIGNED_161});
+  assign _zz__zz_decode_IS_RS2_SIGNED_163 = {(|_zz__zz_decode_IS_RS2_SIGNED_164),{_zz__zz_decode_IS_RS2_SIGNED_166,_zz__zz_decode_IS_RS2_SIGNED_169}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_115 = 32'h00000028;
+  assign _zz__zz_decode_IS_RS2_SIGNED_136 = 32'h00000044;
+  assign _zz__zz_decode_IS_RS2_SIGNED_138 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_139) == 32'h00002000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_140 = (_zz__zz_decode_IS_RS2_SIGNED_141 == _zz__zz_decode_IS_RS2_SIGNED_142);
+  assign _zz__zz_decode_IS_RS2_SIGNED_143 = {_zz__zz_decode_IS_RS2_SIGNED_144,_zz_decode_IS_RS2_SIGNED_5};
+  assign _zz__zz_decode_IS_RS2_SIGNED_147 = (decode_INSTRUCTION & 32'h00000058);
+  assign _zz__zz_decode_IS_RS2_SIGNED_148 = 32'h00000000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_151 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_152) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_153 = (_zz__zz_decode_IS_RS2_SIGNED_154 == _zz__zz_decode_IS_RS2_SIGNED_155);
+  assign _zz__zz_decode_IS_RS2_SIGNED_156 = (_zz__zz_decode_IS_RS2_SIGNED_157 == _zz__zz_decode_IS_RS2_SIGNED_158);
+  assign _zz__zz_decode_IS_RS2_SIGNED_160 = _zz_decode_IS_RS2_SIGNED_4;
+  assign _zz__zz_decode_IS_RS2_SIGNED_161 = {_zz_decode_IS_RS2_SIGNED_3,_zz__zz_decode_IS_RS2_SIGNED_162};
+  assign _zz__zz_decode_IS_RS2_SIGNED_164 = {_zz_decode_IS_RS2_SIGNED_3,_zz__zz_decode_IS_RS2_SIGNED_165};
   assign _zz__zz_decode_IS_RS2_SIGNED_166 = (|{_zz__zz_decode_IS_RS2_SIGNED_167,_zz__zz_decode_IS_RS2_SIGNED_168});
-  assign _zz__zz_decode_IS_RS2_SIGNED_169 = (|_zz__zz_decode_IS_RS2_SIGNED_170);
-  assign _zz__zz_decode_IS_RS2_SIGNED_146 = (decode_INSTRUCTION & 32'h00006004);
-  assign _zz__zz_decode_IS_RS2_SIGNED_147 = 32'h00002000;
-  assign _zz__zz_decode_IS_RS2_SIGNED_148 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_149 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_150 = _zz_decode_IS_RS2_SIGNED_3;
-  assign _zz__zz_decode_IS_RS2_SIGNED_155 = 32'h00000058;
-  assign _zz__zz_decode_IS_RS2_SIGNED_158 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz__zz_decode_IS_RS2_SIGNED_159 = 32'h00000040;
-  assign _zz__zz_decode_IS_RS2_SIGNED_160 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00002010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_161 = ((decode_INSTRUCTION & 32'h40000034) == 32'h40000030);
-  assign _zz__zz_decode_IS_RS2_SIGNED_164 = _zz_decode_IS_RS2_SIGNED_1;
-  assign _zz__zz_decode_IS_RS2_SIGNED_165 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00000004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_169 = (|_zz_decode_IS_RS2_SIGNED_1);
+  assign _zz__zz_decode_IS_RS2_SIGNED_139 = 32'h00006004;
+  assign _zz__zz_decode_IS_RS2_SIGNED_141 = (decode_INSTRUCTION & 32'h00005004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_142 = 32'h00001000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_144 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_152 = 32'h00000044;
+  assign _zz__zz_decode_IS_RS2_SIGNED_154 = (decode_INSTRUCTION & 32'h00002014);
+  assign _zz__zz_decode_IS_RS2_SIGNED_155 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_157 = (decode_INSTRUCTION & 32'h40000034);
+  assign _zz__zz_decode_IS_RS2_SIGNED_158 = 32'h40000030;
+  assign _zz__zz_decode_IS_RS2_SIGNED_162 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00000004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_165 = ((decode_INSTRUCTION & 32'h0000004c) == 32'h00000004);
   assign _zz__zz_decode_IS_RS2_SIGNED_167 = _zz_decode_IS_RS2_SIGNED_1;
-  assign _zz__zz_decode_IS_RS2_SIGNED_168 = ((decode_INSTRUCTION & 32'h0000004c) == 32'h00000004);
-  assign _zz__zz_decode_IS_RS2_SIGNED_170 = ((decode_INSTRUCTION & 32'h00005048) == 32'h00001008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_168 = _zz_decode_IS_RS2_SIGNED_2;
   assign _zz_execute_BranchPlugin_branch_src2_6 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_7 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_8 = execute_INSTRUCTION[7];
-  assign _zz_CsrPlugin_csrMapping_readDataInit_28 = 32'h0;
+  assign _zz_CsrPlugin_csrMapping_readDataInit_26 = 32'h00000000;
   always @(posedge clk) begin
     if(_zz_decode_RegFilePlugin_rs1Data) begin
       _zz_RegFilePlugin_regFile_port0 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
@@ -2221,8 +2232,8 @@ module VexRiscv (
     .io_mem_rsp_valid                      (iBus_rsp_valid                                            ), //i
     .io_mem_rsp_payload_data               (iBus_rsp_payload_data[31:0]                               ), //i
     .io_mem_rsp_payload_error              (iBus_rsp_payload_error                                    ), //i
-    ._zz_when_Fetcher_l401                 (switch_Fetcher_l365[2:0]                                  ), //i
-    ._zz_io_cpu_fetch_data_regNextWhen     (IBusCachedPlugin_injectionPort_payload[31:0]              ), //i
+    ._zz_when_Fetcher_l411                 (IBusCachedPlugin_injector_port_state[2:0]                 ), //i
+    ._zz_io_cpu_fetch_data_regNextWhen     (DebugPlugin_injectionPort_payload[31:0]                   ), //i
     .clk                                   (clk                                                       ), //i
     .reset                                 (reset                                                     )  //i
   );
@@ -2287,8 +2298,9 @@ module VexRiscv (
     .io_cpu_flush_ready                     (dataCache_1_io_cpu_flush_ready                   ), //o
     .io_cpu_flush_payload_singleLine        (dataCache_1_io_cpu_flush_payload_singleLine      ), //i
     .io_cpu_flush_payload_lineId            (dataCache_1_io_cpu_flush_payload_lineId[6:0]     ), //i
+    .io_cpu_writesPending                   (dataCache_1_io_cpu_writesPending                 ), //o
     .io_mem_cmd_valid                       (dataCache_1_io_mem_cmd_valid                     ), //o
-    .io_mem_cmd_ready                       (dataCache_1_io_mem_cmd_ready                     ), //i
+    .io_mem_cmd_ready                       (toplevel_dataCache_1_io_mem_cmd_rValidN          ), //i
     .io_mem_cmd_payload_wr                  (dataCache_1_io_mem_cmd_payload_wr                ), //o
     .io_mem_cmd_payload_uncached            (dataCache_1_io_mem_cmd_payload_uncached          ), //o
     .io_mem_cmd_payload_address             (dataCache_1_io_mem_cmd_payload_address[31:0]     ), //o
@@ -3140,7 +3152,7 @@ module VexRiscv (
   end
   `endif
 
-  assign memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW) + $signed(_zz_memory_MUL_LOW_7));
+  assign memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW) + $signed(_zz_memory_MUL_LOW_6));
   assign memory_MUL_HH = execute_to_memory_MUL_HH;
   assign execute_MUL_HH = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bHigh));
   assign execute_MUL_HL = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bSLow));
@@ -3155,7 +3167,7 @@ module VexRiscv (
   assign execute_MEMORY_STORE_DATA_RF = _zz_execute_MEMORY_STORE_DATA_RF;
   assign decode_DO_EBREAK = (((! DebugPlugin_haltIt) && (decode_IS_EBREAK || ((1'b0 || (DebugPlugin_hardwareBreakpoints_0_valid && (DebugPlugin_hardwareBreakpoints_0_pc == _zz_decode_DO_EBREAK))) || (DebugPlugin_hardwareBreakpoints_1_valid && (DebugPlugin_hardwareBreakpoints_1_pc == _zz_decode_DO_EBREAK_1))))) && DebugPlugin_allowEBreak);
   assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
-  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
+  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h00)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h00))));
   assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
   assign decode_IS_RS2_SIGNED = _zz_decode_IS_RS2_SIGNED[35];
@@ -3176,21 +3188,21 @@ module VexRiscv (
   assign decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL;
   assign _zz_decode_to_execute_ALU_BITWISE_CTRL = _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   assign decode_SRC_LESS_UNSIGNED = _zz_decode_IS_RS2_SIGNED[22];
-  assign decode_IS_SFENCE_VMA = _zz_decode_IS_RS2_SIGNED[21];
-  assign decode_IS_SFENCE_VMA2 = _zz_decode_IS_RS2_SIGNED[20];
-  assign decode_MEMORY_MANAGMENT = _zz_decode_IS_RS2_SIGNED[19];
+  assign decode_IS_SFENCE_VMA2 = _zz_decode_IS_RS2_SIGNED[21];
+  assign decode_MEMORY_MANAGMENT = _zz_decode_IS_RS2_SIGNED[20];
   assign memory_MEMORY_LRSC = execute_to_memory_MEMORY_LRSC;
   assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
-  assign decode_MEMORY_WR = _zz_decode_IS_RS2_SIGNED[13];
+  assign decode_MEMORY_WR = _zz_decode_IS_RS2_SIGNED[14];
   assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_decode_IS_RS2_SIGNED[12];
-  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_decode_IS_RS2_SIGNED[11];
+  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_decode_IS_RS2_SIGNED[13];
+  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_decode_IS_RS2_SIGNED[12];
   assign decode_SRC2_CTRL = _zz_decode_SRC2_CTRL;
   assign _zz_decode_to_execute_SRC2_CTRL = _zz_decode_to_execute_SRC2_CTRL_1;
   assign decode_ALU_CTRL = _zz_decode_ALU_CTRL;
   assign _zz_decode_to_execute_ALU_CTRL = _zz_decode_to_execute_ALU_CTRL_1;
   assign decode_SRC1_CTRL = _zz_decode_SRC1_CTRL;
   assign _zz_decode_to_execute_SRC1_CTRL = _zz_decode_to_execute_SRC1_CTRL_1;
+  assign decode_RESCHEDULE_NEXT = _zz_decode_IS_RS2_SIGNED[1];
   assign decode_MEMORY_FORCE_CONSTISTENCY = _zz_decode_MEMORY_FORCE_CONSTISTENCY;
   assign writeBack_FORMAL_PC_NEXT = memory_to_writeBack_FORMAL_PC_NEXT;
   assign memory_FORMAL_PC_NEXT = execute_to_memory_FORMAL_PC_NEXT;
@@ -3215,18 +3227,18 @@ module VexRiscv (
   assign memory_ENV_CTRL = _zz_memory_ENV_CTRL;
   assign execute_ENV_CTRL = _zz_execute_ENV_CTRL;
   assign writeBack_ENV_CTRL = _zz_writeBack_ENV_CTRL;
-  assign execute_IS_SFENCE_VMA = decode_to_execute_IS_SFENCE_VMA;
+  assign execute_RESCHEDULE_NEXT = decode_to_execute_RESCHEDULE_NEXT;
   assign memory_BRANCH_CALC = execute_to_memory_BRANCH_CALC;
   assign memory_BRANCH_DO = execute_to_memory_BRANCH_DO;
   assign execute_PC = decode_to_execute_PC;
   assign execute_PREDICTION_HAD_BRANCHED2 = decode_to_execute_PREDICTION_HAD_BRANCHED2;
   assign execute_BRANCH_COND_RESULT = _zz_execute_BRANCH_COND_RESULT_1;
   assign execute_BRANCH_CTRL = _zz_execute_BRANCH_CTRL;
-  assign decode_RS2_USE = _zz_decode_IS_RS2_SIGNED[17];
-  assign decode_RS1_USE = _zz_decode_IS_RS2_SIGNED[5];
+  assign decode_RS2_USE = _zz_decode_IS_RS2_SIGNED[18];
+  assign decode_RS1_USE = _zz_decode_IS_RS2_SIGNED[6];
   always @(*) begin
     _zz_decode_RS2 = execute_REGFILE_WRITE_DATA;
-    if(when_CsrPlugin_l1189) begin
+    if(when_CsrPlugin_l1587) begin
       _zz_decode_RS2 = CsrPlugin_csrMapping_readDataSignal;
     end
     if(DBusCachedPlugin_forceDatapath) begin
@@ -3325,15 +3337,15 @@ module VexRiscv (
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_execute_SRC2 = execute_PC;
+  assign _zz_execute_to_memory_PC = execute_PC;
   assign execute_SRC2_CTRL = _zz_execute_SRC2_CTRL;
   assign execute_SRC1_CTRL = _zz_execute_SRC1_CTRL;
-  assign decode_SRC_USE_SUB_LESS = _zz_decode_IS_RS2_SIGNED[3];
-  assign decode_SRC_ADD_ZERO = _zz_decode_IS_RS2_SIGNED[18];
+  assign decode_SRC_USE_SUB_LESS = _zz_decode_IS_RS2_SIGNED[4];
+  assign decode_SRC_ADD_ZERO = _zz_decode_IS_RS2_SIGNED[19];
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
   assign execute_ALU_CTRL = _zz_execute_ALU_CTRL;
-  assign execute_SRC2 = _zz_execute_SRC2_5;
+  assign execute_SRC2 = _zz_execute_SRC2_4;
   assign execute_SRC1 = _zz_execute_SRC1;
   assign execute_ALU_BITWISE_CTRL = _zz_execute_ALU_BITWISE_CTRL;
   assign _zz_lastStageRegFileWrite_payload_address = writeBack_INSTRUCTION;
@@ -3347,19 +3359,19 @@ module VexRiscv (
 
   assign decode_INSTRUCTION_ANTICIPATED = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusCachedPlugin_cache_io_cpu_fetch_data);
   always @(*) begin
-    decode_REGFILE_WRITE_VALID = _zz_decode_IS_RS2_SIGNED[10];
+    decode_REGFILE_WRITE_VALID = _zz_decode_IS_RS2_SIGNED[11];
     if(when_RegFilePlugin_l63) begin
       decode_REGFILE_WRITE_VALID = 1'b0;
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00001073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
+  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000107f) == 32'h00001073),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00002073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
   assign execute_IS_SFENCE_VMA2 = decode_to_execute_IS_SFENCE_VMA2;
   assign writeBack_IS_DBUS_SHARING = memory_to_writeBack_IS_DBUS_SHARING;
   assign memory_IS_DBUS_SHARING = execute_to_memory_IS_DBUS_SHARING;
   always @(*) begin
     _zz_decode_RS2_2 = writeBack_REGFILE_WRITE_DATA;
-    if(when_DBusCachedPlugin_l492) begin
+    if(when_DBusCachedPlugin_l580) begin
       _zz_decode_RS2_2 = writeBack_DBusCachedPlugin_rspFormated;
     end
     if(when_MulPlugin_l147) begin
@@ -3384,7 +3396,7 @@ module VexRiscv (
   always @(*) begin
     execute_MEMORY_AMO = decode_to_execute_MEMORY_AMO;
     if(MmuPlugin_dBusAccess_cmd_valid) begin
-      if(when_DBusCachedPlugin_l506) begin
+      if(when_DBusCachedPlugin_l604) begin
         execute_MEMORY_AMO = 1'b0;
       end
     end
@@ -3393,7 +3405,7 @@ module VexRiscv (
   always @(*) begin
     execute_MEMORY_LRSC = decode_to_execute_MEMORY_LRSC;
     if(MmuPlugin_dBusAccess_cmd_valid) begin
-      if(when_DBusCachedPlugin_l506) begin
+      if(when_DBusCachedPlugin_l604) begin
         execute_MEMORY_LRSC = 1'b0;
       end
     end
@@ -3407,34 +3419,34 @@ module VexRiscv (
   assign execute_SRC_ADD = execute_SrcPlugin_addSub;
   assign execute_MEMORY_ENABLE = decode_to_execute_MEMORY_ENABLE;
   assign execute_INSTRUCTION = decode_to_execute_INSTRUCTION;
-  assign decode_MEMORY_AMO = _zz_decode_IS_RS2_SIGNED[16];
-  assign decode_MEMORY_LRSC = _zz_decode_IS_RS2_SIGNED[15];
-  assign decode_MEMORY_ENABLE = _zz_decode_IS_RS2_SIGNED[4];
+  assign decode_MEMORY_AMO = _zz_decode_IS_RS2_SIGNED[17];
+  assign decode_MEMORY_LRSC = _zz_decode_IS_RS2_SIGNED[16];
+  assign decode_MEMORY_ENABLE = _zz_decode_IS_RS2_SIGNED[5];
   assign decode_FLUSH_ALL = _zz_decode_IS_RS2_SIGNED[0];
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_4 = IBusCachedPlugin_rsp_issueDetected_3;
-    if(when_IBusCachedPlugin_l256) begin
+    if(when_IBusCachedPlugin_l262) begin
       IBusCachedPlugin_rsp_issueDetected_4 = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_3 = IBusCachedPlugin_rsp_issueDetected_2;
-    if(when_IBusCachedPlugin_l250) begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_rsp_issueDetected_3 = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
-    if(when_IBusCachedPlugin_l244) begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
-    if(when_IBusCachedPlugin_l239) begin
+    if(when_IBusCachedPlugin_l245) begin
       IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
@@ -3467,10 +3479,10 @@ module VexRiscv (
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
   always @(*) begin
     decode_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l308) begin
+    if(when_DBusCachedPlugin_l352) begin
       decode_arbitration_haltItself = 1'b1;
     end
-    case(switch_Fetcher_l365)
+    case(IBusCachedPlugin_injector_port_state)
       3'b010 : begin
         decode_arbitration_haltItself = 1'b1;
       end
@@ -3493,7 +3505,7 @@ module VexRiscv (
     if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(when_CsrPlugin_l1129) begin
+    if(when_CsrPlugin_l1527) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
@@ -3521,15 +3533,15 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l350) begin
+    if(when_DBusCachedPlugin_l394) begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(when_CsrPlugin_l1121) begin
-      if(when_CsrPlugin_l1123) begin
+    if(when_CsrPlugin_l1519) begin
+      if(when_CsrPlugin_l1521) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(when_CsrPlugin_l1193) begin
+    if(when_CsrPlugin_l1591) begin
       if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
@@ -3538,10 +3550,10 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if(when_DBusCachedPlugin_l366) begin
+    if(when_DBusCachedPlugin_l410) begin
       execute_arbitration_haltByOther = 1'b1;
     end
-    if(when_DebugPlugin_l295) begin
+    if(when_DebugPlugin_l308) begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
@@ -3558,8 +3570,8 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_flushIt = 1'b0;
-    if(when_DebugPlugin_l295) begin
-      if(when_DebugPlugin_l298) begin
+    if(when_DebugPlugin_l308) begin
+      if(when_DebugPlugin_l311) begin
         execute_arbitration_flushIt = 1'b1;
       end
     end
@@ -3573,8 +3585,8 @@ module VexRiscv (
     if(CsrPlugin_selfException_valid) begin
       execute_arbitration_flushNext = 1'b1;
     end
-    if(when_DebugPlugin_l295) begin
-      if(when_DebugPlugin_l298) begin
+    if(when_DebugPlugin_l308) begin
+      if(when_DebugPlugin_l311) begin
         execute_arbitration_flushNext = 1'b1;
       end
     end
@@ -3613,7 +3625,7 @@ module VexRiscv (
 
   always @(*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l466) begin
+    if(when_DBusCachedPlugin_l553) begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
@@ -3644,10 +3656,10 @@ module VexRiscv (
     if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -3658,24 +3670,24 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @(*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(when_CsrPlugin_l935) begin
+    if(when_CsrPlugin_l1272) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_DebugPlugin_l295) begin
-      if(when_DebugPlugin_l298) begin
+    if(when_DebugPlugin_l308) begin
+      if(when_DebugPlugin_l311) begin
         IBusCachedPlugin_fetcherHalt = 1'b1;
       end
     end
     if(DebugPlugin_haltIt) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_DebugPlugin_l311) begin
+    if(when_DebugPlugin_l324) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
@@ -3683,15 +3695,15 @@ module VexRiscv (
   assign IBusCachedPlugin_forceNoDecodeCond = 1'b0;
   always @(*) begin
     IBusCachedPlugin_incomingInstruction = 1'b0;
-    if(when_Fetcher_l243) begin
+    if(when_Fetcher_l242) begin
       IBusCachedPlugin_incomingInstruction = 1'b1;
     end
   end
 
   always @(*) begin
-    _zz_when_DBusCachedPlugin_l393 = 1'b0;
+    _zz_when_DBusCachedPlugin_l472 = 1'b0;
     if(DebugPlugin_godmode) begin
-      _zz_when_DBusCachedPlugin_l393 = 1'b1;
+      _zz_when_DBusCachedPlugin_l472 = 1'b1;
     end
   end
 
@@ -3702,11 +3714,21 @@ module VexRiscv (
     end
   end
 
-  assign CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+  always @(*) begin
+    CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+    if(when_CsrPlugin_l1702) begin
+      CsrPlugin_csrMapping_allowCsrSignal = 1'b1;
+    end
+    if(when_CsrPlugin_l1709) begin
+      CsrPlugin_csrMapping_allowCsrSignal = 1'b1;
+    end
+  end
+
+  assign CsrPlugin_csrMapping_doForceFailCsr = 1'b0;
   assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
   always @(*) begin
     CsrPlugin_inWfi = 1'b0;
-    if(when_CsrPlugin_l1121) begin
+    if(when_CsrPlugin_l1519) begin
       CsrPlugin_inWfi = 1'b1;
     end
   end
@@ -3720,21 +3742,21 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(when_CsrPlugin_l1077) begin
-      case(switch_CsrPlugin_l1081)
+    if(when_CsrPlugin_l1456) begin
+      case(switch_CsrPlugin_l1460)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -3756,7 +3778,7 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_allowInterrupts = 1'b1;
-    if(when_DebugPlugin_l331) begin
+    if(when_DebugPlugin_l344) begin
       CsrPlugin_allowInterrupts = 1'b0;
     end
   end
@@ -3775,8 +3797,26 @@ module VexRiscv (
     end
   end
 
+  always @(*) begin
+    CsrPlugin_xretAwayFromMachine = 1'b0;
+    if(when_CsrPlugin_l1456) begin
+      case(switch_CsrPlugin_l1460)
+        2'b11 : begin
+          if(when_CsrPlugin_l1468) begin
+            CsrPlugin_xretAwayFromMachine = 1'b1;
+          end
+        end
+        2'b01 : begin
+          CsrPlugin_xretAwayFromMachine = 1'b1;
+        end
+        default : begin
+        end
+      endcase
+    end
+  end
+
   assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
-  assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_redoInterface_valid,{CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusCachedPlugin_redoBranch_valid,IBusCachedPlugin_predictionJumpInterface_valid}}}} != 5'h0);
+  assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_redoInterface_valid,{CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusCachedPlugin_redoBranch_valid,IBusCachedPlugin_predictionJumpInterface_valid}}}} != 5'h00);
   assign _zz_IBusCachedPlugin_jump_pcLoad_payload = {IBusCachedPlugin_predictionJumpInterface_valid,{CsrPlugin_redoInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}}};
   assign _zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload & (~ _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1));
   assign _zz_IBusCachedPlugin_jump_pcLoad_payload_2 = _zz_IBusCachedPlugin_jump_pcLoad_payload_1[3];
@@ -3803,9 +3843,8 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l134 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
-  assign IBusCachedPlugin_fetchPc_output_fire_1 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
-  assign when_Fetcher_l134_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
+  assign when_Fetcher_l133 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l133_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
   always @(*) begin
     IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_IBusCachedPlugin_fetchPc_pc);
     if(IBusCachedPlugin_fetchPc_redo_valid) begin
@@ -3828,7 +3867,7 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l161 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
+  assign when_Fetcher_l160 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
   assign IBusCachedPlugin_fetchPc_output_valid = ((! IBusCachedPlugin_fetcherHalt) && IBusCachedPlugin_fetchPc_booted);
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
   always @(*) begin
@@ -3865,7 +3904,7 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_1_output_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b0;
-    if(when_IBusCachedPlugin_l267) begin
+    if(when_IBusCachedPlugin_l273) begin
       IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b1;
     end
   end
@@ -3878,9 +3917,9 @@ module VexRiscv (
   assign IBusCachedPlugin_fetchPc_redo_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_iBusRsp_flush = ((decode_arbitration_removeIt || (decode_arbitration_flushNext && (! decode_arbitration_isStuck))) || IBusCachedPlugin_iBusRsp_redoFetch);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
-  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1 = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
   assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid)) || IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready);
   assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
@@ -3890,18 +3929,18 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
   always @(*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
-    if(when_Fetcher_l323) begin
+    if(when_Fetcher_l322) begin
       IBusCachedPlugin_iBusRsp_readyForError = 1'b0;
     end
   end
 
-  assign when_Fetcher_l243 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
-  assign when_Fetcher_l323 = (! IBusCachedPlugin_pcValids_0);
-  assign when_Fetcher_l332 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
-  assign when_Fetcher_l332_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
-  assign when_Fetcher_l332_2 = (! execute_arbitration_isStuck);
-  assign when_Fetcher_l332_3 = (! memory_arbitration_isStuck);
-  assign when_Fetcher_l332_4 = (! writeBack_arbitration_isStuck);
+  assign when_Fetcher_l242 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
+  assign when_Fetcher_l322 = (! IBusCachedPlugin_pcValids_0);
+  assign when_Fetcher_l331 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l331_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
+  assign when_Fetcher_l331_2 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l331_3 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l331_4 = (! writeBack_arbitration_isStuck);
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
@@ -3909,7 +3948,7 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
   always @(*) begin
     decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
-    case(switch_Fetcher_l365)
+    case(IBusCachedPlugin_injector_port_state)
       3'b010 : begin
         decode_arbitration_isValid = 1'b1;
       end
@@ -4066,90 +4105,89 @@ module VexRiscv (
   assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
   always @(*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(when_IBusCachedPlugin_l239) begin
+    if(when_IBusCachedPlugin_l245) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(when_IBusCachedPlugin_l250) begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_cache_io_cpu_fill_valid = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
-    if(when_IBusCachedPlugin_l250) begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_cache_io_cpu_fill_valid = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_valid = 1'b0;
-    if(when_IBusCachedPlugin_l244) begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
-    if(when_IBusCachedPlugin_l256) begin
+    if(when_IBusCachedPlugin_l262) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_payload_code = 4'bxxxx;
-    if(when_IBusCachedPlugin_l244) begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b1100;
     end
-    if(when_IBusCachedPlugin_l256) begin
+    if(when_IBusCachedPlugin_l262) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b0001;
     end
   end
 
   assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_2_input_payload[31 : 2],2'b00};
-  assign when_IBusCachedPlugin_l239 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign when_IBusCachedPlugin_l244 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
-  assign when_IBusCachedPlugin_l250 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
-  assign when_IBusCachedPlugin_l256 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
-  assign when_IBusCachedPlugin_l267 = (IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt);
+  assign when_IBusCachedPlugin_l245 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign when_IBusCachedPlugin_l250 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign when_IBusCachedPlugin_l256 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
+  assign when_IBusCachedPlugin_l262 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
+  assign when_IBusCachedPlugin_l273 = (IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt);
   assign IBusCachedPlugin_iBusRsp_output_valid = IBusCachedPlugin_iBusRsp_stages_2_output_valid;
   assign IBusCachedPlugin_iBusRsp_stages_2_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
   assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_decode_data;
   assign IBusCachedPlugin_iBusRsp_output_payload_pc = IBusCachedPlugin_iBusRsp_stages_2_output_payload;
   assign IBusCachedPlugin_cache_io_flush = (decode_arbitration_isValid && decode_FLUSH_ALL);
-  assign dataCache_1_io_mem_cmd_ready = (! dataCache_1_io_mem_cmd_rValid);
-  assign dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || dataCache_1_io_mem_cmd_rValid);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_wr : dataCache_1_io_mem_cmd_payload_wr);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_uncached : dataCache_1_io_mem_cmd_payload_uncached);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_address = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_address : dataCache_1_io_mem_cmd_payload_address);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_data = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_data : dataCache_1_io_mem_cmd_payload_data);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_mask : dataCache_1_io_mem_cmd_payload_mask);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_size = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_size : dataCache_1_io_mem_cmd_payload_size);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_last : dataCache_1_io_mem_cmd_payload_last);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || (! toplevel_dataCache_1_io_mem_cmd_rValidN));
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_wr : toplevel_dataCache_1_io_mem_cmd_rData_wr);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_uncached : toplevel_dataCache_1_io_mem_cmd_rData_uncached);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_address = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_address : toplevel_dataCache_1_io_mem_cmd_rData_address);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_data = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_data : toplevel_dataCache_1_io_mem_cmd_rData_data);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_mask : toplevel_dataCache_1_io_mem_cmd_rData_mask);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_size = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_size : toplevel_dataCache_1_io_mem_cmd_rData_size);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_last = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_last : toplevel_dataCache_1_io_mem_cmd_rData_last);
   always @(*) begin
-    dataCache_1_io_mem_cmd_s2mPipe_ready = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
-    if(when_Stream_l368) begin
-      dataCache_1_io_mem_cmd_s2mPipe_ready = 1'b1;
+    toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
+    if(when_Stream_l369) begin
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l368 = (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_rValid;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_rData_address;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_rData_data;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size = dataCache_1_io_mem_cmd_s2mPipe_rData_size;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_rData_last;
-  assign dBus_cmd_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
-  assign dBus_cmd_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
-  assign dBus_cmd_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
-  assign dBus_cmd_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
-  assign dBus_cmd_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
-  assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  assign dBus_cmd_payload_size = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
-  assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  assign when_DBusCachedPlugin_l308 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
+  assign when_Stream_l369 = (! toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_address;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_data;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_size;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  assign dBus_cmd_valid = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
+  assign dBus_cmd_payload_wr = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
+  assign dBus_cmd_payload_uncached = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
+  assign dBus_cmd_payload_address = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
+  assign dBus_cmd_payload_data = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
+  assign dBus_cmd_payload_mask = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
+  assign dBus_cmd_payload_size = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
+  assign dBus_cmd_payload_last = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  assign when_DBusCachedPlugin_l352 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
   always @(*) begin
     _zz_decode_MEMORY_FORCE_CONSTISTENCY = 1'b0;
-    if(when_DBusCachedPlugin_l316) begin
+    if(when_DBusCachedPlugin_l360) begin
       if(decode_MEMORY_LRSC) begin
         _zz_decode_MEMORY_FORCE_CONSTISTENCY = 1'b1;
       end
@@ -4159,13 +4197,13 @@ module VexRiscv (
     end
   end
 
-  assign when_DBusCachedPlugin_l316 = decode_INSTRUCTION[25];
+  assign when_DBusCachedPlugin_l360 = decode_INSTRUCTION[25];
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
   always @(*) begin
     dataCache_1_io_cpu_execute_isValid = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
     if(MmuPlugin_dBusAccess_cmd_valid) begin
-      if(when_DBusCachedPlugin_l506) begin
-        if(when_DBusCachedPlugin_l507) begin
+      if(when_DBusCachedPlugin_l604) begin
+        if(when_DBusCachedPlugin_l605) begin
           dataCache_1_io_cpu_execute_isValid = 1'b1;
         end
       end
@@ -4175,7 +4213,7 @@ module VexRiscv (
   always @(*) begin
     dataCache_1_io_cpu_execute_address = execute_SRC_ADD;
     if(MmuPlugin_dBusAccess_cmd_valid) begin
-      if(when_DBusCachedPlugin_l506) begin
+      if(when_DBusCachedPlugin_l604) begin
         dataCache_1_io_cpu_execute_address = MmuPlugin_dBusAccess_cmd_payload_address;
       end
     end
@@ -4184,7 +4222,7 @@ module VexRiscv (
   always @(*) begin
     dataCache_1_io_cpu_execute_args_wr = execute_MEMORY_WR;
     if(MmuPlugin_dBusAccess_cmd_valid) begin
-      if(when_DBusCachedPlugin_l506) begin
+      if(when_DBusCachedPlugin_l604) begin
         dataCache_1_io_cpu_execute_args_wr = 1'b0;
       end
     end
@@ -4207,17 +4245,17 @@ module VexRiscv (
   always @(*) begin
     dataCache_1_io_cpu_execute_args_size = execute_DBusCachedPlugin_size;
     if(MmuPlugin_dBusAccess_cmd_valid) begin
-      if(when_DBusCachedPlugin_l506) begin
+      if(when_DBusCachedPlugin_l604) begin
         dataCache_1_io_cpu_execute_args_size = MmuPlugin_dBusAccess_cmd_payload_size;
       end
     end
   end
 
   assign dataCache_1_io_cpu_flush_valid = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
-  assign dataCache_1_io_cpu_flush_payload_singleLine = (execute_INSTRUCTION[19 : 15] != 5'h0);
+  assign dataCache_1_io_cpu_flush_payload_singleLine = (execute_INSTRUCTION[19 : 15] != 5'h00);
   assign dataCache_1_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId[6:0];
-  assign dataCache_1_io_cpu_flush_isStall = (dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready));
-  assign when_DBusCachedPlugin_l350 = (dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
+  assign toplevel_dataCache_1_io_cpu_flush_isStall = (dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready));
+  assign when_DBusCachedPlugin_l394 = (toplevel_dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
   always @(*) begin
     dataCache_1_io_cpu_execute_args_isLrsc = 1'b0;
     if(execute_MEMORY_LRSC) begin
@@ -4227,7 +4265,7 @@ module VexRiscv (
 
   assign dataCache_1_io_cpu_execute_args_amoCtrl_alu = execute_INSTRUCTION[31 : 29];
   assign dataCache_1_io_cpu_execute_args_amoCtrl_swap = execute_INSTRUCTION[27];
-  assign when_DBusCachedPlugin_l366 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
+  assign when_DBusCachedPlugin_l410 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
   always @(*) begin
     dataCache_1_io_cpu_memory_isValid = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
     if(memory_IS_DBUS_SHARING) begin
@@ -4249,12 +4287,12 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
   always @(*) begin
     dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if(when_DBusCachedPlugin_l393) begin
+    if(when_DBusCachedPlugin_l472) begin
       dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = 1'b1;
     end
   end
 
-  assign when_DBusCachedPlugin_l393 = (_zz_when_DBusCachedPlugin_l393 && (! dataCache_1_io_cpu_memory_isWrite));
+  assign when_DBusCachedPlugin_l472 = (_zz_when_DBusCachedPlugin_l472 && (! dataCache_1_io_cpu_memory_isWrite));
   always @(*) begin
     dataCache_1_io_cpu_writeBack_isValid = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
     if(writeBack_IS_DBUS_SHARING) begin
@@ -4270,7 +4308,7 @@ module VexRiscv (
   assign dataCache_1_io_cpu_writeBack_storeData[31 : 0] = writeBack_MEMORY_STORE_DATA_RF;
   always @(*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(when_DBusCachedPlugin_l446) begin
+    if(when_DBusCachedPlugin_l533) begin
       if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
@@ -4280,7 +4318,7 @@ module VexRiscv (
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(when_DBusCachedPlugin_l446) begin
+    if(when_DBusCachedPlugin_l533) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
@@ -4299,7 +4337,7 @@ module VexRiscv (
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
-    if(when_DBusCachedPlugin_l446) begin
+    if(when_DBusCachedPlugin_l533) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code};
       end
@@ -4312,12 +4350,13 @@ module VexRiscv (
     end
   end
 
-  assign when_DBusCachedPlugin_l446 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign when_DBusCachedPlugin_l466 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
-  assign writeBack_DBusCachedPlugin_rspSplits_0 = dataCache_1_io_cpu_writeBack_data[7 : 0];
-  assign writeBack_DBusCachedPlugin_rspSplits_1 = dataCache_1_io_cpu_writeBack_data[15 : 8];
-  assign writeBack_DBusCachedPlugin_rspSplits_2 = dataCache_1_io_cpu_writeBack_data[23 : 16];
-  assign writeBack_DBusCachedPlugin_rspSplits_3 = dataCache_1_io_cpu_writeBack_data[31 : 24];
+  assign when_DBusCachedPlugin_l533 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l553 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
+  assign writeBack_DBusCachedPlugin_rspData = dataCache_1_io_cpu_writeBack_data;
+  assign writeBack_DBusCachedPlugin_rspSplits_0 = writeBack_DBusCachedPlugin_rspData[7 : 0];
+  assign writeBack_DBusCachedPlugin_rspSplits_1 = writeBack_DBusCachedPlugin_rspData[15 : 8];
+  assign writeBack_DBusCachedPlugin_rspSplits_2 = writeBack_DBusCachedPlugin_rspData[23 : 16];
+  assign writeBack_DBusCachedPlugin_rspSplits_3 = writeBack_DBusCachedPlugin_rspData[31 : 24];
   always @(*) begin
     writeBack_DBusCachedPlugin_rspShifted[7 : 0] = _zz_writeBack_DBusCachedPlugin_rspShifted;
     writeBack_DBusCachedPlugin_rspShifted[15 : 8] = _zz_writeBack_DBusCachedPlugin_rspShifted_2;
@@ -4327,13 +4366,13 @@ module VexRiscv (
 
   always @(*) begin
     writeBack_DBusCachedPlugin_rspRf = writeBack_DBusCachedPlugin_rspShifted[31 : 0];
-    if(when_DBusCachedPlugin_l482) begin
+    if(when_DBusCachedPlugin_l570) begin
       writeBack_DBusCachedPlugin_rspRf = {31'd0, _zz_writeBack_DBusCachedPlugin_rspRf};
     end
   end
 
-  assign when_DBusCachedPlugin_l482 = (writeBack_MEMORY_LRSC && writeBack_MEMORY_WR);
-  assign switch_Misc_l210 = writeBack_INSTRUCTION[13 : 12];
+  assign when_DBusCachedPlugin_l570 = (writeBack_MEMORY_LRSC && writeBack_MEMORY_WR);
+  assign switch_Misc_l232 = writeBack_INSTRUCTION[13 : 12];
   assign _zz_writeBack_DBusCachedPlugin_rspFormated = (writeBack_DBusCachedPlugin_rspRf[7] && (! writeBack_INSTRUCTION[14]));
   always @(*) begin
     _zz_writeBack_DBusCachedPlugin_rspFormated_1[31] = _zz_writeBack_DBusCachedPlugin_rspFormated;
@@ -4385,7 +4424,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    case(switch_Misc_l210)
+    case(switch_Misc_l232)
       2'b00 : begin
         writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_1;
       end
@@ -4398,12 +4437,12 @@ module VexRiscv (
     endcase
   end
 
-  assign when_DBusCachedPlugin_l492 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l580 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
   always @(*) begin
     MmuPlugin_dBusAccess_cmd_ready = 1'b0;
     if(MmuPlugin_dBusAccess_cmd_valid) begin
-      if(when_DBusCachedPlugin_l506) begin
-        if(when_DBusCachedPlugin_l507) begin
+      if(when_DBusCachedPlugin_l604) begin
+        if(when_DBusCachedPlugin_l605) begin
           MmuPlugin_dBusAccess_cmd_ready = (! execute_arbitration_isStuck);
         end
       end
@@ -4413,14 +4452,14 @@ module VexRiscv (
   always @(*) begin
     DBusCachedPlugin_forceDatapath = 1'b0;
     if(MmuPlugin_dBusAccess_cmd_valid) begin
-      if(when_DBusCachedPlugin_l506) begin
+      if(when_DBusCachedPlugin_l604) begin
         DBusCachedPlugin_forceDatapath = 1'b1;
       end
     end
   end
 
-  assign when_DBusCachedPlugin_l506 = (! ({(writeBack_arbitration_isValid || CsrPlugin_exceptionPendings_3),{(memory_arbitration_isValid || CsrPlugin_exceptionPendings_2),(execute_arbitration_isValid || CsrPlugin_exceptionPendings_1)}} != 3'b000));
-  assign when_DBusCachedPlugin_l507 = (! dataCache_1_io_cpu_execute_refilling);
+  assign when_DBusCachedPlugin_l604 = (! ({(writeBack_arbitration_isValid || CsrPlugin_exceptionPendings_3),{(memory_arbitration_isValid || CsrPlugin_exceptionPendings_2),(execute_arbitration_isValid || CsrPlugin_exceptionPendings_1)}} != 3'b000));
+  assign when_DBusCachedPlugin_l605 = (! dataCache_1_io_cpu_execute_refilling);
   assign MmuPlugin_dBusAccess_cmd_fire = (MmuPlugin_dBusAccess_cmd_valid && MmuPlugin_dBusAccess_cmd_ready);
   assign MmuPlugin_dBusAccess_rsp_valid = ((writeBack_IS_DBUS_SHARING && (! dataCache_1_io_cpu_writeBack_isWrite)) && (dataCache_1_io_cpu_redo || (! dataCache_1_io_cpu_writeBack_haltIt)));
   assign MmuPlugin_dBusAccess_rsp_payload_data = writeBack_DBusCachedPlugin_rspRf;
@@ -4429,16 +4468,16 @@ module VexRiscv (
   assign MmuPlugin_ports_0_dirty = 1'b0;
   always @(*) begin
     MmuPlugin_ports_0_requireMmuLockupCalc = ((1'b1 && (! IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation)) && MmuPlugin_satp_mode);
-    if(when_MmuPlugin_l125) begin
+    if(when_MmuPlugin_l131) begin
       MmuPlugin_ports_0_requireMmuLockupCalc = 1'b0;
     end
-    if(when_MmuPlugin_l126) begin
+    if(when_MmuPlugin_l132) begin
       MmuPlugin_ports_0_requireMmuLockupCalc = 1'b0;
     end
   end
 
-  assign when_MmuPlugin_l125 = ((! MmuPlugin_status_mprv) && (CsrPlugin_privilege == 2'b11));
-  assign when_MmuPlugin_l126 = (CsrPlugin_privilege == 2'b11);
+  assign when_MmuPlugin_l131 = ((! MmuPlugin_status_mprv) && (CsrPlugin_privilege == 2'b11));
+  assign when_MmuPlugin_l132 = (CsrPlugin_privilege == 2'b11);
   assign MmuPlugin_ports_0_cacheHitsCalc = {((MmuPlugin_ports_0_cache_3_valid && (MmuPlugin_ports_0_cache_3_virtualAddress_1 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_0_cache_3_superPage || (MmuPlugin_ports_0_cache_3_virtualAddress_0 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12]))),{((MmuPlugin_ports_0_cache_2_valid && (MmuPlugin_ports_0_cache_2_virtualAddress_1 == _zz_MmuPlugin_ports_0_cacheHitsCalc)) && (MmuPlugin_ports_0_cache_2_superPage || (MmuPlugin_ports_0_cache_2_virtualAddress_0 == _zz_MmuPlugin_ports_0_cacheHitsCalc_1))),{((MmuPlugin_ports_0_cache_1_valid && _zz_MmuPlugin_ports_0_cacheHitsCalc_2) && (MmuPlugin_ports_0_cache_1_superPage || _zz_MmuPlugin_ports_0_cacheHitsCalc_3)),((MmuPlugin_ports_0_cache_0_valid && _zz_MmuPlugin_ports_0_cacheHitsCalc_4) && (MmuPlugin_ports_0_cache_0_superPage || _zz_MmuPlugin_ports_0_cacheHitsCalc_5))}}};
   assign MmuPlugin_ports_0_cacheHit = (|MmuPlugin_ports_0_cacheHitsCalc);
   assign _zz_MmuPlugin_ports_0_cacheLine_valid = MmuPlugin_ports_0_cacheHitsCalc[3];
@@ -4458,8 +4497,8 @@ module VexRiscv (
   assign MmuPlugin_ports_0_cacheLine_allowUser = _zz_MmuPlugin_ports_0_cacheLine_allowUser;
   always @(*) begin
     MmuPlugin_ports_0_entryToReplace_willIncrement = 1'b0;
-    if(when_MmuPlugin_l272) begin
-      if(when_MmuPlugin_l274) begin
+    if(when_MmuPlugin_l279) begin
+      if(when_MmuPlugin_l281) begin
         MmuPlugin_ports_0_entryToReplace_willIncrement = 1'b1;
       end
     end
@@ -4544,19 +4583,19 @@ module VexRiscv (
   assign MmuPlugin_ports_1_dirty = 1'b0;
   always @(*) begin
     MmuPlugin_ports_1_requireMmuLockupCalc = ((1'b1 && (! DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation)) && MmuPlugin_satp_mode);
-    if(when_MmuPlugin_l125_1) begin
+    if(when_MmuPlugin_l131_1) begin
       MmuPlugin_ports_1_requireMmuLockupCalc = 1'b0;
     end
-    if(when_MmuPlugin_l126_1) begin
-      if(when_MmuPlugin_l128) begin
+    if(when_MmuPlugin_l132_1) begin
+      if(when_MmuPlugin_l134) begin
         MmuPlugin_ports_1_requireMmuLockupCalc = 1'b0;
       end
     end
   end
 
-  assign when_MmuPlugin_l125_1 = ((! MmuPlugin_status_mprv) && (CsrPlugin_privilege == 2'b11));
-  assign when_MmuPlugin_l126_1 = (CsrPlugin_privilege == 2'b11);
-  assign when_MmuPlugin_l128 = ((! MmuPlugin_status_mprv) || (CsrPlugin_mstatus_MPP == 2'b11));
+  assign when_MmuPlugin_l131_1 = ((! MmuPlugin_status_mprv) && (CsrPlugin_privilege == 2'b11));
+  assign when_MmuPlugin_l132_1 = (CsrPlugin_privilege == 2'b11);
+  assign when_MmuPlugin_l134 = ((! MmuPlugin_status_mprv) || (CsrPlugin_mstatus_MPP == 2'b11));
   assign MmuPlugin_ports_1_cacheHitsCalc = {((MmuPlugin_ports_1_cache_3_valid && (MmuPlugin_ports_1_cache_3_virtualAddress_1 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_1_cache_3_superPage || (MmuPlugin_ports_1_cache_3_virtualAddress_0 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12]))),{((MmuPlugin_ports_1_cache_2_valid && (MmuPlugin_ports_1_cache_2_virtualAddress_1 == _zz_MmuPlugin_ports_1_cacheHitsCalc)) && (MmuPlugin_ports_1_cache_2_superPage || (MmuPlugin_ports_1_cache_2_virtualAddress_0 == _zz_MmuPlugin_ports_1_cacheHitsCalc_1))),{((MmuPlugin_ports_1_cache_1_valid && _zz_MmuPlugin_ports_1_cacheHitsCalc_2) && (MmuPlugin_ports_1_cache_1_superPage || _zz_MmuPlugin_ports_1_cacheHitsCalc_3)),((MmuPlugin_ports_1_cache_0_valid && _zz_MmuPlugin_ports_1_cacheHitsCalc_4) && (MmuPlugin_ports_1_cache_0_superPage || _zz_MmuPlugin_ports_1_cacheHitsCalc_5))}}};
   assign MmuPlugin_ports_1_cacheHit = (|MmuPlugin_ports_1_cacheHitsCalc);
   assign _zz_MmuPlugin_ports_1_cacheLine_valid = MmuPlugin_ports_1_cacheHitsCalc[3];
@@ -4576,8 +4615,8 @@ module VexRiscv (
   assign MmuPlugin_ports_1_cacheLine_allowUser = _zz_MmuPlugin_ports_1_cacheLine_allowUser;
   always @(*) begin
     MmuPlugin_ports_1_entryToReplace_willIncrement = 1'b0;
-    if(when_MmuPlugin_l272) begin
-      if(when_MmuPlugin_l274_1) begin
+    if(when_MmuPlugin_l279) begin
+      if(when_MmuPlugin_l281_1) begin
         MmuPlugin_ports_1_entryToReplace_willIncrement = 1'b1;
       end
     end
@@ -4672,7 +4711,7 @@ module VexRiscv (
   assign MmuPlugin_shared_dBusRsp_pte_PPN1 = MmuPlugin_shared_dBusRspStaged_payload_data[31 : 20];
   assign MmuPlugin_shared_dBusRsp_exception = (((! MmuPlugin_shared_dBusRsp_pte_V) || ((! MmuPlugin_shared_dBusRsp_pte_R) && MmuPlugin_shared_dBusRsp_pte_W)) || MmuPlugin_shared_dBusRspStaged_payload_error);
   assign MmuPlugin_shared_dBusRsp_leaf = (MmuPlugin_shared_dBusRsp_pte_R || MmuPlugin_shared_dBusRsp_pte_X);
-  assign when_MmuPlugin_l205 = (MmuPlugin_shared_dBusRspStaged_valid && (! MmuPlugin_shared_dBusRspStaged_payload_redo));
+  assign when_MmuPlugin_l211 = (MmuPlugin_shared_dBusRspStaged_valid && (! MmuPlugin_shared_dBusRspStaged_payload_redo));
   always @(*) begin
     MmuPlugin_dBusAccess_cmd_valid = 1'b0;
     case(MmuPlugin_shared_state_1)
@@ -4699,7 +4738,7 @@ module VexRiscv (
       MmuPlugin_shared_State_IDLE : begin
       end
       MmuPlugin_shared_State_L1_CMD : begin
-        MmuPlugin_dBusAccess_cmd_payload_address = {{MmuPlugin_satp_ppn,MmuPlugin_shared_vpn_1},2'b00};
+        MmuPlugin_dBusAccess_cmd_payload_address = {{MmuPlugin_satp_ppn[19 : 0],MmuPlugin_shared_vpn_1},2'b00};
       end
       MmuPlugin_shared_State_L1_RSP : begin
       end
@@ -4726,38 +4765,39 @@ module VexRiscv (
   end
 
   assign MmuPlugin_shared_refills = _zz_MmuPlugin_shared_refills_3;
-  assign when_MmuPlugin_l217 = (|MmuPlugin_shared_refills);
+  assign when_MmuPlugin_l223 = (|MmuPlugin_shared_refills);
   assign _zz_MmuPlugin_shared_vpn_0 = (MmuPlugin_shared_refills[0] ? IBusCachedPlugin_mmuBus_cmd_0_virtualAddress : DBusCachedPlugin_mmuBus_cmd_0_virtualAddress);
-  assign when_MmuPlugin_l243 = (MmuPlugin_shared_dBusRsp_leaf || MmuPlugin_shared_dBusRsp_exception);
+  assign when_MmuPlugin_l250 = (MmuPlugin_shared_dBusRsp_leaf || MmuPlugin_shared_dBusRsp_exception);
   assign IBusCachedPlugin_mmuBus_busy = ((MmuPlugin_shared_state_1 != MmuPlugin_shared_State_IDLE) && MmuPlugin_shared_portSortedOh[0]);
   assign DBusCachedPlugin_mmuBus_busy = ((MmuPlugin_shared_state_1 != MmuPlugin_shared_State_IDLE) && MmuPlugin_shared_portSortedOh[1]);
-  assign when_MmuPlugin_l272 = ((MmuPlugin_shared_dBusRspStaged_valid && (! MmuPlugin_shared_dBusRspStaged_payload_redo)) && (MmuPlugin_shared_dBusRsp_leaf || MmuPlugin_shared_dBusRsp_exception));
-  assign when_MmuPlugin_l274 = MmuPlugin_shared_portSortedOh[0];
-  assign when_MmuPlugin_l280 = (MmuPlugin_ports_0_entryToReplace_value == 2'b00);
-  assign when_MmuPlugin_l280_1 = (MmuPlugin_ports_0_entryToReplace_value == 2'b01);
-  assign when_MmuPlugin_l280_2 = (MmuPlugin_ports_0_entryToReplace_value == 2'b10);
-  assign when_MmuPlugin_l280_3 = (MmuPlugin_ports_0_entryToReplace_value == 2'b11);
-  assign when_MmuPlugin_l274_1 = MmuPlugin_shared_portSortedOh[1];
-  assign when_MmuPlugin_l280_4 = (MmuPlugin_ports_1_entryToReplace_value == 2'b00);
-  assign when_MmuPlugin_l280_5 = (MmuPlugin_ports_1_entryToReplace_value == 2'b01);
-  assign when_MmuPlugin_l280_6 = (MmuPlugin_ports_1_entryToReplace_value == 2'b10);
-  assign when_MmuPlugin_l280_7 = (MmuPlugin_ports_1_entryToReplace_value == 2'b11);
-  assign when_MmuPlugin_l304 = ((execute_arbitration_isValid && execute_arbitration_isFiring) && execute_IS_SFENCE_VMA2);
-  assign _zz_decode_IS_RS2_SIGNED_1 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_decode_IS_RS2_SIGNED_2 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_decode_IS_RS2_SIGNED_3 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002000);
-  assign _zz_decode_IS_RS2_SIGNED_4 = ((decode_INSTRUCTION & 32'h00000018) == 32'h0);
-  assign _zz_decode_IS_RS2_SIGNED_5 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_decode_IS_RS2_SIGNED_6 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
-  assign _zz_decode_IS_RS2_SIGNED_7 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
-  assign _zz_decode_IS_RS2_SIGNED_8 = ((decode_INSTRUCTION & 32'h02003050) == 32'h02000050);
-  assign _zz_decode_IS_RS2_SIGNED_9 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
-  assign _zz_decode_IS_RS2_SIGNED = {(|((decode_INSTRUCTION & 32'h10103050) == 32'h00100050)),{(|_zz_decode_IS_RS2_SIGNED_9),{(|_zz_decode_IS_RS2_SIGNED_9),{(|_zz__zz_decode_IS_RS2_SIGNED),{(|_zz__zz_decode_IS_RS2_SIGNED_1),{_zz__zz_decode_IS_RS2_SIGNED_2,{_zz__zz_decode_IS_RS2_SIGNED_7,_zz__zz_decode_IS_RS2_SIGNED_10}}}}}}};
-  assign _zz_decode_SRC1_CTRL_2 = _zz_decode_IS_RS2_SIGNED[2 : 1];
+  assign when_MmuPlugin_l279 = ((MmuPlugin_shared_dBusRspStaged_valid && (! MmuPlugin_shared_dBusRspStaged_payload_redo)) && (MmuPlugin_shared_dBusRsp_leaf || MmuPlugin_shared_dBusRsp_exception));
+  assign when_MmuPlugin_l281 = MmuPlugin_shared_portSortedOh[0];
+  assign when_MmuPlugin_l287 = (MmuPlugin_ports_0_entryToReplace_value == 2'b00);
+  assign when_MmuPlugin_l287_1 = (MmuPlugin_ports_0_entryToReplace_value == 2'b01);
+  assign when_MmuPlugin_l287_2 = (MmuPlugin_ports_0_entryToReplace_value == 2'b10);
+  assign when_MmuPlugin_l287_3 = (MmuPlugin_ports_0_entryToReplace_value == 2'b11);
+  assign when_MmuPlugin_l281_1 = MmuPlugin_shared_portSortedOh[1];
+  assign when_MmuPlugin_l287_4 = (MmuPlugin_ports_1_entryToReplace_value == 2'b00);
+  assign when_MmuPlugin_l287_5 = (MmuPlugin_ports_1_entryToReplace_value == 2'b01);
+  assign when_MmuPlugin_l287_6 = (MmuPlugin_ports_1_entryToReplace_value == 2'b10);
+  assign when_MmuPlugin_l287_7 = (MmuPlugin_ports_1_entryToReplace_value == 2'b11);
+  assign when_MmuPlugin_l311 = ((execute_arbitration_isValid && execute_arbitration_isFiring) && execute_IS_SFENCE_VMA2);
+  assign _zz_decode_IS_RS2_SIGNED_1 = ((decode_INSTRUCTION & 32'h00005048) == 32'h00001008);
+  assign _zz_decode_IS_RS2_SIGNED_2 = ((decode_INSTRUCTION & 32'h02003050) == 32'h02000050);
+  assign _zz_decode_IS_RS2_SIGNED_3 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
+  assign _zz_decode_IS_RS2_SIGNED_4 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_decode_IS_RS2_SIGNED_5 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002000);
+  assign _zz_decode_IS_RS2_SIGNED_6 = ((decode_INSTRUCTION & 32'h00000018) == 32'h00000000);
+  assign _zz_decode_IS_RS2_SIGNED_7 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_decode_IS_RS2_SIGNED_8 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
+  assign _zz_decode_IS_RS2_SIGNED_9 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
+  assign _zz_decode_IS_RS2_SIGNED_10 = ((decode_INSTRUCTION & 32'h00001000) == 32'h00000000);
+  assign _zz_decode_IS_RS2_SIGNED = {(|((decode_INSTRUCTION & 32'h10103050) == 32'h00100050)),{(|_zz_decode_IS_RS2_SIGNED_10),{(|_zz_decode_IS_RS2_SIGNED_10),{(|_zz__zz_decode_IS_RS2_SIGNED),{(|_zz__zz_decode_IS_RS2_SIGNED_1),{_zz__zz_decode_IS_RS2_SIGNED_2,{_zz__zz_decode_IS_RS2_SIGNED_7,_zz__zz_decode_IS_RS2_SIGNED_10}}}}}}};
+  assign _zz_decode_SRC1_CTRL_2 = _zz_decode_IS_RS2_SIGNED[3 : 2];
   assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
-  assign _zz_decode_ALU_CTRL_2 = _zz_decode_IS_RS2_SIGNED[7 : 6];
+  assign _zz_decode_ALU_CTRL_2 = _zz_decode_IS_RS2_SIGNED[8 : 7];
   assign _zz_decode_ALU_CTRL_1 = _zz_decode_ALU_CTRL_2;
-  assign _zz_decode_SRC2_CTRL_2 = _zz_decode_IS_RS2_SIGNED[9 : 8];
+  assign _zz_decode_SRC2_CTRL_2 = _zz_decode_IS_RS2_SIGNED[10 : 9];
   assign _zz_decode_SRC2_CTRL_1 = _zz_decode_SRC2_CTRL_2;
   assign _zz_decode_ALU_BITWISE_CTRL_2 = _zz_decode_IS_RS2_SIGNED[24 : 23];
   assign _zz_decode_ALU_BITWISE_CTRL_1 = _zz_decode_ALU_BITWISE_CTRL_2;
@@ -4770,29 +4810,29 @@ module VexRiscv (
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
-  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h0);
+  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h00);
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
   assign decode_RegFilePlugin_rs1Data = _zz_RegFilePlugin_regFile_port0;
   assign decode_RegFilePlugin_rs2Data = _zz_RegFilePlugin_regFile_port1;
   always @(*) begin
     lastStageRegFileWrite_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
-    if(_zz_7) begin
+    if(_zz_10) begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
   always @(*) begin
     lastStageRegFileWrite_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
-    if(_zz_7) begin
-      lastStageRegFileWrite_payload_address = 5'h0;
+    if(_zz_10) begin
+      lastStageRegFileWrite_payload_address = 5'h00;
     end
   end
 
   always @(*) begin
     lastStageRegFileWrite_payload_data = _zz_decode_RS2_2;
-    if(_zz_7) begin
-      lastStageRegFileWrite_payload_data = 32'h0;
+    if(_zz_10) begin
+      lastStageRegFileWrite_payload_data = 32'h00000000;
     end
   end
 
@@ -4833,7 +4873,7 @@ module VexRiscv (
         _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
       Src1CtrlEnum_IMU : begin
-        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h000};
       end
       default : begin
         _zz_execute_SRC1 = {27'd0, _zz__zz_execute_SRC1_1};
@@ -4841,67 +4881,67 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_execute_SRC2_1 = execute_INSTRUCTION[31];
+  assign _zz_execute_SRC2 = execute_INSTRUCTION[31];
   always @(*) begin
-    _zz_execute_SRC2_2[19] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[18] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[17] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[16] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[15] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[14] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[13] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[12] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[11] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[10] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[9] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[8] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[7] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[6] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[5] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[4] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[3] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[2] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[1] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[0] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_1[19] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[18] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[17] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[16] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[15] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[14] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[13] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[12] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[11] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[10] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[9] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[8] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[7] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[6] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[5] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[4] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[3] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[2] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[1] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[0] = _zz_execute_SRC2;
   end
 
-  assign _zz_execute_SRC2_3 = _zz__zz_execute_SRC2_3[11];
+  assign _zz_execute_SRC2_2 = _zz__zz_execute_SRC2_2[11];
   always @(*) begin
-    _zz_execute_SRC2_4[19] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[18] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[17] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[16] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[15] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[14] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[13] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[12] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[11] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[10] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[9] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[8] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[7] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[6] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[5] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[4] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[3] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[2] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[1] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[0] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_3[19] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[18] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[17] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[16] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[15] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[14] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[13] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[12] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[11] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[10] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[9] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[8] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[7] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[6] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[5] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[4] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[3] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[2] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[1] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[0] = _zz_execute_SRC2_2;
   end
 
   always @(*) begin
     case(execute_SRC2_CTRL)
       Src2CtrlEnum_RS : begin
-        _zz_execute_SRC2_5 = execute_RS2;
+        _zz_execute_SRC2_4 = execute_RS2;
       end
       Src2CtrlEnum_IMI : begin
-        _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
+        _zz_execute_SRC2_4 = {_zz_execute_SRC2_1,execute_INSTRUCTION[31 : 20]};
       end
       Src2CtrlEnum_IMS : begin
-        _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_execute_SRC2_4 = {_zz_execute_SRC2_3,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_execute_SRC2_5 = _zz_execute_SRC2;
+        _zz_execute_SRC2_4 = _zz_execute_to_memory_PC;
       end
     endcase
   end
@@ -5067,16 +5107,19 @@ module VexRiscv (
   assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
   assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign switch_Misc_l210_1 = execute_INSTRUCTION[14 : 12];
+  assign switch_Misc_l232_1 = execute_INSTRUCTION[14 : 12];
   always @(*) begin
-    casez(switch_Misc_l210_1)
+    case(switch_Misc_l232_1)
       3'b000 : begin
         _zz_execute_BRANCH_COND_RESULT = execute_BranchPlugin_eq;
       end
       3'b001 : begin
         _zz_execute_BRANCH_COND_RESULT = (! execute_BranchPlugin_eq);
       end
-      3'b1?1 : begin
+      3'b101 : begin
+        _zz_execute_BRANCH_COND_RESULT = (! execute_SRC_LESS);
+      end
+      3'b111 : begin
         _zz_execute_BRANCH_COND_RESULT = (! execute_SRC_LESS);
       end
       default : begin
@@ -5281,7 +5324,13 @@ module VexRiscv (
   end
 
   assign CsrPlugin_misa_base = 2'b01;
-  assign CsrPlugin_misa_extensions = 26'h0;
+  assign CsrPlugin_misa_extensions = 26'h0000000;
+  assign CsrPlugin_mcounteren_IR = 1'b1;
+  assign CsrPlugin_mcounteren_TM = 1'b1;
+  assign CsrPlugin_mcounteren_CY = 1'b1;
+  assign CsrPlugin_scounteren_IR = 1'b1;
+  assign CsrPlugin_scounteren_TM = 1'b1;
+  assign CsrPlugin_scounteren_CY = 1'b1;
   assign CsrPlugin_sip_SEIP_OR = (CsrPlugin_sip_SEIP_SOFT || CsrPlugin_sip_SEIP_INPUT);
   always @(*) begin
     CsrPlugin_redoInterface_valid = 1'b0;
@@ -5293,7 +5342,7 @@ module VexRiscv (
   assign CsrPlugin_redoInterface_payload = decode_PC;
   always @(*) begin
     CsrPlugin_rescheduleLogic_rescheduleNext = 1'b0;
-    if(when_CsrPlugin_l816) begin
+    if(when_CsrPlugin_l1153) begin
       CsrPlugin_rescheduleLogic_rescheduleNext = 1'b1;
     end
     if(execute_CsrPlugin_csr_384) begin
@@ -5303,73 +5352,78 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l816 = (execute_arbitration_isValid && execute_IS_SFENCE_VMA);
-  assign _zz_when_CsrPlugin_l965 = (CsrPlugin_sip_STIP && CsrPlugin_sie_STIE);
-  assign _zz_when_CsrPlugin_l965_1 = (CsrPlugin_sip_SSIP && CsrPlugin_sie_SSIE);
-  assign _zz_when_CsrPlugin_l965_2 = (CsrPlugin_sip_SEIP_OR && CsrPlugin_sie_SEIE);
-  assign _zz_when_CsrPlugin_l965_3 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_when_CsrPlugin_l965_4 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_when_CsrPlugin_l965_5 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign when_CsrPlugin_l1153 = (execute_arbitration_isValid && execute_RESCHEDULE_NEXT);
+  assign _zz_when_CsrPlugin_l1302 = (CsrPlugin_sip_STIP && CsrPlugin_sie_STIE);
+  assign _zz_when_CsrPlugin_l1302_1 = (CsrPlugin_sip_SSIP && CsrPlugin_sie_SSIE);
+  assign _zz_when_CsrPlugin_l1302_2 = (CsrPlugin_sip_SEIP_OR && CsrPlugin_sie_SEIE);
+  assign _zz_when_CsrPlugin_l1302_3 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l1302_4 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l1302_5 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
     case(CsrPlugin_exceptionPortCtrl_exceptionContext_code)
       4'b0000 : begin
-        if(when_CsrPlugin_l879) begin
+        if(when_CsrPlugin_l1216) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b0001 : begin
-        if(when_CsrPlugin_l879_1) begin
+        if(when_CsrPlugin_l1216_1) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b0010 : begin
-        if(when_CsrPlugin_l879_2) begin
+        if(when_CsrPlugin_l1216_2) begin
+          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
+        end
+      end
+      4'b0011 : begin
+        if(when_CsrPlugin_l1216_3) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b0100 : begin
-        if(when_CsrPlugin_l879_3) begin
+        if(when_CsrPlugin_l1216_4) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b0101 : begin
-        if(when_CsrPlugin_l879_4) begin
+        if(when_CsrPlugin_l1216_5) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b0110 : begin
-        if(when_CsrPlugin_l879_5) begin
+        if(when_CsrPlugin_l1216_6) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b0111 : begin
-        if(when_CsrPlugin_l879_6) begin
+        if(when_CsrPlugin_l1216_7) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b1000 : begin
-        if(when_CsrPlugin_l879_7) begin
+        if(when_CsrPlugin_l1216_8) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b1001 : begin
-        if(when_CsrPlugin_l879_8) begin
+        if(when_CsrPlugin_l1216_9) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b1100 : begin
-        if(when_CsrPlugin_l879_9) begin
+        if(when_CsrPlugin_l1216_10) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b1101 : begin
-        if(when_CsrPlugin_l879_10) begin
+        if(when_CsrPlugin_l1216_11) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b1111 : begin
-        if(when_CsrPlugin_l879_11) begin
+        if(when_CsrPlugin_l1216_12) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
@@ -5378,18 +5432,19 @@ module VexRiscv (
     endcase
   end
 
-  assign when_CsrPlugin_l879 = ((1'b1 && CsrPlugin_medeleg_IAM) && (! 1'b0));
-  assign when_CsrPlugin_l879_1 = ((1'b1 && CsrPlugin_medeleg_IAF) && (! 1'b0));
-  assign when_CsrPlugin_l879_2 = ((1'b1 && CsrPlugin_medeleg_II) && (! 1'b0));
-  assign when_CsrPlugin_l879_3 = ((1'b1 && CsrPlugin_medeleg_LAM) && (! 1'b0));
-  assign when_CsrPlugin_l879_4 = ((1'b1 && CsrPlugin_medeleg_LAF) && (! 1'b0));
-  assign when_CsrPlugin_l879_5 = ((1'b1 && CsrPlugin_medeleg_SAM) && (! 1'b0));
-  assign when_CsrPlugin_l879_6 = ((1'b1 && CsrPlugin_medeleg_SAF) && (! 1'b0));
-  assign when_CsrPlugin_l879_7 = ((1'b1 && CsrPlugin_medeleg_EU) && (! 1'b0));
-  assign when_CsrPlugin_l879_8 = ((1'b1 && CsrPlugin_medeleg_ES) && (! 1'b0));
-  assign when_CsrPlugin_l879_9 = ((1'b1 && CsrPlugin_medeleg_IPF) && (! 1'b0));
-  assign when_CsrPlugin_l879_10 = ((1'b1 && CsrPlugin_medeleg_LPF) && (! 1'b0));
-  assign when_CsrPlugin_l879_11 = ((1'b1 && CsrPlugin_medeleg_SPF) && (! 1'b0));
+  assign when_CsrPlugin_l1216 = ((1'b1 && CsrPlugin_medeleg_IAM) && (! 1'b0));
+  assign when_CsrPlugin_l1216_1 = ((1'b1 && CsrPlugin_medeleg_IAF) && (! 1'b0));
+  assign when_CsrPlugin_l1216_2 = ((1'b1 && CsrPlugin_medeleg_II) && (! 1'b0));
+  assign when_CsrPlugin_l1216_3 = ((1'b1 && CsrPlugin_medeleg_BP) && (! 1'b0));
+  assign when_CsrPlugin_l1216_4 = ((1'b1 && CsrPlugin_medeleg_LAM) && (! 1'b0));
+  assign when_CsrPlugin_l1216_5 = ((1'b1 && CsrPlugin_medeleg_LAF) && (! 1'b0));
+  assign when_CsrPlugin_l1216_6 = ((1'b1 && CsrPlugin_medeleg_SAM) && (! 1'b0));
+  assign when_CsrPlugin_l1216_7 = ((1'b1 && CsrPlugin_medeleg_SAF) && (! 1'b0));
+  assign when_CsrPlugin_l1216_8 = ((1'b1 && CsrPlugin_medeleg_EU) && (! 1'b0));
+  assign when_CsrPlugin_l1216_9 = ((1'b1 && CsrPlugin_medeleg_ES) && (! 1'b0));
+  assign when_CsrPlugin_l1216_10 = ((1'b1 && CsrPlugin_medeleg_IPF) && (! 1'b0));
+  assign when_CsrPlugin_l1216_11 = ((1'b1 && CsrPlugin_medeleg_LPF) && (! 1'b0));
+  assign when_CsrPlugin_l1216_12 = ((1'b1 && CsrPlugin_medeleg_SPF) && (! 1'b0));
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
   assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
   assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1[0];
@@ -5433,35 +5488,35 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l922 = (! decode_arbitration_isStuck);
-  assign when_CsrPlugin_l922_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l922_2 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l922_3 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l935 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
+  assign when_CsrPlugin_l1259 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l1272 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-  assign when_CsrPlugin_l959 = ((CsrPlugin_sstatus_SIE && (CsrPlugin_privilege == 2'b01)) || (CsrPlugin_privilege < 2'b01));
-  assign when_CsrPlugin_l959_1 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign when_CsrPlugin_l965 = ((_zz_when_CsrPlugin_l965 && (1'b1 && CsrPlugin_mideleg_ST)) && (! 1'b0));
-  assign when_CsrPlugin_l965_1 = ((_zz_when_CsrPlugin_l965_1 && (1'b1 && CsrPlugin_mideleg_SS)) && (! 1'b0));
-  assign when_CsrPlugin_l965_2 = ((_zz_when_CsrPlugin_l965_2 && (1'b1 && CsrPlugin_mideleg_SE)) && (! 1'b0));
-  assign when_CsrPlugin_l965_3 = ((_zz_when_CsrPlugin_l965 && 1'b1) && (! (CsrPlugin_mideleg_ST != 1'b0)));
-  assign when_CsrPlugin_l965_4 = ((_zz_when_CsrPlugin_l965_1 && 1'b1) && (! (CsrPlugin_mideleg_SS != 1'b0)));
-  assign when_CsrPlugin_l965_5 = ((_zz_when_CsrPlugin_l965_2 && 1'b1) && (! (CsrPlugin_mideleg_SE != 1'b0)));
-  assign when_CsrPlugin_l965_6 = ((_zz_when_CsrPlugin_l965_3 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l965_7 = ((_zz_when_CsrPlugin_l965_4 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l965_8 = ((_zz_when_CsrPlugin_l965_5 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1296 = ((CsrPlugin_sstatus_SIE && (CsrPlugin_privilege == 2'b01)) || (CsrPlugin_privilege < 2'b01));
+  assign when_CsrPlugin_l1296_1 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l1302 = ((_zz_when_CsrPlugin_l1302 && (1'b1 && CsrPlugin_mideleg_ST)) && (! 1'b0));
+  assign when_CsrPlugin_l1302_1 = ((_zz_when_CsrPlugin_l1302_1 && (1'b1 && CsrPlugin_mideleg_SS)) && (! 1'b0));
+  assign when_CsrPlugin_l1302_2 = ((_zz_when_CsrPlugin_l1302_2 && (1'b1 && CsrPlugin_mideleg_SE)) && (! 1'b0));
+  assign when_CsrPlugin_l1302_3 = ((_zz_when_CsrPlugin_l1302 && 1'b1) && (! (CsrPlugin_mideleg_ST != 1'b0)));
+  assign when_CsrPlugin_l1302_4 = ((_zz_when_CsrPlugin_l1302_1 && 1'b1) && (! (CsrPlugin_mideleg_SS != 1'b0)));
+  assign when_CsrPlugin_l1302_5 = ((_zz_when_CsrPlugin_l1302_2 && 1'b1) && (! (CsrPlugin_mideleg_SE != 1'b0)));
+  assign when_CsrPlugin_l1302_6 = ((_zz_when_CsrPlugin_l1302_3 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1302_7 = ((_zz_when_CsrPlugin_l1302_4 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1302_8 = ((_zz_when_CsrPlugin_l1302_5 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  assign when_CsrPlugin_l993 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l993_1 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l993_2 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l998 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  assign when_CsrPlugin_l1335 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1335_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l1335_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l1340 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
   always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(when_CsrPlugin_l1004) begin
+    if(when_CsrPlugin_l1346) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException) begin
@@ -5469,7 +5524,7 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l1004 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
+  assign when_CsrPlugin_l1346 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
   always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
@@ -5485,6 +5540,7 @@ module VexRiscv (
     end
   end
 
+  assign CsrPlugin_trapCauseEbreakDebug = 1'b0;
   always @(*) begin
     CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
@@ -5513,13 +5569,16 @@ module VexRiscv (
     endcase
   end
 
-  assign when_CsrPlugin_l1032 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign when_CsrPlugin_l1077 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
-  assign switch_CsrPlugin_l1081 = writeBack_INSTRUCTION[29 : 28];
+  assign CsrPlugin_trapEnterDebug = 1'b0;
+  assign when_CsrPlugin_l1390 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1398 = (! CsrPlugin_trapEnterDebug);
+  assign when_CsrPlugin_l1456 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign switch_CsrPlugin_l1460 = writeBack_INSTRUCTION[29 : 28];
+  assign when_CsrPlugin_l1468 = (CsrPlugin_mstatus_MPP < 2'b11);
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign when_CsrPlugin_l1121 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_WFI));
-  assign when_CsrPlugin_l1123 = (! execute_CsrPlugin_wfiWake);
-  assign when_CsrPlugin_l1129 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
+  assign when_CsrPlugin_l1519 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_WFI));
+  assign when_CsrPlugin_l1521 = (! execute_CsrPlugin_wfiWake);
+  assign when_CsrPlugin_l1527 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
   assign execute_CsrPlugin_blockedBySideEffects = ((|{writeBack_arbitration_isValid,memory_arbitration_isValid}) || 1'b0);
   always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
@@ -5634,18 +5693,18 @@ module VexRiscv (
     if(CsrPlugin_csrMapping_allowCsrSignal) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(when_CsrPlugin_l1315) begin
+    if(when_CsrPlugin_l1725) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if(when_CsrPlugin_l1149) begin
-      if(when_CsrPlugin_l1150) begin
+    if(when_CsrPlugin_l1547) begin
+      if(when_CsrPlugin_l1548) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
@@ -5653,20 +5712,20 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(when_CsrPlugin_l1142) begin
+    if(when_CsrPlugin_l1540) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1157) begin
+    if(when_CsrPlugin_l1555) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(when_CsrPlugin_l1142) begin
+    if(when_CsrPlugin_l1540) begin
       CsrPlugin_selfException_payload_code = 4'b0010;
     end
-    if(when_CsrPlugin_l1157) begin
+    if(when_CsrPlugin_l1555) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -5682,20 +5741,20 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  assign when_CsrPlugin_l1142 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
-  assign when_CsrPlugin_l1149 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
-  assign when_CsrPlugin_l1150 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
-  assign when_CsrPlugin_l1157 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
+  assign when_CsrPlugin_l1540 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
+  assign when_CsrPlugin_l1547 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign when_CsrPlugin_l1548 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1555 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
   always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -5713,9 +5772,9 @@ module VexRiscv (
     end
   end
 
-  assign switch_Misc_l210_2 = execute_INSTRUCTION[13];
+  assign switch_Misc_l232_2 = execute_INSTRUCTION[13];
   always @(*) begin
-    case(switch_Misc_l210_2)
+    case(switch_Misc_l232_2)
       1'b0 : begin
         _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
@@ -5726,8 +5785,8 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
-  assign when_CsrPlugin_l1189 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign when_CsrPlugin_l1193 = (execute_arbitration_isValid && (execute_IS_CSR || execute_IS_SFENCE_VMA));
+  assign when_CsrPlugin_l1587 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1591 = (execute_arbitration_isValid && (execute_IS_CSR || execute_RESCHEDULE_NEXT));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
@@ -5790,12 +5849,12 @@ module VexRiscv (
   assign memory_DivPlugin_div_counter_willOverflow = (memory_DivPlugin_div_counter_willOverflowIfInc && memory_DivPlugin_div_counter_willIncrement);
   always @(*) begin
     if(memory_DivPlugin_div_counter_willOverflow) begin
-      memory_DivPlugin_div_counter_valueNext = 6'h0;
+      memory_DivPlugin_div_counter_valueNext = 6'h00;
     end else begin
       memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_memory_DivPlugin_div_counter_valueNext);
     end
     if(memory_DivPlugin_div_counter_willClear) begin
-      memory_DivPlugin_div_counter_valueNext = 6'h0;
+      memory_DivPlugin_div_counter_valueNext = 6'h00;
     end
   end
 
@@ -5819,19 +5878,19 @@ module VexRiscv (
     _zz_memory_DivPlugin_rs1_1[31 : 0] = execute_RS1;
   end
 
-  assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
-  assign externalInterrupt = (|_zz_CsrPlugin_csrMapping_readDataInit_1);
-  assign _zz_CsrPlugin_csrMapping_readDataInit_3 = (_zz_CsrPlugin_csrMapping_readDataInit_2 & externalInterruptArray_regNext);
-  assign externalInterruptS = (|_zz_CsrPlugin_csrMapping_readDataInit_3);
-  assign when_DebugPlugin_l225 = (DebugPlugin_haltIt && (! DebugPlugin_isPipBusy));
+  assign _zz_externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
+  assign externalInterrupt = (|_zz_externalInterrupt);
+  assign _zz_externalInterruptS = (_zz_CsrPlugin_csrMapping_readDataInit_1 & externalInterruptArray_regNext);
+  assign externalInterruptS = (|_zz_externalInterruptS);
+  assign when_DebugPlugin_l238 = (DebugPlugin_haltIt && (! DebugPlugin_isPipBusy));
   assign DebugPlugin_allowEBreak = (DebugPlugin_debugUsed && (! DebugPlugin_disableEbreak));
   always @(*) begin
     debug_bus_cmd_ready = 1'b1;
     if(debug_bus_cmd_valid) begin
-      case(switch_DebugPlugin_l267)
+      case(switch_DebugPlugin_l280)
         6'h01 : begin
           if(debug_bus_cmd_payload_wr) begin
-            debug_bus_cmd_ready = IBusCachedPlugin_injectionPort_ready;
+            debug_bus_cmd_ready = DebugPlugin_injectionPort_ready;
           end
         end
         default : begin
@@ -5842,7 +5901,7 @@ module VexRiscv (
 
   always @(*) begin
     debug_bus_rsp_data = DebugPlugin_busReadDataReg;
-    if(when_DebugPlugin_l244) begin
+    if(when_DebugPlugin_l257) begin
       debug_bus_rsp_data[0] = DebugPlugin_resetIt;
       debug_bus_rsp_data[1] = DebugPlugin_haltIt;
       debug_bus_rsp_data[2] = DebugPlugin_isPipBusy;
@@ -5851,14 +5910,14 @@ module VexRiscv (
     end
   end
 
-  assign when_DebugPlugin_l244 = (! _zz_when_DebugPlugin_l244);
+  assign when_DebugPlugin_l257 = (! _zz_when_DebugPlugin_l257);
   always @(*) begin
-    IBusCachedPlugin_injectionPort_valid = 1'b0;
+    DebugPlugin_injectionPort_valid = 1'b0;
     if(debug_bus_cmd_valid) begin
-      case(switch_DebugPlugin_l267)
+      case(switch_DebugPlugin_l280)
         6'h01 : begin
           if(debug_bus_cmd_payload_wr) begin
-            IBusCachedPlugin_injectionPort_valid = 1'b1;
+            DebugPlugin_injectionPort_valid = 1'b1;
           end
         end
         default : begin
@@ -5867,21 +5926,21 @@ module VexRiscv (
     end
   end
 
-  assign IBusCachedPlugin_injectionPort_payload = debug_bus_cmd_payload_data;
-  assign switch_DebugPlugin_l267 = debug_bus_cmd_payload_address[7 : 2];
-  assign when_DebugPlugin_l271 = debug_bus_cmd_payload_data[16];
-  assign when_DebugPlugin_l271_1 = debug_bus_cmd_payload_data[24];
-  assign when_DebugPlugin_l272 = debug_bus_cmd_payload_data[17];
-  assign when_DebugPlugin_l272_1 = debug_bus_cmd_payload_data[25];
-  assign when_DebugPlugin_l273 = debug_bus_cmd_payload_data[25];
-  assign when_DebugPlugin_l274 = debug_bus_cmd_payload_data[25];
-  assign when_DebugPlugin_l275 = debug_bus_cmd_payload_data[18];
-  assign when_DebugPlugin_l275_1 = debug_bus_cmd_payload_data[26];
-  assign when_DebugPlugin_l295 = (execute_arbitration_isValid && execute_DO_EBREAK);
-  assign when_DebugPlugin_l298 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
-  assign when_DebugPlugin_l311 = (DebugPlugin_stepIt && IBusCachedPlugin_incomingInstruction);
+  assign DebugPlugin_injectionPort_payload = debug_bus_cmd_payload_data;
+  assign switch_DebugPlugin_l280 = debug_bus_cmd_payload_address[7 : 2];
+  assign when_DebugPlugin_l284 = debug_bus_cmd_payload_data[16];
+  assign when_DebugPlugin_l284_1 = debug_bus_cmd_payload_data[24];
+  assign when_DebugPlugin_l285 = debug_bus_cmd_payload_data[17];
+  assign when_DebugPlugin_l285_1 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l286 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l287 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l288 = debug_bus_cmd_payload_data[18];
+  assign when_DebugPlugin_l288_1 = debug_bus_cmd_payload_data[26];
+  assign when_DebugPlugin_l308 = (execute_arbitration_isValid && execute_DO_EBREAK);
+  assign when_DebugPlugin_l311 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
+  assign when_DebugPlugin_l324 = (DebugPlugin_stepIt && IBusCachedPlugin_incomingInstruction);
   assign debug_resetOut = DebugPlugin_resetIt_regNext;
-  assign when_DebugPlugin_l331 = (DebugPlugin_haltIt || DebugPlugin_stepIt);
+  assign when_DebugPlugin_l344 = (DebugPlugin_haltIt || DebugPlugin_stepIt);
   assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
@@ -5892,35 +5951,35 @@ module VexRiscv (
   assign when_Pipeline_l124_7 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_8 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_9 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_10 = (! execute_arbitration_isStuck);
   assign _zz_decode_to_execute_SRC1_CTRL_1 = decode_SRC1_CTRL;
   assign _zz_decode_SRC1_CTRL = _zz_decode_SRC1_CTRL_1;
-  assign when_Pipeline_l124_10 = (! execute_arbitration_isStuck);
-  assign _zz_execute_SRC1_CTRL = decode_to_execute_SRC1_CTRL;
   assign when_Pipeline_l124_11 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SRC1_CTRL = decode_to_execute_SRC1_CTRL;
   assign when_Pipeline_l124_12 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_13 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_14 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_13 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_14 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_15 = (! writeBack_arbitration_isStuck);
   assign _zz_decode_to_execute_ALU_CTRL_1 = decode_ALU_CTRL;
   assign _zz_decode_ALU_CTRL = _zz_decode_ALU_CTRL_1;
-  assign when_Pipeline_l124_15 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_16 = (! execute_arbitration_isStuck);
   assign _zz_execute_ALU_CTRL = decode_to_execute_ALU_CTRL;
   assign _zz_decode_to_execute_SRC2_CTRL_1 = decode_SRC2_CTRL;
   assign _zz_decode_SRC2_CTRL = _zz_decode_SRC2_CTRL_1;
-  assign when_Pipeline_l124_16 = (! execute_arbitration_isStuck);
-  assign _zz_execute_SRC2_CTRL = decode_to_execute_SRC2_CTRL;
   assign when_Pipeline_l124_17 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_18 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_19 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_20 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SRC2_CTRL = decode_to_execute_SRC2_CTRL;
+  assign when_Pipeline_l124_18 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_19 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_20 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_21 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_22 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_23 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_24 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_25 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_26 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_27 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_28 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_22 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_23 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_24 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_25 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_26 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_27 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_28 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_29 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_30 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_31 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_32 = (! execute_arbitration_isStuck);
@@ -6007,250 +6066,259 @@ module VexRiscv (
   assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
   assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
   always @(*) begin
-    IBusCachedPlugin_injectionPort_ready = 1'b0;
-    case(switch_Fetcher_l365)
+    DebugPlugin_injectionPort_ready = 1'b0;
+    case(IBusCachedPlugin_injector_port_state)
       3'b100 : begin
-        IBusCachedPlugin_injectionPort_ready = 1'b1;
+        DebugPlugin_injectionPort_ready = 1'b1;
       end
       default : begin
       end
     endcase
   end
 
-  assign when_Fetcher_l381 = (! decode_arbitration_isStuck);
-  assign when_CsrPlugin_l1277 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_2 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_3 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_4 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_5 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_6 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_7 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_8 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_9 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_10 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_11 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_12 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_13 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_14 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_15 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_16 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_17 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_18 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_19 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_20 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_21 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_22 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_23 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_24 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_25 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_26 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_27 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l391 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l1669 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_8 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_9 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_10 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_11 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_12 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_13 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_14 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_15 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_16 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_17 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_18 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_19 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_20 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_21 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_22 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_23 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_24 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_25 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_26 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_27 = (! execute_arbitration_isStuck);
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h00000000;
     if(execute_CsrPlugin_csr_3264) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_4[12 : 0] = 13'h1000;
-      _zz_CsrPlugin_csrMapping_readDataInit_4[25 : 20] = 6'h20;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[12 : 0] = 13'h1000;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[25 : 20] = 6'h20;
     end
   end
 
-  assign switch_CsrPlugin_l723 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
+  assign switch_CsrPlugin_l1031 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h00000000;
     if(execute_CsrPlugin_csr_768) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_5[19 : 19] = MmuPlugin_status_mxr;
-      _zz_CsrPlugin_csrMapping_readDataInit_5[18 : 18] = MmuPlugin_status_sum;
-      _zz_CsrPlugin_csrMapping_readDataInit_5[17 : 17] = MmuPlugin_status_mprv;
-      _zz_CsrPlugin_csrMapping_readDataInit_5[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_5[3 : 3] = CsrPlugin_mstatus_MIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_5[12 : 11] = CsrPlugin_mstatus_MPP;
-      _zz_CsrPlugin_csrMapping_readDataInit_5[8 : 8] = CsrPlugin_sstatus_SPP;
-      _zz_CsrPlugin_csrMapping_readDataInit_5[5 : 5] = CsrPlugin_sstatus_SPIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_5[1 : 1] = CsrPlugin_sstatus_SIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[19 : 19] = MmuPlugin_status_mxr;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[18 : 18] = MmuPlugin_status_sum;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[17 : 17] = MmuPlugin_status_mprv;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[8 : 8] = CsrPlugin_sstatus_SPP;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[5 : 5] = CsrPlugin_sstatus_SPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[1 : 1] = CsrPlugin_sstatus_SIE;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h00000000;
     if(execute_CsrPlugin_csr_256) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_6[19 : 19] = MmuPlugin_status_mxr;
-      _zz_CsrPlugin_csrMapping_readDataInit_6[18 : 18] = MmuPlugin_status_sum;
-      _zz_CsrPlugin_csrMapping_readDataInit_6[17 : 17] = MmuPlugin_status_mprv;
-      _zz_CsrPlugin_csrMapping_readDataInit_6[8 : 8] = CsrPlugin_sstatus_SPP;
-      _zz_CsrPlugin_csrMapping_readDataInit_6[5 : 5] = CsrPlugin_sstatus_SPIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_6[1 : 1] = CsrPlugin_sstatus_SIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[19 : 19] = MmuPlugin_status_mxr;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[18 : 18] = MmuPlugin_status_sum;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[17 : 17] = MmuPlugin_status_mprv;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[8 : 8] = CsrPlugin_sstatus_SPP;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[5 : 5] = CsrPlugin_sstatus_SPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[1 : 1] = CsrPlugin_sstatus_SIE;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h00000000;
     if(execute_CsrPlugin_csr_384) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_7[31 : 31] = MmuPlugin_satp_mode;
-      _zz_CsrPlugin_csrMapping_readDataInit_7[30 : 22] = MmuPlugin_satp_asid;
-      _zz_CsrPlugin_csrMapping_readDataInit_7[19 : 0] = MmuPlugin_satp_ppn;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[31 : 31] = MmuPlugin_satp_mode;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[30 : 22] = MmuPlugin_satp_asid;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[21 : 0] = MmuPlugin_satp_ppn;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h00000000;
     if(execute_CsrPlugin_csr_3857) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_8[0 : 0] = 1'b1;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[0 : 0] = 1'b1;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h00000000;
     if(execute_CsrPlugin_csr_3858) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_9[1 : 0] = 2'b10;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[1 : 0] = 2'b10;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_10 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h00000000;
     if(execute_CsrPlugin_csr_3859) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_10[1 : 0] = 2'b11;
+      _zz_CsrPlugin_csrMapping_readDataInit_8[1 : 0] = 2'b11;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_11 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h00000000;
     if(execute_CsrPlugin_csr_836) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_11[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_11[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_11[3 : 3] = CsrPlugin_mip_MSIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_11[5 : 5] = CsrPlugin_sip_STIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_11[1 : 1] = CsrPlugin_sip_SSIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_11[9 : 9] = CsrPlugin_sip_SEIP_OR;
+      _zz_CsrPlugin_csrMapping_readDataInit_9[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_9[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_9[3 : 3] = CsrPlugin_mip_MSIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_9[5 : 5] = CsrPlugin_sip_STIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_9[1 : 1] = CsrPlugin_sip_SSIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_9[9 : 9] = CsrPlugin_sip_SEIP_OR;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_12 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_10 = 32'h00000000;
     if(execute_CsrPlugin_csr_772) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_12[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_12[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_12[3 : 3] = CsrPlugin_mie_MSIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_12[9 : 9] = CsrPlugin_sie_SEIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_12[5 : 5] = CsrPlugin_sie_STIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_12[1 : 1] = CsrPlugin_sie_SSIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_10[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_10[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_10[3 : 3] = CsrPlugin_mie_MSIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_10[9 : 9] = CsrPlugin_sie_SEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_10[5 : 5] = CsrPlugin_sie_STIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_10[1 : 1] = CsrPlugin_sie_SSIE;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_13 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_11 = 32'h00000000;
     if(execute_CsrPlugin_csr_833) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_13[31 : 0] = CsrPlugin_mepc;
+      _zz_CsrPlugin_csrMapping_readDataInit_11[31 : 0] = CsrPlugin_mepc;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_14 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_12 = 32'h00000000;
     if(execute_CsrPlugin_csr_832) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_14[31 : 0] = CsrPlugin_mscratch;
+      _zz_CsrPlugin_csrMapping_readDataInit_12[31 : 0] = CsrPlugin_mscratch;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_15 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_13 = 32'h00000000;
     if(execute_CsrPlugin_csr_834) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_15[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_CsrPlugin_csrMapping_readDataInit_15[3 : 0] = CsrPlugin_mcause_exceptionCode;
+      _zz_CsrPlugin_csrMapping_readDataInit_13[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_CsrPlugin_csrMapping_readDataInit_13[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_16 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_14 = 32'h00000000;
     if(execute_CsrPlugin_csr_835) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_16[31 : 0] = CsrPlugin_mtval;
+      _zz_CsrPlugin_csrMapping_readDataInit_14[31 : 0] = CsrPlugin_mtval;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_17 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_15 = 32'h00000000;
     if(execute_CsrPlugin_csr_324) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_17[5 : 5] = CsrPlugin_sip_STIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_17[1 : 1] = CsrPlugin_sip_SSIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_17[9 : 9] = CsrPlugin_sip_SEIP_OR;
+      _zz_CsrPlugin_csrMapping_readDataInit_15[5 : 5] = CsrPlugin_sip_STIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_15[1 : 1] = CsrPlugin_sip_SSIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_15[9 : 9] = CsrPlugin_sip_SEIP_OR;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_18 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_16 = 32'h00000000;
     if(execute_CsrPlugin_csr_260) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_18[9 : 9] = CsrPlugin_sie_SEIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_18[5 : 5] = CsrPlugin_sie_STIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_18[1 : 1] = CsrPlugin_sie_SSIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_16[9 : 9] = CsrPlugin_sie_SEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_16[5 : 5] = CsrPlugin_sie_STIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_16[1 : 1] = CsrPlugin_sie_SSIE;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_19 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_17 = 32'h00000000;
     if(execute_CsrPlugin_csr_261) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_19[31 : 2] = CsrPlugin_stvec_base;
-      _zz_CsrPlugin_csrMapping_readDataInit_19[1 : 0] = CsrPlugin_stvec_mode;
+      _zz_CsrPlugin_csrMapping_readDataInit_17[31 : 2] = CsrPlugin_stvec_base;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_20 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_18 = 32'h00000000;
     if(execute_CsrPlugin_csr_321) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_20[31 : 0] = CsrPlugin_sepc;
+      _zz_CsrPlugin_csrMapping_readDataInit_18[31 : 0] = CsrPlugin_sepc;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_21 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_19 = 32'h00000000;
     if(execute_CsrPlugin_csr_320) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_21[31 : 0] = CsrPlugin_sscratch;
+      _zz_CsrPlugin_csrMapping_readDataInit_19[31 : 0] = CsrPlugin_sscratch;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_22 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_20 = 32'h00000000;
     if(execute_CsrPlugin_csr_322) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_22[31 : 31] = CsrPlugin_scause_interrupt;
-      _zz_CsrPlugin_csrMapping_readDataInit_22[3 : 0] = CsrPlugin_scause_exceptionCode;
+      _zz_CsrPlugin_csrMapping_readDataInit_20[31 : 31] = CsrPlugin_scause_interrupt;
+      _zz_CsrPlugin_csrMapping_readDataInit_20[3 : 0] = CsrPlugin_scause_exceptionCode;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_23 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_21 = 32'h00000000;
     if(execute_CsrPlugin_csr_323) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_23[31 : 0] = CsrPlugin_stval;
+      _zz_CsrPlugin_csrMapping_readDataInit_21[31 : 0] = CsrPlugin_stval;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_24 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_22 = 32'h00000000;
     if(execute_CsrPlugin_csr_3008) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_24[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
+      _zz_CsrPlugin_csrMapping_readDataInit_22[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_25 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_23 = 32'h00000000;
     if(execute_CsrPlugin_csr_4032) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_25[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_1;
+      _zz_CsrPlugin_csrMapping_readDataInit_23[31 : 0] = _zz_externalInterrupt;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_26 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_24 = 32'h00000000;
     if(execute_CsrPlugin_csr_2496) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_26[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_2;
+      _zz_CsrPlugin_csrMapping_readDataInit_24[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_1;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_27 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_25 = 32'h00000000;
     if(execute_CsrPlugin_csr_3520) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_27[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_3;
+      _zz_CsrPlugin_csrMapping_readDataInit_25[31 : 0] = _zz_externalInterruptS;
     end
   end
 
-  assign CsrPlugin_csrMapping_readDataInit = (((((_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5) | (_zz_CsrPlugin_csrMapping_readDataInit_6 | _zz_CsrPlugin_csrMapping_readDataInit_7)) | ((_zz_CsrPlugin_csrMapping_readDataInit_8 | _zz_CsrPlugin_csrMapping_readDataInit_9) | (_zz_CsrPlugin_csrMapping_readDataInit_10 | _zz_CsrPlugin_csrMapping_readDataInit_28))) | (((_zz_CsrPlugin_csrMapping_readDataInit_11 | _zz_CsrPlugin_csrMapping_readDataInit_12) | (_zz_CsrPlugin_csrMapping_readDataInit_13 | _zz_CsrPlugin_csrMapping_readDataInit_14)) | ((_zz_CsrPlugin_csrMapping_readDataInit_15 | _zz_CsrPlugin_csrMapping_readDataInit_16) | (_zz_CsrPlugin_csrMapping_readDataInit_17 | _zz_CsrPlugin_csrMapping_readDataInit_18)))) | ((((_zz_CsrPlugin_csrMapping_readDataInit_19 | _zz_CsrPlugin_csrMapping_readDataInit_20) | (_zz_CsrPlugin_csrMapping_readDataInit_21 | _zz_CsrPlugin_csrMapping_readDataInit_22)) | ((_zz_CsrPlugin_csrMapping_readDataInit_23 | _zz_CsrPlugin_csrMapping_readDataInit_24) | (_zz_CsrPlugin_csrMapping_readDataInit_25 | _zz_CsrPlugin_csrMapping_readDataInit_26))) | _zz_CsrPlugin_csrMapping_readDataInit_27));
-  assign when_CsrPlugin_l1310 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign when_CsrPlugin_l1315 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign CsrPlugin_csrMapping_readDataInit = (((((_zz_CsrPlugin_csrMapping_readDataInit_2 | _zz_CsrPlugin_csrMapping_readDataInit_3) | (_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5)) | ((_zz_CsrPlugin_csrMapping_readDataInit_6 | _zz_CsrPlugin_csrMapping_readDataInit_7) | (_zz_CsrPlugin_csrMapping_readDataInit_8 | _zz_CsrPlugin_csrMapping_readDataInit_26))) | (((_zz_CsrPlugin_csrMapping_readDataInit_9 | _zz_CsrPlugin_csrMapping_readDataInit_10) | (_zz_CsrPlugin_csrMapping_readDataInit_11 | _zz_CsrPlugin_csrMapping_readDataInit_12)) | ((_zz_CsrPlugin_csrMapping_readDataInit_13 | _zz_CsrPlugin_csrMapping_readDataInit_14) | (_zz_CsrPlugin_csrMapping_readDataInit_15 | _zz_CsrPlugin_csrMapping_readDataInit_16)))) | ((((_zz_CsrPlugin_csrMapping_readDataInit_17 | _zz_CsrPlugin_csrMapping_readDataInit_18) | (_zz_CsrPlugin_csrMapping_readDataInit_19 | _zz_CsrPlugin_csrMapping_readDataInit_20)) | ((_zz_CsrPlugin_csrMapping_readDataInit_21 | _zz_CsrPlugin_csrMapping_readDataInit_22) | (_zz_CsrPlugin_csrMapping_readDataInit_23 | _zz_CsrPlugin_csrMapping_readDataInit_24))) | _zz_CsrPlugin_csrMapping_readDataInit_25));
+  assign when_CsrPlugin_l1702 = ((execute_arbitration_isValid && execute_IS_CSR) && (({execute_CsrPlugin_csrAddress[11 : 2],2'b00} == 12'h3a0) || ({execute_CsrPlugin_csrAddress[11 : 4],4'b0000} == 12'h3b0)));
+  assign _zz_when_CsrPlugin_l1709 = (execute_CsrPlugin_csrAddress & 12'hf60);
+  assign when_CsrPlugin_l1709 = (((execute_arbitration_isValid && execute_IS_CSR) && (5'h03 <= execute_CsrPlugin_csrAddress[4 : 0])) && (((_zz_when_CsrPlugin_l1709 == 12'hb00) || (((_zz_when_CsrPlugin_l1709 == 12'hc00) && (! execute_CsrPlugin_writeInstruction)) && (CsrPlugin_privilege == 2'b11))) || ((execute_CsrPlugin_csrAddress & 12'hfe0) == 12'h320)));
+  always @(*) begin
+    when_CsrPlugin_l1719 = CsrPlugin_csrMapping_doForceFailCsr;
+    if(when_CsrPlugin_l1717) begin
+      when_CsrPlugin_l1719 = 1'b1;
+    end
+  end
+
+  assign when_CsrPlugin_l1717 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1725 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
   assign iBusWishbone_ADR = {_zz_iBusWishbone_ADR_1,_zz_iBusWishbone_ADR};
   assign iBusWishbone_CTI = ((_zz_iBusWishbone_ADR == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
@@ -6276,20 +6344,20 @@ module VexRiscv (
   assign iBus_rsp_valid = _zz_iBus_rsp_valid;
   assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
   assign iBus_rsp_payload_error = 1'b0;
-  assign _zz_dBus_cmd_ready_5 = (dBus_cmd_payload_size == 3'b101);
-  assign _zz_dBus_cmd_ready_1 = dBus_cmd_valid;
-  assign _zz_dBus_cmd_ready_3 = dBus_cmd_payload_wr;
-  assign _zz_dBus_cmd_ready_4 = ((! _zz_dBus_cmd_ready_5) || (_zz_dBus_cmd_ready == 3'b111));
-  assign dBus_cmd_ready = (_zz_dBus_cmd_ready_2 && (_zz_dBus_cmd_ready_3 || _zz_dBus_cmd_ready_4));
-  assign dBusWishbone_ADR = ((_zz_dBus_cmd_ready_5 ? {{dBus_cmd_payload_address[31 : 5],_zz_dBus_cmd_ready},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
-  assign dBusWishbone_CTI = (_zz_dBus_cmd_ready_5 ? (_zz_dBus_cmd_ready_4 ? 3'b111 : 3'b010) : 3'b000);
+  assign _zz_dBusWishbone_ADR_1 = (dBus_cmd_payload_size == 3'b101);
+  assign _zz_dBusWishbone_CYC = dBus_cmd_valid;
+  assign _zz_dBus_cmd_ready_1 = dBus_cmd_payload_wr;
+  assign _zz_dBus_cmd_ready_2 = ((! _zz_dBusWishbone_ADR_1) || (_zz_dBusWishbone_ADR == 3'b111));
+  assign dBus_cmd_ready = (_zz_dBus_cmd_ready && (_zz_dBus_cmd_ready_1 || _zz_dBus_cmd_ready_2));
+  assign dBusWishbone_ADR = ((_zz_dBusWishbone_ADR_1 ? {{dBus_cmd_payload_address[31 : 5],_zz_dBusWishbone_ADR},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2'd2);
+  assign dBusWishbone_CTI = (_zz_dBusWishbone_ADR_1 ? (_zz_dBus_cmd_ready_2 ? 3'b111 : 3'b010) : 3'b000);
   assign dBusWishbone_BTE = 2'b00;
-  assign dBusWishbone_SEL = (_zz_dBus_cmd_ready_3 ? dBus_cmd_payload_mask : 4'b1111);
-  assign dBusWishbone_WE = _zz_dBus_cmd_ready_3;
+  assign dBusWishbone_SEL = (_zz_dBus_cmd_ready_1 ? dBus_cmd_payload_mask : 4'b1111);
+  assign dBusWishbone_WE = _zz_dBus_cmd_ready_1;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_payload_data;
-  assign _zz_dBus_cmd_ready_2 = (_zz_dBus_cmd_ready_1 && dBusWishbone_ACK);
-  assign dBusWishbone_CYC = _zz_dBus_cmd_ready_1;
-  assign dBusWishbone_STB = _zz_dBus_cmd_ready_1;
+  assign _zz_dBus_cmd_ready = (_zz_dBusWishbone_CYC && dBusWishbone_ACK);
+  assign dBusWishbone_CYC = _zz_dBusWishbone_CYC;
+  assign dBusWishbone_STB = _zz_dBusWishbone_CYC;
   assign dBus_rsp_valid = _zz_dBus_rsp_valid;
   assign dBus_rsp_payload_data = dBusWishbone_DAT_MISO_regNext;
   assign dBus_rsp_payload_error = 1'b0;
@@ -6299,17 +6367,17 @@ module VexRiscv (
       IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
-      _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+      _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= 1'b0;
       _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= 32'h0;
-      dataCache_1_io_mem_cmd_rValid <= 1'b0;
-      dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= 32'h0;
+      IBusCachedPlugin_rspCounter <= 32'h00000000;
+      toplevel_dataCache_1_io_mem_cmd_rValidN <= 1'b1;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
+      DBusCachedPlugin_rspCounter <= 32'h00000000;
       MmuPlugin_status_sum <= 1'b0;
       MmuPlugin_status_mxr <= 1'b0;
       MmuPlugin_status_mprv <= 1'b0;
@@ -6326,7 +6394,7 @@ module VexRiscv (
       MmuPlugin_ports_1_entryToReplace_value <= 2'b00;
       MmuPlugin_shared_state_1 <= MmuPlugin_shared_State_IDLE;
       MmuPlugin_shared_dBusRspStaged_valid <= 1'b0;
-      _zz_7 <= 1'b1;
+      _zz_10 <= 1'b1;
       HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
       _zz_CsrPlugin_privilege <= 2'b11;
       CsrPlugin_mstatus_MIE <= 1'b0;
@@ -6335,11 +6403,12 @@ module VexRiscv (
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
-      CsrPlugin_mcycle <= 64'h0;
-      CsrPlugin_minstret <= 64'h0;
+      CsrPlugin_mcycle <= 64'h0000000000000000;
+      CsrPlugin_minstret <= 64'h0000000000000000;
       CsrPlugin_medeleg_IAM <= 1'b0;
       CsrPlugin_medeleg_IAF <= 1'b0;
       CsrPlugin_medeleg_II <= 1'b0;
+      CsrPlugin_medeleg_BP <= 1'b0;
       CsrPlugin_medeleg_LAM <= 1'b0;
       CsrPlugin_medeleg_LAF <= 1'b0;
       CsrPlugin_medeleg_SAM <= 1'b0;
@@ -6372,18 +6441,18 @@ module VexRiscv (
       CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
-      memory_DivPlugin_div_counter_value <= 6'h0;
-      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h0;
-      _zz_CsrPlugin_csrMapping_readDataInit_2 <= 32'h0;
+      memory_DivPlugin_div_counter_value <= 6'h00;
+      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h00000000;
+      _zz_CsrPlugin_csrMapping_readDataInit_1 <= 32'h00000000;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
-      switch_Fetcher_l365 <= 3'b000;
+      IBusCachedPlugin_injector_port_state <= 3'b000;
       execute_to_memory_IS_DBUS_SHARING <= 1'b0;
       memory_to_writeBack_IS_DBUS_SHARING <= 1'b0;
       _zz_iBusWishbone_ADR <= 3'b000;
       _zz_iBus_rsp_valid <= 1'b0;
-      _zz_dBus_cmd_ready <= 3'b000;
+      _zz_dBusWishbone_ADR <= 3'b000;
       _zz_dBus_rsp_valid <= 1'b0;
     end else begin
       if(IBusCachedPlugin_fetchPc_correction) begin
@@ -6393,23 +6462,23 @@ module VexRiscv (
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusCachedPlugin_fetchPc_booted <= 1'b1;
-      if(when_Fetcher_l134) begin
+      if(when_Fetcher_l133) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_output_fire_1) begin
+      if(IBusCachedPlugin_fetchPc_output_fire) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b1;
       end
-      if(when_Fetcher_l134_1) begin
+      if(when_Fetcher_l133_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(when_Fetcher_l161) begin
+      if(when_Fetcher_l160) begin
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
       if(IBusCachedPlugin_iBusRsp_flush) begin
-        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= 1'b0;
       end
       if(_zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready) begin
-        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
       if(IBusCachedPlugin_iBusRsp_flush) begin
         _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
@@ -6420,13 +6489,13 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if(when_Fetcher_l332) begin
+      if(when_Fetcher_l331) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(when_Fetcher_l332_1) begin
+      if(when_Fetcher_l331_1) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= IBusCachedPlugin_injector_nextPcCalc_valids_0;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -6435,7 +6504,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(when_Fetcher_l332_2) begin
+      if(when_Fetcher_l331_2) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= IBusCachedPlugin_injector_nextPcCalc_valids_1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -6444,7 +6513,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(when_Fetcher_l332_3) begin
+      if(when_Fetcher_l331_3) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -6453,7 +6522,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if(when_Fetcher_l332_4) begin
+      if(when_Fetcher_l331_4) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= IBusCachedPlugin_injector_nextPcCalc_valids_3;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -6463,16 +6532,19 @@ module VexRiscv (
         IBusCachedPlugin_rspCounter <= (IBusCachedPlugin_rspCounter + 32'h00000001);
       end
       if(dataCache_1_io_mem_cmd_valid) begin
-        dataCache_1_io_mem_cmd_rValid <= 1'b1;
+        toplevel_dataCache_1_io_mem_cmd_rValidN <= 1'b0;
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
-        dataCache_1_io_mem_cmd_rValid <= 1'b0;
+      if(toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+        toplevel_dataCache_1_io_mem_cmd_rValidN <= 1'b1;
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
-        dataCache_1_io_mem_cmd_s2mPipe_rValid <= dataCache_1_io_mem_cmd_s2mPipe_valid;
+      if(toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+        toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_valid;
       end
       if(dBus_rsp_valid) begin
         DBusCachedPlugin_rspCounter <= (DBusCachedPlugin_rspCounter + 32'h00000001);
+      end
+      if(CsrPlugin_xretAwayFromMachine) begin
+        MmuPlugin_status_mprv <= 1'b0;
       end
       MmuPlugin_ports_0_entryToReplace_value <= MmuPlugin_ports_0_entryToReplace_valueNext;
       if(contextSwitching) begin
@@ -6507,7 +6579,7 @@ module VexRiscv (
       MmuPlugin_shared_dBusRspStaged_valid <= MmuPlugin_dBusAccess_rsp_valid;
       case(MmuPlugin_shared_state_1)
         MmuPlugin_shared_State_IDLE : begin
-          if(when_MmuPlugin_l217) begin
+          if(when_MmuPlugin_l223) begin
             MmuPlugin_shared_state_1 <= MmuPlugin_shared_State_L1_CMD;
           end
         end
@@ -6519,7 +6591,7 @@ module VexRiscv (
         MmuPlugin_shared_State_L1_RSP : begin
           if(MmuPlugin_shared_dBusRspStaged_valid) begin
             MmuPlugin_shared_state_1 <= MmuPlugin_shared_State_L0_CMD;
-            if(when_MmuPlugin_l243) begin
+            if(when_MmuPlugin_l250) begin
               MmuPlugin_shared_state_1 <= MmuPlugin_shared_State_IDLE;
             end
             if(MmuPlugin_shared_dBusRspStaged_payload_redo) begin
@@ -6541,37 +6613,37 @@ module VexRiscv (
           end
         end
       endcase
-      if(when_MmuPlugin_l272) begin
-        if(when_MmuPlugin_l274) begin
-          if(when_MmuPlugin_l280) begin
+      if(when_MmuPlugin_l279) begin
+        if(when_MmuPlugin_l281) begin
+          if(when_MmuPlugin_l287) begin
             MmuPlugin_ports_0_cache_0_valid <= 1'b1;
           end
-          if(when_MmuPlugin_l280_1) begin
+          if(when_MmuPlugin_l287_1) begin
             MmuPlugin_ports_0_cache_1_valid <= 1'b1;
           end
-          if(when_MmuPlugin_l280_2) begin
+          if(when_MmuPlugin_l287_2) begin
             MmuPlugin_ports_0_cache_2_valid <= 1'b1;
           end
-          if(when_MmuPlugin_l280_3) begin
+          if(when_MmuPlugin_l287_3) begin
             MmuPlugin_ports_0_cache_3_valid <= 1'b1;
           end
         end
-        if(when_MmuPlugin_l274_1) begin
-          if(when_MmuPlugin_l280_4) begin
+        if(when_MmuPlugin_l281_1) begin
+          if(when_MmuPlugin_l287_4) begin
             MmuPlugin_ports_1_cache_0_valid <= 1'b1;
           end
-          if(when_MmuPlugin_l280_5) begin
+          if(when_MmuPlugin_l287_5) begin
             MmuPlugin_ports_1_cache_1_valid <= 1'b1;
           end
-          if(when_MmuPlugin_l280_6) begin
+          if(when_MmuPlugin_l287_6) begin
             MmuPlugin_ports_1_cache_2_valid <= 1'b1;
           end
-          if(when_MmuPlugin_l280_7) begin
+          if(when_MmuPlugin_l287_7) begin
             MmuPlugin_ports_1_cache_3_valid <= 1'b1;
           end
         end
       end
-      if(when_MmuPlugin_l304) begin
+      if(when_MmuPlugin_l311) begin
         MmuPlugin_ports_0_cache_0_valid <= 1'b0;
         MmuPlugin_ports_0_cache_1_valid <= 1'b0;
         MmuPlugin_ports_0_cache_2_valid <= 1'b0;
@@ -6581,77 +6653,77 @@ module VexRiscv (
         MmuPlugin_ports_1_cache_2_valid <= 1'b0;
         MmuPlugin_ports_1_cache_3_valid <= 1'b0;
       end
-      _zz_7 <= 1'b0;
+      _zz_10 <= 1'b0;
       HazardSimplePlugin_writeBackBuffer_valid <= HazardSimplePlugin_writeBackWrites_valid;
       CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
       if(writeBack_arbitration_isFiring) begin
         CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
       end
-      if(when_CsrPlugin_l922) begin
+      if(when_CsrPlugin_l1259) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if(when_CsrPlugin_l922_1) begin
+      if(when_CsrPlugin_l1259_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if(when_CsrPlugin_l922_2) begin
+      if(when_CsrPlugin_l1259_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if(when_CsrPlugin_l922_3) begin
+      if(when_CsrPlugin_l1259_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(when_CsrPlugin_l959) begin
-        if(when_CsrPlugin_l965) begin
+      if(when_CsrPlugin_l1296) begin
+        if(when_CsrPlugin_l1302) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_1) begin
+        if(when_CsrPlugin_l1302_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_2) begin
+        if(when_CsrPlugin_l1302_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
-      if(when_CsrPlugin_l959_1) begin
-        if(when_CsrPlugin_l965_3) begin
+      if(when_CsrPlugin_l1296_1) begin
+        if(when_CsrPlugin_l1302_3) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_4) begin
+        if(when_CsrPlugin_l1302_4) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_5) begin
+        if(when_CsrPlugin_l1302_5) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_6) begin
+        if(when_CsrPlugin_l1302_6) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_7) begin
+        if(when_CsrPlugin_l1302_7) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_8) begin
+        if(when_CsrPlugin_l1302_8) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
       CsrPlugin_lastStageWasWfi <= (writeBack_arbitration_isFiring && (writeBack_ENV_CTRL == EnvCtrlEnum_WFI));
       if(CsrPlugin_pipelineLiberator_active) begin
-        if(when_CsrPlugin_l993) begin
+        if(when_CsrPlugin_l1335) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if(when_CsrPlugin_l993_1) begin
+        if(when_CsrPlugin_l1335_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if(when_CsrPlugin_l993_2) begin
+        if(when_CsrPlugin_l1335_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(when_CsrPlugin_l998) begin
+      if(when_CsrPlugin_l1340) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
@@ -6660,25 +6732,27 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(when_CsrPlugin_l1032) begin
-        _zz_CsrPlugin_privilege <= CsrPlugin_targetPrivilege;
-        case(CsrPlugin_targetPrivilege)
-          2'b01 : begin
-            CsrPlugin_sstatus_SIE <= 1'b0;
-            CsrPlugin_sstatus_SPIE <= CsrPlugin_sstatus_SIE;
-            CsrPlugin_sstatus_SPP <= CsrPlugin_privilege[0 : 0];
-          end
-          2'b11 : begin
-            CsrPlugin_mstatus_MIE <= 1'b0;
-            CsrPlugin_mstatus_MPIE <= CsrPlugin_mstatus_MIE;
-            CsrPlugin_mstatus_MPP <= CsrPlugin_privilege;
-          end
-          default : begin
-          end
-        endcase
+      if(when_CsrPlugin_l1390) begin
+        if(when_CsrPlugin_l1398) begin
+          _zz_CsrPlugin_privilege <= CsrPlugin_targetPrivilege;
+          case(CsrPlugin_targetPrivilege)
+            2'b01 : begin
+              CsrPlugin_sstatus_SIE <= 1'b0;
+              CsrPlugin_sstatus_SPIE <= CsrPlugin_sstatus_SIE;
+              CsrPlugin_sstatus_SPP <= CsrPlugin_privilege[0 : 0];
+            end
+            2'b11 : begin
+              CsrPlugin_mstatus_MIE <= 1'b0;
+              CsrPlugin_mstatus_MPIE <= CsrPlugin_mstatus_MIE;
+              CsrPlugin_mstatus_MPP <= CsrPlugin_privilege;
+            end
+            default : begin
+            end
+          endcase
+        end
       end
-      if(when_CsrPlugin_l1077) begin
-        case(switch_CsrPlugin_l1081)
+      if(when_CsrPlugin_l1456) begin
+        case(switch_CsrPlugin_l1460)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -6695,7 +6769,7 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l965_5,{_zz_when_CsrPlugin_l965_4,{_zz_when_CsrPlugin_l965_3,{_zz_when_CsrPlugin_l965_2,{_zz_when_CsrPlugin_l965_1,_zz_when_CsrPlugin_l965}}}}} != 6'h0) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l1302_5,{_zz_when_CsrPlugin_l1302_4,{_zz_when_CsrPlugin_l1302_3,{_zz_when_CsrPlugin_l1302_2,{_zz_when_CsrPlugin_l1302_1,_zz_when_CsrPlugin_l1302}}}}} != 6'h00) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
       if(when_Pipeline_l124_58) begin
         execute_to_memory_IS_DBUS_SHARING <= execute_IS_DBUS_SHARING;
@@ -6721,25 +6795,25 @@ module VexRiscv (
       if(when_Pipeline_l154_2) begin
         writeBack_arbitration_isValid <= memory_arbitration_isValid;
       end
-      case(switch_Fetcher_l365)
+      case(IBusCachedPlugin_injector_port_state)
         3'b000 : begin
-          if(IBusCachedPlugin_injectionPort_valid) begin
-            switch_Fetcher_l365 <= 3'b001;
+          if(DebugPlugin_injectionPort_valid) begin
+            IBusCachedPlugin_injector_port_state <= 3'b001;
           end
         end
         3'b001 : begin
-          switch_Fetcher_l365 <= 3'b010;
+          IBusCachedPlugin_injector_port_state <= 3'b010;
         end
         3'b010 : begin
-          switch_Fetcher_l365 <= 3'b011;
+          IBusCachedPlugin_injector_port_state <= 3'b011;
         end
         3'b011 : begin
-          if(when_Fetcher_l381) begin
-            switch_Fetcher_l365 <= 3'b100;
+          if(when_Fetcher_l391) begin
+            IBusCachedPlugin_injector_port_state <= 3'b100;
           end
         end
         3'b100 : begin
-          switch_Fetcher_l365 <= 3'b000;
+          IBusCachedPlugin_injector_port_state <= 3'b000;
         end
         default : begin
         end
@@ -6757,7 +6831,7 @@ module VexRiscv (
           MmuPlugin_status_mprv <= CsrPlugin_csrMapping_writeDataSignal[17];
           CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
           CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
-          case(switch_CsrPlugin_l723)
+          case(switch_CsrPlugin_l1031)
             2'b11 : begin
               CsrPlugin_mstatus_MPP <= 2'b11;
             end
@@ -6820,6 +6894,7 @@ module VexRiscv (
           CsrPlugin_medeleg_IAM <= CsrPlugin_csrMapping_writeDataSignal[0];
           CsrPlugin_medeleg_IAF <= CsrPlugin_csrMapping_writeDataSignal[1];
           CsrPlugin_medeleg_II <= CsrPlugin_csrMapping_writeDataSignal[2];
+          CsrPlugin_medeleg_BP <= CsrPlugin_csrMapping_writeDataSignal[3];
           CsrPlugin_medeleg_LAM <= CsrPlugin_csrMapping_writeDataSignal[4];
           CsrPlugin_medeleg_LAF <= CsrPlugin_csrMapping_writeDataSignal[5];
           CsrPlugin_medeleg_SAM <= CsrPlugin_csrMapping_writeDataSignal[6];
@@ -6859,7 +6934,7 @@ module VexRiscv (
       end
       if(execute_CsrPlugin_csr_2496) begin
         if(execute_CsrPlugin_writeEnable) begin
-          _zz_CsrPlugin_csrMapping_readDataInit_2 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+          _zz_CsrPlugin_csrMapping_readDataInit_1 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
         end
       end
       if(when_InstructionCache_l239) begin
@@ -6868,13 +6943,13 @@ module VexRiscv (
         end
       end
       _zz_iBus_rsp_valid <= (iBusWishbone_CYC && iBusWishbone_ACK);
-      if((_zz_dBus_cmd_ready_1 && _zz_dBus_cmd_ready_2)) begin
-        _zz_dBus_cmd_ready <= (_zz_dBus_cmd_ready + 3'b001);
-        if(_zz_dBus_cmd_ready_4) begin
-          _zz_dBus_cmd_ready <= 3'b000;
+      if((_zz_dBusWishbone_CYC && _zz_dBus_cmd_ready)) begin
+        _zz_dBusWishbone_ADR <= (_zz_dBusWishbone_ADR + 3'b001);
+        if(_zz_dBus_cmd_ready_2) begin
+          _zz_dBusWishbone_ADR <= 3'b000;
         end
       end
-      _zz_dBus_rsp_valid <= ((_zz_dBus_cmd_ready_1 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
+      _zz_dBus_rsp_valid <= ((_zz_dBusWishbone_CYC && (! dBusWishbone_WE)) && dBusWishbone_ACK);
     end
   end
 
@@ -6888,28 +6963,28 @@ module VexRiscv (
     if(IBusCachedPlugin_iBusRsp_stages_2_input_ready) begin
       IBusCachedPlugin_s2_tightlyCoupledHit <= IBusCachedPlugin_s1_tightlyCoupledHit;
     end
-    if(dataCache_1_io_mem_cmd_ready) begin
-      dataCache_1_io_mem_cmd_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
-      dataCache_1_io_mem_cmd_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
-      dataCache_1_io_mem_cmd_rData_address <= dataCache_1_io_mem_cmd_payload_address;
-      dataCache_1_io_mem_cmd_rData_data <= dataCache_1_io_mem_cmd_payload_data;
-      dataCache_1_io_mem_cmd_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
-      dataCache_1_io_mem_cmd_rData_size <= dataCache_1_io_mem_cmd_payload_size;
-      dataCache_1_io_mem_cmd_rData_last <= dataCache_1_io_mem_cmd_payload_last;
+    if(toplevel_dataCache_1_io_mem_cmd_rValidN) begin
+      toplevel_dataCache_1_io_mem_cmd_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
+      toplevel_dataCache_1_io_mem_cmd_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
+      toplevel_dataCache_1_io_mem_cmd_rData_address <= dataCache_1_io_mem_cmd_payload_address;
+      toplevel_dataCache_1_io_mem_cmd_rData_data <= dataCache_1_io_mem_cmd_payload_data;
+      toplevel_dataCache_1_io_mem_cmd_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
+      toplevel_dataCache_1_io_mem_cmd_rData_size <= dataCache_1_io_mem_cmd_payload_size;
+      toplevel_dataCache_1_io_mem_cmd_rData_last <= dataCache_1_io_mem_cmd_payload_last;
     end
-    if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
-      dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_address <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_data <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_size <= dataCache_1_io_mem_cmd_s2mPipe_payload_size;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_last <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+    if(toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_address <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_data <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_size <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_size;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_last <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_last;
     end
     MmuPlugin_shared_dBusRspStaged_payload_data <= MmuPlugin_dBusAccess_rsp_payload_data;
     MmuPlugin_shared_dBusRspStaged_payload_error <= MmuPlugin_dBusAccess_rsp_payload_error;
     MmuPlugin_shared_dBusRspStaged_payload_redo <= MmuPlugin_dBusAccess_rsp_payload_redo;
-    if(when_MmuPlugin_l205) begin
+    if(when_MmuPlugin_l211) begin
       MmuPlugin_shared_pteBuffer_V <= MmuPlugin_shared_dBusRsp_pte_V;
       MmuPlugin_shared_pteBuffer_R <= MmuPlugin_shared_dBusRsp_pte_R;
       MmuPlugin_shared_pteBuffer_W <= MmuPlugin_shared_dBusRsp_pte_W;
@@ -6924,7 +6999,7 @@ module VexRiscv (
     end
     case(MmuPlugin_shared_state_1)
       MmuPlugin_shared_State_IDLE : begin
-        if(when_MmuPlugin_l217) begin
+        if(when_MmuPlugin_l223) begin
           MmuPlugin_shared_portSortedOh <= MmuPlugin_shared_refills;
           MmuPlugin_shared_vpn_1 <= _zz_MmuPlugin_shared_vpn_0[31 : 22];
           MmuPlugin_shared_vpn_0 <= _zz_MmuPlugin_shared_vpn_0[21 : 12];
@@ -6939,102 +7014,102 @@ module VexRiscv (
       default : begin
       end
     endcase
-    if(when_MmuPlugin_l272) begin
-      if(when_MmuPlugin_l274) begin
-        if(when_MmuPlugin_l280) begin
-          MmuPlugin_ports_0_cache_0_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
+    if(when_MmuPlugin_l279) begin
+      if(when_MmuPlugin_l281) begin
+        if(when_MmuPlugin_l287) begin
+          MmuPlugin_ports_0_cache_0_exception <= ((MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h000))) || (! MmuPlugin_shared_dBusRsp_pte_A));
           MmuPlugin_ports_0_cache_0_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_0_cache_0_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
           MmuPlugin_ports_0_cache_0_physicalAddress_0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
           MmuPlugin_ports_0_cache_0_physicalAddress_1 <= MmuPlugin_shared_dBusRsp_pte_PPN1[9 : 0];
           MmuPlugin_ports_0_cache_0_allowRead <= MmuPlugin_shared_dBusRsp_pte_R;
-          MmuPlugin_ports_0_cache_0_allowWrite <= MmuPlugin_shared_dBusRsp_pte_W;
+          MmuPlugin_ports_0_cache_0_allowWrite <= (MmuPlugin_shared_dBusRsp_pte_W && MmuPlugin_shared_dBusRsp_pte_D);
           MmuPlugin_ports_0_cache_0_allowExecute <= MmuPlugin_shared_dBusRsp_pte_X;
           MmuPlugin_ports_0_cache_0_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
           MmuPlugin_ports_0_cache_0_superPage <= (MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP);
         end
-        if(when_MmuPlugin_l280_1) begin
-          MmuPlugin_ports_0_cache_1_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
+        if(when_MmuPlugin_l287_1) begin
+          MmuPlugin_ports_0_cache_1_exception <= ((MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h000))) || (! MmuPlugin_shared_dBusRsp_pte_A));
           MmuPlugin_ports_0_cache_1_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_0_cache_1_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
           MmuPlugin_ports_0_cache_1_physicalAddress_0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
           MmuPlugin_ports_0_cache_1_physicalAddress_1 <= MmuPlugin_shared_dBusRsp_pte_PPN1[9 : 0];
           MmuPlugin_ports_0_cache_1_allowRead <= MmuPlugin_shared_dBusRsp_pte_R;
-          MmuPlugin_ports_0_cache_1_allowWrite <= MmuPlugin_shared_dBusRsp_pte_W;
+          MmuPlugin_ports_0_cache_1_allowWrite <= (MmuPlugin_shared_dBusRsp_pte_W && MmuPlugin_shared_dBusRsp_pte_D);
           MmuPlugin_ports_0_cache_1_allowExecute <= MmuPlugin_shared_dBusRsp_pte_X;
           MmuPlugin_ports_0_cache_1_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
           MmuPlugin_ports_0_cache_1_superPage <= (MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP);
         end
-        if(when_MmuPlugin_l280_2) begin
-          MmuPlugin_ports_0_cache_2_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
+        if(when_MmuPlugin_l287_2) begin
+          MmuPlugin_ports_0_cache_2_exception <= ((MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h000))) || (! MmuPlugin_shared_dBusRsp_pte_A));
           MmuPlugin_ports_0_cache_2_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_0_cache_2_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
           MmuPlugin_ports_0_cache_2_physicalAddress_0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
           MmuPlugin_ports_0_cache_2_physicalAddress_1 <= MmuPlugin_shared_dBusRsp_pte_PPN1[9 : 0];
           MmuPlugin_ports_0_cache_2_allowRead <= MmuPlugin_shared_dBusRsp_pte_R;
-          MmuPlugin_ports_0_cache_2_allowWrite <= MmuPlugin_shared_dBusRsp_pte_W;
+          MmuPlugin_ports_0_cache_2_allowWrite <= (MmuPlugin_shared_dBusRsp_pte_W && MmuPlugin_shared_dBusRsp_pte_D);
           MmuPlugin_ports_0_cache_2_allowExecute <= MmuPlugin_shared_dBusRsp_pte_X;
           MmuPlugin_ports_0_cache_2_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
           MmuPlugin_ports_0_cache_2_superPage <= (MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP);
         end
-        if(when_MmuPlugin_l280_3) begin
-          MmuPlugin_ports_0_cache_3_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
+        if(when_MmuPlugin_l287_3) begin
+          MmuPlugin_ports_0_cache_3_exception <= ((MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h000))) || (! MmuPlugin_shared_dBusRsp_pte_A));
           MmuPlugin_ports_0_cache_3_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_0_cache_3_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
           MmuPlugin_ports_0_cache_3_physicalAddress_0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
           MmuPlugin_ports_0_cache_3_physicalAddress_1 <= MmuPlugin_shared_dBusRsp_pte_PPN1[9 : 0];
           MmuPlugin_ports_0_cache_3_allowRead <= MmuPlugin_shared_dBusRsp_pte_R;
-          MmuPlugin_ports_0_cache_3_allowWrite <= MmuPlugin_shared_dBusRsp_pte_W;
+          MmuPlugin_ports_0_cache_3_allowWrite <= (MmuPlugin_shared_dBusRsp_pte_W && MmuPlugin_shared_dBusRsp_pte_D);
           MmuPlugin_ports_0_cache_3_allowExecute <= MmuPlugin_shared_dBusRsp_pte_X;
           MmuPlugin_ports_0_cache_3_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
           MmuPlugin_ports_0_cache_3_superPage <= (MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP);
         end
       end
-      if(when_MmuPlugin_l274_1) begin
-        if(when_MmuPlugin_l280_4) begin
-          MmuPlugin_ports_1_cache_0_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
+      if(when_MmuPlugin_l281_1) begin
+        if(when_MmuPlugin_l287_4) begin
+          MmuPlugin_ports_1_cache_0_exception <= ((MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h000))) || (! MmuPlugin_shared_dBusRsp_pte_A));
           MmuPlugin_ports_1_cache_0_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_1_cache_0_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
           MmuPlugin_ports_1_cache_0_physicalAddress_0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
           MmuPlugin_ports_1_cache_0_physicalAddress_1 <= MmuPlugin_shared_dBusRsp_pte_PPN1[9 : 0];
           MmuPlugin_ports_1_cache_0_allowRead <= MmuPlugin_shared_dBusRsp_pte_R;
-          MmuPlugin_ports_1_cache_0_allowWrite <= MmuPlugin_shared_dBusRsp_pte_W;
+          MmuPlugin_ports_1_cache_0_allowWrite <= (MmuPlugin_shared_dBusRsp_pte_W && MmuPlugin_shared_dBusRsp_pte_D);
           MmuPlugin_ports_1_cache_0_allowExecute <= MmuPlugin_shared_dBusRsp_pte_X;
           MmuPlugin_ports_1_cache_0_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
           MmuPlugin_ports_1_cache_0_superPage <= (MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP);
         end
-        if(when_MmuPlugin_l280_5) begin
-          MmuPlugin_ports_1_cache_1_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
+        if(when_MmuPlugin_l287_5) begin
+          MmuPlugin_ports_1_cache_1_exception <= ((MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h000))) || (! MmuPlugin_shared_dBusRsp_pte_A));
           MmuPlugin_ports_1_cache_1_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_1_cache_1_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
           MmuPlugin_ports_1_cache_1_physicalAddress_0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
           MmuPlugin_ports_1_cache_1_physicalAddress_1 <= MmuPlugin_shared_dBusRsp_pte_PPN1[9 : 0];
           MmuPlugin_ports_1_cache_1_allowRead <= MmuPlugin_shared_dBusRsp_pte_R;
-          MmuPlugin_ports_1_cache_1_allowWrite <= MmuPlugin_shared_dBusRsp_pte_W;
+          MmuPlugin_ports_1_cache_1_allowWrite <= (MmuPlugin_shared_dBusRsp_pte_W && MmuPlugin_shared_dBusRsp_pte_D);
           MmuPlugin_ports_1_cache_1_allowExecute <= MmuPlugin_shared_dBusRsp_pte_X;
           MmuPlugin_ports_1_cache_1_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
           MmuPlugin_ports_1_cache_1_superPage <= (MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP);
         end
-        if(when_MmuPlugin_l280_6) begin
-          MmuPlugin_ports_1_cache_2_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
+        if(when_MmuPlugin_l287_6) begin
+          MmuPlugin_ports_1_cache_2_exception <= ((MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h000))) || (! MmuPlugin_shared_dBusRsp_pte_A));
           MmuPlugin_ports_1_cache_2_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_1_cache_2_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
           MmuPlugin_ports_1_cache_2_physicalAddress_0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
           MmuPlugin_ports_1_cache_2_physicalAddress_1 <= MmuPlugin_shared_dBusRsp_pte_PPN1[9 : 0];
           MmuPlugin_ports_1_cache_2_allowRead <= MmuPlugin_shared_dBusRsp_pte_R;
-          MmuPlugin_ports_1_cache_2_allowWrite <= MmuPlugin_shared_dBusRsp_pte_W;
+          MmuPlugin_ports_1_cache_2_allowWrite <= (MmuPlugin_shared_dBusRsp_pte_W && MmuPlugin_shared_dBusRsp_pte_D);
           MmuPlugin_ports_1_cache_2_allowExecute <= MmuPlugin_shared_dBusRsp_pte_X;
           MmuPlugin_ports_1_cache_2_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
           MmuPlugin_ports_1_cache_2_superPage <= (MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP);
         end
-        if(when_MmuPlugin_l280_7) begin
-          MmuPlugin_ports_1_cache_3_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
+        if(when_MmuPlugin_l287_7) begin
+          MmuPlugin_ports_1_cache_3_exception <= ((MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h000))) || (! MmuPlugin_shared_dBusRsp_pte_A));
           MmuPlugin_ports_1_cache_3_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_1_cache_3_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
           MmuPlugin_ports_1_cache_3_physicalAddress_0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
           MmuPlugin_ports_1_cache_3_physicalAddress_1 <= MmuPlugin_shared_dBusRsp_pte_PPN1[9 : 0];
           MmuPlugin_ports_1_cache_3_allowRead <= MmuPlugin_shared_dBusRsp_pte_R;
-          MmuPlugin_ports_1_cache_3_allowWrite <= MmuPlugin_shared_dBusRsp_pte_W;
+          MmuPlugin_ports_1_cache_3_allowWrite <= (MmuPlugin_shared_dBusRsp_pte_W && MmuPlugin_shared_dBusRsp_pte_D);
           MmuPlugin_ports_1_cache_3_allowExecute <= MmuPlugin_shared_dBusRsp_pte_X;
           MmuPlugin_ports_1_cache_3_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
           MmuPlugin_ports_1_cache_3_superPage <= (MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP);
@@ -7063,67 +7138,69 @@ module VexRiscv (
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(when_CsrPlugin_l959) begin
-      if(when_CsrPlugin_l965) begin
+    if(when_CsrPlugin_l1296) begin
+      if(when_CsrPlugin_l1302) begin
         CsrPlugin_interrupt_code <= 4'b0101;
         CsrPlugin_interrupt_targetPrivilege <= 2'b01;
       end
-      if(when_CsrPlugin_l965_1) begin
+      if(when_CsrPlugin_l1302_1) begin
         CsrPlugin_interrupt_code <= 4'b0001;
         CsrPlugin_interrupt_targetPrivilege <= 2'b01;
       end
-      if(when_CsrPlugin_l965_2) begin
+      if(when_CsrPlugin_l1302_2) begin
         CsrPlugin_interrupt_code <= 4'b1001;
         CsrPlugin_interrupt_targetPrivilege <= 2'b01;
       end
     end
-    if(when_CsrPlugin_l959_1) begin
-      if(when_CsrPlugin_l965_3) begin
+    if(when_CsrPlugin_l1296_1) begin
+      if(when_CsrPlugin_l1302_3) begin
         CsrPlugin_interrupt_code <= 4'b0101;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l965_4) begin
+      if(when_CsrPlugin_l1302_4) begin
         CsrPlugin_interrupt_code <= 4'b0001;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l965_5) begin
+      if(when_CsrPlugin_l1302_5) begin
         CsrPlugin_interrupt_code <= 4'b1001;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l965_6) begin
+      if(when_CsrPlugin_l1302_6) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l965_7) begin
+      if(when_CsrPlugin_l1302_7) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l965_8) begin
+      if(when_CsrPlugin_l1302_8) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(when_CsrPlugin_l1032) begin
-      case(CsrPlugin_targetPrivilege)
-        2'b01 : begin
-          CsrPlugin_scause_interrupt <= (! CsrPlugin_hadException);
-          CsrPlugin_scause_exceptionCode <= CsrPlugin_trapCause;
-          CsrPlugin_sepc <= writeBack_PC;
-          if(CsrPlugin_hadException) begin
-            CsrPlugin_stval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
+    if(when_CsrPlugin_l1390) begin
+      if(when_CsrPlugin_l1398) begin
+        case(CsrPlugin_targetPrivilege)
+          2'b01 : begin
+            CsrPlugin_scause_interrupt <= (! CsrPlugin_hadException);
+            CsrPlugin_scause_exceptionCode <= CsrPlugin_trapCause;
+            CsrPlugin_sepc <= writeBack_PC;
+            if(CsrPlugin_hadException) begin
+              CsrPlugin_stval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
+            end
           end
-        end
-        2'b11 : begin
-          CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
-          CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
-          CsrPlugin_mepc <= writeBack_PC;
-          if(CsrPlugin_hadException) begin
-            CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
+          2'b11 : begin
+            CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
+            CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
+            CsrPlugin_mepc <= writeBack_PC;
+            if(CsrPlugin_hadException) begin
+              CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
+            end
           end
-        end
-        default : begin
-        end
-      endcase
+          default : begin
+          end
+        endcase
+      end
     end
     if(when_MulDivIterativePlugin_l126) begin
       memory_DivPlugin_div_done <= 1'b1;
@@ -7141,17 +7218,17 @@ module VexRiscv (
       end
     end
     if(when_MulDivIterativePlugin_l162) begin
-      memory_DivPlugin_accumulator <= 65'h0;
+      memory_DivPlugin_accumulator <= 65'h00000000000000000;
       memory_DivPlugin_rs1 <= ((_zz_memory_DivPlugin_rs1 ? (~ _zz_memory_DivPlugin_rs1_1) : _zz_memory_DivPlugin_rs1_1) + _zz_memory_DivPlugin_rs1_2);
       memory_DivPlugin_rs2 <= ((_zz_memory_DivPlugin_rs2 ? (~ execute_RS2) : execute_RS2) + _zz_memory_DivPlugin_rs2_1);
-      memory_DivPlugin_div_needRevert <= ((_zz_memory_DivPlugin_rs1 ^ (_zz_memory_DivPlugin_rs2 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
+      memory_DivPlugin_div_needRevert <= ((_zz_memory_DivPlugin_rs1 ^ (_zz_memory_DivPlugin_rs2 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h00000000) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
     end
     externalInterruptArray_regNext <= externalInterruptArray;
     if(when_Pipeline_l124) begin
       decode_to_execute_PC <= decode_PC;
     end
     if(when_Pipeline_l124_1) begin
-      execute_to_memory_PC <= _zz_execute_SRC2;
+      execute_to_memory_PC <= _zz_execute_to_memory_PC;
     end
     if(when_Pipeline_l124_2) begin
       memory_to_writeBack_PC <= memory_PC;
@@ -7178,73 +7255,73 @@ module VexRiscv (
       decode_to_execute_MEMORY_FORCE_CONSTISTENCY <= decode_MEMORY_FORCE_CONSTISTENCY;
     end
     if(when_Pipeline_l124_10) begin
-      decode_to_execute_SRC1_CTRL <= _zz_decode_to_execute_SRC1_CTRL;
+      decode_to_execute_RESCHEDULE_NEXT <= decode_RESCHEDULE_NEXT;
     end
     if(when_Pipeline_l124_11) begin
-      decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
+      decode_to_execute_SRC1_CTRL <= _zz_decode_to_execute_SRC1_CTRL;
     end
     if(when_Pipeline_l124_12) begin
-      decode_to_execute_MEMORY_ENABLE <= decode_MEMORY_ENABLE;
+      decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
     end
     if(when_Pipeline_l124_13) begin
-      execute_to_memory_MEMORY_ENABLE <= execute_MEMORY_ENABLE;
+      decode_to_execute_MEMORY_ENABLE <= decode_MEMORY_ENABLE;
     end
     if(when_Pipeline_l124_14) begin
-      memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
+      execute_to_memory_MEMORY_ENABLE <= execute_MEMORY_ENABLE;
     end
     if(when_Pipeline_l124_15) begin
-      decode_to_execute_ALU_CTRL <= _zz_decode_to_execute_ALU_CTRL;
+      memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
     end
     if(when_Pipeline_l124_16) begin
-      decode_to_execute_SRC2_CTRL <= _zz_decode_to_execute_SRC2_CTRL;
+      decode_to_execute_ALU_CTRL <= _zz_decode_to_execute_ALU_CTRL;
     end
     if(when_Pipeline_l124_17) begin
-      decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
+      decode_to_execute_SRC2_CTRL <= _zz_decode_to_execute_SRC2_CTRL;
     end
     if(when_Pipeline_l124_18) begin
-      execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
+      decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
     end
     if(when_Pipeline_l124_19) begin
-      memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
+      execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
     end
     if(when_Pipeline_l124_20) begin
-      decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
+      memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
     end
     if(when_Pipeline_l124_21) begin
-      decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
+      decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
     end
     if(when_Pipeline_l124_22) begin
-      execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
+      decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
     end
     if(when_Pipeline_l124_23) begin
-      decode_to_execute_MEMORY_WR <= decode_MEMORY_WR;
+      execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
     end
     if(when_Pipeline_l124_24) begin
-      execute_to_memory_MEMORY_WR <= execute_MEMORY_WR;
+      decode_to_execute_MEMORY_WR <= decode_MEMORY_WR;
     end
     if(when_Pipeline_l124_25) begin
-      memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
+      execute_to_memory_MEMORY_WR <= execute_MEMORY_WR;
     end
     if(when_Pipeline_l124_26) begin
-      decode_to_execute_MEMORY_LRSC <= decode_MEMORY_LRSC;
+      memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
     end
     if(when_Pipeline_l124_27) begin
-      execute_to_memory_MEMORY_LRSC <= execute_MEMORY_LRSC;
+      decode_to_execute_MEMORY_LRSC <= decode_MEMORY_LRSC;
     end
     if(when_Pipeline_l124_28) begin
-      memory_to_writeBack_MEMORY_LRSC <= memory_MEMORY_LRSC;
+      execute_to_memory_MEMORY_LRSC <= execute_MEMORY_LRSC;
     end
     if(when_Pipeline_l124_29) begin
-      decode_to_execute_MEMORY_AMO <= decode_MEMORY_AMO;
+      memory_to_writeBack_MEMORY_LRSC <= memory_MEMORY_LRSC;
     end
     if(when_Pipeline_l124_30) begin
-      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
+      decode_to_execute_MEMORY_AMO <= decode_MEMORY_AMO;
     end
     if(when_Pipeline_l124_31) begin
-      decode_to_execute_IS_SFENCE_VMA2 <= decode_IS_SFENCE_VMA2;
+      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
     end
     if(when_Pipeline_l124_32) begin
-      decode_to_execute_IS_SFENCE_VMA <= decode_IS_SFENCE_VMA;
+      decode_to_execute_IS_SFENCE_VMA2 <= decode_IS_SFENCE_VMA2;
     end
     if(when_Pipeline_l124_33) begin
       decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
@@ -7354,94 +7431,94 @@ module VexRiscv (
     if(when_Pipeline_l124_70) begin
       memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
     end
-    if(when_CsrPlugin_l1277) begin
+    if(when_CsrPlugin_l1669) begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
     end
-    if(when_CsrPlugin_l1277_1) begin
+    if(when_CsrPlugin_l1669_1) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if(when_CsrPlugin_l1277_2) begin
+    if(when_CsrPlugin_l1669_2) begin
       execute_CsrPlugin_csr_256 <= (decode_INSTRUCTION[31 : 20] == 12'h100);
     end
-    if(when_CsrPlugin_l1277_3) begin
+    if(when_CsrPlugin_l1669_3) begin
       execute_CsrPlugin_csr_384 <= (decode_INSTRUCTION[31 : 20] == 12'h180);
     end
-    if(when_CsrPlugin_l1277_4) begin
+    if(when_CsrPlugin_l1669_4) begin
       execute_CsrPlugin_csr_3857 <= (decode_INSTRUCTION[31 : 20] == 12'hf11);
     end
-    if(when_CsrPlugin_l1277_5) begin
+    if(when_CsrPlugin_l1669_5) begin
       execute_CsrPlugin_csr_3858 <= (decode_INSTRUCTION[31 : 20] == 12'hf12);
     end
-    if(when_CsrPlugin_l1277_6) begin
+    if(when_CsrPlugin_l1669_6) begin
       execute_CsrPlugin_csr_3859 <= (decode_INSTRUCTION[31 : 20] == 12'hf13);
     end
-    if(when_CsrPlugin_l1277_7) begin
+    if(when_CsrPlugin_l1669_7) begin
       execute_CsrPlugin_csr_3860 <= (decode_INSTRUCTION[31 : 20] == 12'hf14);
     end
-    if(when_CsrPlugin_l1277_8) begin
+    if(when_CsrPlugin_l1669_8) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if(when_CsrPlugin_l1277_9) begin
+    if(when_CsrPlugin_l1669_9) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if(when_CsrPlugin_l1277_10) begin
+    if(when_CsrPlugin_l1669_10) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if(when_CsrPlugin_l1277_11) begin
+    if(when_CsrPlugin_l1669_11) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if(when_CsrPlugin_l1277_12) begin
+    if(when_CsrPlugin_l1669_12) begin
       execute_CsrPlugin_csr_832 <= (decode_INSTRUCTION[31 : 20] == 12'h340);
     end
-    if(when_CsrPlugin_l1277_13) begin
+    if(when_CsrPlugin_l1669_13) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if(when_CsrPlugin_l1277_14) begin
+    if(when_CsrPlugin_l1669_14) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if(when_CsrPlugin_l1277_15) begin
+    if(when_CsrPlugin_l1669_15) begin
       execute_CsrPlugin_csr_770 <= (decode_INSTRUCTION[31 : 20] == 12'h302);
     end
-    if(when_CsrPlugin_l1277_16) begin
+    if(when_CsrPlugin_l1669_16) begin
       execute_CsrPlugin_csr_771 <= (decode_INSTRUCTION[31 : 20] == 12'h303);
     end
-    if(when_CsrPlugin_l1277_17) begin
+    if(when_CsrPlugin_l1669_17) begin
       execute_CsrPlugin_csr_324 <= (decode_INSTRUCTION[31 : 20] == 12'h144);
     end
-    if(when_CsrPlugin_l1277_18) begin
+    if(when_CsrPlugin_l1669_18) begin
       execute_CsrPlugin_csr_260 <= (decode_INSTRUCTION[31 : 20] == 12'h104);
     end
-    if(when_CsrPlugin_l1277_19) begin
+    if(when_CsrPlugin_l1669_19) begin
       execute_CsrPlugin_csr_261 <= (decode_INSTRUCTION[31 : 20] == 12'h105);
     end
-    if(when_CsrPlugin_l1277_20) begin
+    if(when_CsrPlugin_l1669_20) begin
       execute_CsrPlugin_csr_321 <= (decode_INSTRUCTION[31 : 20] == 12'h141);
     end
-    if(when_CsrPlugin_l1277_21) begin
+    if(when_CsrPlugin_l1669_21) begin
       execute_CsrPlugin_csr_320 <= (decode_INSTRUCTION[31 : 20] == 12'h140);
     end
-    if(when_CsrPlugin_l1277_22) begin
+    if(when_CsrPlugin_l1669_22) begin
       execute_CsrPlugin_csr_322 <= (decode_INSTRUCTION[31 : 20] == 12'h142);
     end
-    if(when_CsrPlugin_l1277_23) begin
+    if(when_CsrPlugin_l1669_23) begin
       execute_CsrPlugin_csr_323 <= (decode_INSTRUCTION[31 : 20] == 12'h143);
     end
-    if(when_CsrPlugin_l1277_24) begin
+    if(when_CsrPlugin_l1669_24) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if(when_CsrPlugin_l1277_25) begin
+    if(when_CsrPlugin_l1669_25) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
-    if(when_CsrPlugin_l1277_26) begin
+    if(when_CsrPlugin_l1669_26) begin
       execute_CsrPlugin_csr_2496 <= (decode_INSTRUCTION[31 : 20] == 12'h9c0);
     end
-    if(when_CsrPlugin_l1277_27) begin
+    if(when_CsrPlugin_l1669_27) begin
       execute_CsrPlugin_csr_3520 <= (decode_INSTRUCTION[31 : 20] == 12'hdc0);
     end
     if(execute_CsrPlugin_csr_384) begin
       if(execute_CsrPlugin_writeEnable) begin
         MmuPlugin_satp_asid <= CsrPlugin_csrMapping_writeDataSignal[30 : 22];
-        MmuPlugin_satp_ppn <= CsrPlugin_csrMapping_writeDataSignal[19 : 0];
+        MmuPlugin_satp_ppn <= CsrPlugin_csrMapping_writeDataSignal[21 : 0];
       end
     end
     if(execute_CsrPlugin_csr_836) begin
@@ -7452,7 +7529,6 @@ module VexRiscv (
     if(execute_CsrPlugin_csr_773) begin
       if(execute_CsrPlugin_writeEnable) begin
         CsrPlugin_mtvec_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 2];
-        CsrPlugin_mtvec_mode <= CsrPlugin_csrMapping_writeDataSignal[1 : 0];
       end
     end
     if(execute_CsrPlugin_csr_833) begin
@@ -7468,7 +7544,6 @@ module VexRiscv (
     if(execute_CsrPlugin_csr_261) begin
       if(execute_CsrPlugin_writeEnable) begin
         CsrPlugin_stvec_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 2];
-        CsrPlugin_stvec_mode <= CsrPlugin_csrMapping_writeDataSignal[1 : 0];
       end
     end
     if(execute_CsrPlugin_csr_321) begin
@@ -7506,9 +7581,9 @@ module VexRiscv (
     if(writeBack_arbitration_isValid) begin
       DebugPlugin_busReadDataReg <= _zz_decode_RS2_2;
     end
-    _zz_when_DebugPlugin_l244 <= debug_bus_cmd_payload_address[2];
+    _zz_when_DebugPlugin_l257 <= debug_bus_cmd_payload_address[2];
     if(debug_bus_cmd_valid) begin
-      case(switch_DebugPlugin_l267)
+      case(switch_DebugPlugin_l280)
         6'h10 : begin
           if(debug_bus_cmd_payload_wr) begin
             DebugPlugin_hardwareBreakpoints_0_pc <= debug_bus_cmd_payload_data[31 : 1];
@@ -7523,7 +7598,7 @@ module VexRiscv (
         end
       endcase
     end
-    if(when_DebugPlugin_l295) begin
+    if(when_DebugPlugin_l308) begin
       DebugPlugin_busReadDataReg <= execute_PC;
     end
     DebugPlugin_resetIt_regNext <= DebugPlugin_resetIt;
@@ -7541,39 +7616,39 @@ module VexRiscv (
       DebugPlugin_hardwareBreakpoints_0_valid <= 1'b0;
       DebugPlugin_hardwareBreakpoints_1_valid <= 1'b0;
     end else begin
-      if(when_DebugPlugin_l225) begin
+      if(when_DebugPlugin_l238) begin
         DebugPlugin_godmode <= 1'b1;
       end
       if(debug_bus_cmd_valid) begin
         DebugPlugin_debugUsed <= 1'b1;
       end
       if(debug_bus_cmd_valid) begin
-        case(switch_DebugPlugin_l267)
-          6'h0 : begin
+        case(switch_DebugPlugin_l280)
+          6'h00 : begin
             if(debug_bus_cmd_payload_wr) begin
               DebugPlugin_stepIt <= debug_bus_cmd_payload_data[4];
-              if(when_DebugPlugin_l271) begin
+              if(when_DebugPlugin_l284) begin
                 DebugPlugin_resetIt <= 1'b1;
               end
-              if(when_DebugPlugin_l271_1) begin
+              if(when_DebugPlugin_l284_1) begin
                 DebugPlugin_resetIt <= 1'b0;
               end
-              if(when_DebugPlugin_l272) begin
+              if(when_DebugPlugin_l285) begin
                 DebugPlugin_haltIt <= 1'b1;
               end
-              if(when_DebugPlugin_l272_1) begin
+              if(when_DebugPlugin_l285_1) begin
                 DebugPlugin_haltIt <= 1'b0;
               end
-              if(when_DebugPlugin_l273) begin
+              if(when_DebugPlugin_l286) begin
                 DebugPlugin_haltedByBreak <= 1'b0;
               end
-              if(when_DebugPlugin_l274) begin
+              if(when_DebugPlugin_l287) begin
                 DebugPlugin_godmode <= 1'b0;
               end
-              if(when_DebugPlugin_l275) begin
+              if(when_DebugPlugin_l288) begin
                 DebugPlugin_disableEbreak <= 1'b1;
               end
-              if(when_DebugPlugin_l275_1) begin
+              if(when_DebugPlugin_l288_1) begin
                 DebugPlugin_disableEbreak <= 1'b0;
               end
             end
@@ -7592,13 +7667,13 @@ module VexRiscv (
           end
         endcase
       end
-      if(when_DebugPlugin_l295) begin
-        if(when_DebugPlugin_l298) begin
+      if(when_DebugPlugin_l308) begin
+        if(when_DebugPlugin_l311) begin
           DebugPlugin_haltIt <= 1'b1;
           DebugPlugin_haltedByBreak <= 1'b1;
         end
       end
-      if(when_DebugPlugin_l311) begin
+      if(when_DebugPlugin_l324) begin
         if(decode_arbitration_isValid) begin
           DebugPlugin_haltIt <= 1'b1;
         end
@@ -7610,96 +7685,93 @@ module VexRiscv (
 endmodule
 
 module DataCache (
-  input               io_cpu_execute_isValid,
-  input      [31:0]   io_cpu_execute_address,
-  output reg          io_cpu_execute_haltIt,
-  input               io_cpu_execute_args_wr,
-  input      [1:0]    io_cpu_execute_args_size,
-  input               io_cpu_execute_args_isLrsc,
-  input               io_cpu_execute_args_isAmo,
-  input               io_cpu_execute_args_amoCtrl_swap,
-  input      [2:0]    io_cpu_execute_args_amoCtrl_alu,
-  input               io_cpu_execute_args_totalyConsistent,
-  output              io_cpu_execute_refilling,
-  input               io_cpu_memory_isValid,
-  input               io_cpu_memory_isStuck,
-  output              io_cpu_memory_isWrite,
-  input      [31:0]   io_cpu_memory_address,
-  input      [31:0]   io_cpu_memory_mmuRsp_physicalAddress,
-  input               io_cpu_memory_mmuRsp_isIoAccess,
-  input               io_cpu_memory_mmuRsp_isPaging,
-  input               io_cpu_memory_mmuRsp_allowRead,
-  input               io_cpu_memory_mmuRsp_allowWrite,
-  input               io_cpu_memory_mmuRsp_allowExecute,
-  input               io_cpu_memory_mmuRsp_exception,
-  input               io_cpu_memory_mmuRsp_refilling,
-  input               io_cpu_memory_mmuRsp_bypassTranslation,
-  input               io_cpu_memory_mmuRsp_ways_0_sel,
-  input      [31:0]   io_cpu_memory_mmuRsp_ways_0_physical,
-  input               io_cpu_memory_mmuRsp_ways_1_sel,
-  input      [31:0]   io_cpu_memory_mmuRsp_ways_1_physical,
-  input               io_cpu_memory_mmuRsp_ways_2_sel,
-  input      [31:0]   io_cpu_memory_mmuRsp_ways_2_physical,
-  input               io_cpu_memory_mmuRsp_ways_3_sel,
-  input      [31:0]   io_cpu_memory_mmuRsp_ways_3_physical,
-  input               io_cpu_writeBack_isValid,
-  input               io_cpu_writeBack_isStuck,
-  input               io_cpu_writeBack_isFiring,
-  input               io_cpu_writeBack_isUser,
-  output reg          io_cpu_writeBack_haltIt,
-  output              io_cpu_writeBack_isWrite,
-  input      [31:0]   io_cpu_writeBack_storeData,
-  output reg [31:0]   io_cpu_writeBack_data,
-  input      [31:0]   io_cpu_writeBack_address,
-  output              io_cpu_writeBack_mmuException,
-  output              io_cpu_writeBack_unalignedAccess,
-  output reg          io_cpu_writeBack_accessError,
-  output              io_cpu_writeBack_keepMemRspData,
-  input               io_cpu_writeBack_fence_SW,
-  input               io_cpu_writeBack_fence_SR,
-  input               io_cpu_writeBack_fence_SO,
-  input               io_cpu_writeBack_fence_SI,
-  input               io_cpu_writeBack_fence_PW,
-  input               io_cpu_writeBack_fence_PR,
-  input               io_cpu_writeBack_fence_PO,
-  input               io_cpu_writeBack_fence_PI,
-  input      [3:0]    io_cpu_writeBack_fence_FM,
-  output              io_cpu_writeBack_exclusiveOk,
-  output reg          io_cpu_redo,
-  input               io_cpu_flush_valid,
-  output              io_cpu_flush_ready,
-  input               io_cpu_flush_payload_singleLine,
-  input      [6:0]    io_cpu_flush_payload_lineId,
-  output reg          io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output reg          io_mem_cmd_payload_wr,
-  output              io_mem_cmd_payload_uncached,
-  output reg [31:0]   io_mem_cmd_payload_address,
-  output     [31:0]   io_mem_cmd_payload_data,
-  output     [3:0]    io_mem_cmd_payload_mask,
-  output reg [2:0]    io_mem_cmd_payload_size,
-  output              io_mem_cmd_payload_last,
-  input               io_mem_rsp_valid,
-  input               io_mem_rsp_payload_last,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input               clk,
-  input               reset
+  input  wire          io_cpu_execute_isValid,
+  input  wire [31:0]   io_cpu_execute_address,
+  output reg           io_cpu_execute_haltIt,
+  input  wire          io_cpu_execute_args_wr,
+  input  wire [1:0]    io_cpu_execute_args_size,
+  input  wire          io_cpu_execute_args_isLrsc,
+  input  wire          io_cpu_execute_args_isAmo,
+  input  wire          io_cpu_execute_args_amoCtrl_swap,
+  input  wire [2:0]    io_cpu_execute_args_amoCtrl_alu,
+  input  wire          io_cpu_execute_args_totalyConsistent,
+  output wire          io_cpu_execute_refilling,
+  input  wire          io_cpu_memory_isValid,
+  input  wire          io_cpu_memory_isStuck,
+  output wire          io_cpu_memory_isWrite,
+  input  wire [31:0]   io_cpu_memory_address,
+  input  wire [31:0]   io_cpu_memory_mmuRsp_physicalAddress,
+  input  wire          io_cpu_memory_mmuRsp_isIoAccess,
+  input  wire          io_cpu_memory_mmuRsp_isPaging,
+  input  wire          io_cpu_memory_mmuRsp_allowRead,
+  input  wire          io_cpu_memory_mmuRsp_allowWrite,
+  input  wire          io_cpu_memory_mmuRsp_allowExecute,
+  input  wire          io_cpu_memory_mmuRsp_exception,
+  input  wire          io_cpu_memory_mmuRsp_refilling,
+  input  wire          io_cpu_memory_mmuRsp_bypassTranslation,
+  input  wire          io_cpu_memory_mmuRsp_ways_0_sel,
+  input  wire [31:0]   io_cpu_memory_mmuRsp_ways_0_physical,
+  input  wire          io_cpu_memory_mmuRsp_ways_1_sel,
+  input  wire [31:0]   io_cpu_memory_mmuRsp_ways_1_physical,
+  input  wire          io_cpu_memory_mmuRsp_ways_2_sel,
+  input  wire [31:0]   io_cpu_memory_mmuRsp_ways_2_physical,
+  input  wire          io_cpu_memory_mmuRsp_ways_3_sel,
+  input  wire [31:0]   io_cpu_memory_mmuRsp_ways_3_physical,
+  input  wire          io_cpu_writeBack_isValid,
+  input  wire          io_cpu_writeBack_isStuck,
+  input  wire          io_cpu_writeBack_isFiring,
+  input  wire          io_cpu_writeBack_isUser,
+  output reg           io_cpu_writeBack_haltIt,
+  output wire          io_cpu_writeBack_isWrite,
+  input  wire [31:0]   io_cpu_writeBack_storeData,
+  output reg  [31:0]   io_cpu_writeBack_data,
+  input  wire [31:0]   io_cpu_writeBack_address,
+  output wire          io_cpu_writeBack_mmuException,
+  output wire          io_cpu_writeBack_unalignedAccess,
+  output reg           io_cpu_writeBack_accessError,
+  output wire          io_cpu_writeBack_keepMemRspData,
+  input  wire          io_cpu_writeBack_fence_SW,
+  input  wire          io_cpu_writeBack_fence_SR,
+  input  wire          io_cpu_writeBack_fence_SO,
+  input  wire          io_cpu_writeBack_fence_SI,
+  input  wire          io_cpu_writeBack_fence_PW,
+  input  wire          io_cpu_writeBack_fence_PR,
+  input  wire          io_cpu_writeBack_fence_PO,
+  input  wire          io_cpu_writeBack_fence_PI,
+  input  wire [3:0]    io_cpu_writeBack_fence_FM,
+  output wire          io_cpu_writeBack_exclusiveOk,
+  output reg           io_cpu_redo,
+  input  wire          io_cpu_flush_valid,
+  output wire          io_cpu_flush_ready,
+  input  wire          io_cpu_flush_payload_singleLine,
+  input  wire [6:0]    io_cpu_flush_payload_lineId,
+  output wire          io_cpu_writesPending,
+  output reg           io_mem_cmd_valid,
+  input  wire          io_mem_cmd_ready,
+  output reg           io_mem_cmd_payload_wr,
+  output wire          io_mem_cmd_payload_uncached,
+  output reg  [31:0]   io_mem_cmd_payload_address,
+  output wire [31:0]   io_mem_cmd_payload_data,
+  output wire [3:0]    io_mem_cmd_payload_mask,
+  output reg  [2:0]    io_mem_cmd_payload_size,
+  output wire          io_mem_cmd_payload_last,
+  input  wire          io_mem_rsp_valid,
+  input  wire          io_mem_rsp_payload_last,
+  input  wire [31:0]   io_mem_rsp_payload_data,
+  input  wire          io_mem_rsp_payload_error,
+  input  wire          clk,
+  input  wire          reset
 );
 
   reg        [21:0]   _zz_ways_0_tags_port0;
   reg        [31:0]   _zz_ways_0_data_port0;
   wire       [21:0]   _zz_ways_0_tags_port;
-  wire       [9:0]    _zz_stage0_dataColisions;
-  wire       [9:0]    _zz__zz_stageA_dataColisions;
   wire       [31:0]   _zz_stageB_amo_addSub;
   wire       [31:0]   _zz_stageB_amo_addSub_1;
   wire       [31:0]   _zz_stageB_amo_addSub_2;
   wire       [31:0]   _zz_stageB_amo_addSub_3;
   wire       [31:0]   _zz_stageB_amo_addSub_4;
   wire       [1:0]    _zz_stageB_amo_addSub_5;
-  wire       [1:0]    _zz_stageB_amo_addSub_6;
-  wire       [1:0]    _zz_stageB_amo_addSub_7;
   wire       [0:0]    _zz_when;
   wire       [2:0]    _zz_loader_counter_valueNext;
   wire       [0:0]    _zz_loader_counter_valueNext_1;
@@ -7736,19 +7808,19 @@ module DataCache (
   wire                _zz_ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRsp;
-  wire                when_DataCache_l642;
   wire                when_DataCache_l645;
-  wire                when_DataCache_l664;
+  wire                when_DataCache_l648;
+  wire                when_DataCache_l667;
   wire                rspSync;
   wire                rspLast;
   reg                 memCmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_DataCache_l686;
+  wire                when_DataCache_l689;
   reg        [3:0]    _zz_stage0_mask;
   wire       [3:0]    stage0_mask;
   wire       [0:0]    stage0_dataColisions;
   wire       [0:0]    stage0_wayInvalidate;
-  wire                when_DataCache_l771;
+  wire                when_DataCache_l776;
   reg                 stageA_request_wr;
   reg        [1:0]    stageA_request_size;
   reg                 stageA_request_isLrsc;
@@ -7756,16 +7828,16 @@ module DataCache (
   reg                 stageA_request_amoCtrl_swap;
   reg        [2:0]    stageA_request_amoCtrl_alu;
   reg                 stageA_request_totalyConsistent;
-  wire                when_DataCache_l771_1;
+  wire                when_DataCache_l776_1;
   reg        [3:0]    stageA_mask;
   wire       [0:0]    stageA_wayHits;
-  wire                when_DataCache_l771_2;
+  wire                when_DataCache_l776_2;
   reg        [0:0]    stageA_wayInvalidate;
-  wire                when_DataCache_l771_3;
+  wire                when_DataCache_l776_3;
   reg        [0:0]    stage0_dataColisions_regNextWhen;
   wire       [0:0]    _zz_stageA_dataColisions;
   wire       [0:0]    stageA_dataColisions;
-  wire                when_DataCache_l822;
+  wire                when_DataCache_l827;
   reg                 stageB_request_wr;
   reg        [1:0]    stageB_request_size;
   reg                 stageB_request_isLrsc;
@@ -7774,7 +7846,7 @@ module DataCache (
   reg        [2:0]    stageB_request_amoCtrl_alu;
   reg                 stageB_request_totalyConsistent;
   reg                 stageB_mmuRspFreeze;
-  wire                when_DataCache_l824;
+  wire                when_DataCache_l829;
   reg        [31:0]   stageB_mmuRsp_physicalAddress;
   reg                 stageB_mmuRsp_isIoAccess;
   reg                 stageB_mmuRsp_isPaging;
@@ -7792,36 +7864,38 @@ module DataCache (
   reg        [31:0]   stageB_mmuRsp_ways_2_physical;
   reg                 stageB_mmuRsp_ways_3_sel;
   reg        [31:0]   stageB_mmuRsp_ways_3_physical;
-  wire                when_DataCache_l821;
+  wire                when_DataCache_l826;
   reg                 stageB_tagsReadRsp_0_valid;
   reg                 stageB_tagsReadRsp_0_error;
   reg        [19:0]   stageB_tagsReadRsp_0_address;
-  wire                when_DataCache_l821_1;
+  wire                when_DataCache_l826_1;
   reg        [31:0]   stageB_dataReadRsp_0;
-  wire                when_DataCache_l820;
+  wire                when_DataCache_l825;
   reg        [0:0]    stageB_wayInvalidate;
   wire                stageB_consistancyHazard;
-  wire                when_DataCache_l820_1;
+  wire                when_DataCache_l825_1;
   reg        [0:0]    stageB_dataColisions;
-  wire                when_DataCache_l820_2;
+  wire                when_DataCache_l825_2;
   reg                 stageB_unaligned;
-  wire                when_DataCache_l820_3;
+  wire                when_DataCache_l825_3;
   reg        [0:0]    stageB_waysHitsBeforeInvalidate;
   wire       [0:0]    stageB_waysHits;
   wire                stageB_waysHit;
   wire       [31:0]   stageB_dataMux;
-  wire                when_DataCache_l820_4;
+  wire                when_DataCache_l825_4;
   reg        [3:0]    stageB_mask;
   reg                 stageB_loaderValid;
   wire       [31:0]   stageB_ioMemRspMuxed;
   reg                 stageB_flusher_waitDone;
   wire                stageB_flusher_hold;
   reg        [7:0]    stageB_flusher_counter;
-  wire                when_DataCache_l850;
-  wire                when_DataCache_l856;
+  wire                when_DataCache_l855;
+  wire                when_DataCache_l861;
+  wire                when_DataCache_l863;
   reg                 stageB_flusher_start;
+  wire                when_DataCache_l877;
   reg                 stageB_lrSc_reserved;
-  wire                when_DataCache_l880;
+  wire                when_DataCache_l885;
   wire                stageB_isExternalLsrc;
   wire                stageB_isExternalAmo;
   reg        [31:0]   stageB_requestDataBypass;
@@ -7830,26 +7904,26 @@ module DataCache (
   wire       [31:0]   stageB_amo_addSub;
   wire                stageB_amo_less;
   wire                stageB_amo_selectRf;
-  wire       [2:0]    switch_Misc_l210;
+  wire       [2:0]    switch_Misc_l232;
   reg        [31:0]   stageB_amo_result;
   reg        [31:0]   stageB_amo_resultReg;
   reg                 stageB_amo_internal_resultRegValid;
   reg                 stageB_cpuWriteToCache;
-  wire                when_DataCache_l926;
+  wire                when_DataCache_l931;
   wire                stageB_badPermissions;
   wire                stageB_loadStoreFault;
   wire                stageB_bypassCache;
-  wire                when_DataCache_l995;
-  wire                when_DataCache_l999;
+  wire                when_DataCache_l1000;
   wire                when_DataCache_l1004;
   wire                when_DataCache_l1009;
-  wire                when_DataCache_l1012;
-  wire                when_DataCache_l1020;
+  wire                when_DataCache_l1014;
+  wire                when_DataCache_l1017;
   wire                when_DataCache_l1025;
-  wire                when_DataCache_l1032;
-  wire                when_DataCache_l991;
-  wire                when_DataCache_l1066;
-  wire                when_DataCache_l1075;
+  wire                when_DataCache_l1030;
+  wire                when_DataCache_l1037;
+  wire                when_DataCache_l996;
+  wire                when_DataCache_l1072;
+  wire                when_DataCache_l1081;
   reg                 loader_valid;
   reg                 loader_counter_willIncrement;
   wire                loader_counter_willClear;
@@ -7861,12 +7935,12 @@ module DataCache (
   reg                 loader_error;
   wire                loader_kill;
   reg                 loader_killReg;
-  wire                when_DataCache_l1090;
+  wire                when_DataCache_l1097;
   wire                loader_done;
-  wire                when_DataCache_l1118;
-  reg                 loader_valid_regNext;
-  wire                when_DataCache_l1122;
   wire                when_DataCache_l1125;
+  reg                 loader_valid_regNext;
+  wire                when_DataCache_l1129;
+  wire                when_DataCache_l1132;
   (* no_rw_check , ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
   (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
   (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
@@ -7877,16 +7951,12 @@ module DataCache (
   reg [7:0] _zz_ways_0_datasymbol_read_2;
   reg [7:0] _zz_ways_0_datasymbol_read_3;
 
-  assign _zz_stage0_dataColisions = (io_cpu_execute_address[11 : 2] >>> 0);
-  assign _zz__zz_stageA_dataColisions = (io_cpu_memory_address[11 : 2] >>> 0);
   assign _zz_stageB_amo_addSub = ($signed(_zz_stageB_amo_addSub_1) + $signed(_zz_stageB_amo_addSub_4));
   assign _zz_stageB_amo_addSub_1 = ($signed(_zz_stageB_amo_addSub_2) + $signed(_zz_stageB_amo_addSub_3));
   assign _zz_stageB_amo_addSub_2 = io_cpu_writeBack_storeData[31 : 0];
   assign _zz_stageB_amo_addSub_3 = (stageB_amo_compare ? (~ stageB_dataMux[31 : 0]) : stageB_dataMux[31 : 0]);
-  assign _zz_stageB_amo_addSub_5 = (stageB_amo_compare ? _zz_stageB_amo_addSub_6 : _zz_stageB_amo_addSub_7);
+  assign _zz_stageB_amo_addSub_5 = (stageB_amo_compare ? 2'b01 : 2'b00);
   assign _zz_stageB_amo_addSub_4 = {{30{_zz_stageB_amo_addSub_5[1]}}, _zz_stageB_amo_addSub_5};
-  assign _zz_stageB_amo_addSub_6 = 2'b01;
-  assign _zz_stageB_amo_addSub_7 = 2'b00;
   assign _zz_when = 1'b1;
   assign _zz_loader_counter_valueNext_1 = loader_counter_willIncrement;
   assign _zz_loader_counter_valueNext = {2'd0, _zz_loader_counter_valueNext_1};
@@ -7933,14 +8003,14 @@ module DataCache (
 
   always @(*) begin
     _zz_1 = 1'b0;
-    if(when_DataCache_l645) begin
+    if(when_DataCache_l648) begin
       _zz_1 = 1'b1;
     end
   end
 
   always @(*) begin
     _zz_2 = 1'b0;
-    if(when_DataCache_l642) begin
+    if(when_DataCache_l645) begin
       _zz_2 = 1'b1;
     end
   end
@@ -7954,43 +8024,45 @@ module DataCache (
   assign _zz_ways_0_dataReadRspMem = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
   assign ways_0_dataReadRspMem = _zz_ways_0_data_port0;
   assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
-  assign when_DataCache_l642 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
-  assign when_DataCache_l645 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
+  assign when_DataCache_l645 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
+  assign when_DataCache_l648 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
   always @(*) begin
     tagsReadCmd_valid = 1'b0;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       tagsReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     tagsReadCmd_payload = 7'bxxxxxxx;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
     end
   end
 
   always @(*) begin
     dataReadCmd_valid = 1'b0;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       dataReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     dataReadCmd_payload = 10'bxxxxxxxxxx;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       dataReadCmd_payload = io_cpu_execute_address[11 : 2];
     end
   end
 
   always @(*) begin
     tagsWriteCmd_valid = 1'b0;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_valid = 1'b1;
     end
-    if(when_DataCache_l1066) begin
-      tagsWriteCmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        tagsWriteCmd_valid = 1'b0;
+      end
     end
     if(loader_done) begin
       tagsWriteCmd_valid = 1'b1;
@@ -7999,7 +8071,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_way = 1'bx;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_payload_way = 1'b1;
     end
     if(loader_done) begin
@@ -8009,7 +8081,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_address = 7'bxxxxxxx;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_payload_address = stageB_flusher_counter[6:0];
     end
     if(loader_done) begin
@@ -8019,7 +8091,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_data_valid = 1'bx;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_payload_data_valid = 1'b0;
     end
     if(loader_done) begin
@@ -8044,30 +8116,32 @@ module DataCache (
   always @(*) begin
     dataWriteCmd_valid = 1'b0;
     if(stageB_cpuWriteToCache) begin
-      if(when_DataCache_l926) begin
+      if(when_DataCache_l931) begin
         dataWriteCmd_valid = 1'b1;
       end
     end
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(when_DataCache_l1009) begin
             if(stageB_request_isAmo) begin
-              if(when_DataCache_l1012) begin
+              if(when_DataCache_l1017) begin
                 dataWriteCmd_valid = 1'b0;
               end
             end
-            if(when_DataCache_l1025) begin
+            if(when_DataCache_l1030) begin
               dataWriteCmd_valid = 1'b0;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1066) begin
-      dataWriteCmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        dataWriteCmd_valid = 1'b0;
+      end
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_valid = 1'b1;
     end
   end
@@ -8077,7 +8151,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_way = stageB_waysHits;
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_way = loader_waysAllocator;
     end
   end
@@ -8087,7 +8161,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
     end
   end
@@ -8097,7 +8171,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_data = io_mem_rsp_payload_data;
     end
   end
@@ -8110,15 +8184,15 @@ module DataCache (
         dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
       end
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_mask = 4'b1111;
     end
   end
 
-  assign when_DataCache_l664 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  assign when_DataCache_l667 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
   always @(*) begin
     io_cpu_execute_haltIt = 1'b0;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       io_cpu_execute_haltIt = 1'b1;
     end
   end
@@ -8126,7 +8200,7 @@ module DataCache (
   assign rspSync = 1'b1;
   assign rspLast = 1'b1;
   assign io_mem_cmd_fire = (io_mem_cmd_valid && io_mem_cmd_ready);
-  assign when_DataCache_l686 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l689 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     _zz_stage0_mask = 4'bxxxx;
     case(io_cpu_execute_args_size)
@@ -8145,42 +8219,42 @@ module DataCache (
   end
 
   assign stage0_mask = (_zz_stage0_mask <<< io_cpu_execute_address[1 : 0]);
-  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_stage0_dataColisions)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_execute_address[11 : 2])) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stage0_wayInvalidate = 1'b0;
-  assign when_DataCache_l771 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l771_1 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l776 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l776_1 = (! io_cpu_memory_isStuck);
   assign io_cpu_memory_isWrite = stageA_request_wr;
   assign stageA_wayHits = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign when_DataCache_l771_2 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l771_3 = (! io_cpu_memory_isStuck);
-  assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz__zz_stageA_dataColisions)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign when_DataCache_l776_2 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l776_3 = (! io_cpu_memory_isStuck);
+  assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_memory_address[11 : 2])) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_stageA_dataColisions);
-  assign when_DataCache_l822 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l827 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_mmuRspFreeze = 1'b0;
-    if(when_DataCache_l1125) begin
+    if(when_DataCache_l1132) begin
       stageB_mmuRspFreeze = 1'b1;
     end
   end
 
-  assign when_DataCache_l824 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
-  assign when_DataCache_l821 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l821_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l820 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l829 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
+  assign when_DataCache_l826 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l826_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825 = (! io_cpu_writeBack_isStuck);
   assign stageB_consistancyHazard = 1'b0;
-  assign when_DataCache_l820_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l820_2 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l820_3 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_2 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_3 = (! io_cpu_writeBack_isStuck);
   assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
   assign stageB_waysHit = (|stageB_waysHits);
   assign stageB_dataMux = stageB_dataReadRsp_0;
-  assign when_DataCache_l820_4 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_4 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_loaderValid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
             if(io_mem_cmd_ready) begin
               stageB_loaderValid = 1'b1;
             end
@@ -8188,8 +8262,10 @@ module DataCache (
         end
       end
     end
-    if(when_DataCache_l1066) begin
-      stageB_loaderValid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        stageB_loaderValid = 1'b0;
+      end
     end
   end
 
@@ -8198,40 +8274,44 @@ module DataCache (
     io_cpu_writeBack_haltIt = 1'b1;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l991) begin
-          if(when_DataCache_l995) begin
+        if(when_DataCache_l996) begin
+          if(when_DataCache_l1000) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
-          if(when_DataCache_l999) begin
+          if(when_DataCache_l1004) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
         end else begin
-          if(when_DataCache_l1004) begin
-            if(when_DataCache_l1009) begin
+          if(when_DataCache_l1009) begin
+            if(when_DataCache_l1014) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
             if(stageB_request_isAmo) begin
-              if(when_DataCache_l1012) begin
+              if(when_DataCache_l1017) begin
                 io_cpu_writeBack_haltIt = 1'b1;
               end
             end
-            if(when_DataCache_l1025) begin
+            if(when_DataCache_l1030) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1066) begin
-      io_cpu_writeBack_haltIt = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        io_cpu_writeBack_haltIt = 1'b0;
+      end
     end
   end
 
   assign stageB_flusher_hold = 1'b0;
-  assign when_DataCache_l850 = (! stageB_flusher_counter[7]);
-  assign when_DataCache_l856 = (! stageB_flusher_hold);
+  assign when_DataCache_l855 = (! stageB_flusher_counter[7]);
+  assign when_DataCache_l861 = (! stageB_flusher_hold);
+  assign when_DataCache_l863 = (io_cpu_flush_valid && io_cpu_flush_payload_singleLine);
   assign io_cpu_flush_ready = (stageB_flusher_waitDone && stageB_flusher_counter[7]);
-  assign when_DataCache_l880 = (io_cpu_writeBack_isValid && io_cpu_writeBack_isFiring);
+  assign when_DataCache_l877 = (io_cpu_flush_valid && io_cpu_flush_payload_singleLine);
+  assign when_DataCache_l885 = (io_cpu_writeBack_isValid && io_cpu_writeBack_isFiring);
   assign stageB_isExternalLsrc = 1'b0;
   assign stageB_isExternalAmo = 1'b0;
   always @(*) begin
@@ -8246,9 +8326,9 @@ module DataCache (
   assign stageB_amo_addSub = _zz_stageB_amo_addSub;
   assign stageB_amo_less = ((io_cpu_writeBack_storeData[31] == stageB_dataMux[31]) ? stageB_amo_addSub[31] : (stageB_amo_unsigned ? stageB_dataMux[31] : io_cpu_writeBack_storeData[31]));
   assign stageB_amo_selectRf = (stageB_request_amoCtrl_swap ? 1'b1 : (stageB_request_amoCtrl_alu[0] ^ stageB_amo_less));
-  assign switch_Misc_l210 = (stageB_request_amoCtrl_alu | {stageB_request_amoCtrl_swap,2'b00});
+  assign switch_Misc_l232 = (stageB_request_amoCtrl_alu | {stageB_request_amoCtrl_swap,2'b00});
   always @(*) begin
-    case(switch_Misc_l210)
+    case(switch_Misc_l232)
       3'b000 : begin
         stageB_amo_result = stageB_amo_addSub;
       end
@@ -8271,8 +8351,8 @@ module DataCache (
     stageB_cpuWriteToCache = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(when_DataCache_l1009) begin
             stageB_cpuWriteToCache = 1'b1;
           end
         end
@@ -8280,26 +8360,28 @@ module DataCache (
     end
   end
 
-  assign when_DataCache_l926 = (stageB_request_wr && stageB_waysHit);
+  assign when_DataCache_l931 = (stageB_request_wr && stageB_waysHit);
   assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_request_isAmo)));
   assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
   always @(*) begin
     io_cpu_redo = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(when_DataCache_l1004) begin
-            if(when_DataCache_l1020) begin
+        if(!when_DataCache_l996) begin
+          if(when_DataCache_l1009) begin
+            if(when_DataCache_l1025) begin
               io_cpu_redo = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1075) begin
-      io_cpu_redo = 1'b1;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1081) begin
+        io_cpu_redo = 1'b1;
+      end
     end
-    if(when_DataCache_l1122) begin
+    if(when_DataCache_l1129) begin
       io_cpu_redo = 1'b1;
     end
   end
@@ -8320,37 +8402,39 @@ module DataCache (
     io_mem_cmd_valid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l991) begin
+        if(when_DataCache_l996) begin
           io_mem_cmd_valid = (! memCmdSent);
-          if(when_DataCache_l999) begin
+          if(when_DataCache_l1004) begin
             io_mem_cmd_valid = 1'b0;
           end
         end else begin
-          if(when_DataCache_l1004) begin
+          if(when_DataCache_l1009) begin
             if(stageB_request_wr) begin
               io_mem_cmd_valid = 1'b1;
             end
             if(stageB_request_isAmo) begin
-              if(when_DataCache_l1012) begin
+              if(when_DataCache_l1017) begin
                 io_mem_cmd_valid = 1'b0;
               end
-            end
-            if(when_DataCache_l1020) begin
-              io_mem_cmd_valid = 1'b0;
             end
             if(when_DataCache_l1025) begin
               io_mem_cmd_valid = 1'b0;
             end
+            if(when_DataCache_l1030) begin
+              io_mem_cmd_valid = 1'b0;
+            end
           end else begin
-            if(when_DataCache_l1032) begin
+            if(when_DataCache_l1037) begin
               io_mem_cmd_valid = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1066) begin
-      io_mem_cmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        io_mem_cmd_valid = 1'b0;
+      end
     end
   end
 
@@ -8358,9 +8442,9 @@ module DataCache (
     io_mem_cmd_payload_address = stageB_mmuRsp_physicalAddress;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
-            io_mem_cmd_payload_address[4 : 0] = 5'h0;
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
+            io_mem_cmd_payload_address[4 : 0] = 5'h00;
           end
         end
       end
@@ -8372,8 +8456,8 @@ module DataCache (
     io_mem_cmd_payload_wr = stageB_request_wr;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
             io_mem_cmd_payload_wr = 1'b0;
           end
         end
@@ -8388,8 +8472,8 @@ module DataCache (
     io_mem_cmd_payload_size = {1'd0, stageB_request_size};
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
             io_mem_cmd_payload_size = 3'b101;
           end
         end
@@ -8399,15 +8483,15 @@ module DataCache (
 
   assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
   assign io_cpu_writeBack_keepMemRspData = 1'b0;
-  assign when_DataCache_l995 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
-  assign when_DataCache_l999 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
-  assign when_DataCache_l1004 = (stageB_waysHit || (stageB_request_wr && (! stageB_request_isAmo)));
-  assign when_DataCache_l1009 = ((! stageB_request_wr) || io_mem_cmd_ready);
-  assign when_DataCache_l1012 = (! stageB_amo_internal_resultRegValid);
-  assign when_DataCache_l1020 = (((! stageB_request_wr) || stageB_request_isAmo) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
-  assign when_DataCache_l1025 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
-  assign when_DataCache_l1032 = (! memCmdSent);
-  assign when_DataCache_l991 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  assign when_DataCache_l1000 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
+  assign when_DataCache_l1004 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
+  assign when_DataCache_l1009 = (stageB_waysHit || (stageB_request_wr && (! stageB_request_isAmo)));
+  assign when_DataCache_l1014 = ((! stageB_request_wr) || io_mem_cmd_ready);
+  assign when_DataCache_l1017 = (! stageB_amo_internal_resultRegValid);
+  assign when_DataCache_l1025 = (((! stageB_request_wr) || stageB_request_isAmo) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
+  assign when_DataCache_l1030 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
+  assign when_DataCache_l1037 = (! memCmdSent);
+  assign when_DataCache_l996 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
   always @(*) begin
     if(stageB_bypassCache) begin
       io_cpu_writeBack_data = stageB_ioMemRspMuxed;
@@ -8417,11 +8501,11 @@ module DataCache (
   end
 
   assign io_cpu_writeBack_exclusiveOk = stageB_lrSc_reserved;
-  assign when_DataCache_l1066 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign when_DataCache_l1075 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
+  assign when_DataCache_l1072 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign when_DataCache_l1081 = (stageB_mmuRsp_refilling || stageB_consistancyHazard);
   always @(*) begin
     loader_counter_willIncrement = 1'b0;
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       loader_counter_willIncrement = 1'b1;
     end
   end
@@ -8437,12 +8521,12 @@ module DataCache (
   end
 
   assign loader_kill = 1'b0;
-  assign when_DataCache_l1090 = ((loader_valid && io_mem_rsp_valid) && rspLast);
+  assign when_DataCache_l1097 = ((loader_valid && io_mem_rsp_valid) && rspLast);
   assign loader_done = loader_counter_willOverflow;
-  assign when_DataCache_l1118 = (! loader_valid);
-  assign when_DataCache_l1122 = (loader_valid && (! loader_valid_regNext));
+  assign when_DataCache_l1125 = (! loader_valid);
+  assign when_DataCache_l1129 = (loader_valid && (! loader_valid_regNext));
   assign io_cpu_execute_refilling = loader_valid;
-  assign when_DataCache_l1125 = (stageB_loaderValid || loader_valid);
+  assign when_DataCache_l1132 = (stageB_loaderValid || loader_valid);
   always @(posedge clk) begin
     tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
     tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
@@ -8450,7 +8534,7 @@ module DataCache (
     tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
     tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
     tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if(when_DataCache_l771) begin
+    if(when_DataCache_l776) begin
       stageA_request_wr <= io_cpu_execute_args_wr;
       stageA_request_size <= io_cpu_execute_args_size;
       stageA_request_isLrsc <= io_cpu_execute_args_isLrsc;
@@ -8459,16 +8543,16 @@ module DataCache (
       stageA_request_amoCtrl_alu <= io_cpu_execute_args_amoCtrl_alu;
       stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
     end
-    if(when_DataCache_l771_1) begin
+    if(when_DataCache_l776_1) begin
       stageA_mask <= stage0_mask;
     end
-    if(when_DataCache_l771_2) begin
+    if(when_DataCache_l776_2) begin
       stageA_wayInvalidate <= stage0_wayInvalidate;
     end
-    if(when_DataCache_l771_3) begin
+    if(when_DataCache_l776_3) begin
       stage0_dataColisions_regNextWhen <= stage0_dataColisions;
     end
-    if(when_DataCache_l822) begin
+    if(when_DataCache_l827) begin
       stageB_request_wr <= stageA_request_wr;
       stageB_request_size <= stageA_request_size;
       stageB_request_isLrsc <= stageA_request_isLrsc;
@@ -8477,7 +8561,7 @@ module DataCache (
       stageB_request_amoCtrl_alu <= stageA_request_amoCtrl_alu;
       stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
     end
-    if(when_DataCache_l824) begin
+    if(when_DataCache_l829) begin
       stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
       stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
       stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
@@ -8496,27 +8580,27 @@ module DataCache (
       stageB_mmuRsp_ways_3_sel <= io_cpu_memory_mmuRsp_ways_3_sel;
       stageB_mmuRsp_ways_3_physical <= io_cpu_memory_mmuRsp_ways_3_physical;
     end
-    if(when_DataCache_l821) begin
+    if(when_DataCache_l826) begin
       stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
       stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
       stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
     end
-    if(when_DataCache_l821_1) begin
+    if(when_DataCache_l826_1) begin
       stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
     end
-    if(when_DataCache_l820) begin
+    if(when_DataCache_l825) begin
       stageB_wayInvalidate <= stageA_wayInvalidate;
     end
-    if(when_DataCache_l820_1) begin
+    if(when_DataCache_l825_1) begin
       stageB_dataColisions <= stageA_dataColisions;
     end
-    if(when_DataCache_l820_2) begin
+    if(when_DataCache_l825_2) begin
       stageB_unaligned <= ({((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)),((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0))} != 2'b00);
     end
-    if(when_DataCache_l820_3) begin
+    if(when_DataCache_l825_3) begin
       stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
     end
-    if(when_DataCache_l820_4) begin
+    if(when_DataCache_l825_4) begin
       stageB_mask <= stageA_mask;
     end
     stageB_amo_internal_resultRegValid <= io_cpu_writeBack_isStuck;
@@ -8528,7 +8612,7 @@ module DataCache (
     if(reset) begin
       memCmdSent <= 1'b0;
       stageB_flusher_waitDone <= 1'b0;
-      stageB_flusher_counter <= 8'h0;
+      stageB_flusher_counter <= 8'h00;
       stageB_flusher_start <= 1'b1;
       stageB_lrSc_reserved <= 1'b0;
       loader_valid <= 1'b0;
@@ -8540,16 +8624,16 @@ module DataCache (
       if(io_mem_cmd_fire) begin
         memCmdSent <= 1'b1;
       end
-      if(when_DataCache_l686) begin
+      if(when_DataCache_l689) begin
         memCmdSent <= 1'b0;
       end
       if(io_cpu_flush_ready) begin
         stageB_flusher_waitDone <= 1'b0;
       end
-      if(when_DataCache_l850) begin
-        if(when_DataCache_l856) begin
+      if(when_DataCache_l855) begin
+        if(when_DataCache_l861) begin
           stageB_flusher_counter <= (stageB_flusher_counter + 8'h01);
-          if(io_cpu_flush_payload_singleLine) begin
+          if(when_DataCache_l863) begin
             stageB_flusher_counter[7] <= 1'b1;
           end
         end
@@ -8557,12 +8641,12 @@ module DataCache (
       stageB_flusher_start <= (((((((! stageB_flusher_waitDone) && (! stageB_flusher_start)) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
       if(stageB_flusher_start) begin
         stageB_flusher_waitDone <= 1'b1;
-        stageB_flusher_counter <= 8'h0;
-        if(io_cpu_flush_payload_singleLine) begin
+        stageB_flusher_counter <= 8'h00;
+        if(when_DataCache_l877) begin
           stageB_flusher_counter <= {1'b0,io_cpu_flush_payload_lineId};
         end
       end
-      if(when_DataCache_l880) begin
+      if(when_DataCache_l885) begin
         if(stageB_request_isLrsc) begin
           stageB_lrSc_reserved <= 1'b1;
         end
@@ -8570,15 +8654,17 @@ module DataCache (
           stageB_lrSc_reserved <= 1'b0;
         end
       end
-      if(when_DataCache_l1066) begin
-        stageB_lrSc_reserved <= stageB_lrSc_reserved;
+      if(io_cpu_writeBack_isValid) begin
+        if(when_DataCache_l1072) begin
+          stageB_lrSc_reserved <= stageB_lrSc_reserved;
+        end
       end
       `ifndef SYNTHESIS
         `ifdef FORMAL
-          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))); // DataCache.scala:L1077
+          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))); // DataCache.scala:L1084
         `else
           if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-            $display("ERROR writeBack stuck by another plugin is not allowed"); // DataCache.scala:L1077
+            $display("ERROR writeBack stuck by another plugin is not allowed"); // DataCache.scala:L1084
           end
         `endif
       `endif
@@ -8589,7 +8675,7 @@ module DataCache (
       if(loader_kill) begin
         loader_killReg <= 1'b1;
       end
-      if(when_DataCache_l1090) begin
+      if(when_DataCache_l1097) begin
         loader_error <= (loader_error || io_mem_rsp_payload_error);
       end
       if(loader_done) begin
@@ -8597,7 +8683,7 @@ module DataCache (
         loader_error <= 1'b0;
         loader_killReg <= 1'b0;
       end
-      if(when_DataCache_l1118) begin
+      if(when_DataCache_l1125) begin
         loader_waysAllocator <= _zz_loader_waysAllocator[0:0];
       end
     end
@@ -8607,56 +8693,56 @@ module DataCache (
 endmodule
 
 module InstructionCache (
-  input               io_flush,
-  input               io_cpu_prefetch_isValid,
-  output reg          io_cpu_prefetch_haltIt,
-  input      [31:0]   io_cpu_prefetch_pc,
-  input               io_cpu_fetch_isValid,
-  input               io_cpu_fetch_isStuck,
-  input               io_cpu_fetch_isRemoved,
-  input      [31:0]   io_cpu_fetch_pc,
-  output     [31:0]   io_cpu_fetch_data,
-  input      [31:0]   io_cpu_fetch_mmuRsp_physicalAddress,
-  input               io_cpu_fetch_mmuRsp_isIoAccess,
-  input               io_cpu_fetch_mmuRsp_isPaging,
-  input               io_cpu_fetch_mmuRsp_allowRead,
-  input               io_cpu_fetch_mmuRsp_allowWrite,
-  input               io_cpu_fetch_mmuRsp_allowExecute,
-  input               io_cpu_fetch_mmuRsp_exception,
-  input               io_cpu_fetch_mmuRsp_refilling,
-  input               io_cpu_fetch_mmuRsp_bypassTranslation,
-  input               io_cpu_fetch_mmuRsp_ways_0_sel,
-  input      [31:0]   io_cpu_fetch_mmuRsp_ways_0_physical,
-  input               io_cpu_fetch_mmuRsp_ways_1_sel,
-  input      [31:0]   io_cpu_fetch_mmuRsp_ways_1_physical,
-  input               io_cpu_fetch_mmuRsp_ways_2_sel,
-  input      [31:0]   io_cpu_fetch_mmuRsp_ways_2_physical,
-  input               io_cpu_fetch_mmuRsp_ways_3_sel,
-  input      [31:0]   io_cpu_fetch_mmuRsp_ways_3_physical,
-  output     [31:0]   io_cpu_fetch_physicalAddress,
-  input               io_cpu_decode_isValid,
-  input               io_cpu_decode_isStuck,
-  input      [31:0]   io_cpu_decode_pc,
-  output     [31:0]   io_cpu_decode_physicalAddress,
-  output     [31:0]   io_cpu_decode_data,
-  output              io_cpu_decode_cacheMiss,
-  output              io_cpu_decode_error,
-  output              io_cpu_decode_mmuRefilling,
-  output              io_cpu_decode_mmuException,
-  input               io_cpu_decode_isUser,
-  input               io_cpu_fill_valid,
-  input      [31:0]   io_cpu_fill_payload,
-  output              io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output     [31:0]   io_mem_cmd_payload_address,
-  output     [2:0]    io_mem_cmd_payload_size,
-  input               io_mem_rsp_valid,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input      [2:0]    _zz_when_Fetcher_l401,
-  input      [31:0]   _zz_io_cpu_fetch_data_regNextWhen,
-  input               clk,
-  input               reset
+  input  wire          io_flush,
+  input  wire          io_cpu_prefetch_isValid,
+  output reg           io_cpu_prefetch_haltIt,
+  input  wire [31:0]   io_cpu_prefetch_pc,
+  input  wire          io_cpu_fetch_isValid,
+  input  wire          io_cpu_fetch_isStuck,
+  input  wire          io_cpu_fetch_isRemoved,
+  input  wire [31:0]   io_cpu_fetch_pc,
+  output wire [31:0]   io_cpu_fetch_data,
+  input  wire [31:0]   io_cpu_fetch_mmuRsp_physicalAddress,
+  input  wire          io_cpu_fetch_mmuRsp_isIoAccess,
+  input  wire          io_cpu_fetch_mmuRsp_isPaging,
+  input  wire          io_cpu_fetch_mmuRsp_allowRead,
+  input  wire          io_cpu_fetch_mmuRsp_allowWrite,
+  input  wire          io_cpu_fetch_mmuRsp_allowExecute,
+  input  wire          io_cpu_fetch_mmuRsp_exception,
+  input  wire          io_cpu_fetch_mmuRsp_refilling,
+  input  wire          io_cpu_fetch_mmuRsp_bypassTranslation,
+  input  wire          io_cpu_fetch_mmuRsp_ways_0_sel,
+  input  wire [31:0]   io_cpu_fetch_mmuRsp_ways_0_physical,
+  input  wire          io_cpu_fetch_mmuRsp_ways_1_sel,
+  input  wire [31:0]   io_cpu_fetch_mmuRsp_ways_1_physical,
+  input  wire          io_cpu_fetch_mmuRsp_ways_2_sel,
+  input  wire [31:0]   io_cpu_fetch_mmuRsp_ways_2_physical,
+  input  wire          io_cpu_fetch_mmuRsp_ways_3_sel,
+  input  wire [31:0]   io_cpu_fetch_mmuRsp_ways_3_physical,
+  output wire [31:0]   io_cpu_fetch_physicalAddress,
+  input  wire          io_cpu_decode_isValid,
+  input  wire          io_cpu_decode_isStuck,
+  input  wire [31:0]   io_cpu_decode_pc,
+  output wire [31:0]   io_cpu_decode_physicalAddress,
+  output wire [31:0]   io_cpu_decode_data,
+  output wire          io_cpu_decode_cacheMiss,
+  output wire          io_cpu_decode_error,
+  output wire          io_cpu_decode_mmuRefilling,
+  output wire          io_cpu_decode_mmuException,
+  input  wire          io_cpu_decode_isUser,
+  input  wire          io_cpu_fill_valid,
+  input  wire [31:0]   io_cpu_fill_payload,
+  output wire          io_mem_cmd_valid,
+  input  wire          io_mem_cmd_ready,
+  output wire [31:0]   io_mem_cmd_payload_address,
+  output wire [2:0]    io_mem_cmd_payload_size,
+  input  wire          io_mem_rsp_valid,
+  input  wire [31:0]   io_mem_rsp_payload_data,
+  input  wire          io_mem_rsp_payload_error,
+  input  wire [2:0]    _zz_when_Fetcher_l411,
+  input  wire [31:0]   _zz_io_cpu_fetch_data_regNextWhen,
+  input  wire          clk,
+  input  wire          reset
 );
 
   reg        [31:0]   _zz_banks_0_port1;
@@ -8676,7 +8762,7 @@ module InstructionCache (
   wire                when_InstructionCache_l351;
   reg                 lineLoader_cmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_Utils_l515;
+  wire                when_Utils_l560;
   reg                 lineLoader_wayToAllocate_willIncrement;
   wire                lineLoader_wayToAllocate_willClear;
   wire                lineLoader_wayToAllocate_willOverflowIfInc;
@@ -8730,7 +8816,7 @@ module InstructionCache (
   reg                 decodeStage_hit_valid;
   wire                when_InstructionCache_l459_2;
   reg                 decodeStage_hit_error;
-  wire                when_Fetcher_l401;
+  wire                when_Fetcher_l411;
   (* no_rw_check , ram_style = "block" *) reg [31:0] banks_0 [0:1023];
   (* no_rw_check , ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
 
@@ -8800,12 +8886,12 @@ module InstructionCache (
   assign when_InstructionCache_l351 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
   assign io_mem_cmd_fire = (io_mem_cmd_valid && io_mem_cmd_ready);
   assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
-  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
+  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h00};
   assign io_mem_cmd_payload_size = 3'b101;
-  assign when_Utils_l515 = (! lineLoader_valid);
+  assign when_Utils_l560 = (! lineLoader_valid);
   always @(*) begin
     lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if(when_Utils_l515) begin
+    if(when_Utils_l560) begin
       lineLoader_wayToAllocate_willIncrement = 1'b1;
     end
   end
@@ -8849,7 +8935,7 @@ module InstructionCache (
   assign io_cpu_decode_mmuRefilling = decodeStage_mmuRsp_refilling;
   assign io_cpu_decode_mmuException = (((! decodeStage_mmuRsp_refilling) && decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute)));
   assign io_cpu_decode_physicalAddress = decodeStage_mmuRsp_physicalAddress;
-  assign when_Fetcher_l401 = (_zz_when_Fetcher_l401 != 3'b000);
+  assign when_Fetcher_l411 = (_zz_when_Fetcher_l411 != 3'b000);
   always @(posedge clk) begin
     if(reset) begin
       lineLoader_valid <= 1'b0;
@@ -8897,7 +8983,7 @@ module InstructionCache (
     end
     _zz_when_InstructionCache_l342 <= lineLoader_flushCounter[7];
     if(when_InstructionCache_l351) begin
-      lineLoader_flushCounter <= 8'h0;
+      lineLoader_flushCounter <= 8'h00;
     end
     if(when_InstructionCache_l435) begin
       io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;
@@ -8927,7 +9013,7 @@ module InstructionCache (
     if(when_InstructionCache_l459_2) begin
       decodeStage_hit_error <= fetchStage_hit_error;
     end
-    if(when_Fetcher_l401) begin
+    if(when_Fetcher_l411) begin
       io_cpu_fetch_data_regNextWhen <= _zz_io_cpu_fetch_data_regNextWhen;
     end
   end

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_LinuxNoDspFmax.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_LinuxNoDspFmax.v
@@ -1,38 +1,38 @@
-// Generator : SpinalHDL v1.7.1    git head : 0444bb76ab1d6e19f0ec46bc03c4769776deb7d5
+// Generator : SpinalHDL v1.9.4    git head : 270018552577f3bb8e5339ee2583c9c22d324215
 // Component : VexRiscv
-// Git hash  : 581fcb065adf7ea8b626f939ff51679d4c95872f
+// Git hash  : 63430af99f84cc1d11d58b556debe1cc3f238c67
 
 `timescale 1ns/1ps
 
 module VexRiscv (
-  input      [31:0]   externalResetVector,
-  input               timerInterrupt,
-  input               softwareInterrupt,
-  input      [31:0]   externalInterruptArray,
-  output reg          iBusWishbone_CYC,
-  output reg          iBusWishbone_STB,
-  input               iBusWishbone_ACK,
-  output              iBusWishbone_WE,
-  output     [29:0]   iBusWishbone_ADR,
-  input      [31:0]   iBusWishbone_DAT_MISO,
-  output     [31:0]   iBusWishbone_DAT_MOSI,
-  output     [3:0]    iBusWishbone_SEL,
-  input               iBusWishbone_ERR,
-  output     [2:0]    iBusWishbone_CTI,
-  output     [1:0]    iBusWishbone_BTE,
-  output              dBusWishbone_CYC,
-  output              dBusWishbone_STB,
-  input               dBusWishbone_ACK,
-  output              dBusWishbone_WE,
-  output     [29:0]   dBusWishbone_ADR,
-  input      [31:0]   dBusWishbone_DAT_MISO,
-  output     [31:0]   dBusWishbone_DAT_MOSI,
-  output     [3:0]    dBusWishbone_SEL,
-  input               dBusWishbone_ERR,
-  output     [2:0]    dBusWishbone_CTI,
-  output     [1:0]    dBusWishbone_BTE,
-  input               clk,
-  input               reset
+  input  wire [31:0]   externalResetVector,
+  input  wire          timerInterrupt,
+  input  wire          softwareInterrupt,
+  input  wire [31:0]   externalInterruptArray,
+  output reg           iBusWishbone_CYC,
+  output reg           iBusWishbone_STB,
+  input  wire          iBusWishbone_ACK,
+  output wire          iBusWishbone_WE,
+  output wire [29:0]   iBusWishbone_ADR,
+  input  wire [31:0]   iBusWishbone_DAT_MISO,
+  output wire [31:0]   iBusWishbone_DAT_MOSI,
+  output wire [3:0]    iBusWishbone_SEL,
+  input  wire          iBusWishbone_ERR,
+  output wire [2:0]    iBusWishbone_CTI,
+  output wire [1:0]    iBusWishbone_BTE,
+  output wire          dBusWishbone_CYC,
+  output wire          dBusWishbone_STB,
+  input  wire          dBusWishbone_ACK,
+  output wire          dBusWishbone_WE,
+  output wire [29:0]   dBusWishbone_ADR,
+  input  wire [31:0]   dBusWishbone_DAT_MISO,
+  output wire [31:0]   dBusWishbone_DAT_MOSI,
+  output wire [3:0]    dBusWishbone_SEL,
+  input  wire          dBusWishbone_ERR,
+  output wire [2:0]    dBusWishbone_CTI,
+  output wire [1:0]    dBusWishbone_BTE,
+  input  wire          clk,
+  input  wire          reset
 );
   localparam ShiftCtrlEnum_DISABLE_1 = 2'd0;
   localparam ShiftCtrlEnum_SLL_1 = 2'd1;
@@ -101,7 +101,6 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_flush_valid;
   wire                dataCache_1_io_cpu_flush_payload_singleLine;
   wire       [6:0]    dataCache_1_io_cpu_flush_payload_lineId;
-  wire                dataCache_1_io_mem_cmd_ready;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
@@ -129,6 +128,7 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_writeBack_exclusiveOk;
   wire                dataCache_1_io_cpu_flush_ready;
   wire                dataCache_1_io_cpu_redo;
+  wire                dataCache_1_io_cpu_writesPending;
   wire                dataCache_1_io_mem_cmd_valid;
   wire                dataCache_1_io_mem_cmd_payload_wr;
   wire                dataCache_1_io_mem_cmd_payload_uncached;
@@ -145,24 +145,24 @@ module VexRiscv (
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_2;
   wire                _zz_decode_LEGAL_INSTRUCTION_3;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_4;
-  wire       [17:0]   _zz_decode_LEGAL_INSTRUCTION_5;
+  wire       [16:0]   _zz_decode_LEGAL_INSTRUCTION_5;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_6;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_7;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_8;
   wire                _zz_decode_LEGAL_INSTRUCTION_9;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_10;
-  wire       [11:0]   _zz_decode_LEGAL_INSTRUCTION_11;
+  wire       [10:0]   _zz_decode_LEGAL_INSTRUCTION_11;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_12;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_13;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_14;
   wire                _zz_decode_LEGAL_INSTRUCTION_15;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_16;
-  wire       [5:0]    _zz_decode_LEGAL_INSTRUCTION_17;
+  wire       [4:0]    _zz_decode_LEGAL_INSTRUCTION_17;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_18;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_19;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_20;
-  wire                _zz_decode_LEGAL_INSTRUCTION_21;
-  wire                _zz_decode_LEGAL_INSTRUCTION_22;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_21;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_22;
   wire       [3:0]    _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1;
   reg        [31:0]   _zz_IBusCachedPlugin_jump_pcLoad_payload_5;
   wire       [1:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_6;
@@ -227,154 +227,148 @@ module VexRiscv (
   wire       [31:0]   _zz__zz_decode_IS_DIV_8;
   wire       [29:0]   _zz__zz_decode_IS_DIV_9;
   wire       [0:0]    _zz__zz_decode_IS_DIV_10;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_11;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_12;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_11;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_12;
   wire       [31:0]   _zz__zz_decode_IS_DIV_13;
-  wire       [1:0]    _zz__zz_decode_IS_DIV_14;
+  wire                _zz__zz_decode_IS_DIV_14;
   wire       [31:0]   _zz__zz_decode_IS_DIV_15;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_16;
-  wire                _zz__zz_decode_IS_DIV_17;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_16;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_17;
   wire       [31:0]   _zz__zz_decode_IS_DIV_18;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_19;
+  wire       [25:0]   _zz__zz_decode_IS_DIV_19;
   wire       [0:0]    _zz__zz_decode_IS_DIV_20;
   wire       [0:0]    _zz__zz_decode_IS_DIV_21;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_22;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_23;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_24;
-  wire       [25:0]   _zz__zz_decode_IS_DIV_25;
-  wire       [2:0]    _zz__zz_decode_IS_DIV_26;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_27;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_28;
-  wire                _zz__zz_decode_IS_DIV_29;
-  wire                _zz__zz_decode_IS_DIV_30;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_22;
+  wire                _zz__zz_decode_IS_DIV_23;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_24;
+  wire                _zz__zz_decode_IS_DIV_25;
+  wire       [21:0]   _zz__zz_decode_IS_DIV_26;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_27;
+  wire                _zz__zz_decode_IS_DIV_28;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_29;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_30;
   wire                _zz__zz_decode_IS_DIV_31;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_32;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_32;
   wire       [31:0]   _zz__zz_decode_IS_DIV_33;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_34;
-  wire       [22:0]   _zz__zz_decode_IS_DIV_35;
-  wire       [1:0]    _zz__zz_decode_IS_DIV_36;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_34;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_35;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_36;
   wire       [31:0]   _zz__zz_decode_IS_DIV_37;
-  wire                _zz__zz_decode_IS_DIV_38;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_39;
-  wire       [19:0]   _zz__zz_decode_IS_DIV_40;
-  wire                _zz__zz_decode_IS_DIV_41;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_42;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_38;
+  wire       [17:0]   _zz__zz_decode_IS_DIV_39;
+  wire                _zz__zz_decode_IS_DIV_40;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_41;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_42;
   wire                _zz__zz_decode_IS_DIV_43;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_44;
+  wire                _zz__zz_decode_IS_DIV_44;
   wire       [31:0]   _zz__zz_decode_IS_DIV_45;
-  wire                _zz__zz_decode_IS_DIV_46;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_47;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_46;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_47;
   wire       [31:0]   _zz__zz_decode_IS_DIV_48;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_49;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_50;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_51;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_52;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_53;
-  wire       [15:0]   _zz__zz_decode_IS_DIV_54;
-  wire                _zz__zz_decode_IS_DIV_55;
-  wire       [5:0]    _zz__zz_decode_IS_DIV_56;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_57;
+  wire       [3:0]    _zz__zz_decode_IS_DIV_49;
+  wire                _zz__zz_decode_IS_DIV_50;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_51;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_52;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_53;
+  wire                _zz__zz_decode_IS_DIV_54;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_55;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_56;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_57;
   wire       [31:0]   _zz__zz_decode_IS_DIV_58;
-  wire                _zz__zz_decode_IS_DIV_59;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_60;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_61;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_59;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_60;
+  wire                _zz__zz_decode_IS_DIV_61;
   wire       [31:0]   _zz__zz_decode_IS_DIV_62;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_63;
-  wire       [2:0]    _zz__zz_decode_IS_DIV_64;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_65;
+  wire                _zz__zz_decode_IS_DIV_63;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_64;
+  wire       [13:0]   _zz__zz_decode_IS_DIV_65;
   wire       [0:0]    _zz__zz_decode_IS_DIV_66;
   wire       [31:0]   _zz__zz_decode_IS_DIV_67;
   wire       [31:0]   _zz__zz_decode_IS_DIV_68;
   wire                _zz__zz_decode_IS_DIV_69;
-  wire                _zz__zz_decode_IS_DIV_70;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_71;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_72;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_70;
+  wire       [3:0]    _zz__zz_decode_IS_DIV_71;
+  wire                _zz__zz_decode_IS_DIV_72;
   wire       [31:0]   _zz__zz_decode_IS_DIV_73;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_74;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_75;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_74;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_75;
   wire       [31:0]   _zz__zz_decode_IS_DIV_76;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_77;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_78;
-  wire                _zz__zz_decode_IS_DIV_79;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_80;
-  wire       [11:0]   _zz__zz_decode_IS_DIV_81;
-  wire       [4:0]    _zz__zz_decode_IS_DIV_82;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_83;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_84;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_77;
+  wire                _zz__zz_decode_IS_DIV_78;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_79;
+  wire                _zz__zz_decode_IS_DIV_80;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_81;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_82;
+  wire       [6:0]    _zz__zz_decode_IS_DIV_83;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_84;
   wire       [31:0]   _zz__zz_decode_IS_DIV_85;
-  wire       [2:0]    _zz__zz_decode_IS_DIV_86;
-  wire                _zz__zz_decode_IS_DIV_87;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_88;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_89;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_90;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_86;
+  wire       [4:0]    _zz__zz_decode_IS_DIV_87;
+  wire                _zz__zz_decode_IS_DIV_88;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_89;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_90;
   wire       [31:0]   _zz__zz_decode_IS_DIV_91;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_92;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_93;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_94;
-  wire                _zz__zz_decode_IS_DIV_95;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_92;
+  wire       [2:0]    _zz__zz_decode_IS_DIV_93;
+  wire                _zz__zz_decode_IS_DIV_94;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_95;
   wire       [0:0]    _zz__zz_decode_IS_DIV_96;
-  wire       [5:0]    _zz__zz_decode_IS_DIV_97;
-  wire                _zz__zz_decode_IS_DIV_98;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_99;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_97;
+  wire       [10:0]   _zz__zz_decode_IS_DIV_98;
+  wire                _zz__zz_decode_IS_DIV_99;
   wire       [0:0]    _zz__zz_decode_IS_DIV_100;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_101;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_101;
   wire       [31:0]   _zz__zz_decode_IS_DIV_102;
-  wire       [3:0]    _zz__zz_decode_IS_DIV_103;
-  wire                _zz__zz_decode_IS_DIV_104;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_105;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_106;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_103;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_104;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_105;
+  wire                _zz__zz_decode_IS_DIV_106;
   wire       [31:0]   _zz__zz_decode_IS_DIV_107;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_108;
-  wire       [1:0]    _zz__zz_decode_IS_DIV_109;
+  wire       [8:0]    _zz__zz_decode_IS_DIV_108;
+  wire                _zz__zz_decode_IS_DIV_109;
   wire                _zz__zz_decode_IS_DIV_110;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_111;
-  wire       [1:0]    _zz__zz_decode_IS_DIV_112;
-  wire                _zz__zz_decode_IS_DIV_113;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_111;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_112;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_113;
   wire       [31:0]   _zz__zz_decode_IS_DIV_114;
-  wire       [8:0]    _zz__zz_decode_IS_DIV_115;
-  wire                _zz__zz_decode_IS_DIV_116;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_117;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_115;
+  wire       [6:0]    _zz__zz_decode_IS_DIV_116;
+  wire                _zz__zz_decode_IS_DIV_117;
   wire       [0:0]    _zz__zz_decode_IS_DIV_118;
   wire       [31:0]   _zz__zz_decode_IS_DIV_119;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_120;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_121;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_122;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_123;
+  wire       [4:0]    _zz__zz_decode_IS_DIV_120;
+  wire                _zz__zz_decode_IS_DIV_121;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_122;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_123;
   wire       [31:0]   _zz__zz_decode_IS_DIV_124;
-  wire       [6:0]    _zz__zz_decode_IS_DIV_125;
-  wire                _zz__zz_decode_IS_DIV_126;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_125;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_126;
   wire                _zz__zz_decode_IS_DIV_127;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_128;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_129;
-  wire       [5:0]    _zz__zz_decode_IS_DIV_130;
-  wire                _zz__zz_decode_IS_DIV_131;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_132;
-  wire       [3:0]    _zz__zz_decode_IS_DIV_133;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_134;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_128;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_129;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_130;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_131;
+  wire       [4:0]    _zz__zz_decode_IS_DIV_132;
+  wire                _zz__zz_decode_IS_DIV_133;
+  wire                _zz__zz_decode_IS_DIV_134;
   wire       [31:0]   _zz__zz_decode_IS_DIV_135;
-  wire                _zz__zz_decode_IS_DIV_136;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_137;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_138;
-  wire       [4:0]    _zz__zz_decode_IS_DIV_139;
-  wire                _zz__zz_decode_IS_DIV_140;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_141;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_136;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_137;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_138;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_139;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_140;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_141;
   wire       [0:0]    _zz__zz_decode_IS_DIV_142;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_143;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_144;
-  wire       [2:0]    _zz__zz_decode_IS_DIV_145;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_146;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_147;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_143;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_144;
+  wire                _zz__zz_decode_IS_DIV_145;
+  wire       [2:0]    _zz__zz_decode_IS_DIV_146;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_147;
   wire                _zz__zz_decode_IS_DIV_148;
   wire                _zz__zz_decode_IS_DIV_149;
-  wire       [2:0]    _zz__zz_decode_IS_DIV_150;
-  wire                _zz__zz_decode_IS_DIV_151;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_152;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_153;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_154;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_155;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_156;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_157;
-  wire                _zz__zz_decode_IS_DIV_158;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_150;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_151;
+  wire                _zz__zz_decode_IS_DIV_152;
   wire                _zz_RegFilePlugin_regFile_port;
   wire                _zz_decode_RegFilePlugin_rs1Data;
   wire                _zz_RegFilePlugin_regFile_port_1;
@@ -382,14 +376,12 @@ module VexRiscv (
   wire       [0:0]    _zz__zz_execute_REGFILE_WRITE_DATA;
   wire       [2:0]    _zz__zz_execute_SRC1;
   wire       [4:0]    _zz__zz_execute_SRC1_1;
-  wire       [11:0]   _zz__zz_execute_SRC2_3;
+  wire       [11:0]   _zz__zz_execute_SRC2_2;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_1;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_2;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_3;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_4;
-  wire       [31:0]   _zz_execute_SrcPlugin_addSub_5;
-  wire       [31:0]   _zz_execute_SrcPlugin_addSub_6;
   wire       [19:0]   _zz__zz_execute_BranchPlugin_branch_src2;
   wire       [11:0]   _zz__zz_execute_BranchPlugin_branch_src2_4;
   wire       [1:0]    _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
@@ -414,11 +406,11 @@ module VexRiscv (
   wire       [32:0]   _zz_memory_MulDivIterativePlugin_div_result_3;
   wire       [32:0]   _zz_memory_MulDivIterativePlugin_div_result_4;
   wire       [0:0]    _zz_memory_MulDivIterativePlugin_div_result_5;
-  wire       [32:0]   _zz_memory_MulDivIterativePlugin_rs1_3;
-  wire       [0:0]    _zz_memory_MulDivIterativePlugin_rs1_4;
-  wire       [31:0]   _zz_memory_MulDivIterativePlugin_rs2;
-  wire       [0:0]    _zz_memory_MulDivIterativePlugin_rs2_1;
-  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_28;
+  wire       [32:0]   _zz_memory_MulDivIterativePlugin_rs1_2;
+  wire       [0:0]    _zz_memory_MulDivIterativePlugin_rs1_3;
+  wire       [31:0]   _zz_memory_MulDivIterativePlugin_rs2_1;
+  wire       [0:0]    _zz_memory_MulDivIterativePlugin_rs2_2;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_26;
   wire       [26:0]   _zz_iBusWishbone_ADR_1;
   wire       [31:0]   execute_BRANCH_CALC;
   wire                execute_BRANCH_DO;
@@ -458,7 +450,6 @@ module VexRiscv (
   wire       [1:0]    _zz_decode_to_execute_ALU_BITWISE_CTRL;
   wire       [1:0]    _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   wire                decode_SRC_LESS_UNSIGNED;
-  wire                decode_IS_SFENCE_VMA;
   wire                decode_IS_SFENCE_VMA2;
   wire                decode_MEMORY_MANAGMENT;
   wire                memory_MEMORY_LRSC;
@@ -479,6 +470,7 @@ module VexRiscv (
   wire       [1:0]    _zz_decode_SRC1_CTRL;
   wire       [1:0]    _zz_decode_to_execute_SRC1_CTRL;
   wire       [1:0]    _zz_decode_to_execute_SRC1_CTRL_1;
+  wire                decode_RESCHEDULE_NEXT;
   wire                decode_MEMORY_FORCE_CONSTISTENCY;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
@@ -500,7 +492,7 @@ module VexRiscv (
   wire       [1:0]    _zz_execute_ENV_CTRL;
   wire       [1:0]    writeBack_ENV_CTRL;
   wire       [1:0]    _zz_writeBack_ENV_CTRL;
-  wire                execute_IS_SFENCE_VMA;
+  wire                execute_RESCHEDULE_NEXT;
   wire       [31:0]   memory_BRANCH_CALC;
   wire                memory_BRANCH_DO;
   wire       [31:0]   execute_PC;
@@ -526,7 +518,7 @@ module VexRiscv (
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_execute_SRC2;
+  wire       [31:0]   _zz_execute_to_memory_PC;
   wire       [1:0]    execute_SRC2_CTRL;
   wire       [1:0]    _zz_execute_SRC2_CTRL;
   wire       [1:0]    execute_SRC1_CTRL;
@@ -735,8 +727,9 @@ module VexRiscv (
   wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
   wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
   wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
-  wire                CsrPlugin_csrMapping_allowCsrSignal;
+  reg                 CsrPlugin_csrMapping_allowCsrSignal;
   wire                CsrPlugin_csrMapping_hazardFree;
+  wire                CsrPlugin_csrMapping_doForceFailCsr;
   reg                 CsrPlugin_inWfi /* verilator public */ ;
   wire                CsrPlugin_thirdPartyWake;
   reg                 CsrPlugin_jumpInterface_valid;
@@ -758,6 +751,7 @@ module VexRiscv (
   wire                CsrPlugin_allowInterrupts;
   wire                CsrPlugin_allowException;
   wire                CsrPlugin_allowEbreakException;
+  reg                 CsrPlugin_xretAwayFromMachine;
   wire                IBusCachedPlugin_externalFlush;
   wire                IBusCachedPlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
@@ -777,14 +771,13 @@ module VexRiscv (
   reg                 IBusCachedPlugin_fetchPc_pcRegPropagate;
   reg                 IBusCachedPlugin_fetchPc_booted;
   reg                 IBusCachedPlugin_fetchPc_inc;
-  wire                when_Fetcher_l134;
-  wire                IBusCachedPlugin_fetchPc_output_fire_1;
-  wire                when_Fetcher_l134_1;
+  wire                when_Fetcher_l133;
+  wire                when_Fetcher_l133_1;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pc;
   wire                IBusCachedPlugin_fetchPc_redo_valid;
   wire       [31:0]   IBusCachedPlugin_fetchPc_redo_payload;
   reg                 IBusCachedPlugin_fetchPc_flushed;
-  wire                when_Fetcher_l161;
+  wire                when_Fetcher_l160;
   reg                 IBusCachedPlugin_iBusRsp_redoFetch;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_ready;
@@ -820,8 +813,8 @@ module VexRiscv (
   wire                _zz_IBusCachedPlugin_iBusRsp_stages_3_input_ready;
   wire                IBusCachedPlugin_iBusRsp_flush;
   wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
-  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
-  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid;
+  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1;
   wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
@@ -839,20 +832,20 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_output_payload_rsp_error;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   wire                IBusCachedPlugin_iBusRsp_output_payload_isRvc;
-  wire                when_Fetcher_l243;
-  wire                when_Fetcher_l323;
+  wire                when_Fetcher_l242;
+  wire                when_Fetcher_l322;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
-  wire                when_Fetcher_l332;
+  wire                when_Fetcher_l331;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
-  wire                when_Fetcher_l332_1;
+  wire                when_Fetcher_l331_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
-  wire                when_Fetcher_l332_2;
+  wire                when_Fetcher_l331_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
-  wire                when_Fetcher_l332_3;
+  wire                when_Fetcher_l331_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                when_Fetcher_l332_4;
+  wire                when_Fetcher_l331_4;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_5;
-  wire                when_Fetcher_l332_5;
+  wire                when_Fetcher_l331_5;
   wire                iBus_cmd_valid;
   wire                iBus_cmd_ready;
   reg        [31:0]   iBus_cmd_payload_address;
@@ -867,81 +860,82 @@ module VexRiscv (
   wire                IBusCachedPlugin_rsp_iBusRspOutputHalt;
   wire                IBusCachedPlugin_rsp_issueDetected;
   reg                 IBusCachedPlugin_rsp_redoFetch;
-  wire                when_IBusCachedPlugin_l239;
-  wire                when_IBusCachedPlugin_l244;
+  wire                when_IBusCachedPlugin_l245;
   wire                when_IBusCachedPlugin_l250;
   wire                when_IBusCachedPlugin_l256;
-  wire                when_IBusCachedPlugin_l267;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_valid;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_ready;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_address;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_data;
-  wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_size;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_last;
-  reg                 dataCache_1_io_mem_cmd_rValid;
-  reg                 dataCache_1_io_mem_cmd_rData_wr;
-  reg                 dataCache_1_io_mem_cmd_rData_uncached;
-  reg        [31:0]   dataCache_1_io_mem_cmd_rData_address;
-  reg        [31:0]   dataCache_1_io_mem_cmd_rData_data;
-  reg        [3:0]    dataCache_1_io_mem_cmd_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_rData_size;
-  reg                 dataCache_1_io_mem_cmd_rData_last;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
-  wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data;
-  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
-  wire                when_Stream_l368;
+  wire                when_IBusCachedPlugin_l262;
+  wire                when_IBusCachedPlugin_l273;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_valid;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+  wire       [3:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+  wire       [2:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_size;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rValidN;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rData_wr;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rData_uncached;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_rData_address;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_rData_data;
+  reg        [3:0]    toplevel_dataCache_1_io_mem_cmd_rData_mask;
+  reg        [2:0]    toplevel_dataCache_1_io_mem_cmd_rData_size;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rData_last;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
+  wire       [3:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
+  wire       [2:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_address;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_data;
+  reg        [3:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
+  reg        [2:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_size;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  wire                when_Stream_l369;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
-  wire                when_DBusCachedPlugin_l308;
-  wire                when_DBusCachedPlugin_l316;
+  wire                when_DBusCachedPlugin_l352;
+  wire                when_DBusCachedPlugin_l360;
   wire       [1:0]    execute_DBusCachedPlugin_size;
   reg        [31:0]   _zz_execute_MEMORY_STORE_DATA_RF;
-  wire                dataCache_1_io_cpu_flush_isStall;
-  wire                when_DBusCachedPlugin_l350;
-  wire                when_DBusCachedPlugin_l366;
-  wire                when_DBusCachedPlugin_l393;
-  wire                when_DBusCachedPlugin_l446;
-  wire                when_DBusCachedPlugin_l466;
+  wire                toplevel_dataCache_1_io_cpu_flush_isStall;
+  wire                when_DBusCachedPlugin_l394;
+  wire                when_DBusCachedPlugin_l410;
+  wire                when_DBusCachedPlugin_l472;
+  wire                when_DBusCachedPlugin_l533;
+  wire                when_DBusCachedPlugin_l553;
+  wire       [31:0]   writeBack_DBusCachedPlugin_rspData;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_0;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_1;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_2;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspRf;
-  wire                when_DBusCachedPlugin_l482;
-  wire       [1:0]    switch_Misc_l210;
+  wire                when_DBusCachedPlugin_l570;
+  wire       [1:0]    switch_Misc_l232;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_1;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated_2;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
-  wire                when_DBusCachedPlugin_l492;
+  wire                when_DBusCachedPlugin_l580;
   reg                 DBusCachedPlugin_forceDatapath;
-  wire                when_DBusCachedPlugin_l506;
-  wire                when_DBusCachedPlugin_l507;
+  wire                when_DBusCachedPlugin_l604;
+  wire                when_DBusCachedPlugin_l605;
   wire                MmuPlugin_dBusAccess_cmd_fire;
   reg                 MmuPlugin_status_sum;
   reg                 MmuPlugin_status_mxr;
   reg                 MmuPlugin_status_mprv;
   reg                 MmuPlugin_satp_mode;
   reg        [8:0]    MmuPlugin_satp_asid;
-  reg        [19:0]   MmuPlugin_satp_ppn;
+  reg        [21:0]   MmuPlugin_satp_ppn;
   reg                 MmuPlugin_ports_0_cache_0_valid;
   reg                 MmuPlugin_ports_0_cache_0_exception;
   reg                 MmuPlugin_ports_0_cache_0_superPage;
@@ -988,8 +982,8 @@ module VexRiscv (
   reg                 MmuPlugin_ports_0_cache_3_allowUser;
   wire                MmuPlugin_ports_0_dirty;
   reg                 MmuPlugin_ports_0_requireMmuLockupCalc;
-  wire                when_MmuPlugin_l125;
-  wire                when_MmuPlugin_l126;
+  wire                when_MmuPlugin_l131;
+  wire                when_MmuPlugin_l132;
   wire       [3:0]    MmuPlugin_ports_0_cacheHitsCalc;
   wire                MmuPlugin_ports_0_cacheHit;
   wire                _zz_MmuPlugin_ports_0_cacheLine_valid;
@@ -1059,9 +1053,9 @@ module VexRiscv (
   reg                 MmuPlugin_ports_1_cache_3_allowUser;
   wire                MmuPlugin_ports_1_dirty;
   reg                 MmuPlugin_ports_1_requireMmuLockupCalc;
-  wire                when_MmuPlugin_l125_1;
-  wire                when_MmuPlugin_l126_1;
-  wire                when_MmuPlugin_l128;
+  wire                when_MmuPlugin_l131_1;
+  wire                when_MmuPlugin_l132_1;
+  wire                when_MmuPlugin_l134;
   wire       [3:0]    MmuPlugin_ports_1_cacheHitsCalc;
   wire                MmuPlugin_ports_1_cacheHit;
   wire                _zz_MmuPlugin_ports_1_cacheLine_valid;
@@ -1106,7 +1100,7 @@ module VexRiscv (
   wire       [11:0]   MmuPlugin_shared_dBusRsp_pte_PPN1;
   wire                MmuPlugin_shared_dBusRsp_exception;
   wire                MmuPlugin_shared_dBusRsp_leaf;
-  wire                when_MmuPlugin_l205;
+  wire                when_MmuPlugin_l211;
   reg                 MmuPlugin_shared_pteBuffer_V;
   reg                 MmuPlugin_shared_pteBuffer_R;
   reg                 MmuPlugin_shared_pteBuffer_W;
@@ -1123,21 +1117,21 @@ module VexRiscv (
   wire       [1:0]    MmuPlugin_shared_refills;
   wire       [1:0]    _zz_MmuPlugin_shared_refills_2;
   reg        [1:0]    _zz_MmuPlugin_shared_refills_3;
-  wire                when_MmuPlugin_l217;
+  wire                when_MmuPlugin_l223;
   wire       [31:0]   _zz_MmuPlugin_shared_vpn_0;
-  wire                when_MmuPlugin_l243;
-  wire                when_MmuPlugin_l272;
-  wire                when_MmuPlugin_l274;
-  wire                when_MmuPlugin_l280;
-  wire                when_MmuPlugin_l280_1;
-  wire                when_MmuPlugin_l280_2;
-  wire                when_MmuPlugin_l280_3;
-  wire                when_MmuPlugin_l274_1;
-  wire                when_MmuPlugin_l280_4;
-  wire                when_MmuPlugin_l280_5;
-  wire                when_MmuPlugin_l280_6;
-  wire                when_MmuPlugin_l280_7;
-  wire                when_MmuPlugin_l304;
+  wire                when_MmuPlugin_l250;
+  wire                when_MmuPlugin_l279;
+  wire                when_MmuPlugin_l281;
+  wire                when_MmuPlugin_l287;
+  wire                when_MmuPlugin_l287_1;
+  wire                when_MmuPlugin_l287_2;
+  wire                when_MmuPlugin_l287_3;
+  wire                when_MmuPlugin_l281_1;
+  wire                when_MmuPlugin_l287_4;
+  wire                when_MmuPlugin_l287_5;
+  wire                when_MmuPlugin_l287_6;
+  wire                when_MmuPlugin_l287_7;
+  wire                when_MmuPlugin_l311;
   wire       [35:0]   _zz_decode_IS_DIV;
   wire                _zz_decode_IS_DIV_1;
   wire                _zz_decode_IS_DIV_2;
@@ -1150,6 +1144,7 @@ module VexRiscv (
   wire                _zz_decode_IS_DIV_9;
   wire                _zz_decode_IS_DIV_10;
   wire                _zz_decode_IS_DIV_11;
+  wire                _zz_decode_IS_DIV_12;
   wire       [1:0]    _zz_decode_SRC1_CTRL_2;
   wire       [1:0]    _zz_decode_ALU_CTRL_2;
   wire       [1:0]    _zz_decode_SRC2_CTRL_2;
@@ -1165,15 +1160,15 @@ module VexRiscv (
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
   reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
   reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_2;
+  reg                 _zz_5;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
   reg        [31:0]   _zz_execute_REGFILE_WRITE_DATA;
   reg        [31:0]   _zz_execute_SRC1;
-  wire                _zz_execute_SRC2_1;
-  reg        [19:0]   _zz_execute_SRC2_2;
-  wire                _zz_execute_SRC2_3;
-  reg        [19:0]   _zz_execute_SRC2_4;
-  reg        [31:0]   _zz_execute_SRC2_5;
+  wire                _zz_execute_SRC2;
+  reg        [19:0]   _zz_execute_SRC2_1;
+  wire                _zz_execute_SRC2_2;
+  reg        [19:0]   _zz_execute_SRC2_3;
+  reg        [31:0]   _zz_execute_SRC2_4;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   wire       [4:0]    execute_FullBarrelShifterPlugin_amplitude;
@@ -1210,7 +1205,7 @@ module VexRiscv (
   wire                when_HazardSimplePlugin_l108;
   wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    switch_Misc_l210_1;
+  wire       [2:0]    switch_Misc_l232_1;
   reg                 _zz_execute_BRANCH_DO;
   reg                 _zz_execute_BRANCH_DO_1;
   wire       [31:0]   execute_BranchPlugin_branch_src1;
@@ -1247,6 +1242,7 @@ module VexRiscv (
   reg                 CsrPlugin_medeleg_IAM;
   reg                 CsrPlugin_medeleg_IAF;
   reg                 CsrPlugin_medeleg_II;
+  reg                 CsrPlugin_medeleg_BP;
   reg                 CsrPlugin_medeleg_LAM;
   reg                 CsrPlugin_medeleg_LAF;
   reg                 CsrPlugin_medeleg_SAM;
@@ -1259,6 +1255,12 @@ module VexRiscv (
   reg                 CsrPlugin_mideleg_ST;
   reg                 CsrPlugin_mideleg_SE;
   reg                 CsrPlugin_mideleg_SS;
+  wire                CsrPlugin_mcounteren_IR;
+  wire                CsrPlugin_mcounteren_TM;
+  wire                CsrPlugin_mcounteren_CY;
+  wire                CsrPlugin_scounteren_IR;
+  wire                CsrPlugin_scounteren_TM;
+  wire                CsrPlugin_scounteren_CY;
   reg                 CsrPlugin_sstatus_SIE;
   reg                 CsrPlugin_sstatus_SPIE;
   reg        [0:0]    CsrPlugin_sstatus_SPP;
@@ -1281,13 +1283,13 @@ module VexRiscv (
   reg        [8:0]    CsrPlugin_satp_ASID;
   reg        [0:0]    CsrPlugin_satp_MODE;
   reg                 CsrPlugin_rescheduleLogic_rescheduleNext;
-  wire                when_CsrPlugin_l816;
-  wire                _zz_when_CsrPlugin_l965;
-  wire                _zz_when_CsrPlugin_l965_1;
-  wire                _zz_when_CsrPlugin_l965_2;
-  wire                _zz_when_CsrPlugin_l965_3;
-  wire                _zz_when_CsrPlugin_l965_4;
-  wire                _zz_when_CsrPlugin_l965_5;
+  wire                when_CsrPlugin_l1153;
+  wire                _zz_when_CsrPlugin_l1302;
+  wire                _zz_when_CsrPlugin_l1302_1;
+  wire                _zz_when_CsrPlugin_l1302_2;
+  wire                _zz_when_CsrPlugin_l1302_3;
+  wire                _zz_when_CsrPlugin_l1302_4;
+  wire                _zz_when_CsrPlugin_l1302_5;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -1299,81 +1301,86 @@ module VexRiscv (
   reg        [3:0]    CsrPlugin_exceptionPortCtrl_exceptionContext_code;
   reg        [31:0]   CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
   reg        [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped;
-  wire                when_CsrPlugin_l879;
-  wire                when_CsrPlugin_l879_1;
-  wire                when_CsrPlugin_l879_2;
-  wire                when_CsrPlugin_l879_3;
-  wire                when_CsrPlugin_l879_4;
-  wire                when_CsrPlugin_l879_5;
-  wire                when_CsrPlugin_l879_6;
-  wire                when_CsrPlugin_l879_7;
-  wire                when_CsrPlugin_l879_8;
-  wire                when_CsrPlugin_l879_9;
-  wire                when_CsrPlugin_l879_10;
-  wire                when_CsrPlugin_l879_11;
+  wire                when_CsrPlugin_l1216;
+  wire                when_CsrPlugin_l1216_1;
+  wire                when_CsrPlugin_l1216_2;
+  wire                when_CsrPlugin_l1216_3;
+  wire                when_CsrPlugin_l1216_4;
+  wire                when_CsrPlugin_l1216_5;
+  wire                when_CsrPlugin_l1216_6;
+  wire                when_CsrPlugin_l1216_7;
+  wire                when_CsrPlugin_l1216_8;
+  wire                when_CsrPlugin_l1216_9;
+  wire                when_CsrPlugin_l1216_10;
+  wire                when_CsrPlugin_l1216_11;
+  wire                when_CsrPlugin_l1216_12;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
   wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code;
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
-  wire                when_CsrPlugin_l922;
-  wire                when_CsrPlugin_l922_1;
-  wire                when_CsrPlugin_l922_2;
-  wire                when_CsrPlugin_l922_3;
-  wire                when_CsrPlugin_l935;
+  wire                when_CsrPlugin_l1259;
+  wire                when_CsrPlugin_l1259_1;
+  wire                when_CsrPlugin_l1259_2;
+  wire                when_CsrPlugin_l1259_3;
+  wire                when_CsrPlugin_l1272;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
-  wire                when_CsrPlugin_l959;
-  wire                when_CsrPlugin_l959_1;
-  wire                when_CsrPlugin_l965;
-  wire                when_CsrPlugin_l965_1;
-  wire                when_CsrPlugin_l965_2;
-  wire                when_CsrPlugin_l965_3;
-  wire                when_CsrPlugin_l965_4;
-  wire                when_CsrPlugin_l965_5;
-  wire                when_CsrPlugin_l965_6;
-  wire                when_CsrPlugin_l965_7;
-  wire                when_CsrPlugin_l965_8;
+  wire                when_CsrPlugin_l1296;
+  wire                when_CsrPlugin_l1296_1;
+  wire                when_CsrPlugin_l1302;
+  wire                when_CsrPlugin_l1302_1;
+  wire                when_CsrPlugin_l1302_2;
+  wire                when_CsrPlugin_l1302_3;
+  wire                when_CsrPlugin_l1302_4;
+  wire                when_CsrPlugin_l1302_5;
+  wire                when_CsrPlugin_l1302_6;
+  wire                when_CsrPlugin_l1302_7;
+  wire                when_CsrPlugin_l1302_8;
   wire                CsrPlugin_exception;
   reg                 CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
-  wire                when_CsrPlugin_l993;
-  wire                when_CsrPlugin_l993_1;
-  wire                when_CsrPlugin_l993_2;
-  wire                when_CsrPlugin_l998;
+  wire                when_CsrPlugin_l1335;
+  wire                when_CsrPlugin_l1335_1;
+  wire                when_CsrPlugin_l1335_2;
+  wire                when_CsrPlugin_l1340;
   reg                 CsrPlugin_pipelineLiberator_done;
-  wire                when_CsrPlugin_l1004;
+  wire                when_CsrPlugin_l1346;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
+  wire                CsrPlugin_trapCauseEbreakDebug;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
-  wire                when_CsrPlugin_l1032;
-  wire                when_CsrPlugin_l1077;
-  wire       [1:0]    switch_CsrPlugin_l1081;
+  wire                CsrPlugin_trapEnterDebug;
+  wire                when_CsrPlugin_l1390;
+  wire                when_CsrPlugin_l1398;
+  wire                when_CsrPlugin_l1456;
+  wire       [1:0]    switch_CsrPlugin_l1460;
+  wire                when_CsrPlugin_l1468;
   reg                 execute_CsrPlugin_wfiWake;
-  wire                when_CsrPlugin_l1121;
-  wire                when_CsrPlugin_l1123;
-  wire                when_CsrPlugin_l1129;
+  wire                when_CsrPlugin_l1519;
+  wire                when_CsrPlugin_l1521;
+  wire                when_CsrPlugin_l1527;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire                when_CsrPlugin_l1142;
-  wire                when_CsrPlugin_l1149;
-  wire                when_CsrPlugin_l1150;
-  wire                when_CsrPlugin_l1157;
+  wire                when_CsrPlugin_l1540;
+  wire                when_CsrPlugin_l1547;
+  wire                when_CsrPlugin_l1548;
+  wire                when_CsrPlugin_l1555;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   reg        [31:0]   execute_CsrPlugin_readToWriteData;
-  wire                switch_Misc_l210_2;
+  wire                switch_Misc_l232_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
-  wire                when_CsrPlugin_l1189;
-  wire                when_CsrPlugin_l1193;
+  wire                when_CsrPlugin_l1587;
+  wire                when_CsrPlugin_l1591;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg        [32:0]   memory_MulDivIterativePlugin_rs1;
   reg        [31:0]   memory_MulDivIterativePlugin_rs2;
@@ -1411,14 +1418,14 @@ module VexRiscv (
   wire                when_MulDivIterativePlugin_l151;
   wire       [31:0]   _zz_memory_MulDivIterativePlugin_div_result;
   wire                when_MulDivIterativePlugin_l162;
+  wire                _zz_memory_MulDivIterativePlugin_rs2;
   wire                _zz_memory_MulDivIterativePlugin_rs1;
-  wire                _zz_memory_MulDivIterativePlugin_rs1_1;
-  reg        [32:0]   _zz_memory_MulDivIterativePlugin_rs1_2;
+  reg        [32:0]   _zz_memory_MulDivIterativePlugin_rs1_1;
   reg        [31:0]   externalInterruptArray_regNext;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit;
-  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
-  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
+  wire       [31:0]   _zz_externalInterrupt;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
+  wire       [31:0]   _zz_externalInterruptS;
   wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
   wire                when_Pipeline_l124_1;
@@ -1440,51 +1447,51 @@ module VexRiscv (
   wire                when_Pipeline_l124_9;
   reg                 decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
   wire                when_Pipeline_l124_10;
-  reg        [1:0]    decode_to_execute_SRC1_CTRL;
+  reg                 decode_to_execute_RESCHEDULE_NEXT;
   wire                when_Pipeline_l124_11;
-  reg                 decode_to_execute_SRC_USE_SUB_LESS;
+  reg        [1:0]    decode_to_execute_SRC1_CTRL;
   wire                when_Pipeline_l124_12;
-  reg                 decode_to_execute_MEMORY_ENABLE;
+  reg                 decode_to_execute_SRC_USE_SUB_LESS;
   wire                when_Pipeline_l124_13;
-  reg                 execute_to_memory_MEMORY_ENABLE;
+  reg                 decode_to_execute_MEMORY_ENABLE;
   wire                when_Pipeline_l124_14;
-  reg                 memory_to_writeBack_MEMORY_ENABLE;
+  reg                 execute_to_memory_MEMORY_ENABLE;
   wire                when_Pipeline_l124_15;
-  reg        [1:0]    decode_to_execute_ALU_CTRL;
+  reg                 memory_to_writeBack_MEMORY_ENABLE;
   wire                when_Pipeline_l124_16;
-  reg        [1:0]    decode_to_execute_SRC2_CTRL;
+  reg        [1:0]    decode_to_execute_ALU_CTRL;
   wire                when_Pipeline_l124_17;
-  reg                 decode_to_execute_REGFILE_WRITE_VALID;
+  reg        [1:0]    decode_to_execute_SRC2_CTRL;
   wire                when_Pipeline_l124_18;
-  reg                 execute_to_memory_REGFILE_WRITE_VALID;
+  reg                 decode_to_execute_REGFILE_WRITE_VALID;
   wire                when_Pipeline_l124_19;
-  reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
+  reg                 execute_to_memory_REGFILE_WRITE_VALID;
   wire                when_Pipeline_l124_20;
-  reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
+  reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
   wire                when_Pipeline_l124_21;
-  reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
   wire                when_Pipeline_l124_22;
-  reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
+  reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
   wire                when_Pipeline_l124_23;
-  reg                 decode_to_execute_MEMORY_WR;
+  reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
   wire                when_Pipeline_l124_24;
-  reg                 execute_to_memory_MEMORY_WR;
+  reg                 decode_to_execute_MEMORY_WR;
   wire                when_Pipeline_l124_25;
-  reg                 memory_to_writeBack_MEMORY_WR;
+  reg                 execute_to_memory_MEMORY_WR;
   wire                when_Pipeline_l124_26;
-  reg                 decode_to_execute_MEMORY_LRSC;
+  reg                 memory_to_writeBack_MEMORY_WR;
   wire                when_Pipeline_l124_27;
-  reg                 execute_to_memory_MEMORY_LRSC;
+  reg                 decode_to_execute_MEMORY_LRSC;
   wire                when_Pipeline_l124_28;
-  reg                 memory_to_writeBack_MEMORY_LRSC;
+  reg                 execute_to_memory_MEMORY_LRSC;
   wire                when_Pipeline_l124_29;
-  reg                 decode_to_execute_MEMORY_AMO;
+  reg                 memory_to_writeBack_MEMORY_LRSC;
   wire                when_Pipeline_l124_30;
-  reg                 decode_to_execute_MEMORY_MANAGMENT;
+  reg                 decode_to_execute_MEMORY_AMO;
   wire                when_Pipeline_l124_31;
-  reg                 decode_to_execute_IS_SFENCE_VMA2;
+  reg                 decode_to_execute_MEMORY_MANAGMENT;
   wire                when_Pipeline_l124_32;
-  reg                 decode_to_execute_IS_SFENCE_VMA;
+  reg                 decode_to_execute_IS_SFENCE_VMA2;
   wire                when_Pipeline_l124_33;
   reg                 decode_to_execute_SRC_LESS_UNSIGNED;
   wire                when_Pipeline_l124_34;
@@ -1549,64 +1556,66 @@ module VexRiscv (
   wire                when_Pipeline_l154_1;
   wire                when_Pipeline_l151_2;
   wire                when_Pipeline_l154_2;
-  wire                when_CsrPlugin_l1277;
+  wire                when_CsrPlugin_l1669;
   reg                 execute_CsrPlugin_csr_3264;
-  wire                when_CsrPlugin_l1277_1;
+  wire                when_CsrPlugin_l1669_1;
   reg                 execute_CsrPlugin_csr_768;
-  wire                when_CsrPlugin_l1277_2;
+  wire                when_CsrPlugin_l1669_2;
   reg                 execute_CsrPlugin_csr_256;
-  wire                when_CsrPlugin_l1277_3;
+  wire                when_CsrPlugin_l1669_3;
   reg                 execute_CsrPlugin_csr_384;
-  wire                when_CsrPlugin_l1277_4;
+  wire                when_CsrPlugin_l1669_4;
   reg                 execute_CsrPlugin_csr_3857;
-  wire                when_CsrPlugin_l1277_5;
+  wire                when_CsrPlugin_l1669_5;
   reg                 execute_CsrPlugin_csr_3858;
-  wire                when_CsrPlugin_l1277_6;
+  wire                when_CsrPlugin_l1669_6;
   reg                 execute_CsrPlugin_csr_3859;
-  wire                when_CsrPlugin_l1277_7;
+  wire                when_CsrPlugin_l1669_7;
   reg                 execute_CsrPlugin_csr_3860;
-  wire                when_CsrPlugin_l1277_8;
+  wire                when_CsrPlugin_l1669_8;
   reg                 execute_CsrPlugin_csr_836;
-  wire                when_CsrPlugin_l1277_9;
+  wire                when_CsrPlugin_l1669_9;
   reg                 execute_CsrPlugin_csr_772;
-  wire                when_CsrPlugin_l1277_10;
+  wire                when_CsrPlugin_l1669_10;
   reg                 execute_CsrPlugin_csr_773;
-  wire                when_CsrPlugin_l1277_11;
+  wire                when_CsrPlugin_l1669_11;
   reg                 execute_CsrPlugin_csr_833;
-  wire                when_CsrPlugin_l1277_12;
+  wire                when_CsrPlugin_l1669_12;
   reg                 execute_CsrPlugin_csr_832;
-  wire                when_CsrPlugin_l1277_13;
+  wire                when_CsrPlugin_l1669_13;
   reg                 execute_CsrPlugin_csr_834;
-  wire                when_CsrPlugin_l1277_14;
+  wire                when_CsrPlugin_l1669_14;
   reg                 execute_CsrPlugin_csr_835;
-  wire                when_CsrPlugin_l1277_15;
+  wire                when_CsrPlugin_l1669_15;
   reg                 execute_CsrPlugin_csr_770;
-  wire                when_CsrPlugin_l1277_16;
+  wire                when_CsrPlugin_l1669_16;
   reg                 execute_CsrPlugin_csr_771;
-  wire                when_CsrPlugin_l1277_17;
+  wire                when_CsrPlugin_l1669_17;
   reg                 execute_CsrPlugin_csr_324;
-  wire                when_CsrPlugin_l1277_18;
+  wire                when_CsrPlugin_l1669_18;
   reg                 execute_CsrPlugin_csr_260;
-  wire                when_CsrPlugin_l1277_19;
+  wire                when_CsrPlugin_l1669_19;
   reg                 execute_CsrPlugin_csr_261;
-  wire                when_CsrPlugin_l1277_20;
+  wire                when_CsrPlugin_l1669_20;
   reg                 execute_CsrPlugin_csr_321;
-  wire                when_CsrPlugin_l1277_21;
+  wire                when_CsrPlugin_l1669_21;
   reg                 execute_CsrPlugin_csr_320;
-  wire                when_CsrPlugin_l1277_22;
+  wire                when_CsrPlugin_l1669_22;
   reg                 execute_CsrPlugin_csr_322;
-  wire                when_CsrPlugin_l1277_23;
+  wire                when_CsrPlugin_l1669_23;
   reg                 execute_CsrPlugin_csr_323;
-  wire                when_CsrPlugin_l1277_24;
+  wire                when_CsrPlugin_l1669_24;
   reg                 execute_CsrPlugin_csr_3008;
-  wire                when_CsrPlugin_l1277_25;
+  wire                when_CsrPlugin_l1669_25;
   reg                 execute_CsrPlugin_csr_4032;
-  wire                when_CsrPlugin_l1277_26;
+  wire                when_CsrPlugin_l1669_26;
   reg                 execute_CsrPlugin_csr_2496;
-  wire                when_CsrPlugin_l1277_27;
+  wire                when_CsrPlugin_l1669_27;
   reg                 execute_CsrPlugin_csr_3520;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
+  wire       [1:0]    switch_CsrPlugin_l1031;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
-  wire       [1:0]    switch_CsrPlugin_l723;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_5;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_6;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
@@ -1628,20 +1637,22 @@ module VexRiscv (
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_23;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_24;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_25;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_26;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_27;
-  wire                when_CsrPlugin_l1310;
-  wire                when_CsrPlugin_l1315;
+  wire                when_CsrPlugin_l1702;
+  wire       [11:0]   _zz_when_CsrPlugin_l1709;
+  wire                when_CsrPlugin_l1709;
+  reg                 when_CsrPlugin_l1719;
+  wire                when_CsrPlugin_l1717;
+  wire                when_CsrPlugin_l1725;
   reg        [2:0]    _zz_iBusWishbone_ADR;
   wire                when_InstructionCache_l239;
   reg                 _zz_iBus_rsp_valid;
   reg        [31:0]   iBusWishbone_DAT_MISO_regNext;
-  reg        [2:0]    _zz_dBus_cmd_ready;
+  reg        [2:0]    _zz_dBusWishbone_ADR;
+  wire                _zz_dBusWishbone_CYC;
+  wire                _zz_dBus_cmd_ready;
   wire                _zz_dBus_cmd_ready_1;
   wire                _zz_dBus_cmd_ready_2;
-  wire                _zz_dBus_cmd_ready_3;
-  wire                _zz_dBus_cmd_ready_4;
-  wire                _zz_dBus_cmd_ready_5;
+  wire                _zz_dBusWishbone_ADR_1;
   reg                 _zz_dBus_rsp_valid;
   reg        [31:0]   dBusWishbone_DAT_MISO_regNext;
   `ifndef SYNTHESIS
@@ -1736,7 +1747,7 @@ module VexRiscv (
   assign _zz_IBusCachedPlugin_fetchPc_pc_1 = {IBusCachedPlugin_fetchPc_inc,2'b00};
   assign _zz_IBusCachedPlugin_fetchPc_pc = {29'd0, _zz_IBusCachedPlugin_fetchPc_pc_1};
   assign _zz_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId_1;
-  assign _zz_io_cpu_flush_payload_lineId_1 = (execute_RS1 >>> 5);
+  assign _zz_io_cpu_flush_payload_lineId_1 = (execute_RS1 >>> 3'd5);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code_1 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
   assign _zz_writeBack_DBusCachedPlugin_rspRf = (! dataCache_1_io_cpu_writeBack_exclusiveOk);
@@ -1748,14 +1759,12 @@ module VexRiscv (
   assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
   assign _zz__zz_execute_SRC1 = 3'b100;
   assign _zz__zz_execute_SRC1_1 = execute_INSTRUCTION[19 : 15];
-  assign _zz__zz_execute_SRC2_3 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz__zz_execute_SRC2_2 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
   assign _zz_execute_SrcPlugin_addSub = ($signed(_zz_execute_SrcPlugin_addSub_1) + $signed(_zz_execute_SrcPlugin_addSub_4));
   assign _zz_execute_SrcPlugin_addSub_1 = ($signed(_zz_execute_SrcPlugin_addSub_2) + $signed(_zz_execute_SrcPlugin_addSub_3));
   assign _zz_execute_SrcPlugin_addSub_2 = execute_SRC1;
   assign _zz_execute_SrcPlugin_addSub_3 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? _zz_execute_SrcPlugin_addSub_5 : _zz_execute_SrcPlugin_addSub_6);
-  assign _zz_execute_SrcPlugin_addSub_5 = 32'h00000001;
-  assign _zz_execute_SrcPlugin_addSub_6 = 32'h0;
+  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? 32'h00000001 : 32'h00000000);
   assign _zz__zz_execute_BranchPlugin_branch_src2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
   assign _zz__zz_execute_BranchPlugin_branch_src2_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
   assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code & (~ _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1));
@@ -1763,11 +1772,11 @@ module VexRiscv (
   assign _zz_memory_MulDivIterativePlugin_mul_counter_valueNext_1 = memory_MulDivIterativePlugin_mul_counter_willIncrement;
   assign _zz_memory_MulDivIterativePlugin_mul_counter_valueNext = {5'd0, _zz_memory_MulDivIterativePlugin_mul_counter_valueNext_1};
   assign _zz_memory_MulDivIterativePlugin_accumulator = (_zz_memory_MulDivIterativePlugin_accumulator_1 + _zz_memory_MulDivIterativePlugin_accumulator_3);
-  assign _zz_memory_MulDivIterativePlugin_accumulator_2 = (memory_MulDivIterativePlugin_rs2[0] ? memory_MulDivIterativePlugin_rs1 : 33'h0);
+  assign _zz_memory_MulDivIterativePlugin_accumulator_2 = (memory_MulDivIterativePlugin_rs2[0] ? memory_MulDivIterativePlugin_rs1 : 33'h000000000);
   assign _zz_memory_MulDivIterativePlugin_accumulator_1 = {{1{_zz_memory_MulDivIterativePlugin_accumulator_2[32]}}, _zz_memory_MulDivIterativePlugin_accumulator_2};
   assign _zz_memory_MulDivIterativePlugin_accumulator_4 = _zz_memory_MulDivIterativePlugin_accumulator_5;
   assign _zz_memory_MulDivIterativePlugin_accumulator_3 = {{1{_zz_memory_MulDivIterativePlugin_accumulator_4[32]}}, _zz_memory_MulDivIterativePlugin_accumulator_4};
-  assign _zz_memory_MulDivIterativePlugin_accumulator_5 = (memory_MulDivIterativePlugin_accumulator >>> 32);
+  assign _zz_memory_MulDivIterativePlugin_accumulator_5 = (memory_MulDivIterativePlugin_accumulator >>> 6'd32);
   assign _zz_memory_MulDivIterativePlugin_div_counter_valueNext_1 = memory_MulDivIterativePlugin_div_counter_willIncrement;
   assign _zz_memory_MulDivIterativePlugin_div_counter_valueNext = {5'd0, _zz_memory_MulDivIterativePlugin_div_counter_valueNext_1};
   assign _zz_memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator = {1'd0, memory_MulDivIterativePlugin_rs2};
@@ -1779,39 +1788,39 @@ module VexRiscv (
   assign _zz_memory_MulDivIterativePlugin_div_result_3 = ({memory_MulDivIterativePlugin_div_needRevert,(memory_MulDivIterativePlugin_div_needRevert ? (~ _zz_memory_MulDivIterativePlugin_div_result) : _zz_memory_MulDivIterativePlugin_div_result)} + _zz_memory_MulDivIterativePlugin_div_result_4);
   assign _zz_memory_MulDivIterativePlugin_div_result_5 = memory_MulDivIterativePlugin_div_needRevert;
   assign _zz_memory_MulDivIterativePlugin_div_result_4 = {32'd0, _zz_memory_MulDivIterativePlugin_div_result_5};
-  assign _zz_memory_MulDivIterativePlugin_rs1_4 = _zz_memory_MulDivIterativePlugin_rs1_1;
-  assign _zz_memory_MulDivIterativePlugin_rs1_3 = {32'd0, _zz_memory_MulDivIterativePlugin_rs1_4};
-  assign _zz_memory_MulDivIterativePlugin_rs2_1 = _zz_memory_MulDivIterativePlugin_rs1;
-  assign _zz_memory_MulDivIterativePlugin_rs2 = {31'd0, _zz_memory_MulDivIterativePlugin_rs2_1};
-  assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 5);
+  assign _zz_memory_MulDivIterativePlugin_rs1_3 = _zz_memory_MulDivIterativePlugin_rs1;
+  assign _zz_memory_MulDivIterativePlugin_rs1_2 = {32'd0, _zz_memory_MulDivIterativePlugin_rs1_3};
+  assign _zz_memory_MulDivIterativePlugin_rs2_2 = _zz_memory_MulDivIterativePlugin_rs2;
+  assign _zz_memory_MulDivIterativePlugin_rs2_1 = {31'd0, _zz_memory_MulDivIterativePlugin_rs2_2};
+  assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 3'd5);
   assign _zz_decode_RegFilePlugin_rs1Data = 1'b1;
   assign _zz_decode_RegFilePlugin_rs2Data = 1'b1;
   assign _zz_IBusCachedPlugin_jump_pcLoad_payload_6 = {_zz_IBusCachedPlugin_jump_pcLoad_payload_4,_zz_IBusCachedPlugin_jump_pcLoad_payload_3};
   assign _zz_writeBack_DBusCachedPlugin_rspShifted_1 = dataCache_1_io_cpu_writeBack_address[1 : 0];
   assign _zz_writeBack_DBusCachedPlugin_rspShifted_3 = dataCache_1_io_cpu_writeBack_address[1 : 1];
-  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000107f;
-  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00002073;
-  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000207f;
+  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000407f);
+  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00004063;
+  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000107f) == 32'h00000013);
   assign _zz_decode_LEGAL_INSTRUCTION_5 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_6) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_7 == _zz_decode_LEGAL_INSTRUCTION_8),{_zz_decode_LEGAL_INSTRUCTION_9,{_zz_decode_LEGAL_INSTRUCTION_10,_zz_decode_LEGAL_INSTRUCTION_11}}}}}};
   assign _zz_decode_LEGAL_INSTRUCTION_6 = 32'h0000505f;
   assign _zz_decode_LEGAL_INSTRUCTION_7 = (decode_INSTRUCTION & 32'h0000707b);
   assign _zz_decode_LEGAL_INSTRUCTION_8 = 32'h00000063;
   assign _zz_decode_LEGAL_INSTRUCTION_9 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
   assign _zz_decode_LEGAL_INSTRUCTION_10 = ((decode_INSTRUCTION & 32'h1800707f) == 32'h0000202f);
-  assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033),{((decode_INSTRUCTION & 32'he800707f) == 32'h0800202f),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h00001013),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,{_zz_decode_LEGAL_INSTRUCTION_16,_zz_decode_LEGAL_INSTRUCTION_17}}}}}};
-  assign _zz_decode_LEGAL_INSTRUCTION_12 = 32'hfc00305f;
-  assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'h01f0707f);
-  assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h0000500f;
-  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013);
-  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00005033);
-  assign _zz_decode_LEGAL_INSTRUCTION_17 = {((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033),{((decode_INSTRUCTION & 32'hf9f0707f) == 32'h1000202f),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_18) == 32'h12000073),{(_zz_decode_LEGAL_INSTRUCTION_19 == _zz_decode_LEGAL_INSTRUCTION_20),{_zz_decode_LEGAL_INSTRUCTION_21,_zz_decode_LEGAL_INSTRUCTION_22}}}}};
-  assign _zz_decode_LEGAL_INSTRUCTION_18 = 32'hfe007fff;
-  assign _zz_decode_LEGAL_INSTRUCTION_19 = (decode_INSTRUCTION & 32'hdfffffff);
-  assign _zz_decode_LEGAL_INSTRUCTION_20 = 32'h10200073;
-  assign _zz_decode_LEGAL_INSTRUCTION_21 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073);
-  assign _zz_decode_LEGAL_INSTRUCTION_22 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073);
+  assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033),{((decode_INSTRUCTION & 32'he800707f) == 32'h0800202f),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h0000500f),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,{_zz_decode_LEGAL_INSTRUCTION_16,_zz_decode_LEGAL_INSTRUCTION_17}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_12 = 32'h01f0707f;
+  assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'hbe00705f);
+  assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h00005013;
+  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hfe00305f) == 32'h00001013);
+  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
+  assign _zz_decode_LEGAL_INSTRUCTION_17 = {((decode_INSTRUCTION & 32'hf9f0707f) == 32'h1000202f),{((decode_INSTRUCTION & 32'hfe007fff) == 32'h12000073),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_18) == 32'h10200073),{(_zz_decode_LEGAL_INSTRUCTION_19 == _zz_decode_LEGAL_INSTRUCTION_20),(_zz_decode_LEGAL_INSTRUCTION_21 == _zz_decode_LEGAL_INSTRUCTION_22)}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_18 = 32'hdfffffff;
+  assign _zz_decode_LEGAL_INSTRUCTION_19 = (decode_INSTRUCTION & 32'hffffffff);
+  assign _zz_decode_LEGAL_INSTRUCTION_20 = 32'h10500073;
+  assign _zz_decode_LEGAL_INSTRUCTION_21 = (decode_INSTRUCTION & 32'hffffffff);
+  assign _zz_decode_LEGAL_INSTRUCTION_22 = 32'h00000073;
   assign _zz_MmuPlugin_ports_0_cacheHitsCalc = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22];
   assign _zz_MmuPlugin_ports_0_cacheHitsCalc_1 = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12];
   assign _zz_MmuPlugin_ports_0_cacheHitsCalc_2 = (MmuPlugin_ports_0_cache_1_virtualAddress_1 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22]);
@@ -1825,165 +1834,159 @@ module VexRiscv (
   assign _zz_MmuPlugin_ports_1_cacheHitsCalc_4 = (MmuPlugin_ports_1_cache_0_virtualAddress_1 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22]);
   assign _zz_MmuPlugin_ports_1_cacheHitsCalc_5 = (MmuPlugin_ports_1_cache_0_virtualAddress_0 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12]);
   assign _zz__zz_decode_IS_DIV = 32'h02004064;
-  assign _zz__zz_decode_IS_DIV_1 = _zz_decode_IS_DIV_11;
-  assign _zz__zz_decode_IS_DIV_2 = {_zz_decode_IS_DIV_9,_zz_decode_IS_DIV_10};
+  assign _zz__zz_decode_IS_DIV_1 = _zz_decode_IS_DIV_12;
+  assign _zz__zz_decode_IS_DIV_2 = {_zz_decode_IS_DIV_10,_zz_decode_IS_DIV_11};
   assign _zz__zz_decode_IS_DIV_3 = ((decode_INSTRUCTION & 32'h02004074) == 32'h02000030);
   assign _zz__zz_decode_IS_DIV_4 = (|((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_5) == 32'h00000050));
   assign _zz__zz_decode_IS_DIV_6 = (|(_zz__zz_decode_IS_DIV_7 == _zz__zz_decode_IS_DIV_8));
-  assign _zz__zz_decode_IS_DIV_9 = {(|{_zz__zz_decode_IS_DIV_10,_zz__zz_decode_IS_DIV_12}),{(|_zz__zz_decode_IS_DIV_14),{_zz__zz_decode_IS_DIV_17,{_zz__zz_decode_IS_DIV_20,_zz__zz_decode_IS_DIV_25}}}};
+  assign _zz__zz_decode_IS_DIV_9 = {(|{_zz__zz_decode_IS_DIV_10,_zz__zz_decode_IS_DIV_11}),{(|_zz__zz_decode_IS_DIV_12),{_zz__zz_decode_IS_DIV_14,{_zz__zz_decode_IS_DIV_16,_zz__zz_decode_IS_DIV_19}}}};
   assign _zz__zz_decode_IS_DIV_5 = 32'h02203050;
   assign _zz__zz_decode_IS_DIV_7 = (decode_INSTRUCTION & 32'h02403050);
   assign _zz__zz_decode_IS_DIV_8 = 32'h00000050;
-  assign _zz__zz_decode_IS_DIV_10 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_11) == 32'h00001050);
-  assign _zz__zz_decode_IS_DIV_12 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_13) == 32'h00002050);
-  assign _zz__zz_decode_IS_DIV_14 = {_zz_decode_IS_DIV_2,(_zz__zz_decode_IS_DIV_15 == _zz__zz_decode_IS_DIV_16)};
-  assign _zz__zz_decode_IS_DIV_17 = (|(_zz__zz_decode_IS_DIV_18 == _zz__zz_decode_IS_DIV_19));
-  assign _zz__zz_decode_IS_DIV_20 = (|{_zz__zz_decode_IS_DIV_21,_zz__zz_decode_IS_DIV_23});
-  assign _zz__zz_decode_IS_DIV_25 = {(|_zz__zz_decode_IS_DIV_26),{_zz__zz_decode_IS_DIV_31,{_zz__zz_decode_IS_DIV_34,_zz__zz_decode_IS_DIV_35}}};
-  assign _zz__zz_decode_IS_DIV_11 = 32'h00001050;
-  assign _zz__zz_decode_IS_DIV_13 = 32'h00002050;
-  assign _zz__zz_decode_IS_DIV_15 = (decode_INSTRUCTION & 32'h0000001c);
-  assign _zz__zz_decode_IS_DIV_16 = 32'h00000004;
-  assign _zz__zz_decode_IS_DIV_18 = (decode_INSTRUCTION & 32'h00000058);
-  assign _zz__zz_decode_IS_DIV_19 = 32'h00000040;
-  assign _zz__zz_decode_IS_DIV_21 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_22) == 32'h00005010);
-  assign _zz__zz_decode_IS_DIV_23 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_24) == 32'h00005020);
-  assign _zz__zz_decode_IS_DIV_26 = {(_zz__zz_decode_IS_DIV_27 == _zz__zz_decode_IS_DIV_28),{_zz__zz_decode_IS_DIV_29,_zz__zz_decode_IS_DIV_30}};
-  assign _zz__zz_decode_IS_DIV_31 = (|(_zz__zz_decode_IS_DIV_32 == _zz__zz_decode_IS_DIV_33));
-  assign _zz__zz_decode_IS_DIV_34 = (|_zz_decode_IS_DIV_9);
-  assign _zz__zz_decode_IS_DIV_35 = {(|_zz__zz_decode_IS_DIV_36),{_zz__zz_decode_IS_DIV_38,{_zz__zz_decode_IS_DIV_39,_zz__zz_decode_IS_DIV_40}}};
-  assign _zz__zz_decode_IS_DIV_22 = 32'h00007034;
-  assign _zz__zz_decode_IS_DIV_24 = 32'h02007064;
-  assign _zz__zz_decode_IS_DIV_27 = (decode_INSTRUCTION & 32'h40003054);
-  assign _zz__zz_decode_IS_DIV_28 = 32'h40001010;
-  assign _zz__zz_decode_IS_DIV_29 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00001010);
-  assign _zz__zz_decode_IS_DIV_30 = ((decode_INSTRUCTION & 32'h02007054) == 32'h00001010);
-  assign _zz__zz_decode_IS_DIV_32 = (decode_INSTRUCTION & 32'h00001000);
-  assign _zz__zz_decode_IS_DIV_33 = 32'h00001000;
-  assign _zz__zz_decode_IS_DIV_36 = {_zz_decode_IS_DIV_7,((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_37) == 32'h00001000)};
-  assign _zz__zz_decode_IS_DIV_38 = (|_zz_decode_IS_DIV_8);
-  assign _zz__zz_decode_IS_DIV_39 = (|_zz_decode_IS_DIV_8);
-  assign _zz__zz_decode_IS_DIV_40 = {(|_zz__zz_decode_IS_DIV_41),{(|_zz__zz_decode_IS_DIV_42),{_zz__zz_decode_IS_DIV_43,{_zz__zz_decode_IS_DIV_51,_zz__zz_decode_IS_DIV_54}}}};
-  assign _zz__zz_decode_IS_DIV_37 = 32'h00005000;
-  assign _zz__zz_decode_IS_DIV_41 = ((decode_INSTRUCTION & 32'h00004048) == 32'h00004008);
-  assign _zz__zz_decode_IS_DIV_42 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
-  assign _zz__zz_decode_IS_DIV_43 = (|{(_zz__zz_decode_IS_DIV_44 == _zz__zz_decode_IS_DIV_45),{_zz__zz_decode_IS_DIV_46,{_zz__zz_decode_IS_DIV_47,_zz__zz_decode_IS_DIV_49}}});
-  assign _zz__zz_decode_IS_DIV_51 = (|(_zz__zz_decode_IS_DIV_52 == _zz__zz_decode_IS_DIV_53));
-  assign _zz__zz_decode_IS_DIV_54 = {(|_zz__zz_decode_IS_DIV_55),{(|_zz__zz_decode_IS_DIV_56),{_zz__zz_decode_IS_DIV_69,{_zz__zz_decode_IS_DIV_78,_zz__zz_decode_IS_DIV_81}}}};
-  assign _zz__zz_decode_IS_DIV_44 = (decode_INSTRUCTION & 32'h00000034);
-  assign _zz__zz_decode_IS_DIV_45 = 32'h00000020;
-  assign _zz__zz_decode_IS_DIV_46 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000020);
-  assign _zz__zz_decode_IS_DIV_47 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_48) == 32'h08000020);
-  assign _zz__zz_decode_IS_DIV_49 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_50) == 32'h00000020);
-  assign _zz__zz_decode_IS_DIV_52 = (decode_INSTRUCTION & 32'h10000008);
-  assign _zz__zz_decode_IS_DIV_53 = 32'h00000008;
-  assign _zz__zz_decode_IS_DIV_55 = ((decode_INSTRUCTION & 32'h10000008) == 32'h10000008);
-  assign _zz__zz_decode_IS_DIV_56 = {(_zz__zz_decode_IS_DIV_57 == _zz__zz_decode_IS_DIV_58),{_zz__zz_decode_IS_DIV_59,{_zz__zz_decode_IS_DIV_61,_zz__zz_decode_IS_DIV_64}}};
-  assign _zz__zz_decode_IS_DIV_69 = (|{_zz__zz_decode_IS_DIV_70,{_zz__zz_decode_IS_DIV_72,_zz__zz_decode_IS_DIV_75}});
-  assign _zz__zz_decode_IS_DIV_78 = (|_zz__zz_decode_IS_DIV_79);
-  assign _zz__zz_decode_IS_DIV_81 = {(|_zz__zz_decode_IS_DIV_82),{_zz__zz_decode_IS_DIV_95,{_zz__zz_decode_IS_DIV_111,_zz__zz_decode_IS_DIV_115}}};
-  assign _zz__zz_decode_IS_DIV_48 = 32'h08000070;
-  assign _zz__zz_decode_IS_DIV_50 = 32'h10000070;
-  assign _zz__zz_decode_IS_DIV_57 = (decode_INSTRUCTION & 32'h00002040);
-  assign _zz__zz_decode_IS_DIV_58 = 32'h00002040;
-  assign _zz__zz_decode_IS_DIV_59 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_60) == 32'h00001040);
-  assign _zz__zz_decode_IS_DIV_61 = (_zz__zz_decode_IS_DIV_62 == _zz__zz_decode_IS_DIV_63);
-  assign _zz__zz_decode_IS_DIV_64 = {_zz_decode_IS_DIV_7,{_zz__zz_decode_IS_DIV_65,_zz__zz_decode_IS_DIV_66}};
-  assign _zz__zz_decode_IS_DIV_70 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_71) == 32'h08000020);
-  assign _zz__zz_decode_IS_DIV_72 = (_zz__zz_decode_IS_DIV_73 == _zz__zz_decode_IS_DIV_74);
-  assign _zz__zz_decode_IS_DIV_75 = (_zz__zz_decode_IS_DIV_76 == _zz__zz_decode_IS_DIV_77);
-  assign _zz__zz_decode_IS_DIV_79 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_80) == 32'h00000010);
-  assign _zz__zz_decode_IS_DIV_82 = {_zz_decode_IS_DIV_6,{_zz__zz_decode_IS_DIV_83,_zz__zz_decode_IS_DIV_86}};
-  assign _zz__zz_decode_IS_DIV_95 = (|{_zz__zz_decode_IS_DIV_96,_zz__zz_decode_IS_DIV_97});
-  assign _zz__zz_decode_IS_DIV_111 = (|_zz__zz_decode_IS_DIV_112);
-  assign _zz__zz_decode_IS_DIV_115 = {_zz__zz_decode_IS_DIV_116,{_zz__zz_decode_IS_DIV_121,_zz__zz_decode_IS_DIV_125}};
-  assign _zz__zz_decode_IS_DIV_60 = 32'h00001040;
-  assign _zz__zz_decode_IS_DIV_62 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz__zz_decode_IS_DIV_63 = 32'h00000040;
-  assign _zz__zz_decode_IS_DIV_65 = _zz_decode_IS_DIV_4;
+  assign _zz__zz_decode_IS_DIV_10 = ((decode_INSTRUCTION & 32'h00001050) == 32'h00001050);
+  assign _zz__zz_decode_IS_DIV_11 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002050);
+  assign _zz__zz_decode_IS_DIV_12 = {_zz_decode_IS_DIV_4,((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_13) == 32'h00000004)};
+  assign _zz__zz_decode_IS_DIV_14 = (|((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_15) == 32'h00000040));
+  assign _zz__zz_decode_IS_DIV_16 = (|(_zz__zz_decode_IS_DIV_17 == _zz__zz_decode_IS_DIV_18));
+  assign _zz__zz_decode_IS_DIV_19 = {(|{_zz__zz_decode_IS_DIV_20,_zz__zz_decode_IS_DIV_21}),{(|_zz__zz_decode_IS_DIV_22),{_zz__zz_decode_IS_DIV_23,{_zz__zz_decode_IS_DIV_24,_zz__zz_decode_IS_DIV_26}}}};
+  assign _zz__zz_decode_IS_DIV_13 = 32'h0000001c;
+  assign _zz__zz_decode_IS_DIV_15 = 32'h00000058;
+  assign _zz__zz_decode_IS_DIV_17 = (decode_INSTRUCTION & 32'h02007054);
+  assign _zz__zz_decode_IS_DIV_18 = 32'h00005010;
+  assign _zz__zz_decode_IS_DIV_20 = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
+  assign _zz__zz_decode_IS_DIV_21 = ((decode_INSTRUCTION & 32'h02007054) == 32'h00001010);
+  assign _zz__zz_decode_IS_DIV_22 = ((decode_INSTRUCTION & 32'h00001000) == 32'h00001000);
+  assign _zz__zz_decode_IS_DIV_23 = (|_zz_decode_IS_DIV_10);
+  assign _zz__zz_decode_IS_DIV_24 = (|{_zz_decode_IS_DIV_9,_zz__zz_decode_IS_DIV_25});
+  assign _zz__zz_decode_IS_DIV_26 = {(|_zz_decode_IS_DIV_2),{(|_zz__zz_decode_IS_DIV_27),{_zz__zz_decode_IS_DIV_28,{_zz__zz_decode_IS_DIV_30,_zz__zz_decode_IS_DIV_39}}}};
+  assign _zz__zz_decode_IS_DIV_25 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00001000);
+  assign _zz__zz_decode_IS_DIV_27 = ((decode_INSTRUCTION & 32'h00004048) == 32'h00004008);
+  assign _zz__zz_decode_IS_DIV_28 = (|((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_29) == 32'h00000024));
+  assign _zz__zz_decode_IS_DIV_30 = (|{_zz__zz_decode_IS_DIV_31,{_zz__zz_decode_IS_DIV_32,_zz__zz_decode_IS_DIV_34}});
+  assign _zz__zz_decode_IS_DIV_39 = {(|_zz__zz_decode_IS_DIV_40),{(|_zz__zz_decode_IS_DIV_41),{_zz__zz_decode_IS_DIV_43,{_zz__zz_decode_IS_DIV_56,_zz__zz_decode_IS_DIV_65}}}};
+  assign _zz__zz_decode_IS_DIV_29 = 32'h00000064;
+  assign _zz__zz_decode_IS_DIV_31 = ((decode_INSTRUCTION & 32'h00000034) == 32'h00000020);
+  assign _zz__zz_decode_IS_DIV_32 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_33) == 32'h00000020);
+  assign _zz__zz_decode_IS_DIV_34 = {(_zz__zz_decode_IS_DIV_35 == _zz__zz_decode_IS_DIV_36),(_zz__zz_decode_IS_DIV_37 == _zz__zz_decode_IS_DIV_38)};
+  assign _zz__zz_decode_IS_DIV_40 = ((decode_INSTRUCTION & 32'h10000008) == 32'h00000008);
+  assign _zz__zz_decode_IS_DIV_41 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_42) == 32'h10000008);
+  assign _zz__zz_decode_IS_DIV_43 = (|{_zz__zz_decode_IS_DIV_44,{_zz__zz_decode_IS_DIV_46,_zz__zz_decode_IS_DIV_49}});
+  assign _zz__zz_decode_IS_DIV_56 = (|{_zz__zz_decode_IS_DIV_57,_zz__zz_decode_IS_DIV_60});
+  assign _zz__zz_decode_IS_DIV_65 = {(|_zz__zz_decode_IS_DIV_66),{_zz__zz_decode_IS_DIV_69,{_zz__zz_decode_IS_DIV_82,_zz__zz_decode_IS_DIV_98}}};
+  assign _zz__zz_decode_IS_DIV_33 = 32'h00000064;
+  assign _zz__zz_decode_IS_DIV_35 = (decode_INSTRUCTION & 32'h08000070);
+  assign _zz__zz_decode_IS_DIV_36 = 32'h08000020;
+  assign _zz__zz_decode_IS_DIV_37 = (decode_INSTRUCTION & 32'h10000070);
+  assign _zz__zz_decode_IS_DIV_38 = 32'h00000020;
+  assign _zz__zz_decode_IS_DIV_42 = 32'h10000008;
+  assign _zz__zz_decode_IS_DIV_44 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_45) == 32'h00002040);
+  assign _zz__zz_decode_IS_DIV_46 = (_zz__zz_decode_IS_DIV_47 == _zz__zz_decode_IS_DIV_48);
+  assign _zz__zz_decode_IS_DIV_49 = {_zz__zz_decode_IS_DIV_50,{_zz__zz_decode_IS_DIV_52,_zz__zz_decode_IS_DIV_53}};
+  assign _zz__zz_decode_IS_DIV_57 = (_zz__zz_decode_IS_DIV_58 == _zz__zz_decode_IS_DIV_59);
+  assign _zz__zz_decode_IS_DIV_60 = {_zz__zz_decode_IS_DIV_61,_zz__zz_decode_IS_DIV_63};
   assign _zz__zz_decode_IS_DIV_66 = (_zz__zz_decode_IS_DIV_67 == _zz__zz_decode_IS_DIV_68);
-  assign _zz__zz_decode_IS_DIV_71 = 32'h08000020;
-  assign _zz__zz_decode_IS_DIV_73 = (decode_INSTRUCTION & 32'h10000020);
-  assign _zz__zz_decode_IS_DIV_74 = 32'h00000020;
-  assign _zz__zz_decode_IS_DIV_76 = (decode_INSTRUCTION & 32'h00000028);
-  assign _zz__zz_decode_IS_DIV_77 = 32'h00000020;
-  assign _zz__zz_decode_IS_DIV_80 = 32'h00000010;
-  assign _zz__zz_decode_IS_DIV_83 = (_zz__zz_decode_IS_DIV_84 == _zz__zz_decode_IS_DIV_85);
-  assign _zz__zz_decode_IS_DIV_86 = {_zz__zz_decode_IS_DIV_87,{_zz__zz_decode_IS_DIV_89,_zz__zz_decode_IS_DIV_92}};
-  assign _zz__zz_decode_IS_DIV_96 = _zz_decode_IS_DIV_2;
-  assign _zz__zz_decode_IS_DIV_97 = {_zz__zz_decode_IS_DIV_98,{_zz__zz_decode_IS_DIV_100,_zz__zz_decode_IS_DIV_103}};
-  assign _zz__zz_decode_IS_DIV_112 = {_zz_decode_IS_DIV_5,_zz__zz_decode_IS_DIV_113};
-  assign _zz__zz_decode_IS_DIV_116 = (|{_zz__zz_decode_IS_DIV_117,_zz__zz_decode_IS_DIV_118});
-  assign _zz__zz_decode_IS_DIV_121 = (|_zz__zz_decode_IS_DIV_122);
-  assign _zz__zz_decode_IS_DIV_125 = {_zz__zz_decode_IS_DIV_126,{_zz__zz_decode_IS_DIV_129,_zz__zz_decode_IS_DIV_139}};
-  assign _zz__zz_decode_IS_DIV_67 = (decode_INSTRUCTION & 32'h02400040);
-  assign _zz__zz_decode_IS_DIV_68 = 32'h00000040;
-  assign _zz__zz_decode_IS_DIV_84 = (decode_INSTRUCTION & 32'h00002030);
-  assign _zz__zz_decode_IS_DIV_85 = 32'h00002010;
-  assign _zz__zz_decode_IS_DIV_87 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_88) == 32'h00000010);
-  assign _zz__zz_decode_IS_DIV_89 = (_zz__zz_decode_IS_DIV_90 == _zz__zz_decode_IS_DIV_91);
-  assign _zz__zz_decode_IS_DIV_92 = (_zz__zz_decode_IS_DIV_93 == _zz__zz_decode_IS_DIV_94);
-  assign _zz__zz_decode_IS_DIV_98 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_99) == 32'h00001010);
-  assign _zz__zz_decode_IS_DIV_100 = (_zz__zz_decode_IS_DIV_101 == _zz__zz_decode_IS_DIV_102);
-  assign _zz__zz_decode_IS_DIV_103 = {_zz__zz_decode_IS_DIV_104,{_zz__zz_decode_IS_DIV_106,_zz__zz_decode_IS_DIV_109}};
-  assign _zz__zz_decode_IS_DIV_113 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_114) == 32'h00000020);
-  assign _zz__zz_decode_IS_DIV_117 = _zz_decode_IS_DIV_5;
-  assign _zz__zz_decode_IS_DIV_118 = (_zz__zz_decode_IS_DIV_119 == _zz__zz_decode_IS_DIV_120);
-  assign _zz__zz_decode_IS_DIV_122 = (_zz__zz_decode_IS_DIV_123 == _zz__zz_decode_IS_DIV_124);
-  assign _zz__zz_decode_IS_DIV_126 = (|_zz__zz_decode_IS_DIV_127);
-  assign _zz__zz_decode_IS_DIV_129 = (|_zz__zz_decode_IS_DIV_130);
-  assign _zz__zz_decode_IS_DIV_139 = {_zz__zz_decode_IS_DIV_140,{_zz__zz_decode_IS_DIV_144,_zz__zz_decode_IS_DIV_150}};
-  assign _zz__zz_decode_IS_DIV_88 = 32'h00001030;
-  assign _zz__zz_decode_IS_DIV_90 = (decode_INSTRUCTION & 32'h02003020);
-  assign _zz__zz_decode_IS_DIV_91 = 32'h00000020;
-  assign _zz__zz_decode_IS_DIV_93 = (decode_INSTRUCTION & 32'h02002068);
-  assign _zz__zz_decode_IS_DIV_94 = 32'h00002020;
-  assign _zz__zz_decode_IS_DIV_99 = 32'h00001010;
-  assign _zz__zz_decode_IS_DIV_101 = (decode_INSTRUCTION & 32'h00002010);
-  assign _zz__zz_decode_IS_DIV_102 = 32'h00002010;
-  assign _zz__zz_decode_IS_DIV_104 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_105) == 32'h00002008);
-  assign _zz__zz_decode_IS_DIV_106 = (_zz__zz_decode_IS_DIV_107 == _zz__zz_decode_IS_DIV_108);
-  assign _zz__zz_decode_IS_DIV_109 = {_zz_decode_IS_DIV_6,_zz__zz_decode_IS_DIV_110};
-  assign _zz__zz_decode_IS_DIV_114 = 32'h00000070;
-  assign _zz__zz_decode_IS_DIV_119 = (decode_INSTRUCTION & 32'h00000020);
-  assign _zz__zz_decode_IS_DIV_120 = 32'h0;
-  assign _zz__zz_decode_IS_DIV_123 = (decode_INSTRUCTION & 32'h00004014);
-  assign _zz__zz_decode_IS_DIV_124 = 32'h00004010;
-  assign _zz__zz_decode_IS_DIV_127 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_128) == 32'h00002010);
-  assign _zz__zz_decode_IS_DIV_130 = {_zz__zz_decode_IS_DIV_131,{_zz__zz_decode_IS_DIV_132,_zz__zz_decode_IS_DIV_133}};
-  assign _zz__zz_decode_IS_DIV_140 = (|{_zz__zz_decode_IS_DIV_141,_zz__zz_decode_IS_DIV_142});
-  assign _zz__zz_decode_IS_DIV_144 = (|_zz__zz_decode_IS_DIV_145);
-  assign _zz__zz_decode_IS_DIV_150 = {_zz__zz_decode_IS_DIV_151,{_zz__zz_decode_IS_DIV_154,_zz__zz_decode_IS_DIV_157}};
-  assign _zz__zz_decode_IS_DIV_105 = 32'h00002008;
-  assign _zz__zz_decode_IS_DIV_107 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz__zz_decode_IS_DIV_108 = 32'h00000010;
-  assign _zz__zz_decode_IS_DIV_110 = ((decode_INSTRUCTION & 32'h00000028) == 32'h0);
-  assign _zz__zz_decode_IS_DIV_128 = 32'h00006014;
-  assign _zz__zz_decode_IS_DIV_131 = ((decode_INSTRUCTION & 32'h00000044) == 32'h0);
-  assign _zz__zz_decode_IS_DIV_132 = _zz_decode_IS_DIV_4;
-  assign _zz__zz_decode_IS_DIV_133 = {(_zz__zz_decode_IS_DIV_134 == _zz__zz_decode_IS_DIV_135),{_zz__zz_decode_IS_DIV_136,{_zz__zz_decode_IS_DIV_137,_zz__zz_decode_IS_DIV_138}}};
-  assign _zz__zz_decode_IS_DIV_141 = _zz_decode_IS_DIV_3;
-  assign _zz__zz_decode_IS_DIV_142 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_143) == 32'h0);
-  assign _zz__zz_decode_IS_DIV_145 = {(_zz__zz_decode_IS_DIV_146 == _zz__zz_decode_IS_DIV_147),{_zz__zz_decode_IS_DIV_148,_zz__zz_decode_IS_DIV_149}};
-  assign _zz__zz_decode_IS_DIV_151 = (|{_zz_decode_IS_DIV_2,{_zz__zz_decode_IS_DIV_152,_zz__zz_decode_IS_DIV_153}});
-  assign _zz__zz_decode_IS_DIV_154 = (|{_zz__zz_decode_IS_DIV_155,_zz__zz_decode_IS_DIV_156});
-  assign _zz__zz_decode_IS_DIV_157 = (|_zz__zz_decode_IS_DIV_158);
-  assign _zz__zz_decode_IS_DIV_134 = (decode_INSTRUCTION & 32'h00006004);
-  assign _zz__zz_decode_IS_DIV_135 = 32'h00002000;
-  assign _zz__zz_decode_IS_DIV_136 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
-  assign _zz__zz_decode_IS_DIV_137 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004000);
-  assign _zz__zz_decode_IS_DIV_138 = _zz_decode_IS_DIV_3;
-  assign _zz__zz_decode_IS_DIV_143 = 32'h00000058;
-  assign _zz__zz_decode_IS_DIV_146 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz__zz_decode_IS_DIV_147 = 32'h00000040;
-  assign _zz__zz_decode_IS_DIV_148 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00002010);
-  assign _zz__zz_decode_IS_DIV_149 = ((decode_INSTRUCTION & 32'h40000034) == 32'h40000030);
-  assign _zz__zz_decode_IS_DIV_152 = _zz_decode_IS_DIV_1;
-  assign _zz__zz_decode_IS_DIV_153 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00000004);
-  assign _zz__zz_decode_IS_DIV_155 = _zz_decode_IS_DIV_1;
-  assign _zz__zz_decode_IS_DIV_156 = ((decode_INSTRUCTION & 32'h0000004c) == 32'h00000004);
-  assign _zz__zz_decode_IS_DIV_158 = ((decode_INSTRUCTION & 32'h00005048) == 32'h00001008);
-  assign _zz_CsrPlugin_csrMapping_readDataInit_28 = 32'h0;
+  assign _zz__zz_decode_IS_DIV_69 = (|{_zz__zz_decode_IS_DIV_70,_zz__zz_decode_IS_DIV_71});
+  assign _zz__zz_decode_IS_DIV_82 = (|_zz__zz_decode_IS_DIV_83);
+  assign _zz__zz_decode_IS_DIV_98 = {_zz__zz_decode_IS_DIV_99,{_zz__zz_decode_IS_DIV_104,_zz__zz_decode_IS_DIV_108}};
+  assign _zz__zz_decode_IS_DIV_45 = 32'h00002040;
+  assign _zz__zz_decode_IS_DIV_47 = (decode_INSTRUCTION & 32'h00001040);
+  assign _zz__zz_decode_IS_DIV_48 = 32'h00001040;
+  assign _zz__zz_decode_IS_DIV_50 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_51) == 32'h00000040);
+  assign _zz__zz_decode_IS_DIV_52 = _zz_decode_IS_DIV_9;
+  assign _zz__zz_decode_IS_DIV_53 = {_zz_decode_IS_DIV_6,_zz__zz_decode_IS_DIV_54};
+  assign _zz__zz_decode_IS_DIV_58 = (decode_INSTRUCTION & 32'h08000020);
+  assign _zz__zz_decode_IS_DIV_59 = 32'h08000020;
+  assign _zz__zz_decode_IS_DIV_61 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_62) == 32'h00000020);
+  assign _zz__zz_decode_IS_DIV_63 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_64) == 32'h00000020);
+  assign _zz__zz_decode_IS_DIV_67 = (decode_INSTRUCTION & 32'h00000010);
+  assign _zz__zz_decode_IS_DIV_68 = 32'h00000010;
+  assign _zz__zz_decode_IS_DIV_70 = _zz_decode_IS_DIV_8;
+  assign _zz__zz_decode_IS_DIV_71 = {_zz__zz_decode_IS_DIV_72,{_zz__zz_decode_IS_DIV_74,_zz__zz_decode_IS_DIV_77}};
+  assign _zz__zz_decode_IS_DIV_83 = {_zz_decode_IS_DIV_4,{_zz__zz_decode_IS_DIV_84,_zz__zz_decode_IS_DIV_87}};
+  assign _zz__zz_decode_IS_DIV_99 = (|{_zz__zz_decode_IS_DIV_100,_zz__zz_decode_IS_DIV_101});
+  assign _zz__zz_decode_IS_DIV_104 = (|_zz__zz_decode_IS_DIV_105);
+  assign _zz__zz_decode_IS_DIV_108 = {_zz__zz_decode_IS_DIV_109,{_zz__zz_decode_IS_DIV_112,_zz__zz_decode_IS_DIV_116}};
+  assign _zz__zz_decode_IS_DIV_51 = 32'h00000050;
+  assign _zz__zz_decode_IS_DIV_54 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_55) == 32'h00000040);
+  assign _zz__zz_decode_IS_DIV_62 = 32'h10000020;
+  assign _zz__zz_decode_IS_DIV_64 = 32'h00000028;
+  assign _zz__zz_decode_IS_DIV_72 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_73) == 32'h00002010);
+  assign _zz__zz_decode_IS_DIV_74 = (_zz__zz_decode_IS_DIV_75 == _zz__zz_decode_IS_DIV_76);
+  assign _zz__zz_decode_IS_DIV_77 = {_zz__zz_decode_IS_DIV_78,_zz__zz_decode_IS_DIV_80};
+  assign _zz__zz_decode_IS_DIV_84 = (_zz__zz_decode_IS_DIV_85 == _zz__zz_decode_IS_DIV_86);
+  assign _zz__zz_decode_IS_DIV_87 = {_zz__zz_decode_IS_DIV_88,{_zz__zz_decode_IS_DIV_90,_zz__zz_decode_IS_DIV_93}};
+  assign _zz__zz_decode_IS_DIV_100 = _zz_decode_IS_DIV_7;
+  assign _zz__zz_decode_IS_DIV_101 = (_zz__zz_decode_IS_DIV_102 == _zz__zz_decode_IS_DIV_103);
+  assign _zz__zz_decode_IS_DIV_105 = {_zz_decode_IS_DIV_7,_zz__zz_decode_IS_DIV_106};
+  assign _zz__zz_decode_IS_DIV_109 = (|_zz__zz_decode_IS_DIV_110);
+  assign _zz__zz_decode_IS_DIV_112 = (|_zz__zz_decode_IS_DIV_113);
+  assign _zz__zz_decode_IS_DIV_116 = {_zz__zz_decode_IS_DIV_117,{_zz__zz_decode_IS_DIV_128,_zz__zz_decode_IS_DIV_132}};
+  assign _zz__zz_decode_IS_DIV_55 = 32'h02400040;
+  assign _zz__zz_decode_IS_DIV_73 = 32'h00002030;
+  assign _zz__zz_decode_IS_DIV_75 = (decode_INSTRUCTION & 32'h00001030);
+  assign _zz__zz_decode_IS_DIV_76 = 32'h00000010;
+  assign _zz__zz_decode_IS_DIV_78 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_79) == 32'h00000020);
+  assign _zz__zz_decode_IS_DIV_80 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_81) == 32'h00002020);
+  assign _zz__zz_decode_IS_DIV_85 = (decode_INSTRUCTION & 32'h00001010);
+  assign _zz__zz_decode_IS_DIV_86 = 32'h00001010;
+  assign _zz__zz_decode_IS_DIV_88 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_89) == 32'h00002010);
+  assign _zz__zz_decode_IS_DIV_90 = (_zz__zz_decode_IS_DIV_91 == _zz__zz_decode_IS_DIV_92);
+  assign _zz__zz_decode_IS_DIV_93 = {_zz__zz_decode_IS_DIV_94,{_zz__zz_decode_IS_DIV_95,_zz__zz_decode_IS_DIV_96}};
+  assign _zz__zz_decode_IS_DIV_102 = (decode_INSTRUCTION & 32'h00000070);
+  assign _zz__zz_decode_IS_DIV_103 = 32'h00000020;
+  assign _zz__zz_decode_IS_DIV_106 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_107) == 32'h00000000);
+  assign _zz__zz_decode_IS_DIV_110 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_111) == 32'h00004010);
+  assign _zz__zz_decode_IS_DIV_113 = (_zz__zz_decode_IS_DIV_114 == _zz__zz_decode_IS_DIV_115);
+  assign _zz__zz_decode_IS_DIV_117 = (|{_zz__zz_decode_IS_DIV_118,_zz__zz_decode_IS_DIV_120});
+  assign _zz__zz_decode_IS_DIV_128 = (|_zz__zz_decode_IS_DIV_129);
+  assign _zz__zz_decode_IS_DIV_132 = {_zz__zz_decode_IS_DIV_133,{_zz__zz_decode_IS_DIV_142,_zz__zz_decode_IS_DIV_146}};
+  assign _zz__zz_decode_IS_DIV_79 = 32'h02003020;
+  assign _zz__zz_decode_IS_DIV_81 = 32'h02002068;
+  assign _zz__zz_decode_IS_DIV_89 = 32'h00002010;
+  assign _zz__zz_decode_IS_DIV_91 = (decode_INSTRUCTION & 32'h00002008);
+  assign _zz__zz_decode_IS_DIV_92 = 32'h00002008;
+  assign _zz__zz_decode_IS_DIV_94 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000010);
+  assign _zz__zz_decode_IS_DIV_95 = _zz_decode_IS_DIV_8;
+  assign _zz__zz_decode_IS_DIV_96 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_97) == 32'h00000000);
+  assign _zz__zz_decode_IS_DIV_107 = 32'h00000020;
+  assign _zz__zz_decode_IS_DIV_111 = 32'h00004014;
+  assign _zz__zz_decode_IS_DIV_114 = (decode_INSTRUCTION & 32'h00006014);
+  assign _zz__zz_decode_IS_DIV_115 = 32'h00002010;
+  assign _zz__zz_decode_IS_DIV_118 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_119) == 32'h00000000);
+  assign _zz__zz_decode_IS_DIV_120 = {_zz_decode_IS_DIV_6,{_zz__zz_decode_IS_DIV_121,{_zz__zz_decode_IS_DIV_123,_zz__zz_decode_IS_DIV_126}}};
+  assign _zz__zz_decode_IS_DIV_129 = {_zz_decode_IS_DIV_5,(_zz__zz_decode_IS_DIV_130 == _zz__zz_decode_IS_DIV_131)};
+  assign _zz__zz_decode_IS_DIV_133 = (|{_zz__zz_decode_IS_DIV_134,{_zz__zz_decode_IS_DIV_136,_zz__zz_decode_IS_DIV_139}});
+  assign _zz__zz_decode_IS_DIV_142 = (|{_zz__zz_decode_IS_DIV_143,_zz__zz_decode_IS_DIV_144});
+  assign _zz__zz_decode_IS_DIV_146 = {(|_zz__zz_decode_IS_DIV_147),{_zz__zz_decode_IS_DIV_149,_zz__zz_decode_IS_DIV_152}};
+  assign _zz__zz_decode_IS_DIV_97 = 32'h00000028;
+  assign _zz__zz_decode_IS_DIV_119 = 32'h00000044;
+  assign _zz__zz_decode_IS_DIV_121 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_122) == 32'h00002000);
+  assign _zz__zz_decode_IS_DIV_123 = (_zz__zz_decode_IS_DIV_124 == _zz__zz_decode_IS_DIV_125);
+  assign _zz__zz_decode_IS_DIV_126 = {_zz__zz_decode_IS_DIV_127,_zz_decode_IS_DIV_5};
+  assign _zz__zz_decode_IS_DIV_130 = (decode_INSTRUCTION & 32'h00000058);
+  assign _zz__zz_decode_IS_DIV_131 = 32'h00000000;
+  assign _zz__zz_decode_IS_DIV_134 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_135) == 32'h00000040);
+  assign _zz__zz_decode_IS_DIV_136 = (_zz__zz_decode_IS_DIV_137 == _zz__zz_decode_IS_DIV_138);
+  assign _zz__zz_decode_IS_DIV_139 = (_zz__zz_decode_IS_DIV_140 == _zz__zz_decode_IS_DIV_141);
+  assign _zz__zz_decode_IS_DIV_143 = _zz_decode_IS_DIV_4;
+  assign _zz__zz_decode_IS_DIV_144 = {_zz_decode_IS_DIV_3,_zz__zz_decode_IS_DIV_145};
+  assign _zz__zz_decode_IS_DIV_147 = {_zz_decode_IS_DIV_3,_zz__zz_decode_IS_DIV_148};
+  assign _zz__zz_decode_IS_DIV_149 = (|{_zz__zz_decode_IS_DIV_150,_zz__zz_decode_IS_DIV_151});
+  assign _zz__zz_decode_IS_DIV_152 = (|_zz_decode_IS_DIV_1);
+  assign _zz__zz_decode_IS_DIV_122 = 32'h00006004;
+  assign _zz__zz_decode_IS_DIV_124 = (decode_INSTRUCTION & 32'h00005004);
+  assign _zz__zz_decode_IS_DIV_125 = 32'h00001000;
+  assign _zz__zz_decode_IS_DIV_127 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004000);
+  assign _zz__zz_decode_IS_DIV_135 = 32'h00000044;
+  assign _zz__zz_decode_IS_DIV_137 = (decode_INSTRUCTION & 32'h00002014);
+  assign _zz__zz_decode_IS_DIV_138 = 32'h00002010;
+  assign _zz__zz_decode_IS_DIV_140 = (decode_INSTRUCTION & 32'h40000034);
+  assign _zz__zz_decode_IS_DIV_141 = 32'h40000030;
+  assign _zz__zz_decode_IS_DIV_145 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00000004);
+  assign _zz__zz_decode_IS_DIV_148 = ((decode_INSTRUCTION & 32'h0000004c) == 32'h00000004);
+  assign _zz__zz_decode_IS_DIV_150 = _zz_decode_IS_DIV_1;
+  assign _zz__zz_decode_IS_DIV_151 = _zz_decode_IS_DIV_2;
+  assign _zz_CsrPlugin_csrMapping_readDataInit_26 = 32'h00000000;
   always @(posedge clk) begin
     if(_zz_decode_RegFilePlugin_rs1Data) begin
       _zz_RegFilePlugin_regFile_port0 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
@@ -2113,8 +2116,9 @@ module VexRiscv (
     .io_cpu_flush_ready                     (dataCache_1_io_cpu_flush_ready                   ), //o
     .io_cpu_flush_payload_singleLine        (dataCache_1_io_cpu_flush_payload_singleLine      ), //i
     .io_cpu_flush_payload_lineId            (dataCache_1_io_cpu_flush_payload_lineId[6:0]     ), //i
+    .io_cpu_writesPending                   (dataCache_1_io_cpu_writesPending                 ), //o
     .io_mem_cmd_valid                       (dataCache_1_io_mem_cmd_valid                     ), //o
-    .io_mem_cmd_ready                       (dataCache_1_io_mem_cmd_ready                     ), //i
+    .io_mem_cmd_ready                       (toplevel_dataCache_1_io_mem_cmd_rValidN          ), //i
     .io_mem_cmd_payload_wr                  (dataCache_1_io_mem_cmd_payload_wr                ), //o
     .io_mem_cmd_payload_uncached            (dataCache_1_io_mem_cmd_payload_uncached          ), //o
     .io_mem_cmd_payload_address             (dataCache_1_io_mem_cmd_payload_address[31:0]     ), //o
@@ -2973,7 +2977,7 @@ module VexRiscv (
   assign memory_MEMORY_STORE_DATA_RF = execute_to_memory_MEMORY_STORE_DATA_RF;
   assign execute_MEMORY_STORE_DATA_RF = _zz_execute_MEMORY_STORE_DATA_RF;
   assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
-  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
+  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h00)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h00))));
   assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
   assign decode_IS_DIV = _zz_decode_IS_DIV[35];
   assign decode_IS_RS2_SIGNED = _zz_decode_IS_DIV[34];
@@ -2992,21 +2996,21 @@ module VexRiscv (
   assign decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL;
   assign _zz_decode_to_execute_ALU_BITWISE_CTRL = _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   assign decode_SRC_LESS_UNSIGNED = _zz_decode_IS_DIV[22];
-  assign decode_IS_SFENCE_VMA = _zz_decode_IS_DIV[21];
-  assign decode_IS_SFENCE_VMA2 = _zz_decode_IS_DIV[20];
-  assign decode_MEMORY_MANAGMENT = _zz_decode_IS_DIV[19];
+  assign decode_IS_SFENCE_VMA2 = _zz_decode_IS_DIV[21];
+  assign decode_MEMORY_MANAGMENT = _zz_decode_IS_DIV[20];
   assign memory_MEMORY_LRSC = execute_to_memory_MEMORY_LRSC;
   assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
-  assign decode_MEMORY_WR = _zz_decode_IS_DIV[13];
+  assign decode_MEMORY_WR = _zz_decode_IS_DIV[14];
   assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_decode_IS_DIV[12];
-  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_decode_IS_DIV[11];
+  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_decode_IS_DIV[13];
+  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_decode_IS_DIV[12];
   assign decode_SRC2_CTRL = _zz_decode_SRC2_CTRL;
   assign _zz_decode_to_execute_SRC2_CTRL = _zz_decode_to_execute_SRC2_CTRL_1;
   assign decode_ALU_CTRL = _zz_decode_ALU_CTRL;
   assign _zz_decode_to_execute_ALU_CTRL = _zz_decode_to_execute_ALU_CTRL_1;
   assign decode_SRC1_CTRL = _zz_decode_SRC1_CTRL;
   assign _zz_decode_to_execute_SRC1_CTRL = _zz_decode_to_execute_SRC1_CTRL_1;
+  assign decode_RESCHEDULE_NEXT = _zz_decode_IS_DIV[1];
   assign decode_MEMORY_FORCE_CONSTISTENCY = _zz_decode_MEMORY_FORCE_CONSTISTENCY;
   assign writeBack_FORMAL_PC_NEXT = memory_to_writeBack_FORMAL_PC_NEXT;
   assign memory_FORMAL_PC_NEXT = execute_to_memory_FORMAL_PC_NEXT;
@@ -3025,16 +3029,16 @@ module VexRiscv (
   assign memory_ENV_CTRL = _zz_memory_ENV_CTRL;
   assign execute_ENV_CTRL = _zz_execute_ENV_CTRL;
   assign writeBack_ENV_CTRL = _zz_writeBack_ENV_CTRL;
-  assign execute_IS_SFENCE_VMA = decode_to_execute_IS_SFENCE_VMA;
+  assign execute_RESCHEDULE_NEXT = decode_to_execute_RESCHEDULE_NEXT;
   assign memory_BRANCH_CALC = execute_to_memory_BRANCH_CALC;
   assign memory_BRANCH_DO = execute_to_memory_BRANCH_DO;
   assign execute_PC = decode_to_execute_PC;
   assign execute_BRANCH_CTRL = _zz_execute_BRANCH_CTRL;
-  assign decode_RS2_USE = _zz_decode_IS_DIV[17];
-  assign decode_RS1_USE = _zz_decode_IS_DIV[5];
+  assign decode_RS2_USE = _zz_decode_IS_DIV[18];
+  assign decode_RS1_USE = _zz_decode_IS_DIV[6];
   always @(*) begin
     _zz_decode_RS2 = execute_REGFILE_WRITE_DATA;
-    if(when_CsrPlugin_l1189) begin
+    if(when_CsrPlugin_l1587) begin
       _zz_decode_RS2 = CsrPlugin_csrMapping_readDataSignal;
     end
     if(DBusCachedPlugin_forceDatapath) begin
@@ -3136,15 +3140,15 @@ module VexRiscv (
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_execute_SRC2 = execute_PC;
+  assign _zz_execute_to_memory_PC = execute_PC;
   assign execute_SRC2_CTRL = _zz_execute_SRC2_CTRL;
   assign execute_SRC1_CTRL = _zz_execute_SRC1_CTRL;
-  assign decode_SRC_USE_SUB_LESS = _zz_decode_IS_DIV[3];
-  assign decode_SRC_ADD_ZERO = _zz_decode_IS_DIV[18];
+  assign decode_SRC_USE_SUB_LESS = _zz_decode_IS_DIV[4];
+  assign decode_SRC_ADD_ZERO = _zz_decode_IS_DIV[19];
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
   assign execute_ALU_CTRL = _zz_execute_ALU_CTRL;
-  assign execute_SRC2 = _zz_execute_SRC2_5;
+  assign execute_SRC2 = _zz_execute_SRC2_4;
   assign execute_SRC1 = _zz_execute_SRC1;
   assign execute_ALU_BITWISE_CTRL = _zz_execute_ALU_BITWISE_CTRL;
   assign _zz_lastStageRegFileWrite_payload_address = writeBack_INSTRUCTION;
@@ -3158,19 +3162,19 @@ module VexRiscv (
 
   assign decode_INSTRUCTION_ANTICIPATED = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusCachedPlugin_cache_io_cpu_fetch_data);
   always @(*) begin
-    decode_REGFILE_WRITE_VALID = _zz_decode_IS_DIV[10];
+    decode_REGFILE_WRITE_VALID = _zz_decode_IS_DIV[11];
     if(when_RegFilePlugin_l63) begin
       decode_REGFILE_WRITE_VALID = 1'b0;
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00001073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
+  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000107f) == 32'h00001073),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00002073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
   assign execute_IS_SFENCE_VMA2 = decode_to_execute_IS_SFENCE_VMA2;
   assign writeBack_IS_DBUS_SHARING = memory_to_writeBack_IS_DBUS_SHARING;
   assign memory_IS_DBUS_SHARING = execute_to_memory_IS_DBUS_SHARING;
   always @(*) begin
     _zz_decode_RS2_2 = writeBack_REGFILE_WRITE_DATA;
-    if(when_DBusCachedPlugin_l492) begin
+    if(when_DBusCachedPlugin_l580) begin
       _zz_decode_RS2_2 = writeBack_DBusCachedPlugin_rspFormated;
     end
   end
@@ -3185,7 +3189,7 @@ module VexRiscv (
   always @(*) begin
     execute_MEMORY_AMO = decode_to_execute_MEMORY_AMO;
     if(MmuPlugin_dBusAccess_cmd_valid) begin
-      if(when_DBusCachedPlugin_l506) begin
+      if(when_DBusCachedPlugin_l604) begin
         execute_MEMORY_AMO = 1'b0;
       end
     end
@@ -3194,7 +3198,7 @@ module VexRiscv (
   always @(*) begin
     execute_MEMORY_LRSC = decode_to_execute_MEMORY_LRSC;
     if(MmuPlugin_dBusAccess_cmd_valid) begin
-      if(when_DBusCachedPlugin_l506) begin
+      if(when_DBusCachedPlugin_l604) begin
         execute_MEMORY_LRSC = 1'b0;
       end
     end
@@ -3208,34 +3212,34 @@ module VexRiscv (
   assign execute_SRC_ADD = execute_SrcPlugin_addSub;
   assign execute_MEMORY_ENABLE = decode_to_execute_MEMORY_ENABLE;
   assign execute_INSTRUCTION = decode_to_execute_INSTRUCTION;
-  assign decode_MEMORY_AMO = _zz_decode_IS_DIV[16];
-  assign decode_MEMORY_LRSC = _zz_decode_IS_DIV[15];
-  assign decode_MEMORY_ENABLE = _zz_decode_IS_DIV[4];
+  assign decode_MEMORY_AMO = _zz_decode_IS_DIV[17];
+  assign decode_MEMORY_LRSC = _zz_decode_IS_DIV[16];
+  assign decode_MEMORY_ENABLE = _zz_decode_IS_DIV[5];
   assign decode_FLUSH_ALL = _zz_decode_IS_DIV[0];
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_4 = IBusCachedPlugin_rsp_issueDetected_3;
-    if(when_IBusCachedPlugin_l256) begin
+    if(when_IBusCachedPlugin_l262) begin
       IBusCachedPlugin_rsp_issueDetected_4 = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_3 = IBusCachedPlugin_rsp_issueDetected_2;
-    if(when_IBusCachedPlugin_l250) begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_rsp_issueDetected_3 = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
-    if(when_IBusCachedPlugin_l244) begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
-    if(when_IBusCachedPlugin_l239) begin
+    if(when_IBusCachedPlugin_l245) begin
       IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
@@ -3260,7 +3264,7 @@ module VexRiscv (
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
   always @(*) begin
     decode_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l308) begin
+    if(when_DBusCachedPlugin_l352) begin
       decode_arbitration_haltItself = 1'b1;
     end
   end
@@ -3279,7 +3283,7 @@ module VexRiscv (
     if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(when_CsrPlugin_l1129) begin
+    if(when_CsrPlugin_l1527) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
@@ -3304,15 +3308,15 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l350) begin
+    if(when_DBusCachedPlugin_l394) begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(when_CsrPlugin_l1121) begin
-      if(when_CsrPlugin_l1123) begin
+    if(when_CsrPlugin_l1519) begin
+      if(when_CsrPlugin_l1521) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(when_CsrPlugin_l1193) begin
+    if(when_CsrPlugin_l1591) begin
       if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
@@ -3321,7 +3325,7 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if(when_DBusCachedPlugin_l366) begin
+    if(when_DBusCachedPlugin_l410) begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
@@ -3388,7 +3392,7 @@ module VexRiscv (
 
   always @(*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l466) begin
+    if(when_DBusCachedPlugin_l553) begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
@@ -3419,10 +3423,10 @@ module VexRiscv (
     if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -3433,13 +3437,13 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @(*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(when_CsrPlugin_l935) begin
+    if(when_CsrPlugin_l1272) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
@@ -3447,17 +3451,27 @@ module VexRiscv (
   assign IBusCachedPlugin_forceNoDecodeCond = 1'b0;
   always @(*) begin
     IBusCachedPlugin_incomingInstruction = 1'b0;
-    if(when_Fetcher_l243) begin
+    if(when_Fetcher_l242) begin
       IBusCachedPlugin_incomingInstruction = 1'b1;
     end
   end
 
   assign BranchPlugin_inDebugNoFetchFlag = 1'b0;
-  assign CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+  always @(*) begin
+    CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+    if(when_CsrPlugin_l1702) begin
+      CsrPlugin_csrMapping_allowCsrSignal = 1'b1;
+    end
+    if(when_CsrPlugin_l1709) begin
+      CsrPlugin_csrMapping_allowCsrSignal = 1'b1;
+    end
+  end
+
+  assign CsrPlugin_csrMapping_doForceFailCsr = 1'b0;
   assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
   always @(*) begin
     CsrPlugin_inWfi = 1'b0;
-    if(when_CsrPlugin_l1121) begin
+    if(when_CsrPlugin_l1519) begin
       CsrPlugin_inWfi = 1'b1;
     end
   end
@@ -3465,21 +3479,21 @@ module VexRiscv (
   assign CsrPlugin_thirdPartyWake = 1'b0;
   always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(when_CsrPlugin_l1077) begin
-      case(switch_CsrPlugin_l1081)
+    if(when_CsrPlugin_l1456) begin
+      case(switch_CsrPlugin_l1460)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -3496,6 +3510,24 @@ module VexRiscv (
   assign CsrPlugin_allowInterrupts = 1'b1;
   assign CsrPlugin_allowException = 1'b1;
   assign CsrPlugin_allowEbreakException = 1'b1;
+  always @(*) begin
+    CsrPlugin_xretAwayFromMachine = 1'b0;
+    if(when_CsrPlugin_l1456) begin
+      case(switch_CsrPlugin_l1460)
+        2'b11 : begin
+          if(when_CsrPlugin_l1468) begin
+            CsrPlugin_xretAwayFromMachine = 1'b1;
+          end
+        end
+        2'b01 : begin
+          CsrPlugin_xretAwayFromMachine = 1'b1;
+        end
+        default : begin
+        end
+      endcase
+    end
+  end
+
   assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
   assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_redoInterface_valid,{CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}} != 4'b0000);
   assign _zz_IBusCachedPlugin_jump_pcLoad_payload = {CsrPlugin_redoInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
@@ -3523,9 +3555,8 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l134 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
-  assign IBusCachedPlugin_fetchPc_output_fire_1 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
-  assign when_Fetcher_l134_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
+  assign when_Fetcher_l133 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l133_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
   always @(*) begin
     IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_IBusCachedPlugin_fetchPc_pc);
     if(IBusCachedPlugin_fetchPc_redo_valid) begin
@@ -3548,7 +3579,7 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l161 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
+  assign when_Fetcher_l160 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
   assign IBusCachedPlugin_fetchPc_output_valid = ((! IBusCachedPlugin_fetcherHalt) && IBusCachedPlugin_fetchPc_booted);
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
   always @(*) begin
@@ -3590,7 +3621,7 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_2_output_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_3_halt = 1'b0;
-    if(when_IBusCachedPlugin_l267) begin
+    if(when_IBusCachedPlugin_l273) begin
       IBusCachedPlugin_iBusRsp_stages_3_halt = 1'b1;
     end
   end
@@ -3603,9 +3634,9 @@ module VexRiscv (
   assign IBusCachedPlugin_fetchPc_redo_payload = IBusCachedPlugin_iBusRsp_stages_3_input_payload;
   assign IBusCachedPlugin_iBusRsp_flush = ((decode_arbitration_removeIt || (decode_arbitration_flushNext && (! decode_arbitration_isStuck))) || IBusCachedPlugin_iBusRsp_redoFetch);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
-  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1 = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
   assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid)) || IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready);
   assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
@@ -3621,19 +3652,19 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_3_input_payload = IBusCachedPlugin_iBusRsp_stages_2_output_m2sPipe_payload;
   always @(*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
-    if(when_Fetcher_l323) begin
+    if(when_Fetcher_l322) begin
       IBusCachedPlugin_iBusRsp_readyForError = 1'b0;
     end
   end
 
-  assign when_Fetcher_l243 = ((IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid) || IBusCachedPlugin_iBusRsp_stages_3_input_valid);
-  assign when_Fetcher_l323 = (! IBusCachedPlugin_pcValids_0);
-  assign when_Fetcher_l332 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
-  assign when_Fetcher_l332_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
-  assign when_Fetcher_l332_2 = (! (! IBusCachedPlugin_iBusRsp_stages_3_input_ready));
-  assign when_Fetcher_l332_3 = (! execute_arbitration_isStuck);
-  assign when_Fetcher_l332_4 = (! memory_arbitration_isStuck);
-  assign when_Fetcher_l332_5 = (! writeBack_arbitration_isStuck);
+  assign when_Fetcher_l242 = ((IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid) || IBusCachedPlugin_iBusRsp_stages_3_input_valid);
+  assign when_Fetcher_l322 = (! IBusCachedPlugin_pcValids_0);
+  assign when_Fetcher_l331 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l331_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
+  assign when_Fetcher_l331_2 = (! (! IBusCachedPlugin_iBusRsp_stages_3_input_ready));
+  assign when_Fetcher_l331_3 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l331_4 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l331_5 = (! writeBack_arbitration_isStuck);
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_4;
@@ -3669,90 +3700,89 @@ module VexRiscv (
   assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
   always @(*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(when_IBusCachedPlugin_l239) begin
+    if(when_IBusCachedPlugin_l245) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(when_IBusCachedPlugin_l250) begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_cache_io_cpu_fill_valid = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
-    if(when_IBusCachedPlugin_l250) begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_cache_io_cpu_fill_valid = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_valid = 1'b0;
-    if(when_IBusCachedPlugin_l244) begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
-    if(when_IBusCachedPlugin_l256) begin
+    if(when_IBusCachedPlugin_l262) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_payload_code = 4'bxxxx;
-    if(when_IBusCachedPlugin_l244) begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b1100;
     end
-    if(when_IBusCachedPlugin_l256) begin
+    if(when_IBusCachedPlugin_l262) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b0001;
     end
   end
 
   assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_3_input_payload[31 : 2],2'b00};
-  assign when_IBusCachedPlugin_l239 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign when_IBusCachedPlugin_l244 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
-  assign when_IBusCachedPlugin_l250 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
-  assign when_IBusCachedPlugin_l256 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
-  assign when_IBusCachedPlugin_l267 = (IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt);
+  assign when_IBusCachedPlugin_l245 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign when_IBusCachedPlugin_l250 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign when_IBusCachedPlugin_l256 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
+  assign when_IBusCachedPlugin_l262 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
+  assign when_IBusCachedPlugin_l273 = (IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt);
   assign IBusCachedPlugin_iBusRsp_output_valid = IBusCachedPlugin_iBusRsp_stages_3_output_valid;
   assign IBusCachedPlugin_iBusRsp_stages_3_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
   assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_decode_data;
   assign IBusCachedPlugin_iBusRsp_output_payload_pc = IBusCachedPlugin_iBusRsp_stages_3_output_payload;
   assign IBusCachedPlugin_cache_io_flush = (decode_arbitration_isValid && decode_FLUSH_ALL);
-  assign dataCache_1_io_mem_cmd_ready = (! dataCache_1_io_mem_cmd_rValid);
-  assign dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || dataCache_1_io_mem_cmd_rValid);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_wr : dataCache_1_io_mem_cmd_payload_wr);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_uncached : dataCache_1_io_mem_cmd_payload_uncached);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_address = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_address : dataCache_1_io_mem_cmd_payload_address);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_data = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_data : dataCache_1_io_mem_cmd_payload_data);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_mask : dataCache_1_io_mem_cmd_payload_mask);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_size = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_size : dataCache_1_io_mem_cmd_payload_size);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_last : dataCache_1_io_mem_cmd_payload_last);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || (! toplevel_dataCache_1_io_mem_cmd_rValidN));
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_wr : toplevel_dataCache_1_io_mem_cmd_rData_wr);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_uncached : toplevel_dataCache_1_io_mem_cmd_rData_uncached);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_address = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_address : toplevel_dataCache_1_io_mem_cmd_rData_address);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_data = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_data : toplevel_dataCache_1_io_mem_cmd_rData_data);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_mask : toplevel_dataCache_1_io_mem_cmd_rData_mask);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_size = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_size : toplevel_dataCache_1_io_mem_cmd_rData_size);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_last = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_last : toplevel_dataCache_1_io_mem_cmd_rData_last);
   always @(*) begin
-    dataCache_1_io_mem_cmd_s2mPipe_ready = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
-    if(when_Stream_l368) begin
-      dataCache_1_io_mem_cmd_s2mPipe_ready = 1'b1;
+    toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
+    if(when_Stream_l369) begin
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l368 = (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_rValid;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_rData_address;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_rData_data;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size = dataCache_1_io_mem_cmd_s2mPipe_rData_size;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_rData_last;
-  assign dBus_cmd_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
-  assign dBus_cmd_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
-  assign dBus_cmd_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
-  assign dBus_cmd_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
-  assign dBus_cmd_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
-  assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  assign dBus_cmd_payload_size = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
-  assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  assign when_DBusCachedPlugin_l308 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
+  assign when_Stream_l369 = (! toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_address;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_data;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_size;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  assign dBus_cmd_valid = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
+  assign dBus_cmd_payload_wr = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
+  assign dBus_cmd_payload_uncached = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
+  assign dBus_cmd_payload_address = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
+  assign dBus_cmd_payload_data = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
+  assign dBus_cmd_payload_mask = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
+  assign dBus_cmd_payload_size = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
+  assign dBus_cmd_payload_last = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  assign when_DBusCachedPlugin_l352 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
   always @(*) begin
     _zz_decode_MEMORY_FORCE_CONSTISTENCY = 1'b0;
-    if(when_DBusCachedPlugin_l316) begin
+    if(when_DBusCachedPlugin_l360) begin
       if(decode_MEMORY_LRSC) begin
         _zz_decode_MEMORY_FORCE_CONSTISTENCY = 1'b1;
       end
@@ -3762,13 +3792,13 @@ module VexRiscv (
     end
   end
 
-  assign when_DBusCachedPlugin_l316 = decode_INSTRUCTION[25];
+  assign when_DBusCachedPlugin_l360 = decode_INSTRUCTION[25];
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
   always @(*) begin
     dataCache_1_io_cpu_execute_isValid = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
     if(MmuPlugin_dBusAccess_cmd_valid) begin
-      if(when_DBusCachedPlugin_l506) begin
-        if(when_DBusCachedPlugin_l507) begin
+      if(when_DBusCachedPlugin_l604) begin
+        if(when_DBusCachedPlugin_l605) begin
           dataCache_1_io_cpu_execute_isValid = 1'b1;
         end
       end
@@ -3778,7 +3808,7 @@ module VexRiscv (
   always @(*) begin
     dataCache_1_io_cpu_execute_address = execute_SRC_ADD;
     if(MmuPlugin_dBusAccess_cmd_valid) begin
-      if(when_DBusCachedPlugin_l506) begin
+      if(when_DBusCachedPlugin_l604) begin
         dataCache_1_io_cpu_execute_address = MmuPlugin_dBusAccess_cmd_payload_address;
       end
     end
@@ -3787,7 +3817,7 @@ module VexRiscv (
   always @(*) begin
     dataCache_1_io_cpu_execute_args_wr = execute_MEMORY_WR;
     if(MmuPlugin_dBusAccess_cmd_valid) begin
-      if(when_DBusCachedPlugin_l506) begin
+      if(when_DBusCachedPlugin_l604) begin
         dataCache_1_io_cpu_execute_args_wr = 1'b0;
       end
     end
@@ -3810,17 +3840,17 @@ module VexRiscv (
   always @(*) begin
     dataCache_1_io_cpu_execute_args_size = execute_DBusCachedPlugin_size;
     if(MmuPlugin_dBusAccess_cmd_valid) begin
-      if(when_DBusCachedPlugin_l506) begin
+      if(when_DBusCachedPlugin_l604) begin
         dataCache_1_io_cpu_execute_args_size = MmuPlugin_dBusAccess_cmd_payload_size;
       end
     end
   end
 
   assign dataCache_1_io_cpu_flush_valid = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
-  assign dataCache_1_io_cpu_flush_payload_singleLine = (execute_INSTRUCTION[19 : 15] != 5'h0);
+  assign dataCache_1_io_cpu_flush_payload_singleLine = (execute_INSTRUCTION[19 : 15] != 5'h00);
   assign dataCache_1_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId[6:0];
-  assign dataCache_1_io_cpu_flush_isStall = (dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready));
-  assign when_DBusCachedPlugin_l350 = (dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
+  assign toplevel_dataCache_1_io_cpu_flush_isStall = (dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready));
+  assign when_DBusCachedPlugin_l394 = (toplevel_dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
   always @(*) begin
     dataCache_1_io_cpu_execute_args_isLrsc = 1'b0;
     if(execute_MEMORY_LRSC) begin
@@ -3830,7 +3860,7 @@ module VexRiscv (
 
   assign dataCache_1_io_cpu_execute_args_amoCtrl_alu = execute_INSTRUCTION[31 : 29];
   assign dataCache_1_io_cpu_execute_args_amoCtrl_swap = execute_INSTRUCTION[27];
-  assign when_DBusCachedPlugin_l366 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
+  assign when_DBusCachedPlugin_l410 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
   always @(*) begin
     dataCache_1_io_cpu_memory_isValid = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
     if(memory_IS_DBUS_SHARING) begin
@@ -3852,12 +3882,12 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
   always @(*) begin
     dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if(when_DBusCachedPlugin_l393) begin
+    if(when_DBusCachedPlugin_l472) begin
       dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = 1'b1;
     end
   end
 
-  assign when_DBusCachedPlugin_l393 = (1'b0 && (! dataCache_1_io_cpu_memory_isWrite));
+  assign when_DBusCachedPlugin_l472 = (1'b0 && (! dataCache_1_io_cpu_memory_isWrite));
   always @(*) begin
     dataCache_1_io_cpu_writeBack_isValid = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
     if(writeBack_IS_DBUS_SHARING) begin
@@ -3873,7 +3903,7 @@ module VexRiscv (
   assign dataCache_1_io_cpu_writeBack_storeData[31 : 0] = writeBack_MEMORY_STORE_DATA_RF;
   always @(*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(when_DBusCachedPlugin_l446) begin
+    if(when_DBusCachedPlugin_l533) begin
       if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
@@ -3883,7 +3913,7 @@ module VexRiscv (
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(when_DBusCachedPlugin_l446) begin
+    if(when_DBusCachedPlugin_l533) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
@@ -3902,7 +3932,7 @@ module VexRiscv (
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
-    if(when_DBusCachedPlugin_l446) begin
+    if(when_DBusCachedPlugin_l533) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code};
       end
@@ -3915,12 +3945,13 @@ module VexRiscv (
     end
   end
 
-  assign when_DBusCachedPlugin_l446 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign when_DBusCachedPlugin_l466 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
-  assign writeBack_DBusCachedPlugin_rspSplits_0 = dataCache_1_io_cpu_writeBack_data[7 : 0];
-  assign writeBack_DBusCachedPlugin_rspSplits_1 = dataCache_1_io_cpu_writeBack_data[15 : 8];
-  assign writeBack_DBusCachedPlugin_rspSplits_2 = dataCache_1_io_cpu_writeBack_data[23 : 16];
-  assign writeBack_DBusCachedPlugin_rspSplits_3 = dataCache_1_io_cpu_writeBack_data[31 : 24];
+  assign when_DBusCachedPlugin_l533 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l553 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
+  assign writeBack_DBusCachedPlugin_rspData = dataCache_1_io_cpu_writeBack_data;
+  assign writeBack_DBusCachedPlugin_rspSplits_0 = writeBack_DBusCachedPlugin_rspData[7 : 0];
+  assign writeBack_DBusCachedPlugin_rspSplits_1 = writeBack_DBusCachedPlugin_rspData[15 : 8];
+  assign writeBack_DBusCachedPlugin_rspSplits_2 = writeBack_DBusCachedPlugin_rspData[23 : 16];
+  assign writeBack_DBusCachedPlugin_rspSplits_3 = writeBack_DBusCachedPlugin_rspData[31 : 24];
   always @(*) begin
     writeBack_DBusCachedPlugin_rspShifted[7 : 0] = _zz_writeBack_DBusCachedPlugin_rspShifted;
     writeBack_DBusCachedPlugin_rspShifted[15 : 8] = _zz_writeBack_DBusCachedPlugin_rspShifted_2;
@@ -3930,13 +3961,13 @@ module VexRiscv (
 
   always @(*) begin
     writeBack_DBusCachedPlugin_rspRf = writeBack_DBusCachedPlugin_rspShifted[31 : 0];
-    if(when_DBusCachedPlugin_l482) begin
+    if(when_DBusCachedPlugin_l570) begin
       writeBack_DBusCachedPlugin_rspRf = {31'd0, _zz_writeBack_DBusCachedPlugin_rspRf};
     end
   end
 
-  assign when_DBusCachedPlugin_l482 = (writeBack_MEMORY_LRSC && writeBack_MEMORY_WR);
-  assign switch_Misc_l210 = writeBack_INSTRUCTION[13 : 12];
+  assign when_DBusCachedPlugin_l570 = (writeBack_MEMORY_LRSC && writeBack_MEMORY_WR);
+  assign switch_Misc_l232 = writeBack_INSTRUCTION[13 : 12];
   assign _zz_writeBack_DBusCachedPlugin_rspFormated = (writeBack_DBusCachedPlugin_rspRf[7] && (! writeBack_INSTRUCTION[14]));
   always @(*) begin
     _zz_writeBack_DBusCachedPlugin_rspFormated_1[31] = _zz_writeBack_DBusCachedPlugin_rspFormated;
@@ -3988,7 +4019,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    case(switch_Misc_l210)
+    case(switch_Misc_l232)
       2'b00 : begin
         writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_1;
       end
@@ -4001,12 +4032,12 @@ module VexRiscv (
     endcase
   end
 
-  assign when_DBusCachedPlugin_l492 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l580 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
   always @(*) begin
     MmuPlugin_dBusAccess_cmd_ready = 1'b0;
     if(MmuPlugin_dBusAccess_cmd_valid) begin
-      if(when_DBusCachedPlugin_l506) begin
-        if(when_DBusCachedPlugin_l507) begin
+      if(when_DBusCachedPlugin_l604) begin
+        if(when_DBusCachedPlugin_l605) begin
           MmuPlugin_dBusAccess_cmd_ready = (! execute_arbitration_isStuck);
         end
       end
@@ -4016,14 +4047,14 @@ module VexRiscv (
   always @(*) begin
     DBusCachedPlugin_forceDatapath = 1'b0;
     if(MmuPlugin_dBusAccess_cmd_valid) begin
-      if(when_DBusCachedPlugin_l506) begin
+      if(when_DBusCachedPlugin_l604) begin
         DBusCachedPlugin_forceDatapath = 1'b1;
       end
     end
   end
 
-  assign when_DBusCachedPlugin_l506 = (! ({(writeBack_arbitration_isValid || CsrPlugin_exceptionPendings_3),{(memory_arbitration_isValid || CsrPlugin_exceptionPendings_2),(execute_arbitration_isValid || CsrPlugin_exceptionPendings_1)}} != 3'b000));
-  assign when_DBusCachedPlugin_l507 = (! dataCache_1_io_cpu_execute_refilling);
+  assign when_DBusCachedPlugin_l604 = (! ({(writeBack_arbitration_isValid || CsrPlugin_exceptionPendings_3),{(memory_arbitration_isValid || CsrPlugin_exceptionPendings_2),(execute_arbitration_isValid || CsrPlugin_exceptionPendings_1)}} != 3'b000));
+  assign when_DBusCachedPlugin_l605 = (! dataCache_1_io_cpu_execute_refilling);
   assign MmuPlugin_dBusAccess_cmd_fire = (MmuPlugin_dBusAccess_cmd_valid && MmuPlugin_dBusAccess_cmd_ready);
   assign MmuPlugin_dBusAccess_rsp_valid = ((writeBack_IS_DBUS_SHARING && (! dataCache_1_io_cpu_writeBack_isWrite)) && (dataCache_1_io_cpu_redo || (! dataCache_1_io_cpu_writeBack_haltIt)));
   assign MmuPlugin_dBusAccess_rsp_payload_data = writeBack_DBusCachedPlugin_rspRf;
@@ -4032,16 +4063,16 @@ module VexRiscv (
   assign MmuPlugin_ports_0_dirty = 1'b0;
   always @(*) begin
     MmuPlugin_ports_0_requireMmuLockupCalc = ((1'b1 && (! IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation)) && MmuPlugin_satp_mode);
-    if(when_MmuPlugin_l125) begin
+    if(when_MmuPlugin_l131) begin
       MmuPlugin_ports_0_requireMmuLockupCalc = 1'b0;
     end
-    if(when_MmuPlugin_l126) begin
+    if(when_MmuPlugin_l132) begin
       MmuPlugin_ports_0_requireMmuLockupCalc = 1'b0;
     end
   end
 
-  assign when_MmuPlugin_l125 = ((! MmuPlugin_status_mprv) && (CsrPlugin_privilege == 2'b11));
-  assign when_MmuPlugin_l126 = (CsrPlugin_privilege == 2'b11);
+  assign when_MmuPlugin_l131 = ((! MmuPlugin_status_mprv) && (CsrPlugin_privilege == 2'b11));
+  assign when_MmuPlugin_l132 = (CsrPlugin_privilege == 2'b11);
   assign MmuPlugin_ports_0_cacheHitsCalc = {((MmuPlugin_ports_0_cache_3_valid && (MmuPlugin_ports_0_cache_3_virtualAddress_1 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_0_cache_3_superPage || (MmuPlugin_ports_0_cache_3_virtualAddress_0 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12]))),{((MmuPlugin_ports_0_cache_2_valid && (MmuPlugin_ports_0_cache_2_virtualAddress_1 == _zz_MmuPlugin_ports_0_cacheHitsCalc)) && (MmuPlugin_ports_0_cache_2_superPage || (MmuPlugin_ports_0_cache_2_virtualAddress_0 == _zz_MmuPlugin_ports_0_cacheHitsCalc_1))),{((MmuPlugin_ports_0_cache_1_valid && _zz_MmuPlugin_ports_0_cacheHitsCalc_2) && (MmuPlugin_ports_0_cache_1_superPage || _zz_MmuPlugin_ports_0_cacheHitsCalc_3)),((MmuPlugin_ports_0_cache_0_valid && _zz_MmuPlugin_ports_0_cacheHitsCalc_4) && (MmuPlugin_ports_0_cache_0_superPage || _zz_MmuPlugin_ports_0_cacheHitsCalc_5))}}};
   assign MmuPlugin_ports_0_cacheHit = (|MmuPlugin_ports_0_cacheHitsCalc);
   assign _zz_MmuPlugin_ports_0_cacheLine_valid = MmuPlugin_ports_0_cacheHitsCalc[3];
@@ -4061,8 +4092,8 @@ module VexRiscv (
   assign MmuPlugin_ports_0_cacheLine_allowUser = _zz_MmuPlugin_ports_0_cacheLine_allowUser;
   always @(*) begin
     MmuPlugin_ports_0_entryToReplace_willIncrement = 1'b0;
-    if(when_MmuPlugin_l272) begin
-      if(when_MmuPlugin_l274) begin
+    if(when_MmuPlugin_l279) begin
+      if(when_MmuPlugin_l281) begin
         MmuPlugin_ports_0_entryToReplace_willIncrement = 1'b1;
       end
     end
@@ -4147,19 +4178,19 @@ module VexRiscv (
   assign MmuPlugin_ports_1_dirty = 1'b0;
   always @(*) begin
     MmuPlugin_ports_1_requireMmuLockupCalc = ((1'b1 && (! DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation)) && MmuPlugin_satp_mode);
-    if(when_MmuPlugin_l125_1) begin
+    if(when_MmuPlugin_l131_1) begin
       MmuPlugin_ports_1_requireMmuLockupCalc = 1'b0;
     end
-    if(when_MmuPlugin_l126_1) begin
-      if(when_MmuPlugin_l128) begin
+    if(when_MmuPlugin_l132_1) begin
+      if(when_MmuPlugin_l134) begin
         MmuPlugin_ports_1_requireMmuLockupCalc = 1'b0;
       end
     end
   end
 
-  assign when_MmuPlugin_l125_1 = ((! MmuPlugin_status_mprv) && (CsrPlugin_privilege == 2'b11));
-  assign when_MmuPlugin_l126_1 = (CsrPlugin_privilege == 2'b11);
-  assign when_MmuPlugin_l128 = ((! MmuPlugin_status_mprv) || (CsrPlugin_mstatus_MPP == 2'b11));
+  assign when_MmuPlugin_l131_1 = ((! MmuPlugin_status_mprv) && (CsrPlugin_privilege == 2'b11));
+  assign when_MmuPlugin_l132_1 = (CsrPlugin_privilege == 2'b11);
+  assign when_MmuPlugin_l134 = ((! MmuPlugin_status_mprv) || (CsrPlugin_mstatus_MPP == 2'b11));
   assign MmuPlugin_ports_1_cacheHitsCalc = {((MmuPlugin_ports_1_cache_3_valid && (MmuPlugin_ports_1_cache_3_virtualAddress_1 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_1_cache_3_superPage || (MmuPlugin_ports_1_cache_3_virtualAddress_0 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12]))),{((MmuPlugin_ports_1_cache_2_valid && (MmuPlugin_ports_1_cache_2_virtualAddress_1 == _zz_MmuPlugin_ports_1_cacheHitsCalc)) && (MmuPlugin_ports_1_cache_2_superPage || (MmuPlugin_ports_1_cache_2_virtualAddress_0 == _zz_MmuPlugin_ports_1_cacheHitsCalc_1))),{((MmuPlugin_ports_1_cache_1_valid && _zz_MmuPlugin_ports_1_cacheHitsCalc_2) && (MmuPlugin_ports_1_cache_1_superPage || _zz_MmuPlugin_ports_1_cacheHitsCalc_3)),((MmuPlugin_ports_1_cache_0_valid && _zz_MmuPlugin_ports_1_cacheHitsCalc_4) && (MmuPlugin_ports_1_cache_0_superPage || _zz_MmuPlugin_ports_1_cacheHitsCalc_5))}}};
   assign MmuPlugin_ports_1_cacheHit = (|MmuPlugin_ports_1_cacheHitsCalc);
   assign _zz_MmuPlugin_ports_1_cacheLine_valid = MmuPlugin_ports_1_cacheHitsCalc[3];
@@ -4179,8 +4210,8 @@ module VexRiscv (
   assign MmuPlugin_ports_1_cacheLine_allowUser = _zz_MmuPlugin_ports_1_cacheLine_allowUser;
   always @(*) begin
     MmuPlugin_ports_1_entryToReplace_willIncrement = 1'b0;
-    if(when_MmuPlugin_l272) begin
-      if(when_MmuPlugin_l274_1) begin
+    if(when_MmuPlugin_l279) begin
+      if(when_MmuPlugin_l281_1) begin
         MmuPlugin_ports_1_entryToReplace_willIncrement = 1'b1;
       end
     end
@@ -4275,7 +4306,7 @@ module VexRiscv (
   assign MmuPlugin_shared_dBusRsp_pte_PPN1 = MmuPlugin_shared_dBusRspStaged_payload_data[31 : 20];
   assign MmuPlugin_shared_dBusRsp_exception = (((! MmuPlugin_shared_dBusRsp_pte_V) || ((! MmuPlugin_shared_dBusRsp_pte_R) && MmuPlugin_shared_dBusRsp_pte_W)) || MmuPlugin_shared_dBusRspStaged_payload_error);
   assign MmuPlugin_shared_dBusRsp_leaf = (MmuPlugin_shared_dBusRsp_pte_R || MmuPlugin_shared_dBusRsp_pte_X);
-  assign when_MmuPlugin_l205 = (MmuPlugin_shared_dBusRspStaged_valid && (! MmuPlugin_shared_dBusRspStaged_payload_redo));
+  assign when_MmuPlugin_l211 = (MmuPlugin_shared_dBusRspStaged_valid && (! MmuPlugin_shared_dBusRspStaged_payload_redo));
   always @(*) begin
     MmuPlugin_dBusAccess_cmd_valid = 1'b0;
     case(MmuPlugin_shared_state_1)
@@ -4302,7 +4333,7 @@ module VexRiscv (
       MmuPlugin_shared_State_IDLE : begin
       end
       MmuPlugin_shared_State_L1_CMD : begin
-        MmuPlugin_dBusAccess_cmd_payload_address = {{MmuPlugin_satp_ppn,MmuPlugin_shared_vpn_1},2'b00};
+        MmuPlugin_dBusAccess_cmd_payload_address = {{MmuPlugin_satp_ppn[19 : 0],MmuPlugin_shared_vpn_1},2'b00};
       end
       MmuPlugin_shared_State_L1_RSP : begin
       end
@@ -4329,40 +4360,41 @@ module VexRiscv (
   end
 
   assign MmuPlugin_shared_refills = _zz_MmuPlugin_shared_refills_3;
-  assign when_MmuPlugin_l217 = (|MmuPlugin_shared_refills);
+  assign when_MmuPlugin_l223 = (|MmuPlugin_shared_refills);
   assign _zz_MmuPlugin_shared_vpn_0 = (MmuPlugin_shared_refills[0] ? IBusCachedPlugin_mmuBus_cmd_0_virtualAddress : DBusCachedPlugin_mmuBus_cmd_0_virtualAddress);
-  assign when_MmuPlugin_l243 = (MmuPlugin_shared_dBusRsp_leaf || MmuPlugin_shared_dBusRsp_exception);
+  assign when_MmuPlugin_l250 = (MmuPlugin_shared_dBusRsp_leaf || MmuPlugin_shared_dBusRsp_exception);
   assign IBusCachedPlugin_mmuBus_busy = ((MmuPlugin_shared_state_1 != MmuPlugin_shared_State_IDLE) && MmuPlugin_shared_portSortedOh[0]);
   assign DBusCachedPlugin_mmuBus_busy = ((MmuPlugin_shared_state_1 != MmuPlugin_shared_State_IDLE) && MmuPlugin_shared_portSortedOh[1]);
-  assign when_MmuPlugin_l272 = ((MmuPlugin_shared_dBusRspStaged_valid && (! MmuPlugin_shared_dBusRspStaged_payload_redo)) && (MmuPlugin_shared_dBusRsp_leaf || MmuPlugin_shared_dBusRsp_exception));
-  assign when_MmuPlugin_l274 = MmuPlugin_shared_portSortedOh[0];
-  assign when_MmuPlugin_l280 = (MmuPlugin_ports_0_entryToReplace_value == 2'b00);
-  assign when_MmuPlugin_l280_1 = (MmuPlugin_ports_0_entryToReplace_value == 2'b01);
-  assign when_MmuPlugin_l280_2 = (MmuPlugin_ports_0_entryToReplace_value == 2'b10);
-  assign when_MmuPlugin_l280_3 = (MmuPlugin_ports_0_entryToReplace_value == 2'b11);
-  assign when_MmuPlugin_l274_1 = MmuPlugin_shared_portSortedOh[1];
-  assign when_MmuPlugin_l280_4 = (MmuPlugin_ports_1_entryToReplace_value == 2'b00);
-  assign when_MmuPlugin_l280_5 = (MmuPlugin_ports_1_entryToReplace_value == 2'b01);
-  assign when_MmuPlugin_l280_6 = (MmuPlugin_ports_1_entryToReplace_value == 2'b10);
-  assign when_MmuPlugin_l280_7 = (MmuPlugin_ports_1_entryToReplace_value == 2'b11);
-  assign when_MmuPlugin_l304 = ((execute_arbitration_isValid && execute_arbitration_isFiring) && execute_IS_SFENCE_VMA2);
-  assign _zz_decode_IS_DIV_1 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_decode_IS_DIV_2 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_decode_IS_DIV_3 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002000);
-  assign _zz_decode_IS_DIV_4 = ((decode_INSTRUCTION & 32'h00000018) == 32'h0);
-  assign _zz_decode_IS_DIV_5 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_decode_IS_DIV_6 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
-  assign _zz_decode_IS_DIV_7 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
-  assign _zz_decode_IS_DIV_8 = ((decode_INSTRUCTION & 32'h02003050) == 32'h02000050);
-  assign _zz_decode_IS_DIV_9 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
-  assign _zz_decode_IS_DIV_10 = ((decode_INSTRUCTION & 32'h00007000) == 32'h00001000);
-  assign _zz_decode_IS_DIV_11 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00004000);
-  assign _zz_decode_IS_DIV = {(|((decode_INSTRUCTION & _zz__zz_decode_IS_DIV) == 32'h02004020)),{(|{_zz_decode_IS_DIV_11,_zz_decode_IS_DIV_10}),{(|{_zz__zz_decode_IS_DIV_1,_zz__zz_decode_IS_DIV_2}),{(|_zz__zz_decode_IS_DIV_3),{_zz__zz_decode_IS_DIV_4,{_zz__zz_decode_IS_DIV_6,_zz__zz_decode_IS_DIV_9}}}}}};
-  assign _zz_decode_SRC1_CTRL_2 = _zz_decode_IS_DIV[2 : 1];
+  assign when_MmuPlugin_l279 = ((MmuPlugin_shared_dBusRspStaged_valid && (! MmuPlugin_shared_dBusRspStaged_payload_redo)) && (MmuPlugin_shared_dBusRsp_leaf || MmuPlugin_shared_dBusRsp_exception));
+  assign when_MmuPlugin_l281 = MmuPlugin_shared_portSortedOh[0];
+  assign when_MmuPlugin_l287 = (MmuPlugin_ports_0_entryToReplace_value == 2'b00);
+  assign when_MmuPlugin_l287_1 = (MmuPlugin_ports_0_entryToReplace_value == 2'b01);
+  assign when_MmuPlugin_l287_2 = (MmuPlugin_ports_0_entryToReplace_value == 2'b10);
+  assign when_MmuPlugin_l287_3 = (MmuPlugin_ports_0_entryToReplace_value == 2'b11);
+  assign when_MmuPlugin_l281_1 = MmuPlugin_shared_portSortedOh[1];
+  assign when_MmuPlugin_l287_4 = (MmuPlugin_ports_1_entryToReplace_value == 2'b00);
+  assign when_MmuPlugin_l287_5 = (MmuPlugin_ports_1_entryToReplace_value == 2'b01);
+  assign when_MmuPlugin_l287_6 = (MmuPlugin_ports_1_entryToReplace_value == 2'b10);
+  assign when_MmuPlugin_l287_7 = (MmuPlugin_ports_1_entryToReplace_value == 2'b11);
+  assign when_MmuPlugin_l311 = ((execute_arbitration_isValid && execute_arbitration_isFiring) && execute_IS_SFENCE_VMA2);
+  assign _zz_decode_IS_DIV_1 = ((decode_INSTRUCTION & 32'h00005048) == 32'h00001008);
+  assign _zz_decode_IS_DIV_2 = ((decode_INSTRUCTION & 32'h02003050) == 32'h02000050);
+  assign _zz_decode_IS_DIV_3 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
+  assign _zz_decode_IS_DIV_4 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_decode_IS_DIV_5 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002000);
+  assign _zz_decode_IS_DIV_6 = ((decode_INSTRUCTION & 32'h00000018) == 32'h00000000);
+  assign _zz_decode_IS_DIV_7 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_decode_IS_DIV_8 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
+  assign _zz_decode_IS_DIV_9 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
+  assign _zz_decode_IS_DIV_10 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
+  assign _zz_decode_IS_DIV_11 = ((decode_INSTRUCTION & 32'h00007000) == 32'h00001000);
+  assign _zz_decode_IS_DIV_12 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00004000);
+  assign _zz_decode_IS_DIV = {(|((decode_INSTRUCTION & _zz__zz_decode_IS_DIV) == 32'h02004020)),{(|{_zz_decode_IS_DIV_12,_zz_decode_IS_DIV_11}),{(|{_zz__zz_decode_IS_DIV_1,_zz__zz_decode_IS_DIV_2}),{(|_zz__zz_decode_IS_DIV_3),{_zz__zz_decode_IS_DIV_4,{_zz__zz_decode_IS_DIV_6,_zz__zz_decode_IS_DIV_9}}}}}};
+  assign _zz_decode_SRC1_CTRL_2 = _zz_decode_IS_DIV[3 : 2];
   assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
-  assign _zz_decode_ALU_CTRL_2 = _zz_decode_IS_DIV[7 : 6];
+  assign _zz_decode_ALU_CTRL_2 = _zz_decode_IS_DIV[8 : 7];
   assign _zz_decode_ALU_CTRL_1 = _zz_decode_ALU_CTRL_2;
-  assign _zz_decode_SRC2_CTRL_2 = _zz_decode_IS_DIV[9 : 8];
+  assign _zz_decode_SRC2_CTRL_2 = _zz_decode_IS_DIV[10 : 9];
   assign _zz_decode_SRC2_CTRL_1 = _zz_decode_SRC2_CTRL_2;
   assign _zz_decode_ALU_BITWISE_CTRL_2 = _zz_decode_IS_DIV[24 : 23];
   assign _zz_decode_ALU_BITWISE_CTRL_1 = _zz_decode_ALU_BITWISE_CTRL_2;
@@ -4375,29 +4407,29 @@ module VexRiscv (
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
-  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h0);
+  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h00);
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
   assign decode_RegFilePlugin_rs1Data = _zz_RegFilePlugin_regFile_port0;
   assign decode_RegFilePlugin_rs2Data = _zz_RegFilePlugin_regFile_port1;
   always @(*) begin
     lastStageRegFileWrite_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
-    if(_zz_2) begin
+    if(_zz_5) begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
   always @(*) begin
     lastStageRegFileWrite_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
-    if(_zz_2) begin
-      lastStageRegFileWrite_payload_address = 5'h0;
+    if(_zz_5) begin
+      lastStageRegFileWrite_payload_address = 5'h00;
     end
   end
 
   always @(*) begin
     lastStageRegFileWrite_payload_data = _zz_decode_RS2_2;
-    if(_zz_2) begin
-      lastStageRegFileWrite_payload_data = 32'h0;
+    if(_zz_5) begin
+      lastStageRegFileWrite_payload_data = 32'h00000000;
     end
   end
 
@@ -4438,7 +4470,7 @@ module VexRiscv (
         _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
       Src1CtrlEnum_IMU : begin
-        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h000};
       end
       default : begin
         _zz_execute_SRC1 = {27'd0, _zz__zz_execute_SRC1_1};
@@ -4446,67 +4478,67 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_execute_SRC2_1 = execute_INSTRUCTION[31];
+  assign _zz_execute_SRC2 = execute_INSTRUCTION[31];
   always @(*) begin
-    _zz_execute_SRC2_2[19] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[18] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[17] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[16] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[15] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[14] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[13] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[12] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[11] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[10] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[9] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[8] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[7] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[6] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[5] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[4] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[3] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[2] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[1] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[0] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_1[19] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[18] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[17] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[16] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[15] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[14] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[13] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[12] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[11] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[10] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[9] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[8] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[7] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[6] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[5] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[4] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[3] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[2] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[1] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[0] = _zz_execute_SRC2;
   end
 
-  assign _zz_execute_SRC2_3 = _zz__zz_execute_SRC2_3[11];
+  assign _zz_execute_SRC2_2 = _zz__zz_execute_SRC2_2[11];
   always @(*) begin
-    _zz_execute_SRC2_4[19] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[18] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[17] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[16] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[15] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[14] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[13] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[12] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[11] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[10] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[9] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[8] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[7] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[6] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[5] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[4] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[3] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[2] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[1] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[0] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_3[19] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[18] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[17] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[16] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[15] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[14] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[13] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[12] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[11] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[10] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[9] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[8] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[7] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[6] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[5] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[4] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[3] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[2] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[1] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[0] = _zz_execute_SRC2_2;
   end
 
   always @(*) begin
     case(execute_SRC2_CTRL)
       Src2CtrlEnum_RS : begin
-        _zz_execute_SRC2_5 = execute_RS2;
+        _zz_execute_SRC2_4 = execute_RS2;
       end
       Src2CtrlEnum_IMI : begin
-        _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
+        _zz_execute_SRC2_4 = {_zz_execute_SRC2_1,execute_INSTRUCTION[31 : 20]};
       end
       Src2CtrlEnum_IMS : begin
-        _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_execute_SRC2_4 = {_zz_execute_SRC2_3,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_execute_SRC2_5 = _zz_execute_SRC2;
+        _zz_execute_SRC2_4 = _zz_execute_to_memory_PC;
       end
     endcase
   end
@@ -4672,16 +4704,19 @@ module VexRiscv (
   assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
   assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign switch_Misc_l210_1 = execute_INSTRUCTION[14 : 12];
+  assign switch_Misc_l232_1 = execute_INSTRUCTION[14 : 12];
   always @(*) begin
-    casez(switch_Misc_l210_1)
+    case(switch_Misc_l232_1)
       3'b000 : begin
         _zz_execute_BRANCH_DO = execute_BranchPlugin_eq;
       end
       3'b001 : begin
         _zz_execute_BRANCH_DO = (! execute_BranchPlugin_eq);
       end
-      3'b1?1 : begin
+      3'b101 : begin
+        _zz_execute_BRANCH_DO = (! execute_SRC_LESS);
+      end
+      3'b111 : begin
         _zz_execute_BRANCH_DO = (! execute_SRC_LESS);
       end
       default : begin
@@ -4799,7 +4834,13 @@ module VexRiscv (
   end
 
   assign CsrPlugin_misa_base = 2'b01;
-  assign CsrPlugin_misa_extensions = 26'h0;
+  assign CsrPlugin_misa_extensions = 26'h0000000;
+  assign CsrPlugin_mcounteren_IR = 1'b1;
+  assign CsrPlugin_mcounteren_TM = 1'b1;
+  assign CsrPlugin_mcounteren_CY = 1'b1;
+  assign CsrPlugin_scounteren_IR = 1'b1;
+  assign CsrPlugin_scounteren_TM = 1'b1;
+  assign CsrPlugin_scounteren_CY = 1'b1;
   assign CsrPlugin_sip_SEIP_OR = (CsrPlugin_sip_SEIP_SOFT || CsrPlugin_sip_SEIP_INPUT);
   always @(*) begin
     CsrPlugin_redoInterface_valid = 1'b0;
@@ -4811,7 +4852,7 @@ module VexRiscv (
   assign CsrPlugin_redoInterface_payload = decode_PC;
   always @(*) begin
     CsrPlugin_rescheduleLogic_rescheduleNext = 1'b0;
-    if(when_CsrPlugin_l816) begin
+    if(when_CsrPlugin_l1153) begin
       CsrPlugin_rescheduleLogic_rescheduleNext = 1'b1;
     end
     if(execute_CsrPlugin_csr_384) begin
@@ -4821,73 +4862,78 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l816 = (execute_arbitration_isValid && execute_IS_SFENCE_VMA);
-  assign _zz_when_CsrPlugin_l965 = (CsrPlugin_sip_STIP && CsrPlugin_sie_STIE);
-  assign _zz_when_CsrPlugin_l965_1 = (CsrPlugin_sip_SSIP && CsrPlugin_sie_SSIE);
-  assign _zz_when_CsrPlugin_l965_2 = (CsrPlugin_sip_SEIP_OR && CsrPlugin_sie_SEIE);
-  assign _zz_when_CsrPlugin_l965_3 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_when_CsrPlugin_l965_4 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_when_CsrPlugin_l965_5 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign when_CsrPlugin_l1153 = (execute_arbitration_isValid && execute_RESCHEDULE_NEXT);
+  assign _zz_when_CsrPlugin_l1302 = (CsrPlugin_sip_STIP && CsrPlugin_sie_STIE);
+  assign _zz_when_CsrPlugin_l1302_1 = (CsrPlugin_sip_SSIP && CsrPlugin_sie_SSIE);
+  assign _zz_when_CsrPlugin_l1302_2 = (CsrPlugin_sip_SEIP_OR && CsrPlugin_sie_SEIE);
+  assign _zz_when_CsrPlugin_l1302_3 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l1302_4 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l1302_5 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
     case(CsrPlugin_exceptionPortCtrl_exceptionContext_code)
       4'b0000 : begin
-        if(when_CsrPlugin_l879) begin
+        if(when_CsrPlugin_l1216) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b0001 : begin
-        if(when_CsrPlugin_l879_1) begin
+        if(when_CsrPlugin_l1216_1) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b0010 : begin
-        if(when_CsrPlugin_l879_2) begin
+        if(when_CsrPlugin_l1216_2) begin
+          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
+        end
+      end
+      4'b0011 : begin
+        if(when_CsrPlugin_l1216_3) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b0100 : begin
-        if(when_CsrPlugin_l879_3) begin
+        if(when_CsrPlugin_l1216_4) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b0101 : begin
-        if(when_CsrPlugin_l879_4) begin
+        if(when_CsrPlugin_l1216_5) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b0110 : begin
-        if(when_CsrPlugin_l879_5) begin
+        if(when_CsrPlugin_l1216_6) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b0111 : begin
-        if(when_CsrPlugin_l879_6) begin
+        if(when_CsrPlugin_l1216_7) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b1000 : begin
-        if(when_CsrPlugin_l879_7) begin
+        if(when_CsrPlugin_l1216_8) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b1001 : begin
-        if(when_CsrPlugin_l879_8) begin
+        if(when_CsrPlugin_l1216_9) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b1100 : begin
-        if(when_CsrPlugin_l879_9) begin
+        if(when_CsrPlugin_l1216_10) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b1101 : begin
-        if(when_CsrPlugin_l879_10) begin
+        if(when_CsrPlugin_l1216_11) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b1111 : begin
-        if(when_CsrPlugin_l879_11) begin
+        if(when_CsrPlugin_l1216_12) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
@@ -4896,18 +4942,19 @@ module VexRiscv (
     endcase
   end
 
-  assign when_CsrPlugin_l879 = ((1'b1 && CsrPlugin_medeleg_IAM) && (! 1'b0));
-  assign when_CsrPlugin_l879_1 = ((1'b1 && CsrPlugin_medeleg_IAF) && (! 1'b0));
-  assign when_CsrPlugin_l879_2 = ((1'b1 && CsrPlugin_medeleg_II) && (! 1'b0));
-  assign when_CsrPlugin_l879_3 = ((1'b1 && CsrPlugin_medeleg_LAM) && (! 1'b0));
-  assign when_CsrPlugin_l879_4 = ((1'b1 && CsrPlugin_medeleg_LAF) && (! 1'b0));
-  assign when_CsrPlugin_l879_5 = ((1'b1 && CsrPlugin_medeleg_SAM) && (! 1'b0));
-  assign when_CsrPlugin_l879_6 = ((1'b1 && CsrPlugin_medeleg_SAF) && (! 1'b0));
-  assign when_CsrPlugin_l879_7 = ((1'b1 && CsrPlugin_medeleg_EU) && (! 1'b0));
-  assign when_CsrPlugin_l879_8 = ((1'b1 && CsrPlugin_medeleg_ES) && (! 1'b0));
-  assign when_CsrPlugin_l879_9 = ((1'b1 && CsrPlugin_medeleg_IPF) && (! 1'b0));
-  assign when_CsrPlugin_l879_10 = ((1'b1 && CsrPlugin_medeleg_LPF) && (! 1'b0));
-  assign when_CsrPlugin_l879_11 = ((1'b1 && CsrPlugin_medeleg_SPF) && (! 1'b0));
+  assign when_CsrPlugin_l1216 = ((1'b1 && CsrPlugin_medeleg_IAM) && (! 1'b0));
+  assign when_CsrPlugin_l1216_1 = ((1'b1 && CsrPlugin_medeleg_IAF) && (! 1'b0));
+  assign when_CsrPlugin_l1216_2 = ((1'b1 && CsrPlugin_medeleg_II) && (! 1'b0));
+  assign when_CsrPlugin_l1216_3 = ((1'b1 && CsrPlugin_medeleg_BP) && (! 1'b0));
+  assign when_CsrPlugin_l1216_4 = ((1'b1 && CsrPlugin_medeleg_LAM) && (! 1'b0));
+  assign when_CsrPlugin_l1216_5 = ((1'b1 && CsrPlugin_medeleg_LAF) && (! 1'b0));
+  assign when_CsrPlugin_l1216_6 = ((1'b1 && CsrPlugin_medeleg_SAM) && (! 1'b0));
+  assign when_CsrPlugin_l1216_7 = ((1'b1 && CsrPlugin_medeleg_SAF) && (! 1'b0));
+  assign when_CsrPlugin_l1216_8 = ((1'b1 && CsrPlugin_medeleg_EU) && (! 1'b0));
+  assign when_CsrPlugin_l1216_9 = ((1'b1 && CsrPlugin_medeleg_ES) && (! 1'b0));
+  assign when_CsrPlugin_l1216_10 = ((1'b1 && CsrPlugin_medeleg_IPF) && (! 1'b0));
+  assign when_CsrPlugin_l1216_11 = ((1'b1 && CsrPlugin_medeleg_LPF) && (! 1'b0));
+  assign when_CsrPlugin_l1216_12 = ((1'b1 && CsrPlugin_medeleg_SPF) && (! 1'b0));
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
   assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
   assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1[0];
@@ -4951,35 +4998,35 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l922 = (! decode_arbitration_isStuck);
-  assign when_CsrPlugin_l922_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l922_2 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l922_3 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l935 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
+  assign when_CsrPlugin_l1259 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l1272 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-  assign when_CsrPlugin_l959 = ((CsrPlugin_sstatus_SIE && (CsrPlugin_privilege == 2'b01)) || (CsrPlugin_privilege < 2'b01));
-  assign when_CsrPlugin_l959_1 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign when_CsrPlugin_l965 = ((_zz_when_CsrPlugin_l965 && (1'b1 && CsrPlugin_mideleg_ST)) && (! 1'b0));
-  assign when_CsrPlugin_l965_1 = ((_zz_when_CsrPlugin_l965_1 && (1'b1 && CsrPlugin_mideleg_SS)) && (! 1'b0));
-  assign when_CsrPlugin_l965_2 = ((_zz_when_CsrPlugin_l965_2 && (1'b1 && CsrPlugin_mideleg_SE)) && (! 1'b0));
-  assign when_CsrPlugin_l965_3 = ((_zz_when_CsrPlugin_l965 && 1'b1) && (! (CsrPlugin_mideleg_ST != 1'b0)));
-  assign when_CsrPlugin_l965_4 = ((_zz_when_CsrPlugin_l965_1 && 1'b1) && (! (CsrPlugin_mideleg_SS != 1'b0)));
-  assign when_CsrPlugin_l965_5 = ((_zz_when_CsrPlugin_l965_2 && 1'b1) && (! (CsrPlugin_mideleg_SE != 1'b0)));
-  assign when_CsrPlugin_l965_6 = ((_zz_when_CsrPlugin_l965_3 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l965_7 = ((_zz_when_CsrPlugin_l965_4 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l965_8 = ((_zz_when_CsrPlugin_l965_5 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1296 = ((CsrPlugin_sstatus_SIE && (CsrPlugin_privilege == 2'b01)) || (CsrPlugin_privilege < 2'b01));
+  assign when_CsrPlugin_l1296_1 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l1302 = ((_zz_when_CsrPlugin_l1302 && (1'b1 && CsrPlugin_mideleg_ST)) && (! 1'b0));
+  assign when_CsrPlugin_l1302_1 = ((_zz_when_CsrPlugin_l1302_1 && (1'b1 && CsrPlugin_mideleg_SS)) && (! 1'b0));
+  assign when_CsrPlugin_l1302_2 = ((_zz_when_CsrPlugin_l1302_2 && (1'b1 && CsrPlugin_mideleg_SE)) && (! 1'b0));
+  assign when_CsrPlugin_l1302_3 = ((_zz_when_CsrPlugin_l1302 && 1'b1) && (! (CsrPlugin_mideleg_ST != 1'b0)));
+  assign when_CsrPlugin_l1302_4 = ((_zz_when_CsrPlugin_l1302_1 && 1'b1) && (! (CsrPlugin_mideleg_SS != 1'b0)));
+  assign when_CsrPlugin_l1302_5 = ((_zz_when_CsrPlugin_l1302_2 && 1'b1) && (! (CsrPlugin_mideleg_SE != 1'b0)));
+  assign when_CsrPlugin_l1302_6 = ((_zz_when_CsrPlugin_l1302_3 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1302_7 = ((_zz_when_CsrPlugin_l1302_4 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1302_8 = ((_zz_when_CsrPlugin_l1302_5 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  assign when_CsrPlugin_l993 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l993_1 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l993_2 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l998 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  assign when_CsrPlugin_l1335 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1335_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l1335_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l1340 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
   always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(when_CsrPlugin_l1004) begin
+    if(when_CsrPlugin_l1346) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException) begin
@@ -4987,7 +5034,7 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l1004 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
+  assign when_CsrPlugin_l1346 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
   always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
@@ -5003,6 +5050,7 @@ module VexRiscv (
     end
   end
 
+  assign CsrPlugin_trapCauseEbreakDebug = 1'b0;
   always @(*) begin
     CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
@@ -5031,13 +5079,16 @@ module VexRiscv (
     endcase
   end
 
-  assign when_CsrPlugin_l1032 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign when_CsrPlugin_l1077 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
-  assign switch_CsrPlugin_l1081 = writeBack_INSTRUCTION[29 : 28];
+  assign CsrPlugin_trapEnterDebug = 1'b0;
+  assign when_CsrPlugin_l1390 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1398 = (! CsrPlugin_trapEnterDebug);
+  assign when_CsrPlugin_l1456 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign switch_CsrPlugin_l1460 = writeBack_INSTRUCTION[29 : 28];
+  assign when_CsrPlugin_l1468 = (CsrPlugin_mstatus_MPP < 2'b11);
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign when_CsrPlugin_l1121 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_WFI));
-  assign when_CsrPlugin_l1123 = (! execute_CsrPlugin_wfiWake);
-  assign when_CsrPlugin_l1129 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
+  assign when_CsrPlugin_l1519 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_WFI));
+  assign when_CsrPlugin_l1521 = (! execute_CsrPlugin_wfiWake);
+  assign when_CsrPlugin_l1527 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
   assign execute_CsrPlugin_blockedBySideEffects = ((|{writeBack_arbitration_isValid,memory_arbitration_isValid}) || 1'b0);
   always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
@@ -5152,18 +5203,18 @@ module VexRiscv (
     if(CsrPlugin_csrMapping_allowCsrSignal) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(when_CsrPlugin_l1315) begin
+    if(when_CsrPlugin_l1725) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if(when_CsrPlugin_l1149) begin
-      if(when_CsrPlugin_l1150) begin
+    if(when_CsrPlugin_l1547) begin
+      if(when_CsrPlugin_l1548) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
@@ -5171,20 +5222,20 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(when_CsrPlugin_l1142) begin
+    if(when_CsrPlugin_l1540) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1157) begin
+    if(when_CsrPlugin_l1555) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(when_CsrPlugin_l1142) begin
+    if(when_CsrPlugin_l1540) begin
       CsrPlugin_selfException_payload_code = 4'b0010;
     end
-    if(when_CsrPlugin_l1157) begin
+    if(when_CsrPlugin_l1555) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -5200,20 +5251,20 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  assign when_CsrPlugin_l1142 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
-  assign when_CsrPlugin_l1149 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
-  assign when_CsrPlugin_l1150 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
-  assign when_CsrPlugin_l1157 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
+  assign when_CsrPlugin_l1540 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
+  assign when_CsrPlugin_l1547 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign when_CsrPlugin_l1548 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1555 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
   always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -5231,9 +5282,9 @@ module VexRiscv (
     end
   end
 
-  assign switch_Misc_l210_2 = execute_INSTRUCTION[13];
+  assign switch_Misc_l232_2 = execute_INSTRUCTION[13];
   always @(*) begin
-    case(switch_Misc_l210_2)
+    case(switch_Misc_l232_2)
       1'b0 : begin
         _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
@@ -5244,8 +5295,8 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
-  assign when_CsrPlugin_l1189 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign when_CsrPlugin_l1193 = (execute_arbitration_isValid && (execute_IS_CSR || execute_IS_SFENCE_VMA));
+  assign when_CsrPlugin_l1587 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1591 = (execute_arbitration_isValid && (execute_IS_CSR || execute_RESCHEDULE_NEXT));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign memory_MulDivIterativePlugin_frontendOk = 1'b1;
   always @(*) begin
@@ -5268,12 +5319,12 @@ module VexRiscv (
   assign memory_MulDivIterativePlugin_mul_counter_willOverflow = (memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc && memory_MulDivIterativePlugin_mul_counter_willIncrement);
   always @(*) begin
     if(memory_MulDivIterativePlugin_mul_counter_willOverflow) begin
-      memory_MulDivIterativePlugin_mul_counter_valueNext = 6'h0;
+      memory_MulDivIterativePlugin_mul_counter_valueNext = 6'h00;
     end else begin
       memory_MulDivIterativePlugin_mul_counter_valueNext = (memory_MulDivIterativePlugin_mul_counter_value + _zz_memory_MulDivIterativePlugin_mul_counter_valueNext);
     end
     if(memory_MulDivIterativePlugin_mul_counter_willClear) begin
-      memory_MulDivIterativePlugin_mul_counter_valueNext = 6'h0;
+      memory_MulDivIterativePlugin_mul_counter_valueNext = 6'h00;
     end
   end
 
@@ -5301,12 +5352,12 @@ module VexRiscv (
   assign memory_MulDivIterativePlugin_div_counter_willOverflow = (memory_MulDivIterativePlugin_div_counter_willOverflowIfInc && memory_MulDivIterativePlugin_div_counter_willIncrement);
   always @(*) begin
     if(memory_MulDivIterativePlugin_div_counter_willOverflow) begin
-      memory_MulDivIterativePlugin_div_counter_valueNext = 6'h0;
+      memory_MulDivIterativePlugin_div_counter_valueNext = 6'h00;
     end else begin
       memory_MulDivIterativePlugin_div_counter_valueNext = (memory_MulDivIterativePlugin_div_counter_value + _zz_memory_MulDivIterativePlugin_div_counter_valueNext);
     end
     if(memory_MulDivIterativePlugin_div_counter_willClear) begin
-      memory_MulDivIterativePlugin_div_counter_valueNext = 6'h0;
+      memory_MulDivIterativePlugin_div_counter_valueNext = 6'h00;
     end
   end
 
@@ -5323,17 +5374,17 @@ module VexRiscv (
   assign when_MulDivIterativePlugin_l151 = (memory_MulDivIterativePlugin_div_counter_value == 6'h20);
   assign _zz_memory_MulDivIterativePlugin_div_result = (memory_INSTRUCTION[13] ? memory_MulDivIterativePlugin_accumulator[31 : 0] : memory_MulDivIterativePlugin_rs1[31 : 0]);
   assign when_MulDivIterativePlugin_l162 = (! memory_arbitration_isStuck);
-  assign _zz_memory_MulDivIterativePlugin_rs1 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
-  assign _zz_memory_MulDivIterativePlugin_rs1_1 = ((execute_IS_MUL && _zz_memory_MulDivIterativePlugin_rs1) || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
+  assign _zz_memory_MulDivIterativePlugin_rs2 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
+  assign _zz_memory_MulDivIterativePlugin_rs1 = ((execute_IS_MUL && _zz_memory_MulDivIterativePlugin_rs2) || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
   always @(*) begin
-    _zz_memory_MulDivIterativePlugin_rs1_2[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
-    _zz_memory_MulDivIterativePlugin_rs1_2[31 : 0] = execute_RS1;
+    _zz_memory_MulDivIterativePlugin_rs1_1[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
+    _zz_memory_MulDivIterativePlugin_rs1_1[31 : 0] = execute_RS1;
   end
 
-  assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
-  assign externalInterrupt = (|_zz_CsrPlugin_csrMapping_readDataInit_1);
-  assign _zz_CsrPlugin_csrMapping_readDataInit_3 = (_zz_CsrPlugin_csrMapping_readDataInit_2 & externalInterruptArray_regNext);
-  assign externalInterruptS = (|_zz_CsrPlugin_csrMapping_readDataInit_3);
+  assign _zz_externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
+  assign externalInterrupt = (|_zz_externalInterrupt);
+  assign _zz_externalInterruptS = (_zz_CsrPlugin_csrMapping_readDataInit_1 & externalInterruptArray_regNext);
+  assign externalInterruptS = (|_zz_externalInterruptS);
   assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
@@ -5344,35 +5395,35 @@ module VexRiscv (
   assign when_Pipeline_l124_7 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_8 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_9 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_10 = (! execute_arbitration_isStuck);
   assign _zz_decode_to_execute_SRC1_CTRL_1 = decode_SRC1_CTRL;
   assign _zz_decode_SRC1_CTRL = _zz_decode_SRC1_CTRL_1;
-  assign when_Pipeline_l124_10 = (! execute_arbitration_isStuck);
-  assign _zz_execute_SRC1_CTRL = decode_to_execute_SRC1_CTRL;
   assign when_Pipeline_l124_11 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SRC1_CTRL = decode_to_execute_SRC1_CTRL;
   assign when_Pipeline_l124_12 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_13 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_14 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_13 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_14 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_15 = (! writeBack_arbitration_isStuck);
   assign _zz_decode_to_execute_ALU_CTRL_1 = decode_ALU_CTRL;
   assign _zz_decode_ALU_CTRL = _zz_decode_ALU_CTRL_1;
-  assign when_Pipeline_l124_15 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_16 = (! execute_arbitration_isStuck);
   assign _zz_execute_ALU_CTRL = decode_to_execute_ALU_CTRL;
   assign _zz_decode_to_execute_SRC2_CTRL_1 = decode_SRC2_CTRL;
   assign _zz_decode_SRC2_CTRL = _zz_decode_SRC2_CTRL_1;
-  assign when_Pipeline_l124_16 = (! execute_arbitration_isStuck);
-  assign _zz_execute_SRC2_CTRL = decode_to_execute_SRC2_CTRL;
   assign when_Pipeline_l124_17 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_18 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_19 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_20 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SRC2_CTRL = decode_to_execute_SRC2_CTRL;
+  assign when_Pipeline_l124_18 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_19 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_20 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_21 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_22 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_23 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_24 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_25 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_26 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_27 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_28 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_22 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_23 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_24 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_25 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_26 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_27 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_28 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_29 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_30 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_31 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_32 = (! execute_arbitration_isStuck);
@@ -5449,239 +5500,248 @@ module VexRiscv (
   assign when_Pipeline_l154_1 = ((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt));
   assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
   assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
-  assign when_CsrPlugin_l1277 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_2 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_3 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_4 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_5 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_6 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_7 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_8 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_9 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_10 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_11 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_12 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_13 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_14 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_15 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_16 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_17 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_18 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_19 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_20 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_21 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_22 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_23 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_24 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_25 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_26 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_27 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_8 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_9 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_10 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_11 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_12 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_13 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_14 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_15 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_16 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_17 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_18 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_19 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_20 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_21 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_22 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_23 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_24 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_25 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_26 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_27 = (! execute_arbitration_isStuck);
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h00000000;
     if(execute_CsrPlugin_csr_3264) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_4[12 : 0] = 13'h1000;
-      _zz_CsrPlugin_csrMapping_readDataInit_4[25 : 20] = 6'h20;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[12 : 0] = 13'h1000;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[25 : 20] = 6'h20;
     end
   end
 
-  assign switch_CsrPlugin_l723 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
+  assign switch_CsrPlugin_l1031 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h00000000;
     if(execute_CsrPlugin_csr_768) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_5[19 : 19] = MmuPlugin_status_mxr;
-      _zz_CsrPlugin_csrMapping_readDataInit_5[18 : 18] = MmuPlugin_status_sum;
-      _zz_CsrPlugin_csrMapping_readDataInit_5[17 : 17] = MmuPlugin_status_mprv;
-      _zz_CsrPlugin_csrMapping_readDataInit_5[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_5[3 : 3] = CsrPlugin_mstatus_MIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_5[12 : 11] = CsrPlugin_mstatus_MPP;
-      _zz_CsrPlugin_csrMapping_readDataInit_5[8 : 8] = CsrPlugin_sstatus_SPP;
-      _zz_CsrPlugin_csrMapping_readDataInit_5[5 : 5] = CsrPlugin_sstatus_SPIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_5[1 : 1] = CsrPlugin_sstatus_SIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[19 : 19] = MmuPlugin_status_mxr;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[18 : 18] = MmuPlugin_status_sum;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[17 : 17] = MmuPlugin_status_mprv;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[8 : 8] = CsrPlugin_sstatus_SPP;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[5 : 5] = CsrPlugin_sstatus_SPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[1 : 1] = CsrPlugin_sstatus_SIE;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h00000000;
     if(execute_CsrPlugin_csr_256) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_6[19 : 19] = MmuPlugin_status_mxr;
-      _zz_CsrPlugin_csrMapping_readDataInit_6[18 : 18] = MmuPlugin_status_sum;
-      _zz_CsrPlugin_csrMapping_readDataInit_6[17 : 17] = MmuPlugin_status_mprv;
-      _zz_CsrPlugin_csrMapping_readDataInit_6[8 : 8] = CsrPlugin_sstatus_SPP;
-      _zz_CsrPlugin_csrMapping_readDataInit_6[5 : 5] = CsrPlugin_sstatus_SPIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_6[1 : 1] = CsrPlugin_sstatus_SIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[19 : 19] = MmuPlugin_status_mxr;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[18 : 18] = MmuPlugin_status_sum;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[17 : 17] = MmuPlugin_status_mprv;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[8 : 8] = CsrPlugin_sstatus_SPP;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[5 : 5] = CsrPlugin_sstatus_SPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[1 : 1] = CsrPlugin_sstatus_SIE;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h00000000;
     if(execute_CsrPlugin_csr_384) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_7[31 : 31] = MmuPlugin_satp_mode;
-      _zz_CsrPlugin_csrMapping_readDataInit_7[30 : 22] = MmuPlugin_satp_asid;
-      _zz_CsrPlugin_csrMapping_readDataInit_7[19 : 0] = MmuPlugin_satp_ppn;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[31 : 31] = MmuPlugin_satp_mode;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[30 : 22] = MmuPlugin_satp_asid;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[21 : 0] = MmuPlugin_satp_ppn;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h00000000;
     if(execute_CsrPlugin_csr_3857) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_8[0 : 0] = 1'b1;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[0 : 0] = 1'b1;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h00000000;
     if(execute_CsrPlugin_csr_3858) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_9[1 : 0] = 2'b10;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[1 : 0] = 2'b10;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_10 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h00000000;
     if(execute_CsrPlugin_csr_3859) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_10[1 : 0] = 2'b11;
+      _zz_CsrPlugin_csrMapping_readDataInit_8[1 : 0] = 2'b11;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_11 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h00000000;
     if(execute_CsrPlugin_csr_836) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_11[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_11[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_11[3 : 3] = CsrPlugin_mip_MSIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_11[5 : 5] = CsrPlugin_sip_STIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_11[1 : 1] = CsrPlugin_sip_SSIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_11[9 : 9] = CsrPlugin_sip_SEIP_OR;
+      _zz_CsrPlugin_csrMapping_readDataInit_9[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_9[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_9[3 : 3] = CsrPlugin_mip_MSIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_9[5 : 5] = CsrPlugin_sip_STIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_9[1 : 1] = CsrPlugin_sip_SSIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_9[9 : 9] = CsrPlugin_sip_SEIP_OR;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_12 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_10 = 32'h00000000;
     if(execute_CsrPlugin_csr_772) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_12[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_12[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_12[3 : 3] = CsrPlugin_mie_MSIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_12[9 : 9] = CsrPlugin_sie_SEIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_12[5 : 5] = CsrPlugin_sie_STIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_12[1 : 1] = CsrPlugin_sie_SSIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_10[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_10[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_10[3 : 3] = CsrPlugin_mie_MSIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_10[9 : 9] = CsrPlugin_sie_SEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_10[5 : 5] = CsrPlugin_sie_STIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_10[1 : 1] = CsrPlugin_sie_SSIE;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_13 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_11 = 32'h00000000;
     if(execute_CsrPlugin_csr_833) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_13[31 : 0] = CsrPlugin_mepc;
+      _zz_CsrPlugin_csrMapping_readDataInit_11[31 : 0] = CsrPlugin_mepc;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_14 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_12 = 32'h00000000;
     if(execute_CsrPlugin_csr_832) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_14[31 : 0] = CsrPlugin_mscratch;
+      _zz_CsrPlugin_csrMapping_readDataInit_12[31 : 0] = CsrPlugin_mscratch;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_15 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_13 = 32'h00000000;
     if(execute_CsrPlugin_csr_834) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_15[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_CsrPlugin_csrMapping_readDataInit_15[3 : 0] = CsrPlugin_mcause_exceptionCode;
+      _zz_CsrPlugin_csrMapping_readDataInit_13[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_CsrPlugin_csrMapping_readDataInit_13[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_16 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_14 = 32'h00000000;
     if(execute_CsrPlugin_csr_835) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_16[31 : 0] = CsrPlugin_mtval;
+      _zz_CsrPlugin_csrMapping_readDataInit_14[31 : 0] = CsrPlugin_mtval;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_17 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_15 = 32'h00000000;
     if(execute_CsrPlugin_csr_324) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_17[5 : 5] = CsrPlugin_sip_STIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_17[1 : 1] = CsrPlugin_sip_SSIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_17[9 : 9] = CsrPlugin_sip_SEIP_OR;
+      _zz_CsrPlugin_csrMapping_readDataInit_15[5 : 5] = CsrPlugin_sip_STIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_15[1 : 1] = CsrPlugin_sip_SSIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_15[9 : 9] = CsrPlugin_sip_SEIP_OR;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_18 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_16 = 32'h00000000;
     if(execute_CsrPlugin_csr_260) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_18[9 : 9] = CsrPlugin_sie_SEIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_18[5 : 5] = CsrPlugin_sie_STIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_18[1 : 1] = CsrPlugin_sie_SSIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_16[9 : 9] = CsrPlugin_sie_SEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_16[5 : 5] = CsrPlugin_sie_STIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_16[1 : 1] = CsrPlugin_sie_SSIE;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_19 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_17 = 32'h00000000;
     if(execute_CsrPlugin_csr_261) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_19[31 : 2] = CsrPlugin_stvec_base;
-      _zz_CsrPlugin_csrMapping_readDataInit_19[1 : 0] = CsrPlugin_stvec_mode;
+      _zz_CsrPlugin_csrMapping_readDataInit_17[31 : 2] = CsrPlugin_stvec_base;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_20 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_18 = 32'h00000000;
     if(execute_CsrPlugin_csr_321) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_20[31 : 0] = CsrPlugin_sepc;
+      _zz_CsrPlugin_csrMapping_readDataInit_18[31 : 0] = CsrPlugin_sepc;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_21 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_19 = 32'h00000000;
     if(execute_CsrPlugin_csr_320) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_21[31 : 0] = CsrPlugin_sscratch;
+      _zz_CsrPlugin_csrMapping_readDataInit_19[31 : 0] = CsrPlugin_sscratch;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_22 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_20 = 32'h00000000;
     if(execute_CsrPlugin_csr_322) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_22[31 : 31] = CsrPlugin_scause_interrupt;
-      _zz_CsrPlugin_csrMapping_readDataInit_22[3 : 0] = CsrPlugin_scause_exceptionCode;
+      _zz_CsrPlugin_csrMapping_readDataInit_20[31 : 31] = CsrPlugin_scause_interrupt;
+      _zz_CsrPlugin_csrMapping_readDataInit_20[3 : 0] = CsrPlugin_scause_exceptionCode;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_23 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_21 = 32'h00000000;
     if(execute_CsrPlugin_csr_323) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_23[31 : 0] = CsrPlugin_stval;
+      _zz_CsrPlugin_csrMapping_readDataInit_21[31 : 0] = CsrPlugin_stval;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_24 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_22 = 32'h00000000;
     if(execute_CsrPlugin_csr_3008) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_24[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
+      _zz_CsrPlugin_csrMapping_readDataInit_22[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_25 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_23 = 32'h00000000;
     if(execute_CsrPlugin_csr_4032) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_25[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_1;
+      _zz_CsrPlugin_csrMapping_readDataInit_23[31 : 0] = _zz_externalInterrupt;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_26 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_24 = 32'h00000000;
     if(execute_CsrPlugin_csr_2496) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_26[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_2;
+      _zz_CsrPlugin_csrMapping_readDataInit_24[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_1;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_27 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_25 = 32'h00000000;
     if(execute_CsrPlugin_csr_3520) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_27[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_3;
+      _zz_CsrPlugin_csrMapping_readDataInit_25[31 : 0] = _zz_externalInterruptS;
     end
   end
 
-  assign CsrPlugin_csrMapping_readDataInit = (((((_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5) | (_zz_CsrPlugin_csrMapping_readDataInit_6 | _zz_CsrPlugin_csrMapping_readDataInit_7)) | ((_zz_CsrPlugin_csrMapping_readDataInit_8 | _zz_CsrPlugin_csrMapping_readDataInit_9) | (_zz_CsrPlugin_csrMapping_readDataInit_10 | _zz_CsrPlugin_csrMapping_readDataInit_28))) | (((_zz_CsrPlugin_csrMapping_readDataInit_11 | _zz_CsrPlugin_csrMapping_readDataInit_12) | (_zz_CsrPlugin_csrMapping_readDataInit_13 | _zz_CsrPlugin_csrMapping_readDataInit_14)) | ((_zz_CsrPlugin_csrMapping_readDataInit_15 | _zz_CsrPlugin_csrMapping_readDataInit_16) | (_zz_CsrPlugin_csrMapping_readDataInit_17 | _zz_CsrPlugin_csrMapping_readDataInit_18)))) | ((((_zz_CsrPlugin_csrMapping_readDataInit_19 | _zz_CsrPlugin_csrMapping_readDataInit_20) | (_zz_CsrPlugin_csrMapping_readDataInit_21 | _zz_CsrPlugin_csrMapping_readDataInit_22)) | ((_zz_CsrPlugin_csrMapping_readDataInit_23 | _zz_CsrPlugin_csrMapping_readDataInit_24) | (_zz_CsrPlugin_csrMapping_readDataInit_25 | _zz_CsrPlugin_csrMapping_readDataInit_26))) | _zz_CsrPlugin_csrMapping_readDataInit_27));
-  assign when_CsrPlugin_l1310 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign when_CsrPlugin_l1315 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign CsrPlugin_csrMapping_readDataInit = (((((_zz_CsrPlugin_csrMapping_readDataInit_2 | _zz_CsrPlugin_csrMapping_readDataInit_3) | (_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5)) | ((_zz_CsrPlugin_csrMapping_readDataInit_6 | _zz_CsrPlugin_csrMapping_readDataInit_7) | (_zz_CsrPlugin_csrMapping_readDataInit_8 | _zz_CsrPlugin_csrMapping_readDataInit_26))) | (((_zz_CsrPlugin_csrMapping_readDataInit_9 | _zz_CsrPlugin_csrMapping_readDataInit_10) | (_zz_CsrPlugin_csrMapping_readDataInit_11 | _zz_CsrPlugin_csrMapping_readDataInit_12)) | ((_zz_CsrPlugin_csrMapping_readDataInit_13 | _zz_CsrPlugin_csrMapping_readDataInit_14) | (_zz_CsrPlugin_csrMapping_readDataInit_15 | _zz_CsrPlugin_csrMapping_readDataInit_16)))) | ((((_zz_CsrPlugin_csrMapping_readDataInit_17 | _zz_CsrPlugin_csrMapping_readDataInit_18) | (_zz_CsrPlugin_csrMapping_readDataInit_19 | _zz_CsrPlugin_csrMapping_readDataInit_20)) | ((_zz_CsrPlugin_csrMapping_readDataInit_21 | _zz_CsrPlugin_csrMapping_readDataInit_22) | (_zz_CsrPlugin_csrMapping_readDataInit_23 | _zz_CsrPlugin_csrMapping_readDataInit_24))) | _zz_CsrPlugin_csrMapping_readDataInit_25));
+  assign when_CsrPlugin_l1702 = ((execute_arbitration_isValid && execute_IS_CSR) && (({execute_CsrPlugin_csrAddress[11 : 2],2'b00} == 12'h3a0) || ({execute_CsrPlugin_csrAddress[11 : 4],4'b0000} == 12'h3b0)));
+  assign _zz_when_CsrPlugin_l1709 = (execute_CsrPlugin_csrAddress & 12'hf60);
+  assign when_CsrPlugin_l1709 = (((execute_arbitration_isValid && execute_IS_CSR) && (5'h03 <= execute_CsrPlugin_csrAddress[4 : 0])) && (((_zz_when_CsrPlugin_l1709 == 12'hb00) || (((_zz_when_CsrPlugin_l1709 == 12'hc00) && (! execute_CsrPlugin_writeInstruction)) && (CsrPlugin_privilege == 2'b11))) || ((execute_CsrPlugin_csrAddress & 12'hfe0) == 12'h320)));
+  always @(*) begin
+    when_CsrPlugin_l1719 = CsrPlugin_csrMapping_doForceFailCsr;
+    if(when_CsrPlugin_l1717) begin
+      when_CsrPlugin_l1719 = 1'b1;
+    end
+  end
+
+  assign when_CsrPlugin_l1717 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1725 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
   assign iBusWishbone_ADR = {_zz_iBusWishbone_ADR_1,_zz_iBusWishbone_ADR};
   assign iBusWishbone_CTI = ((_zz_iBusWishbone_ADR == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
@@ -5707,20 +5767,20 @@ module VexRiscv (
   assign iBus_rsp_valid = _zz_iBus_rsp_valid;
   assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
   assign iBus_rsp_payload_error = 1'b0;
-  assign _zz_dBus_cmd_ready_5 = (dBus_cmd_payload_size == 3'b101);
-  assign _zz_dBus_cmd_ready_1 = dBus_cmd_valid;
-  assign _zz_dBus_cmd_ready_3 = dBus_cmd_payload_wr;
-  assign _zz_dBus_cmd_ready_4 = ((! _zz_dBus_cmd_ready_5) || (_zz_dBus_cmd_ready == 3'b111));
-  assign dBus_cmd_ready = (_zz_dBus_cmd_ready_2 && (_zz_dBus_cmd_ready_3 || _zz_dBus_cmd_ready_4));
-  assign dBusWishbone_ADR = ((_zz_dBus_cmd_ready_5 ? {{dBus_cmd_payload_address[31 : 5],_zz_dBus_cmd_ready},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
-  assign dBusWishbone_CTI = (_zz_dBus_cmd_ready_5 ? (_zz_dBus_cmd_ready_4 ? 3'b111 : 3'b010) : 3'b000);
+  assign _zz_dBusWishbone_ADR_1 = (dBus_cmd_payload_size == 3'b101);
+  assign _zz_dBusWishbone_CYC = dBus_cmd_valid;
+  assign _zz_dBus_cmd_ready_1 = dBus_cmd_payload_wr;
+  assign _zz_dBus_cmd_ready_2 = ((! _zz_dBusWishbone_ADR_1) || (_zz_dBusWishbone_ADR == 3'b111));
+  assign dBus_cmd_ready = (_zz_dBus_cmd_ready && (_zz_dBus_cmd_ready_1 || _zz_dBus_cmd_ready_2));
+  assign dBusWishbone_ADR = ((_zz_dBusWishbone_ADR_1 ? {{dBus_cmd_payload_address[31 : 5],_zz_dBusWishbone_ADR},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2'd2);
+  assign dBusWishbone_CTI = (_zz_dBusWishbone_ADR_1 ? (_zz_dBus_cmd_ready_2 ? 3'b111 : 3'b010) : 3'b000);
   assign dBusWishbone_BTE = 2'b00;
-  assign dBusWishbone_SEL = (_zz_dBus_cmd_ready_3 ? dBus_cmd_payload_mask : 4'b1111);
-  assign dBusWishbone_WE = _zz_dBus_cmd_ready_3;
+  assign dBusWishbone_SEL = (_zz_dBus_cmd_ready_1 ? dBus_cmd_payload_mask : 4'b1111);
+  assign dBusWishbone_WE = _zz_dBus_cmd_ready_1;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_payload_data;
-  assign _zz_dBus_cmd_ready_2 = (_zz_dBus_cmd_ready_1 && dBusWishbone_ACK);
-  assign dBusWishbone_CYC = _zz_dBus_cmd_ready_1;
-  assign dBusWishbone_STB = _zz_dBus_cmd_ready_1;
+  assign _zz_dBus_cmd_ready = (_zz_dBusWishbone_CYC && dBusWishbone_ACK);
+  assign dBusWishbone_CYC = _zz_dBusWishbone_CYC;
+  assign dBusWishbone_STB = _zz_dBusWishbone_CYC;
   assign dBus_rsp_valid = _zz_dBus_rsp_valid;
   assign dBus_rsp_payload_data = dBusWishbone_DAT_MISO_regNext;
   assign dBus_rsp_payload_error = 1'b0;
@@ -5730,7 +5790,7 @@ module VexRiscv (
       IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
-      _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+      _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= 1'b0;
       _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
       _zz_IBusCachedPlugin_iBusRsp_stages_2_output_m2sPipe_valid <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
@@ -5739,10 +5799,10 @@ module VexRiscv (
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_5 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= 32'h0;
-      dataCache_1_io_mem_cmd_rValid <= 1'b0;
-      dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= 32'h0;
+      IBusCachedPlugin_rspCounter <= 32'h00000000;
+      toplevel_dataCache_1_io_mem_cmd_rValidN <= 1'b1;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
+      DBusCachedPlugin_rspCounter <= 32'h00000000;
       MmuPlugin_status_sum <= 1'b0;
       MmuPlugin_status_mxr <= 1'b0;
       MmuPlugin_status_mprv <= 1'b0;
@@ -5759,7 +5819,7 @@ module VexRiscv (
       MmuPlugin_ports_1_entryToReplace_value <= 2'b00;
       MmuPlugin_shared_state_1 <= MmuPlugin_shared_State_IDLE;
       MmuPlugin_shared_dBusRspStaged_valid <= 1'b0;
-      _zz_2 <= 1'b1;
+      _zz_5 <= 1'b1;
       HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
       _zz_CsrPlugin_privilege <= 2'b11;
       CsrPlugin_mstatus_MIE <= 1'b0;
@@ -5768,11 +5828,12 @@ module VexRiscv (
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
-      CsrPlugin_mcycle <= 64'h0;
-      CsrPlugin_minstret <= 64'h0;
+      CsrPlugin_mcycle <= 64'h0000000000000000;
+      CsrPlugin_minstret <= 64'h0000000000000000;
       CsrPlugin_medeleg_IAM <= 1'b0;
       CsrPlugin_medeleg_IAF <= 1'b0;
       CsrPlugin_medeleg_II <= 1'b0;
+      CsrPlugin_medeleg_BP <= 1'b0;
       CsrPlugin_medeleg_LAM <= 1'b0;
       CsrPlugin_medeleg_LAF <= 1'b0;
       CsrPlugin_medeleg_SAM <= 1'b0;
@@ -5805,10 +5866,10 @@ module VexRiscv (
       CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
-      memory_MulDivIterativePlugin_mul_counter_value <= 6'h0;
-      memory_MulDivIterativePlugin_div_counter_value <= 6'h0;
-      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h0;
-      _zz_CsrPlugin_csrMapping_readDataInit_2 <= 32'h0;
+      memory_MulDivIterativePlugin_mul_counter_value <= 6'h00;
+      memory_MulDivIterativePlugin_div_counter_value <= 6'h00;
+      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h00000000;
+      _zz_CsrPlugin_csrMapping_readDataInit_1 <= 32'h00000000;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
@@ -5816,7 +5877,7 @@ module VexRiscv (
       memory_to_writeBack_IS_DBUS_SHARING <= 1'b0;
       _zz_iBusWishbone_ADR <= 3'b000;
       _zz_iBus_rsp_valid <= 1'b0;
-      _zz_dBus_cmd_ready <= 3'b000;
+      _zz_dBusWishbone_ADR <= 3'b000;
       _zz_dBus_rsp_valid <= 1'b0;
     end else begin
       if(IBusCachedPlugin_fetchPc_correction) begin
@@ -5826,23 +5887,23 @@ module VexRiscv (
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusCachedPlugin_fetchPc_booted <= 1'b1;
-      if(when_Fetcher_l134) begin
+      if(when_Fetcher_l133) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_output_fire_1) begin
+      if(IBusCachedPlugin_fetchPc_output_fire) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b1;
       end
-      if(when_Fetcher_l134_1) begin
+      if(when_Fetcher_l133_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(when_Fetcher_l161) begin
+      if(when_Fetcher_l160) begin
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
       if(IBusCachedPlugin_iBusRsp_flush) begin
-        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= 1'b0;
       end
       if(_zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready) begin
-        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
       if(IBusCachedPlugin_iBusRsp_flush) begin
         _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
@@ -5859,13 +5920,13 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if(when_Fetcher_l332) begin
+      if(when_Fetcher_l331) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(when_Fetcher_l332_1) begin
+      if(when_Fetcher_l331_1) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= IBusCachedPlugin_injector_nextPcCalc_valids_0;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5874,7 +5935,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(when_Fetcher_l332_2) begin
+      if(when_Fetcher_l331_2) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= IBusCachedPlugin_injector_nextPcCalc_valids_1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5883,7 +5944,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(when_Fetcher_l332_3) begin
+      if(when_Fetcher_l331_3) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5892,7 +5953,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if(when_Fetcher_l332_4) begin
+      if(when_Fetcher_l331_4) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= IBusCachedPlugin_injector_nextPcCalc_valids_3;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5901,7 +5962,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_5 <= 1'b0;
       end
-      if(when_Fetcher_l332_5) begin
+      if(when_Fetcher_l331_5) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_5 <= IBusCachedPlugin_injector_nextPcCalc_valids_4;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5911,16 +5972,19 @@ module VexRiscv (
         IBusCachedPlugin_rspCounter <= (IBusCachedPlugin_rspCounter + 32'h00000001);
       end
       if(dataCache_1_io_mem_cmd_valid) begin
-        dataCache_1_io_mem_cmd_rValid <= 1'b1;
+        toplevel_dataCache_1_io_mem_cmd_rValidN <= 1'b0;
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
-        dataCache_1_io_mem_cmd_rValid <= 1'b0;
+      if(toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+        toplevel_dataCache_1_io_mem_cmd_rValidN <= 1'b1;
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
-        dataCache_1_io_mem_cmd_s2mPipe_rValid <= dataCache_1_io_mem_cmd_s2mPipe_valid;
+      if(toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+        toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_valid;
       end
       if(dBus_rsp_valid) begin
         DBusCachedPlugin_rspCounter <= (DBusCachedPlugin_rspCounter + 32'h00000001);
+      end
+      if(CsrPlugin_xretAwayFromMachine) begin
+        MmuPlugin_status_mprv <= 1'b0;
       end
       MmuPlugin_ports_0_entryToReplace_value <= MmuPlugin_ports_0_entryToReplace_valueNext;
       if(contextSwitching) begin
@@ -5955,7 +6019,7 @@ module VexRiscv (
       MmuPlugin_shared_dBusRspStaged_valid <= MmuPlugin_dBusAccess_rsp_valid;
       case(MmuPlugin_shared_state_1)
         MmuPlugin_shared_State_IDLE : begin
-          if(when_MmuPlugin_l217) begin
+          if(when_MmuPlugin_l223) begin
             MmuPlugin_shared_state_1 <= MmuPlugin_shared_State_L1_CMD;
           end
         end
@@ -5967,7 +6031,7 @@ module VexRiscv (
         MmuPlugin_shared_State_L1_RSP : begin
           if(MmuPlugin_shared_dBusRspStaged_valid) begin
             MmuPlugin_shared_state_1 <= MmuPlugin_shared_State_L0_CMD;
-            if(when_MmuPlugin_l243) begin
+            if(when_MmuPlugin_l250) begin
               MmuPlugin_shared_state_1 <= MmuPlugin_shared_State_IDLE;
             end
             if(MmuPlugin_shared_dBusRspStaged_payload_redo) begin
@@ -5989,37 +6053,37 @@ module VexRiscv (
           end
         end
       endcase
-      if(when_MmuPlugin_l272) begin
-        if(when_MmuPlugin_l274) begin
-          if(when_MmuPlugin_l280) begin
+      if(when_MmuPlugin_l279) begin
+        if(when_MmuPlugin_l281) begin
+          if(when_MmuPlugin_l287) begin
             MmuPlugin_ports_0_cache_0_valid <= 1'b1;
           end
-          if(when_MmuPlugin_l280_1) begin
+          if(when_MmuPlugin_l287_1) begin
             MmuPlugin_ports_0_cache_1_valid <= 1'b1;
           end
-          if(when_MmuPlugin_l280_2) begin
+          if(when_MmuPlugin_l287_2) begin
             MmuPlugin_ports_0_cache_2_valid <= 1'b1;
           end
-          if(when_MmuPlugin_l280_3) begin
+          if(when_MmuPlugin_l287_3) begin
             MmuPlugin_ports_0_cache_3_valid <= 1'b1;
           end
         end
-        if(when_MmuPlugin_l274_1) begin
-          if(when_MmuPlugin_l280_4) begin
+        if(when_MmuPlugin_l281_1) begin
+          if(when_MmuPlugin_l287_4) begin
             MmuPlugin_ports_1_cache_0_valid <= 1'b1;
           end
-          if(when_MmuPlugin_l280_5) begin
+          if(when_MmuPlugin_l287_5) begin
             MmuPlugin_ports_1_cache_1_valid <= 1'b1;
           end
-          if(when_MmuPlugin_l280_6) begin
+          if(when_MmuPlugin_l287_6) begin
             MmuPlugin_ports_1_cache_2_valid <= 1'b1;
           end
-          if(when_MmuPlugin_l280_7) begin
+          if(when_MmuPlugin_l287_7) begin
             MmuPlugin_ports_1_cache_3_valid <= 1'b1;
           end
         end
       end
-      if(when_MmuPlugin_l304) begin
+      if(when_MmuPlugin_l311) begin
         MmuPlugin_ports_0_cache_0_valid <= 1'b0;
         MmuPlugin_ports_0_cache_1_valid <= 1'b0;
         MmuPlugin_ports_0_cache_2_valid <= 1'b0;
@@ -6029,77 +6093,77 @@ module VexRiscv (
         MmuPlugin_ports_1_cache_2_valid <= 1'b0;
         MmuPlugin_ports_1_cache_3_valid <= 1'b0;
       end
-      _zz_2 <= 1'b0;
+      _zz_5 <= 1'b0;
       HazardSimplePlugin_writeBackBuffer_valid <= HazardSimplePlugin_writeBackWrites_valid;
       CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
       if(writeBack_arbitration_isFiring) begin
         CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
       end
-      if(when_CsrPlugin_l922) begin
+      if(when_CsrPlugin_l1259) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if(when_CsrPlugin_l922_1) begin
+      if(when_CsrPlugin_l1259_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if(when_CsrPlugin_l922_2) begin
+      if(when_CsrPlugin_l1259_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if(when_CsrPlugin_l922_3) begin
+      if(when_CsrPlugin_l1259_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(when_CsrPlugin_l959) begin
-        if(when_CsrPlugin_l965) begin
+      if(when_CsrPlugin_l1296) begin
+        if(when_CsrPlugin_l1302) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_1) begin
+        if(when_CsrPlugin_l1302_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_2) begin
+        if(when_CsrPlugin_l1302_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
-      if(when_CsrPlugin_l959_1) begin
-        if(when_CsrPlugin_l965_3) begin
+      if(when_CsrPlugin_l1296_1) begin
+        if(when_CsrPlugin_l1302_3) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_4) begin
+        if(when_CsrPlugin_l1302_4) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_5) begin
+        if(when_CsrPlugin_l1302_5) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_6) begin
+        if(when_CsrPlugin_l1302_6) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_7) begin
+        if(when_CsrPlugin_l1302_7) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_8) begin
+        if(when_CsrPlugin_l1302_8) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
       CsrPlugin_lastStageWasWfi <= (writeBack_arbitration_isFiring && (writeBack_ENV_CTRL == EnvCtrlEnum_WFI));
       if(CsrPlugin_pipelineLiberator_active) begin
-        if(when_CsrPlugin_l993) begin
+        if(when_CsrPlugin_l1335) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if(when_CsrPlugin_l993_1) begin
+        if(when_CsrPlugin_l1335_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if(when_CsrPlugin_l993_2) begin
+        if(when_CsrPlugin_l1335_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(when_CsrPlugin_l998) begin
+      if(when_CsrPlugin_l1340) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
@@ -6108,25 +6172,27 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(when_CsrPlugin_l1032) begin
-        _zz_CsrPlugin_privilege <= CsrPlugin_targetPrivilege;
-        case(CsrPlugin_targetPrivilege)
-          2'b01 : begin
-            CsrPlugin_sstatus_SIE <= 1'b0;
-            CsrPlugin_sstatus_SPIE <= CsrPlugin_sstatus_SIE;
-            CsrPlugin_sstatus_SPP <= CsrPlugin_privilege[0 : 0];
-          end
-          2'b11 : begin
-            CsrPlugin_mstatus_MIE <= 1'b0;
-            CsrPlugin_mstatus_MPIE <= CsrPlugin_mstatus_MIE;
-            CsrPlugin_mstatus_MPP <= CsrPlugin_privilege;
-          end
-          default : begin
-          end
-        endcase
+      if(when_CsrPlugin_l1390) begin
+        if(when_CsrPlugin_l1398) begin
+          _zz_CsrPlugin_privilege <= CsrPlugin_targetPrivilege;
+          case(CsrPlugin_targetPrivilege)
+            2'b01 : begin
+              CsrPlugin_sstatus_SIE <= 1'b0;
+              CsrPlugin_sstatus_SPIE <= CsrPlugin_sstatus_SIE;
+              CsrPlugin_sstatus_SPP <= CsrPlugin_privilege[0 : 0];
+            end
+            2'b11 : begin
+              CsrPlugin_mstatus_MIE <= 1'b0;
+              CsrPlugin_mstatus_MPIE <= CsrPlugin_mstatus_MIE;
+              CsrPlugin_mstatus_MPP <= CsrPlugin_privilege;
+            end
+            default : begin
+            end
+          endcase
+        end
       end
-      if(when_CsrPlugin_l1077) begin
-        case(switch_CsrPlugin_l1081)
+      if(when_CsrPlugin_l1456) begin
+        case(switch_CsrPlugin_l1460)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -6143,7 +6209,7 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l965_5,{_zz_when_CsrPlugin_l965_4,{_zz_when_CsrPlugin_l965_3,{_zz_when_CsrPlugin_l965_2,{_zz_when_CsrPlugin_l965_1,_zz_when_CsrPlugin_l965}}}}} != 6'h0) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l1302_5,{_zz_when_CsrPlugin_l1302_4,{_zz_when_CsrPlugin_l1302_3,{_zz_when_CsrPlugin_l1302_2,{_zz_when_CsrPlugin_l1302_1,_zz_when_CsrPlugin_l1302}}}}} != 6'h00) || CsrPlugin_thirdPartyWake);
       memory_MulDivIterativePlugin_mul_counter_value <= memory_MulDivIterativePlugin_mul_counter_valueNext;
       memory_MulDivIterativePlugin_div_counter_value <= memory_MulDivIterativePlugin_div_counter_valueNext;
       if(when_Pipeline_l124_55) begin
@@ -6183,7 +6249,7 @@ module VexRiscv (
           MmuPlugin_status_mprv <= CsrPlugin_csrMapping_writeDataSignal[17];
           CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
           CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
-          case(switch_CsrPlugin_l723)
+          case(switch_CsrPlugin_l1031)
             2'b11 : begin
               CsrPlugin_mstatus_MPP <= 2'b11;
             end
@@ -6246,6 +6312,7 @@ module VexRiscv (
           CsrPlugin_medeleg_IAM <= CsrPlugin_csrMapping_writeDataSignal[0];
           CsrPlugin_medeleg_IAF <= CsrPlugin_csrMapping_writeDataSignal[1];
           CsrPlugin_medeleg_II <= CsrPlugin_csrMapping_writeDataSignal[2];
+          CsrPlugin_medeleg_BP <= CsrPlugin_csrMapping_writeDataSignal[3];
           CsrPlugin_medeleg_LAM <= CsrPlugin_csrMapping_writeDataSignal[4];
           CsrPlugin_medeleg_LAF <= CsrPlugin_csrMapping_writeDataSignal[5];
           CsrPlugin_medeleg_SAM <= CsrPlugin_csrMapping_writeDataSignal[6];
@@ -6285,7 +6352,7 @@ module VexRiscv (
       end
       if(execute_CsrPlugin_csr_2496) begin
         if(execute_CsrPlugin_writeEnable) begin
-          _zz_CsrPlugin_csrMapping_readDataInit_2 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+          _zz_CsrPlugin_csrMapping_readDataInit_1 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
         end
       end
       if(when_InstructionCache_l239) begin
@@ -6294,13 +6361,13 @@ module VexRiscv (
         end
       end
       _zz_iBus_rsp_valid <= (iBusWishbone_CYC && iBusWishbone_ACK);
-      if((_zz_dBus_cmd_ready_1 && _zz_dBus_cmd_ready_2)) begin
-        _zz_dBus_cmd_ready <= (_zz_dBus_cmd_ready + 3'b001);
-        if(_zz_dBus_cmd_ready_4) begin
-          _zz_dBus_cmd_ready <= 3'b000;
+      if((_zz_dBusWishbone_CYC && _zz_dBus_cmd_ready)) begin
+        _zz_dBusWishbone_ADR <= (_zz_dBusWishbone_ADR + 3'b001);
+        if(_zz_dBus_cmd_ready_2) begin
+          _zz_dBusWishbone_ADR <= 3'b000;
         end
       end
-      _zz_dBus_rsp_valid <= ((_zz_dBus_cmd_ready_1 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
+      _zz_dBus_rsp_valid <= ((_zz_dBusWishbone_CYC && (! dBusWishbone_WE)) && dBusWishbone_ACK);
     end
   end
 
@@ -6317,28 +6384,28 @@ module VexRiscv (
     if(IBusCachedPlugin_iBusRsp_stages_3_input_ready) begin
       IBusCachedPlugin_s2_tightlyCoupledHit <= IBusCachedPlugin_s1_tightlyCoupledHit;
     end
-    if(dataCache_1_io_mem_cmd_ready) begin
-      dataCache_1_io_mem_cmd_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
-      dataCache_1_io_mem_cmd_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
-      dataCache_1_io_mem_cmd_rData_address <= dataCache_1_io_mem_cmd_payload_address;
-      dataCache_1_io_mem_cmd_rData_data <= dataCache_1_io_mem_cmd_payload_data;
-      dataCache_1_io_mem_cmd_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
-      dataCache_1_io_mem_cmd_rData_size <= dataCache_1_io_mem_cmd_payload_size;
-      dataCache_1_io_mem_cmd_rData_last <= dataCache_1_io_mem_cmd_payload_last;
+    if(toplevel_dataCache_1_io_mem_cmd_rValidN) begin
+      toplevel_dataCache_1_io_mem_cmd_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
+      toplevel_dataCache_1_io_mem_cmd_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
+      toplevel_dataCache_1_io_mem_cmd_rData_address <= dataCache_1_io_mem_cmd_payload_address;
+      toplevel_dataCache_1_io_mem_cmd_rData_data <= dataCache_1_io_mem_cmd_payload_data;
+      toplevel_dataCache_1_io_mem_cmd_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
+      toplevel_dataCache_1_io_mem_cmd_rData_size <= dataCache_1_io_mem_cmd_payload_size;
+      toplevel_dataCache_1_io_mem_cmd_rData_last <= dataCache_1_io_mem_cmd_payload_last;
     end
-    if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
-      dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_address <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_data <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_size <= dataCache_1_io_mem_cmd_s2mPipe_payload_size;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_last <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+    if(toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_address <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_data <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_size <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_size;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_last <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_last;
     end
     MmuPlugin_shared_dBusRspStaged_payload_data <= MmuPlugin_dBusAccess_rsp_payload_data;
     MmuPlugin_shared_dBusRspStaged_payload_error <= MmuPlugin_dBusAccess_rsp_payload_error;
     MmuPlugin_shared_dBusRspStaged_payload_redo <= MmuPlugin_dBusAccess_rsp_payload_redo;
-    if(when_MmuPlugin_l205) begin
+    if(when_MmuPlugin_l211) begin
       MmuPlugin_shared_pteBuffer_V <= MmuPlugin_shared_dBusRsp_pte_V;
       MmuPlugin_shared_pteBuffer_R <= MmuPlugin_shared_dBusRsp_pte_R;
       MmuPlugin_shared_pteBuffer_W <= MmuPlugin_shared_dBusRsp_pte_W;
@@ -6353,7 +6420,7 @@ module VexRiscv (
     end
     case(MmuPlugin_shared_state_1)
       MmuPlugin_shared_State_IDLE : begin
-        if(when_MmuPlugin_l217) begin
+        if(when_MmuPlugin_l223) begin
           MmuPlugin_shared_portSortedOh <= MmuPlugin_shared_refills;
           MmuPlugin_shared_vpn_1 <= _zz_MmuPlugin_shared_vpn_0[31 : 22];
           MmuPlugin_shared_vpn_0 <= _zz_MmuPlugin_shared_vpn_0[21 : 12];
@@ -6368,102 +6435,102 @@ module VexRiscv (
       default : begin
       end
     endcase
-    if(when_MmuPlugin_l272) begin
-      if(when_MmuPlugin_l274) begin
-        if(when_MmuPlugin_l280) begin
-          MmuPlugin_ports_0_cache_0_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
+    if(when_MmuPlugin_l279) begin
+      if(when_MmuPlugin_l281) begin
+        if(when_MmuPlugin_l287) begin
+          MmuPlugin_ports_0_cache_0_exception <= ((MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h000))) || (! MmuPlugin_shared_dBusRsp_pte_A));
           MmuPlugin_ports_0_cache_0_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_0_cache_0_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
           MmuPlugin_ports_0_cache_0_physicalAddress_0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
           MmuPlugin_ports_0_cache_0_physicalAddress_1 <= MmuPlugin_shared_dBusRsp_pte_PPN1[9 : 0];
           MmuPlugin_ports_0_cache_0_allowRead <= MmuPlugin_shared_dBusRsp_pte_R;
-          MmuPlugin_ports_0_cache_0_allowWrite <= MmuPlugin_shared_dBusRsp_pte_W;
+          MmuPlugin_ports_0_cache_0_allowWrite <= (MmuPlugin_shared_dBusRsp_pte_W && MmuPlugin_shared_dBusRsp_pte_D);
           MmuPlugin_ports_0_cache_0_allowExecute <= MmuPlugin_shared_dBusRsp_pte_X;
           MmuPlugin_ports_0_cache_0_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
           MmuPlugin_ports_0_cache_0_superPage <= (MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP);
         end
-        if(when_MmuPlugin_l280_1) begin
-          MmuPlugin_ports_0_cache_1_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
+        if(when_MmuPlugin_l287_1) begin
+          MmuPlugin_ports_0_cache_1_exception <= ((MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h000))) || (! MmuPlugin_shared_dBusRsp_pte_A));
           MmuPlugin_ports_0_cache_1_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_0_cache_1_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
           MmuPlugin_ports_0_cache_1_physicalAddress_0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
           MmuPlugin_ports_0_cache_1_physicalAddress_1 <= MmuPlugin_shared_dBusRsp_pte_PPN1[9 : 0];
           MmuPlugin_ports_0_cache_1_allowRead <= MmuPlugin_shared_dBusRsp_pte_R;
-          MmuPlugin_ports_0_cache_1_allowWrite <= MmuPlugin_shared_dBusRsp_pte_W;
+          MmuPlugin_ports_0_cache_1_allowWrite <= (MmuPlugin_shared_dBusRsp_pte_W && MmuPlugin_shared_dBusRsp_pte_D);
           MmuPlugin_ports_0_cache_1_allowExecute <= MmuPlugin_shared_dBusRsp_pte_X;
           MmuPlugin_ports_0_cache_1_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
           MmuPlugin_ports_0_cache_1_superPage <= (MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP);
         end
-        if(when_MmuPlugin_l280_2) begin
-          MmuPlugin_ports_0_cache_2_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
+        if(when_MmuPlugin_l287_2) begin
+          MmuPlugin_ports_0_cache_2_exception <= ((MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h000))) || (! MmuPlugin_shared_dBusRsp_pte_A));
           MmuPlugin_ports_0_cache_2_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_0_cache_2_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
           MmuPlugin_ports_0_cache_2_physicalAddress_0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
           MmuPlugin_ports_0_cache_2_physicalAddress_1 <= MmuPlugin_shared_dBusRsp_pte_PPN1[9 : 0];
           MmuPlugin_ports_0_cache_2_allowRead <= MmuPlugin_shared_dBusRsp_pte_R;
-          MmuPlugin_ports_0_cache_2_allowWrite <= MmuPlugin_shared_dBusRsp_pte_W;
+          MmuPlugin_ports_0_cache_2_allowWrite <= (MmuPlugin_shared_dBusRsp_pte_W && MmuPlugin_shared_dBusRsp_pte_D);
           MmuPlugin_ports_0_cache_2_allowExecute <= MmuPlugin_shared_dBusRsp_pte_X;
           MmuPlugin_ports_0_cache_2_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
           MmuPlugin_ports_0_cache_2_superPage <= (MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP);
         end
-        if(when_MmuPlugin_l280_3) begin
-          MmuPlugin_ports_0_cache_3_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
+        if(when_MmuPlugin_l287_3) begin
+          MmuPlugin_ports_0_cache_3_exception <= ((MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h000))) || (! MmuPlugin_shared_dBusRsp_pte_A));
           MmuPlugin_ports_0_cache_3_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_0_cache_3_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
           MmuPlugin_ports_0_cache_3_physicalAddress_0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
           MmuPlugin_ports_0_cache_3_physicalAddress_1 <= MmuPlugin_shared_dBusRsp_pte_PPN1[9 : 0];
           MmuPlugin_ports_0_cache_3_allowRead <= MmuPlugin_shared_dBusRsp_pte_R;
-          MmuPlugin_ports_0_cache_3_allowWrite <= MmuPlugin_shared_dBusRsp_pte_W;
+          MmuPlugin_ports_0_cache_3_allowWrite <= (MmuPlugin_shared_dBusRsp_pte_W && MmuPlugin_shared_dBusRsp_pte_D);
           MmuPlugin_ports_0_cache_3_allowExecute <= MmuPlugin_shared_dBusRsp_pte_X;
           MmuPlugin_ports_0_cache_3_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
           MmuPlugin_ports_0_cache_3_superPage <= (MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP);
         end
       end
-      if(when_MmuPlugin_l274_1) begin
-        if(when_MmuPlugin_l280_4) begin
-          MmuPlugin_ports_1_cache_0_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
+      if(when_MmuPlugin_l281_1) begin
+        if(when_MmuPlugin_l287_4) begin
+          MmuPlugin_ports_1_cache_0_exception <= ((MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h000))) || (! MmuPlugin_shared_dBusRsp_pte_A));
           MmuPlugin_ports_1_cache_0_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_1_cache_0_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
           MmuPlugin_ports_1_cache_0_physicalAddress_0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
           MmuPlugin_ports_1_cache_0_physicalAddress_1 <= MmuPlugin_shared_dBusRsp_pte_PPN1[9 : 0];
           MmuPlugin_ports_1_cache_0_allowRead <= MmuPlugin_shared_dBusRsp_pte_R;
-          MmuPlugin_ports_1_cache_0_allowWrite <= MmuPlugin_shared_dBusRsp_pte_W;
+          MmuPlugin_ports_1_cache_0_allowWrite <= (MmuPlugin_shared_dBusRsp_pte_W && MmuPlugin_shared_dBusRsp_pte_D);
           MmuPlugin_ports_1_cache_0_allowExecute <= MmuPlugin_shared_dBusRsp_pte_X;
           MmuPlugin_ports_1_cache_0_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
           MmuPlugin_ports_1_cache_0_superPage <= (MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP);
         end
-        if(when_MmuPlugin_l280_5) begin
-          MmuPlugin_ports_1_cache_1_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
+        if(when_MmuPlugin_l287_5) begin
+          MmuPlugin_ports_1_cache_1_exception <= ((MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h000))) || (! MmuPlugin_shared_dBusRsp_pte_A));
           MmuPlugin_ports_1_cache_1_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_1_cache_1_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
           MmuPlugin_ports_1_cache_1_physicalAddress_0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
           MmuPlugin_ports_1_cache_1_physicalAddress_1 <= MmuPlugin_shared_dBusRsp_pte_PPN1[9 : 0];
           MmuPlugin_ports_1_cache_1_allowRead <= MmuPlugin_shared_dBusRsp_pte_R;
-          MmuPlugin_ports_1_cache_1_allowWrite <= MmuPlugin_shared_dBusRsp_pte_W;
+          MmuPlugin_ports_1_cache_1_allowWrite <= (MmuPlugin_shared_dBusRsp_pte_W && MmuPlugin_shared_dBusRsp_pte_D);
           MmuPlugin_ports_1_cache_1_allowExecute <= MmuPlugin_shared_dBusRsp_pte_X;
           MmuPlugin_ports_1_cache_1_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
           MmuPlugin_ports_1_cache_1_superPage <= (MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP);
         end
-        if(when_MmuPlugin_l280_6) begin
-          MmuPlugin_ports_1_cache_2_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
+        if(when_MmuPlugin_l287_6) begin
+          MmuPlugin_ports_1_cache_2_exception <= ((MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h000))) || (! MmuPlugin_shared_dBusRsp_pte_A));
           MmuPlugin_ports_1_cache_2_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_1_cache_2_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
           MmuPlugin_ports_1_cache_2_physicalAddress_0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
           MmuPlugin_ports_1_cache_2_physicalAddress_1 <= MmuPlugin_shared_dBusRsp_pte_PPN1[9 : 0];
           MmuPlugin_ports_1_cache_2_allowRead <= MmuPlugin_shared_dBusRsp_pte_R;
-          MmuPlugin_ports_1_cache_2_allowWrite <= MmuPlugin_shared_dBusRsp_pte_W;
+          MmuPlugin_ports_1_cache_2_allowWrite <= (MmuPlugin_shared_dBusRsp_pte_W && MmuPlugin_shared_dBusRsp_pte_D);
           MmuPlugin_ports_1_cache_2_allowExecute <= MmuPlugin_shared_dBusRsp_pte_X;
           MmuPlugin_ports_1_cache_2_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
           MmuPlugin_ports_1_cache_2_superPage <= (MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP);
         end
-        if(when_MmuPlugin_l280_7) begin
-          MmuPlugin_ports_1_cache_3_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
+        if(when_MmuPlugin_l287_7) begin
+          MmuPlugin_ports_1_cache_3_exception <= ((MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h000))) || (! MmuPlugin_shared_dBusRsp_pte_A));
           MmuPlugin_ports_1_cache_3_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_1_cache_3_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
           MmuPlugin_ports_1_cache_3_physicalAddress_0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
           MmuPlugin_ports_1_cache_3_physicalAddress_1 <= MmuPlugin_shared_dBusRsp_pte_PPN1[9 : 0];
           MmuPlugin_ports_1_cache_3_allowRead <= MmuPlugin_shared_dBusRsp_pte_R;
-          MmuPlugin_ports_1_cache_3_allowWrite <= MmuPlugin_shared_dBusRsp_pte_W;
+          MmuPlugin_ports_1_cache_3_allowWrite <= (MmuPlugin_shared_dBusRsp_pte_W && MmuPlugin_shared_dBusRsp_pte_D);
           MmuPlugin_ports_1_cache_3_allowExecute <= MmuPlugin_shared_dBusRsp_pte_X;
           MmuPlugin_ports_1_cache_3_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
           MmuPlugin_ports_1_cache_3_superPage <= (MmuPlugin_shared_state_1 == MmuPlugin_shared_State_L1_RSP);
@@ -6492,72 +6559,74 @@ module VexRiscv (
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(when_CsrPlugin_l959) begin
-      if(when_CsrPlugin_l965) begin
+    if(when_CsrPlugin_l1296) begin
+      if(when_CsrPlugin_l1302) begin
         CsrPlugin_interrupt_code <= 4'b0101;
         CsrPlugin_interrupt_targetPrivilege <= 2'b01;
       end
-      if(when_CsrPlugin_l965_1) begin
+      if(when_CsrPlugin_l1302_1) begin
         CsrPlugin_interrupt_code <= 4'b0001;
         CsrPlugin_interrupt_targetPrivilege <= 2'b01;
       end
-      if(when_CsrPlugin_l965_2) begin
+      if(when_CsrPlugin_l1302_2) begin
         CsrPlugin_interrupt_code <= 4'b1001;
         CsrPlugin_interrupt_targetPrivilege <= 2'b01;
       end
     end
-    if(when_CsrPlugin_l959_1) begin
-      if(when_CsrPlugin_l965_3) begin
+    if(when_CsrPlugin_l1296_1) begin
+      if(when_CsrPlugin_l1302_3) begin
         CsrPlugin_interrupt_code <= 4'b0101;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l965_4) begin
+      if(when_CsrPlugin_l1302_4) begin
         CsrPlugin_interrupt_code <= 4'b0001;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l965_5) begin
+      if(when_CsrPlugin_l1302_5) begin
         CsrPlugin_interrupt_code <= 4'b1001;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l965_6) begin
+      if(when_CsrPlugin_l1302_6) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l965_7) begin
+      if(when_CsrPlugin_l1302_7) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l965_8) begin
+      if(when_CsrPlugin_l1302_8) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(when_CsrPlugin_l1032) begin
-      case(CsrPlugin_targetPrivilege)
-        2'b01 : begin
-          CsrPlugin_scause_interrupt <= (! CsrPlugin_hadException);
-          CsrPlugin_scause_exceptionCode <= CsrPlugin_trapCause;
-          CsrPlugin_sepc <= writeBack_PC;
-          if(CsrPlugin_hadException) begin
-            CsrPlugin_stval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
+    if(when_CsrPlugin_l1390) begin
+      if(when_CsrPlugin_l1398) begin
+        case(CsrPlugin_targetPrivilege)
+          2'b01 : begin
+            CsrPlugin_scause_interrupt <= (! CsrPlugin_hadException);
+            CsrPlugin_scause_exceptionCode <= CsrPlugin_trapCause;
+            CsrPlugin_sepc <= writeBack_PC;
+            if(CsrPlugin_hadException) begin
+              CsrPlugin_stval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
+            end
           end
-        end
-        2'b11 : begin
-          CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
-          CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
-          CsrPlugin_mepc <= writeBack_PC;
-          if(CsrPlugin_hadException) begin
-            CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
+          2'b11 : begin
+            CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
+            CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
+            CsrPlugin_mepc <= writeBack_PC;
+            if(CsrPlugin_hadException) begin
+              CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
+            end
           end
-        end
-        default : begin
-        end
-      endcase
+          default : begin
+          end
+        endcase
+      end
     end
     if(when_MulDivIterativePlugin_l96) begin
       if(when_MulDivIterativePlugin_l100) begin
         memory_MulDivIterativePlugin_rs2 <= (memory_MulDivIterativePlugin_rs2 >>> 1);
-        memory_MulDivIterativePlugin_accumulator <= ({_zz_memory_MulDivIterativePlugin_accumulator,memory_MulDivIterativePlugin_accumulator[31 : 0]} >>> 1);
+        memory_MulDivIterativePlugin_accumulator <= ({_zz_memory_MulDivIterativePlugin_accumulator,memory_MulDivIterativePlugin_accumulator[31 : 0]} >>> 1'd1);
       end
     end
     if(when_MulDivIterativePlugin_l126) begin
@@ -6576,17 +6645,17 @@ module VexRiscv (
       end
     end
     if(when_MulDivIterativePlugin_l162) begin
-      memory_MulDivIterativePlugin_accumulator <= 65'h0;
-      memory_MulDivIterativePlugin_rs1 <= ((_zz_memory_MulDivIterativePlugin_rs1_1 ? (~ _zz_memory_MulDivIterativePlugin_rs1_2) : _zz_memory_MulDivIterativePlugin_rs1_2) + _zz_memory_MulDivIterativePlugin_rs1_3);
-      memory_MulDivIterativePlugin_rs2 <= ((_zz_memory_MulDivIterativePlugin_rs1 ? (~ execute_RS2) : execute_RS2) + _zz_memory_MulDivIterativePlugin_rs2);
-      memory_MulDivIterativePlugin_div_needRevert <= ((_zz_memory_MulDivIterativePlugin_rs1_1 ^ (_zz_memory_MulDivIterativePlugin_rs1 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
+      memory_MulDivIterativePlugin_accumulator <= 65'h00000000000000000;
+      memory_MulDivIterativePlugin_rs1 <= ((_zz_memory_MulDivIterativePlugin_rs1 ? (~ _zz_memory_MulDivIterativePlugin_rs1_1) : _zz_memory_MulDivIterativePlugin_rs1_1) + _zz_memory_MulDivIterativePlugin_rs1_2);
+      memory_MulDivIterativePlugin_rs2 <= ((_zz_memory_MulDivIterativePlugin_rs2 ? (~ execute_RS2) : execute_RS2) + _zz_memory_MulDivIterativePlugin_rs2_1);
+      memory_MulDivIterativePlugin_div_needRevert <= ((_zz_memory_MulDivIterativePlugin_rs1 ^ (_zz_memory_MulDivIterativePlugin_rs2 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h00000000) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
     end
     externalInterruptArray_regNext <= externalInterruptArray;
     if(when_Pipeline_l124) begin
       decode_to_execute_PC <= decode_PC;
     end
     if(when_Pipeline_l124_1) begin
-      execute_to_memory_PC <= _zz_execute_SRC2;
+      execute_to_memory_PC <= _zz_execute_to_memory_PC;
     end
     if(when_Pipeline_l124_2) begin
       memory_to_writeBack_PC <= memory_PC;
@@ -6613,73 +6682,73 @@ module VexRiscv (
       decode_to_execute_MEMORY_FORCE_CONSTISTENCY <= decode_MEMORY_FORCE_CONSTISTENCY;
     end
     if(when_Pipeline_l124_10) begin
-      decode_to_execute_SRC1_CTRL <= _zz_decode_to_execute_SRC1_CTRL;
+      decode_to_execute_RESCHEDULE_NEXT <= decode_RESCHEDULE_NEXT;
     end
     if(when_Pipeline_l124_11) begin
-      decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
+      decode_to_execute_SRC1_CTRL <= _zz_decode_to_execute_SRC1_CTRL;
     end
     if(when_Pipeline_l124_12) begin
-      decode_to_execute_MEMORY_ENABLE <= decode_MEMORY_ENABLE;
+      decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
     end
     if(when_Pipeline_l124_13) begin
-      execute_to_memory_MEMORY_ENABLE <= execute_MEMORY_ENABLE;
+      decode_to_execute_MEMORY_ENABLE <= decode_MEMORY_ENABLE;
     end
     if(when_Pipeline_l124_14) begin
-      memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
+      execute_to_memory_MEMORY_ENABLE <= execute_MEMORY_ENABLE;
     end
     if(when_Pipeline_l124_15) begin
-      decode_to_execute_ALU_CTRL <= _zz_decode_to_execute_ALU_CTRL;
+      memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
     end
     if(when_Pipeline_l124_16) begin
-      decode_to_execute_SRC2_CTRL <= _zz_decode_to_execute_SRC2_CTRL;
+      decode_to_execute_ALU_CTRL <= _zz_decode_to_execute_ALU_CTRL;
     end
     if(when_Pipeline_l124_17) begin
-      decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
+      decode_to_execute_SRC2_CTRL <= _zz_decode_to_execute_SRC2_CTRL;
     end
     if(when_Pipeline_l124_18) begin
-      execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
+      decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
     end
     if(when_Pipeline_l124_19) begin
-      memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
+      execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
     end
     if(when_Pipeline_l124_20) begin
-      decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
+      memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
     end
     if(when_Pipeline_l124_21) begin
-      decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
+      decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
     end
     if(when_Pipeline_l124_22) begin
-      execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
+      decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
     end
     if(when_Pipeline_l124_23) begin
-      decode_to_execute_MEMORY_WR <= decode_MEMORY_WR;
+      execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
     end
     if(when_Pipeline_l124_24) begin
-      execute_to_memory_MEMORY_WR <= execute_MEMORY_WR;
+      decode_to_execute_MEMORY_WR <= decode_MEMORY_WR;
     end
     if(when_Pipeline_l124_25) begin
-      memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
+      execute_to_memory_MEMORY_WR <= execute_MEMORY_WR;
     end
     if(when_Pipeline_l124_26) begin
-      decode_to_execute_MEMORY_LRSC <= decode_MEMORY_LRSC;
+      memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
     end
     if(when_Pipeline_l124_27) begin
-      execute_to_memory_MEMORY_LRSC <= execute_MEMORY_LRSC;
+      decode_to_execute_MEMORY_LRSC <= decode_MEMORY_LRSC;
     end
     if(when_Pipeline_l124_28) begin
-      memory_to_writeBack_MEMORY_LRSC <= memory_MEMORY_LRSC;
+      execute_to_memory_MEMORY_LRSC <= execute_MEMORY_LRSC;
     end
     if(when_Pipeline_l124_29) begin
-      decode_to_execute_MEMORY_AMO <= decode_MEMORY_AMO;
+      memory_to_writeBack_MEMORY_LRSC <= memory_MEMORY_LRSC;
     end
     if(when_Pipeline_l124_30) begin
-      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
+      decode_to_execute_MEMORY_AMO <= decode_MEMORY_AMO;
     end
     if(when_Pipeline_l124_31) begin
-      decode_to_execute_IS_SFENCE_VMA2 <= decode_IS_SFENCE_VMA2;
+      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
     end
     if(when_Pipeline_l124_32) begin
-      decode_to_execute_IS_SFENCE_VMA <= decode_IS_SFENCE_VMA;
+      decode_to_execute_IS_SFENCE_VMA2 <= decode_IS_SFENCE_VMA2;
     end
     if(when_Pipeline_l124_33) begin
       decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
@@ -6762,94 +6831,94 @@ module VexRiscv (
     if(when_Pipeline_l124_61) begin
       execute_to_memory_BRANCH_CALC <= execute_BRANCH_CALC;
     end
-    if(when_CsrPlugin_l1277) begin
+    if(when_CsrPlugin_l1669) begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
     end
-    if(when_CsrPlugin_l1277_1) begin
+    if(when_CsrPlugin_l1669_1) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if(when_CsrPlugin_l1277_2) begin
+    if(when_CsrPlugin_l1669_2) begin
       execute_CsrPlugin_csr_256 <= (decode_INSTRUCTION[31 : 20] == 12'h100);
     end
-    if(when_CsrPlugin_l1277_3) begin
+    if(when_CsrPlugin_l1669_3) begin
       execute_CsrPlugin_csr_384 <= (decode_INSTRUCTION[31 : 20] == 12'h180);
     end
-    if(when_CsrPlugin_l1277_4) begin
+    if(when_CsrPlugin_l1669_4) begin
       execute_CsrPlugin_csr_3857 <= (decode_INSTRUCTION[31 : 20] == 12'hf11);
     end
-    if(when_CsrPlugin_l1277_5) begin
+    if(when_CsrPlugin_l1669_5) begin
       execute_CsrPlugin_csr_3858 <= (decode_INSTRUCTION[31 : 20] == 12'hf12);
     end
-    if(when_CsrPlugin_l1277_6) begin
+    if(when_CsrPlugin_l1669_6) begin
       execute_CsrPlugin_csr_3859 <= (decode_INSTRUCTION[31 : 20] == 12'hf13);
     end
-    if(when_CsrPlugin_l1277_7) begin
+    if(when_CsrPlugin_l1669_7) begin
       execute_CsrPlugin_csr_3860 <= (decode_INSTRUCTION[31 : 20] == 12'hf14);
     end
-    if(when_CsrPlugin_l1277_8) begin
+    if(when_CsrPlugin_l1669_8) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if(when_CsrPlugin_l1277_9) begin
+    if(when_CsrPlugin_l1669_9) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if(when_CsrPlugin_l1277_10) begin
+    if(when_CsrPlugin_l1669_10) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if(when_CsrPlugin_l1277_11) begin
+    if(when_CsrPlugin_l1669_11) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if(when_CsrPlugin_l1277_12) begin
+    if(when_CsrPlugin_l1669_12) begin
       execute_CsrPlugin_csr_832 <= (decode_INSTRUCTION[31 : 20] == 12'h340);
     end
-    if(when_CsrPlugin_l1277_13) begin
+    if(when_CsrPlugin_l1669_13) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if(when_CsrPlugin_l1277_14) begin
+    if(when_CsrPlugin_l1669_14) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if(when_CsrPlugin_l1277_15) begin
+    if(when_CsrPlugin_l1669_15) begin
       execute_CsrPlugin_csr_770 <= (decode_INSTRUCTION[31 : 20] == 12'h302);
     end
-    if(when_CsrPlugin_l1277_16) begin
+    if(when_CsrPlugin_l1669_16) begin
       execute_CsrPlugin_csr_771 <= (decode_INSTRUCTION[31 : 20] == 12'h303);
     end
-    if(when_CsrPlugin_l1277_17) begin
+    if(when_CsrPlugin_l1669_17) begin
       execute_CsrPlugin_csr_324 <= (decode_INSTRUCTION[31 : 20] == 12'h144);
     end
-    if(when_CsrPlugin_l1277_18) begin
+    if(when_CsrPlugin_l1669_18) begin
       execute_CsrPlugin_csr_260 <= (decode_INSTRUCTION[31 : 20] == 12'h104);
     end
-    if(when_CsrPlugin_l1277_19) begin
+    if(when_CsrPlugin_l1669_19) begin
       execute_CsrPlugin_csr_261 <= (decode_INSTRUCTION[31 : 20] == 12'h105);
     end
-    if(when_CsrPlugin_l1277_20) begin
+    if(when_CsrPlugin_l1669_20) begin
       execute_CsrPlugin_csr_321 <= (decode_INSTRUCTION[31 : 20] == 12'h141);
     end
-    if(when_CsrPlugin_l1277_21) begin
+    if(when_CsrPlugin_l1669_21) begin
       execute_CsrPlugin_csr_320 <= (decode_INSTRUCTION[31 : 20] == 12'h140);
     end
-    if(when_CsrPlugin_l1277_22) begin
+    if(when_CsrPlugin_l1669_22) begin
       execute_CsrPlugin_csr_322 <= (decode_INSTRUCTION[31 : 20] == 12'h142);
     end
-    if(when_CsrPlugin_l1277_23) begin
+    if(when_CsrPlugin_l1669_23) begin
       execute_CsrPlugin_csr_323 <= (decode_INSTRUCTION[31 : 20] == 12'h143);
     end
-    if(when_CsrPlugin_l1277_24) begin
+    if(when_CsrPlugin_l1669_24) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if(when_CsrPlugin_l1277_25) begin
+    if(when_CsrPlugin_l1669_25) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
-    if(when_CsrPlugin_l1277_26) begin
+    if(when_CsrPlugin_l1669_26) begin
       execute_CsrPlugin_csr_2496 <= (decode_INSTRUCTION[31 : 20] == 12'h9c0);
     end
-    if(when_CsrPlugin_l1277_27) begin
+    if(when_CsrPlugin_l1669_27) begin
       execute_CsrPlugin_csr_3520 <= (decode_INSTRUCTION[31 : 20] == 12'hdc0);
     end
     if(execute_CsrPlugin_csr_384) begin
       if(execute_CsrPlugin_writeEnable) begin
         MmuPlugin_satp_asid <= CsrPlugin_csrMapping_writeDataSignal[30 : 22];
-        MmuPlugin_satp_ppn <= CsrPlugin_csrMapping_writeDataSignal[19 : 0];
+        MmuPlugin_satp_ppn <= CsrPlugin_csrMapping_writeDataSignal[21 : 0];
       end
     end
     if(execute_CsrPlugin_csr_836) begin
@@ -6860,7 +6929,6 @@ module VexRiscv (
     if(execute_CsrPlugin_csr_773) begin
       if(execute_CsrPlugin_writeEnable) begin
         CsrPlugin_mtvec_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 2];
-        CsrPlugin_mtvec_mode <= CsrPlugin_csrMapping_writeDataSignal[1 : 0];
       end
     end
     if(execute_CsrPlugin_csr_833) begin
@@ -6876,7 +6944,6 @@ module VexRiscv (
     if(execute_CsrPlugin_csr_261) begin
       if(execute_CsrPlugin_writeEnable) begin
         CsrPlugin_stvec_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 2];
-        CsrPlugin_stvec_mode <= CsrPlugin_csrMapping_writeDataSignal[1 : 0];
       end
     end
     if(execute_CsrPlugin_csr_321) begin
@@ -6908,96 +6975,93 @@ module VexRiscv (
 endmodule
 
 module DataCache (
-  input               io_cpu_execute_isValid,
-  input      [31:0]   io_cpu_execute_address,
-  output reg          io_cpu_execute_haltIt,
-  input               io_cpu_execute_args_wr,
-  input      [1:0]    io_cpu_execute_args_size,
-  input               io_cpu_execute_args_isLrsc,
-  input               io_cpu_execute_args_isAmo,
-  input               io_cpu_execute_args_amoCtrl_swap,
-  input      [2:0]    io_cpu_execute_args_amoCtrl_alu,
-  input               io_cpu_execute_args_totalyConsistent,
-  output              io_cpu_execute_refilling,
-  input               io_cpu_memory_isValid,
-  input               io_cpu_memory_isStuck,
-  output              io_cpu_memory_isWrite,
-  input      [31:0]   io_cpu_memory_address,
-  input      [31:0]   io_cpu_memory_mmuRsp_physicalAddress,
-  input               io_cpu_memory_mmuRsp_isIoAccess,
-  input               io_cpu_memory_mmuRsp_isPaging,
-  input               io_cpu_memory_mmuRsp_allowRead,
-  input               io_cpu_memory_mmuRsp_allowWrite,
-  input               io_cpu_memory_mmuRsp_allowExecute,
-  input               io_cpu_memory_mmuRsp_exception,
-  input               io_cpu_memory_mmuRsp_refilling,
-  input               io_cpu_memory_mmuRsp_bypassTranslation,
-  input               io_cpu_memory_mmuRsp_ways_0_sel,
-  input      [31:0]   io_cpu_memory_mmuRsp_ways_0_physical,
-  input               io_cpu_memory_mmuRsp_ways_1_sel,
-  input      [31:0]   io_cpu_memory_mmuRsp_ways_1_physical,
-  input               io_cpu_memory_mmuRsp_ways_2_sel,
-  input      [31:0]   io_cpu_memory_mmuRsp_ways_2_physical,
-  input               io_cpu_memory_mmuRsp_ways_3_sel,
-  input      [31:0]   io_cpu_memory_mmuRsp_ways_3_physical,
-  input               io_cpu_writeBack_isValid,
-  input               io_cpu_writeBack_isStuck,
-  input               io_cpu_writeBack_isFiring,
-  input               io_cpu_writeBack_isUser,
-  output reg          io_cpu_writeBack_haltIt,
-  output              io_cpu_writeBack_isWrite,
-  input      [31:0]   io_cpu_writeBack_storeData,
-  output reg [31:0]   io_cpu_writeBack_data,
-  input      [31:0]   io_cpu_writeBack_address,
-  output              io_cpu_writeBack_mmuException,
-  output              io_cpu_writeBack_unalignedAccess,
-  output reg          io_cpu_writeBack_accessError,
-  output              io_cpu_writeBack_keepMemRspData,
-  input               io_cpu_writeBack_fence_SW,
-  input               io_cpu_writeBack_fence_SR,
-  input               io_cpu_writeBack_fence_SO,
-  input               io_cpu_writeBack_fence_SI,
-  input               io_cpu_writeBack_fence_PW,
-  input               io_cpu_writeBack_fence_PR,
-  input               io_cpu_writeBack_fence_PO,
-  input               io_cpu_writeBack_fence_PI,
-  input      [3:0]    io_cpu_writeBack_fence_FM,
-  output              io_cpu_writeBack_exclusiveOk,
-  output reg          io_cpu_redo,
-  input               io_cpu_flush_valid,
-  output              io_cpu_flush_ready,
-  input               io_cpu_flush_payload_singleLine,
-  input      [6:0]    io_cpu_flush_payload_lineId,
-  output reg          io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output reg          io_mem_cmd_payload_wr,
-  output              io_mem_cmd_payload_uncached,
-  output reg [31:0]   io_mem_cmd_payload_address,
-  output     [31:0]   io_mem_cmd_payload_data,
-  output     [3:0]    io_mem_cmd_payload_mask,
-  output reg [2:0]    io_mem_cmd_payload_size,
-  output              io_mem_cmd_payload_last,
-  input               io_mem_rsp_valid,
-  input               io_mem_rsp_payload_last,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input               clk,
-  input               reset
+  input  wire          io_cpu_execute_isValid,
+  input  wire [31:0]   io_cpu_execute_address,
+  output reg           io_cpu_execute_haltIt,
+  input  wire          io_cpu_execute_args_wr,
+  input  wire [1:0]    io_cpu_execute_args_size,
+  input  wire          io_cpu_execute_args_isLrsc,
+  input  wire          io_cpu_execute_args_isAmo,
+  input  wire          io_cpu_execute_args_amoCtrl_swap,
+  input  wire [2:0]    io_cpu_execute_args_amoCtrl_alu,
+  input  wire          io_cpu_execute_args_totalyConsistent,
+  output wire          io_cpu_execute_refilling,
+  input  wire          io_cpu_memory_isValid,
+  input  wire          io_cpu_memory_isStuck,
+  output wire          io_cpu_memory_isWrite,
+  input  wire [31:0]   io_cpu_memory_address,
+  input  wire [31:0]   io_cpu_memory_mmuRsp_physicalAddress,
+  input  wire          io_cpu_memory_mmuRsp_isIoAccess,
+  input  wire          io_cpu_memory_mmuRsp_isPaging,
+  input  wire          io_cpu_memory_mmuRsp_allowRead,
+  input  wire          io_cpu_memory_mmuRsp_allowWrite,
+  input  wire          io_cpu_memory_mmuRsp_allowExecute,
+  input  wire          io_cpu_memory_mmuRsp_exception,
+  input  wire          io_cpu_memory_mmuRsp_refilling,
+  input  wire          io_cpu_memory_mmuRsp_bypassTranslation,
+  input  wire          io_cpu_memory_mmuRsp_ways_0_sel,
+  input  wire [31:0]   io_cpu_memory_mmuRsp_ways_0_physical,
+  input  wire          io_cpu_memory_mmuRsp_ways_1_sel,
+  input  wire [31:0]   io_cpu_memory_mmuRsp_ways_1_physical,
+  input  wire          io_cpu_memory_mmuRsp_ways_2_sel,
+  input  wire [31:0]   io_cpu_memory_mmuRsp_ways_2_physical,
+  input  wire          io_cpu_memory_mmuRsp_ways_3_sel,
+  input  wire [31:0]   io_cpu_memory_mmuRsp_ways_3_physical,
+  input  wire          io_cpu_writeBack_isValid,
+  input  wire          io_cpu_writeBack_isStuck,
+  input  wire          io_cpu_writeBack_isFiring,
+  input  wire          io_cpu_writeBack_isUser,
+  output reg           io_cpu_writeBack_haltIt,
+  output wire          io_cpu_writeBack_isWrite,
+  input  wire [31:0]   io_cpu_writeBack_storeData,
+  output reg  [31:0]   io_cpu_writeBack_data,
+  input  wire [31:0]   io_cpu_writeBack_address,
+  output wire          io_cpu_writeBack_mmuException,
+  output wire          io_cpu_writeBack_unalignedAccess,
+  output reg           io_cpu_writeBack_accessError,
+  output wire          io_cpu_writeBack_keepMemRspData,
+  input  wire          io_cpu_writeBack_fence_SW,
+  input  wire          io_cpu_writeBack_fence_SR,
+  input  wire          io_cpu_writeBack_fence_SO,
+  input  wire          io_cpu_writeBack_fence_SI,
+  input  wire          io_cpu_writeBack_fence_PW,
+  input  wire          io_cpu_writeBack_fence_PR,
+  input  wire          io_cpu_writeBack_fence_PO,
+  input  wire          io_cpu_writeBack_fence_PI,
+  input  wire [3:0]    io_cpu_writeBack_fence_FM,
+  output wire          io_cpu_writeBack_exclusiveOk,
+  output reg           io_cpu_redo,
+  input  wire          io_cpu_flush_valid,
+  output wire          io_cpu_flush_ready,
+  input  wire          io_cpu_flush_payload_singleLine,
+  input  wire [6:0]    io_cpu_flush_payload_lineId,
+  output wire          io_cpu_writesPending,
+  output reg           io_mem_cmd_valid,
+  input  wire          io_mem_cmd_ready,
+  output reg           io_mem_cmd_payload_wr,
+  output wire          io_mem_cmd_payload_uncached,
+  output reg  [31:0]   io_mem_cmd_payload_address,
+  output wire [31:0]   io_mem_cmd_payload_data,
+  output wire [3:0]    io_mem_cmd_payload_mask,
+  output reg  [2:0]    io_mem_cmd_payload_size,
+  output wire          io_mem_cmd_payload_last,
+  input  wire          io_mem_rsp_valid,
+  input  wire          io_mem_rsp_payload_last,
+  input  wire [31:0]   io_mem_rsp_payload_data,
+  input  wire          io_mem_rsp_payload_error,
+  input  wire          clk,
+  input  wire          reset
 );
 
   reg        [21:0]   _zz_ways_0_tags_port0;
   reg        [31:0]   _zz_ways_0_data_port0;
   wire       [21:0]   _zz_ways_0_tags_port;
-  wire       [9:0]    _zz_stage0_dataColisions;
-  wire       [9:0]    _zz__zz_stageA_dataColisions;
   wire       [31:0]   _zz_stageB_amo_addSub;
   wire       [31:0]   _zz_stageB_amo_addSub_1;
   wire       [31:0]   _zz_stageB_amo_addSub_2;
   wire       [31:0]   _zz_stageB_amo_addSub_3;
   wire       [31:0]   _zz_stageB_amo_addSub_4;
   wire       [1:0]    _zz_stageB_amo_addSub_5;
-  wire       [1:0]    _zz_stageB_amo_addSub_6;
-  wire       [1:0]    _zz_stageB_amo_addSub_7;
   wire       [0:0]    _zz_when;
   wire       [2:0]    _zz_loader_counter_valueNext;
   wire       [0:0]    _zz_loader_counter_valueNext_1;
@@ -7034,19 +7098,19 @@ module DataCache (
   wire                _zz_ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRsp;
-  wire                when_DataCache_l642;
   wire                when_DataCache_l645;
-  wire                when_DataCache_l664;
+  wire                when_DataCache_l648;
+  wire                when_DataCache_l667;
   wire                rspSync;
   wire                rspLast;
   reg                 memCmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_DataCache_l686;
+  wire                when_DataCache_l689;
   reg        [3:0]    _zz_stage0_mask;
   wire       [3:0]    stage0_mask;
   wire       [0:0]    stage0_dataColisions;
   wire       [0:0]    stage0_wayInvalidate;
-  wire                when_DataCache_l771;
+  wire                when_DataCache_l776;
   reg                 stageA_request_wr;
   reg        [1:0]    stageA_request_size;
   reg                 stageA_request_isLrsc;
@@ -7054,16 +7118,16 @@ module DataCache (
   reg                 stageA_request_amoCtrl_swap;
   reg        [2:0]    stageA_request_amoCtrl_alu;
   reg                 stageA_request_totalyConsistent;
-  wire                when_DataCache_l771_1;
+  wire                when_DataCache_l776_1;
   reg        [3:0]    stageA_mask;
   wire       [0:0]    stageA_wayHits;
-  wire                when_DataCache_l771_2;
+  wire                when_DataCache_l776_2;
   reg        [0:0]    stageA_wayInvalidate;
-  wire                when_DataCache_l771_3;
+  wire                when_DataCache_l776_3;
   reg        [0:0]    stage0_dataColisions_regNextWhen;
   wire       [0:0]    _zz_stageA_dataColisions;
   wire       [0:0]    stageA_dataColisions;
-  wire                when_DataCache_l822;
+  wire                when_DataCache_l827;
   reg                 stageB_request_wr;
   reg        [1:0]    stageB_request_size;
   reg                 stageB_request_isLrsc;
@@ -7072,7 +7136,7 @@ module DataCache (
   reg        [2:0]    stageB_request_amoCtrl_alu;
   reg                 stageB_request_totalyConsistent;
   reg                 stageB_mmuRspFreeze;
-  wire                when_DataCache_l824;
+  wire                when_DataCache_l829;
   reg        [31:0]   stageB_mmuRsp_physicalAddress;
   reg                 stageB_mmuRsp_isIoAccess;
   reg                 stageB_mmuRsp_isPaging;
@@ -7090,36 +7154,38 @@ module DataCache (
   reg        [31:0]   stageB_mmuRsp_ways_2_physical;
   reg                 stageB_mmuRsp_ways_3_sel;
   reg        [31:0]   stageB_mmuRsp_ways_3_physical;
-  wire                when_DataCache_l821;
+  wire                when_DataCache_l826;
   reg                 stageB_tagsReadRsp_0_valid;
   reg                 stageB_tagsReadRsp_0_error;
   reg        [19:0]   stageB_tagsReadRsp_0_address;
-  wire                when_DataCache_l821_1;
+  wire                when_DataCache_l826_1;
   reg        [31:0]   stageB_dataReadRsp_0;
-  wire                when_DataCache_l820;
+  wire                when_DataCache_l825;
   reg        [0:0]    stageB_wayInvalidate;
   wire                stageB_consistancyHazard;
-  wire                when_DataCache_l820_1;
+  wire                when_DataCache_l825_1;
   reg        [0:0]    stageB_dataColisions;
-  wire                when_DataCache_l820_2;
+  wire                when_DataCache_l825_2;
   reg                 stageB_unaligned;
-  wire                when_DataCache_l820_3;
+  wire                when_DataCache_l825_3;
   reg        [0:0]    stageB_waysHitsBeforeInvalidate;
   wire       [0:0]    stageB_waysHits;
   wire                stageB_waysHit;
   wire       [31:0]   stageB_dataMux;
-  wire                when_DataCache_l820_4;
+  wire                when_DataCache_l825_4;
   reg        [3:0]    stageB_mask;
   reg                 stageB_loaderValid;
   wire       [31:0]   stageB_ioMemRspMuxed;
   reg                 stageB_flusher_waitDone;
   wire                stageB_flusher_hold;
   reg        [7:0]    stageB_flusher_counter;
-  wire                when_DataCache_l850;
-  wire                when_DataCache_l856;
+  wire                when_DataCache_l855;
+  wire                when_DataCache_l861;
+  wire                when_DataCache_l863;
   reg                 stageB_flusher_start;
+  wire                when_DataCache_l877;
   reg                 stageB_lrSc_reserved;
-  wire                when_DataCache_l880;
+  wire                when_DataCache_l885;
   wire                stageB_isExternalLsrc;
   wire                stageB_isExternalAmo;
   reg        [31:0]   stageB_requestDataBypass;
@@ -7128,26 +7194,26 @@ module DataCache (
   wire       [31:0]   stageB_amo_addSub;
   wire                stageB_amo_less;
   wire                stageB_amo_selectRf;
-  wire       [2:0]    switch_Misc_l210;
+  wire       [2:0]    switch_Misc_l232;
   reg        [31:0]   stageB_amo_result;
   reg        [31:0]   stageB_amo_resultReg;
   reg                 stageB_amo_internal_resultRegValid;
   reg                 stageB_cpuWriteToCache;
-  wire                when_DataCache_l926;
+  wire                when_DataCache_l931;
   wire                stageB_badPermissions;
   wire                stageB_loadStoreFault;
   wire                stageB_bypassCache;
-  wire                when_DataCache_l995;
-  wire                when_DataCache_l999;
+  wire                when_DataCache_l1000;
   wire                when_DataCache_l1004;
   wire                when_DataCache_l1009;
-  wire                when_DataCache_l1012;
-  wire                when_DataCache_l1020;
+  wire                when_DataCache_l1014;
+  wire                when_DataCache_l1017;
   wire                when_DataCache_l1025;
-  wire                when_DataCache_l1032;
-  wire                when_DataCache_l991;
-  wire                when_DataCache_l1066;
-  wire                when_DataCache_l1075;
+  wire                when_DataCache_l1030;
+  wire                when_DataCache_l1037;
+  wire                when_DataCache_l996;
+  wire                when_DataCache_l1072;
+  wire                when_DataCache_l1081;
   reg                 loader_valid;
   reg                 loader_counter_willIncrement;
   wire                loader_counter_willClear;
@@ -7159,12 +7225,12 @@ module DataCache (
   reg                 loader_error;
   wire                loader_kill;
   reg                 loader_killReg;
-  wire                when_DataCache_l1090;
+  wire                when_DataCache_l1097;
   wire                loader_done;
-  wire                when_DataCache_l1118;
-  reg                 loader_valid_regNext;
-  wire                when_DataCache_l1122;
   wire                when_DataCache_l1125;
+  reg                 loader_valid_regNext;
+  wire                when_DataCache_l1129;
+  wire                when_DataCache_l1132;
   (* no_rw_check , ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
   (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
   (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
@@ -7175,16 +7241,12 @@ module DataCache (
   reg [7:0] _zz_ways_0_datasymbol_read_2;
   reg [7:0] _zz_ways_0_datasymbol_read_3;
 
-  assign _zz_stage0_dataColisions = (io_cpu_execute_address[11 : 2] >>> 0);
-  assign _zz__zz_stageA_dataColisions = (io_cpu_memory_address[11 : 2] >>> 0);
   assign _zz_stageB_amo_addSub = ($signed(_zz_stageB_amo_addSub_1) + $signed(_zz_stageB_amo_addSub_4));
   assign _zz_stageB_amo_addSub_1 = ($signed(_zz_stageB_amo_addSub_2) + $signed(_zz_stageB_amo_addSub_3));
   assign _zz_stageB_amo_addSub_2 = io_cpu_writeBack_storeData[31 : 0];
   assign _zz_stageB_amo_addSub_3 = (stageB_amo_compare ? (~ stageB_dataMux[31 : 0]) : stageB_dataMux[31 : 0]);
-  assign _zz_stageB_amo_addSub_5 = (stageB_amo_compare ? _zz_stageB_amo_addSub_6 : _zz_stageB_amo_addSub_7);
+  assign _zz_stageB_amo_addSub_5 = (stageB_amo_compare ? 2'b01 : 2'b00);
   assign _zz_stageB_amo_addSub_4 = {{30{_zz_stageB_amo_addSub_5[1]}}, _zz_stageB_amo_addSub_5};
-  assign _zz_stageB_amo_addSub_6 = 2'b01;
-  assign _zz_stageB_amo_addSub_7 = 2'b00;
   assign _zz_when = 1'b1;
   assign _zz_loader_counter_valueNext_1 = loader_counter_willIncrement;
   assign _zz_loader_counter_valueNext = {2'd0, _zz_loader_counter_valueNext_1};
@@ -7231,14 +7293,14 @@ module DataCache (
 
   always @(*) begin
     _zz_1 = 1'b0;
-    if(when_DataCache_l645) begin
+    if(when_DataCache_l648) begin
       _zz_1 = 1'b1;
     end
   end
 
   always @(*) begin
     _zz_2 = 1'b0;
-    if(when_DataCache_l642) begin
+    if(when_DataCache_l645) begin
       _zz_2 = 1'b1;
     end
   end
@@ -7252,43 +7314,45 @@ module DataCache (
   assign _zz_ways_0_dataReadRspMem = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
   assign ways_0_dataReadRspMem = _zz_ways_0_data_port0;
   assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
-  assign when_DataCache_l642 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
-  assign when_DataCache_l645 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
+  assign when_DataCache_l645 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
+  assign when_DataCache_l648 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
   always @(*) begin
     tagsReadCmd_valid = 1'b0;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       tagsReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     tagsReadCmd_payload = 7'bxxxxxxx;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
     end
   end
 
   always @(*) begin
     dataReadCmd_valid = 1'b0;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       dataReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     dataReadCmd_payload = 10'bxxxxxxxxxx;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       dataReadCmd_payload = io_cpu_execute_address[11 : 2];
     end
   end
 
   always @(*) begin
     tagsWriteCmd_valid = 1'b0;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_valid = 1'b1;
     end
-    if(when_DataCache_l1066) begin
-      tagsWriteCmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        tagsWriteCmd_valid = 1'b0;
+      end
     end
     if(loader_done) begin
       tagsWriteCmd_valid = 1'b1;
@@ -7297,7 +7361,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_way = 1'bx;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_payload_way = 1'b1;
     end
     if(loader_done) begin
@@ -7307,7 +7371,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_address = 7'bxxxxxxx;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_payload_address = stageB_flusher_counter[6:0];
     end
     if(loader_done) begin
@@ -7317,7 +7381,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_data_valid = 1'bx;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_payload_data_valid = 1'b0;
     end
     if(loader_done) begin
@@ -7342,30 +7406,32 @@ module DataCache (
   always @(*) begin
     dataWriteCmd_valid = 1'b0;
     if(stageB_cpuWriteToCache) begin
-      if(when_DataCache_l926) begin
+      if(when_DataCache_l931) begin
         dataWriteCmd_valid = 1'b1;
       end
     end
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(when_DataCache_l1009) begin
             if(stageB_request_isAmo) begin
-              if(when_DataCache_l1012) begin
+              if(when_DataCache_l1017) begin
                 dataWriteCmd_valid = 1'b0;
               end
             end
-            if(when_DataCache_l1025) begin
+            if(when_DataCache_l1030) begin
               dataWriteCmd_valid = 1'b0;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1066) begin
-      dataWriteCmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        dataWriteCmd_valid = 1'b0;
+      end
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_valid = 1'b1;
     end
   end
@@ -7375,7 +7441,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_way = stageB_waysHits;
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_way = loader_waysAllocator;
     end
   end
@@ -7385,7 +7451,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
     end
   end
@@ -7395,7 +7461,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_data = io_mem_rsp_payload_data;
     end
   end
@@ -7408,15 +7474,15 @@ module DataCache (
         dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
       end
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_mask = 4'b1111;
     end
   end
 
-  assign when_DataCache_l664 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  assign when_DataCache_l667 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
   always @(*) begin
     io_cpu_execute_haltIt = 1'b0;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       io_cpu_execute_haltIt = 1'b1;
     end
   end
@@ -7424,7 +7490,7 @@ module DataCache (
   assign rspSync = 1'b1;
   assign rspLast = 1'b1;
   assign io_mem_cmd_fire = (io_mem_cmd_valid && io_mem_cmd_ready);
-  assign when_DataCache_l686 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l689 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     _zz_stage0_mask = 4'bxxxx;
     case(io_cpu_execute_args_size)
@@ -7443,42 +7509,42 @@ module DataCache (
   end
 
   assign stage0_mask = (_zz_stage0_mask <<< io_cpu_execute_address[1 : 0]);
-  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_stage0_dataColisions)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_execute_address[11 : 2])) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stage0_wayInvalidate = 1'b0;
-  assign when_DataCache_l771 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l771_1 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l776 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l776_1 = (! io_cpu_memory_isStuck);
   assign io_cpu_memory_isWrite = stageA_request_wr;
   assign stageA_wayHits = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign when_DataCache_l771_2 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l771_3 = (! io_cpu_memory_isStuck);
-  assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz__zz_stageA_dataColisions)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign when_DataCache_l776_2 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l776_3 = (! io_cpu_memory_isStuck);
+  assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_memory_address[11 : 2])) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_stageA_dataColisions);
-  assign when_DataCache_l822 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l827 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_mmuRspFreeze = 1'b0;
-    if(when_DataCache_l1125) begin
+    if(when_DataCache_l1132) begin
       stageB_mmuRspFreeze = 1'b1;
     end
   end
 
-  assign when_DataCache_l824 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
-  assign when_DataCache_l821 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l821_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l820 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l829 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
+  assign when_DataCache_l826 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l826_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825 = (! io_cpu_writeBack_isStuck);
   assign stageB_consistancyHazard = 1'b0;
-  assign when_DataCache_l820_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l820_2 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l820_3 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_2 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_3 = (! io_cpu_writeBack_isStuck);
   assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
   assign stageB_waysHit = (|stageB_waysHits);
   assign stageB_dataMux = stageB_dataReadRsp_0;
-  assign when_DataCache_l820_4 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_4 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_loaderValid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
             if(io_mem_cmd_ready) begin
               stageB_loaderValid = 1'b1;
             end
@@ -7486,8 +7552,10 @@ module DataCache (
         end
       end
     end
-    if(when_DataCache_l1066) begin
-      stageB_loaderValid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        stageB_loaderValid = 1'b0;
+      end
     end
   end
 
@@ -7496,40 +7564,44 @@ module DataCache (
     io_cpu_writeBack_haltIt = 1'b1;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l991) begin
-          if(when_DataCache_l995) begin
+        if(when_DataCache_l996) begin
+          if(when_DataCache_l1000) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
-          if(when_DataCache_l999) begin
+          if(when_DataCache_l1004) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
         end else begin
-          if(when_DataCache_l1004) begin
-            if(when_DataCache_l1009) begin
+          if(when_DataCache_l1009) begin
+            if(when_DataCache_l1014) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
             if(stageB_request_isAmo) begin
-              if(when_DataCache_l1012) begin
+              if(when_DataCache_l1017) begin
                 io_cpu_writeBack_haltIt = 1'b1;
               end
             end
-            if(when_DataCache_l1025) begin
+            if(when_DataCache_l1030) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1066) begin
-      io_cpu_writeBack_haltIt = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        io_cpu_writeBack_haltIt = 1'b0;
+      end
     end
   end
 
   assign stageB_flusher_hold = 1'b0;
-  assign when_DataCache_l850 = (! stageB_flusher_counter[7]);
-  assign when_DataCache_l856 = (! stageB_flusher_hold);
+  assign when_DataCache_l855 = (! stageB_flusher_counter[7]);
+  assign when_DataCache_l861 = (! stageB_flusher_hold);
+  assign when_DataCache_l863 = (io_cpu_flush_valid && io_cpu_flush_payload_singleLine);
   assign io_cpu_flush_ready = (stageB_flusher_waitDone && stageB_flusher_counter[7]);
-  assign when_DataCache_l880 = (io_cpu_writeBack_isValid && io_cpu_writeBack_isFiring);
+  assign when_DataCache_l877 = (io_cpu_flush_valid && io_cpu_flush_payload_singleLine);
+  assign when_DataCache_l885 = (io_cpu_writeBack_isValid && io_cpu_writeBack_isFiring);
   assign stageB_isExternalLsrc = 1'b0;
   assign stageB_isExternalAmo = 1'b0;
   always @(*) begin
@@ -7544,9 +7616,9 @@ module DataCache (
   assign stageB_amo_addSub = _zz_stageB_amo_addSub;
   assign stageB_amo_less = ((io_cpu_writeBack_storeData[31] == stageB_dataMux[31]) ? stageB_amo_addSub[31] : (stageB_amo_unsigned ? stageB_dataMux[31] : io_cpu_writeBack_storeData[31]));
   assign stageB_amo_selectRf = (stageB_request_amoCtrl_swap ? 1'b1 : (stageB_request_amoCtrl_alu[0] ^ stageB_amo_less));
-  assign switch_Misc_l210 = (stageB_request_amoCtrl_alu | {stageB_request_amoCtrl_swap,2'b00});
+  assign switch_Misc_l232 = (stageB_request_amoCtrl_alu | {stageB_request_amoCtrl_swap,2'b00});
   always @(*) begin
-    case(switch_Misc_l210)
+    case(switch_Misc_l232)
       3'b000 : begin
         stageB_amo_result = stageB_amo_addSub;
       end
@@ -7569,8 +7641,8 @@ module DataCache (
     stageB_cpuWriteToCache = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(when_DataCache_l1009) begin
             stageB_cpuWriteToCache = 1'b1;
           end
         end
@@ -7578,26 +7650,28 @@ module DataCache (
     end
   end
 
-  assign when_DataCache_l926 = (stageB_request_wr && stageB_waysHit);
+  assign when_DataCache_l931 = (stageB_request_wr && stageB_waysHit);
   assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_request_isAmo)));
   assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
   always @(*) begin
     io_cpu_redo = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(when_DataCache_l1004) begin
-            if(when_DataCache_l1020) begin
+        if(!when_DataCache_l996) begin
+          if(when_DataCache_l1009) begin
+            if(when_DataCache_l1025) begin
               io_cpu_redo = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1075) begin
-      io_cpu_redo = 1'b1;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1081) begin
+        io_cpu_redo = 1'b1;
+      end
     end
-    if(when_DataCache_l1122) begin
+    if(when_DataCache_l1129) begin
       io_cpu_redo = 1'b1;
     end
   end
@@ -7618,37 +7692,39 @@ module DataCache (
     io_mem_cmd_valid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l991) begin
+        if(when_DataCache_l996) begin
           io_mem_cmd_valid = (! memCmdSent);
-          if(when_DataCache_l999) begin
+          if(when_DataCache_l1004) begin
             io_mem_cmd_valid = 1'b0;
           end
         end else begin
-          if(when_DataCache_l1004) begin
+          if(when_DataCache_l1009) begin
             if(stageB_request_wr) begin
               io_mem_cmd_valid = 1'b1;
             end
             if(stageB_request_isAmo) begin
-              if(when_DataCache_l1012) begin
+              if(when_DataCache_l1017) begin
                 io_mem_cmd_valid = 1'b0;
               end
-            end
-            if(when_DataCache_l1020) begin
-              io_mem_cmd_valid = 1'b0;
             end
             if(when_DataCache_l1025) begin
               io_mem_cmd_valid = 1'b0;
             end
+            if(when_DataCache_l1030) begin
+              io_mem_cmd_valid = 1'b0;
+            end
           end else begin
-            if(when_DataCache_l1032) begin
+            if(when_DataCache_l1037) begin
               io_mem_cmd_valid = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1066) begin
-      io_mem_cmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        io_mem_cmd_valid = 1'b0;
+      end
     end
   end
 
@@ -7656,9 +7732,9 @@ module DataCache (
     io_mem_cmd_payload_address = stageB_mmuRsp_physicalAddress;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
-            io_mem_cmd_payload_address[4 : 0] = 5'h0;
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
+            io_mem_cmd_payload_address[4 : 0] = 5'h00;
           end
         end
       end
@@ -7670,8 +7746,8 @@ module DataCache (
     io_mem_cmd_payload_wr = stageB_request_wr;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
             io_mem_cmd_payload_wr = 1'b0;
           end
         end
@@ -7686,8 +7762,8 @@ module DataCache (
     io_mem_cmd_payload_size = {1'd0, stageB_request_size};
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
             io_mem_cmd_payload_size = 3'b101;
           end
         end
@@ -7697,15 +7773,15 @@ module DataCache (
 
   assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
   assign io_cpu_writeBack_keepMemRspData = 1'b0;
-  assign when_DataCache_l995 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
-  assign when_DataCache_l999 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
-  assign when_DataCache_l1004 = (stageB_waysHit || (stageB_request_wr && (! stageB_request_isAmo)));
-  assign when_DataCache_l1009 = ((! stageB_request_wr) || io_mem_cmd_ready);
-  assign when_DataCache_l1012 = (! stageB_amo_internal_resultRegValid);
-  assign when_DataCache_l1020 = (((! stageB_request_wr) || stageB_request_isAmo) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
-  assign when_DataCache_l1025 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
-  assign when_DataCache_l1032 = (! memCmdSent);
-  assign when_DataCache_l991 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  assign when_DataCache_l1000 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
+  assign when_DataCache_l1004 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
+  assign when_DataCache_l1009 = (stageB_waysHit || (stageB_request_wr && (! stageB_request_isAmo)));
+  assign when_DataCache_l1014 = ((! stageB_request_wr) || io_mem_cmd_ready);
+  assign when_DataCache_l1017 = (! stageB_amo_internal_resultRegValid);
+  assign when_DataCache_l1025 = (((! stageB_request_wr) || stageB_request_isAmo) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
+  assign when_DataCache_l1030 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
+  assign when_DataCache_l1037 = (! memCmdSent);
+  assign when_DataCache_l996 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
   always @(*) begin
     if(stageB_bypassCache) begin
       io_cpu_writeBack_data = stageB_ioMemRspMuxed;
@@ -7715,11 +7791,11 @@ module DataCache (
   end
 
   assign io_cpu_writeBack_exclusiveOk = stageB_lrSc_reserved;
-  assign when_DataCache_l1066 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign when_DataCache_l1075 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
+  assign when_DataCache_l1072 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign when_DataCache_l1081 = (stageB_mmuRsp_refilling || stageB_consistancyHazard);
   always @(*) begin
     loader_counter_willIncrement = 1'b0;
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       loader_counter_willIncrement = 1'b1;
     end
   end
@@ -7735,12 +7811,12 @@ module DataCache (
   end
 
   assign loader_kill = 1'b0;
-  assign when_DataCache_l1090 = ((loader_valid && io_mem_rsp_valid) && rspLast);
+  assign when_DataCache_l1097 = ((loader_valid && io_mem_rsp_valid) && rspLast);
   assign loader_done = loader_counter_willOverflow;
-  assign when_DataCache_l1118 = (! loader_valid);
-  assign when_DataCache_l1122 = (loader_valid && (! loader_valid_regNext));
+  assign when_DataCache_l1125 = (! loader_valid);
+  assign when_DataCache_l1129 = (loader_valid && (! loader_valid_regNext));
   assign io_cpu_execute_refilling = loader_valid;
-  assign when_DataCache_l1125 = (stageB_loaderValid || loader_valid);
+  assign when_DataCache_l1132 = (stageB_loaderValid || loader_valid);
   always @(posedge clk) begin
     tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
     tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
@@ -7748,7 +7824,7 @@ module DataCache (
     tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
     tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
     tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if(when_DataCache_l771) begin
+    if(when_DataCache_l776) begin
       stageA_request_wr <= io_cpu_execute_args_wr;
       stageA_request_size <= io_cpu_execute_args_size;
       stageA_request_isLrsc <= io_cpu_execute_args_isLrsc;
@@ -7757,16 +7833,16 @@ module DataCache (
       stageA_request_amoCtrl_alu <= io_cpu_execute_args_amoCtrl_alu;
       stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
     end
-    if(when_DataCache_l771_1) begin
+    if(when_DataCache_l776_1) begin
       stageA_mask <= stage0_mask;
     end
-    if(when_DataCache_l771_2) begin
+    if(when_DataCache_l776_2) begin
       stageA_wayInvalidate <= stage0_wayInvalidate;
     end
-    if(when_DataCache_l771_3) begin
+    if(when_DataCache_l776_3) begin
       stage0_dataColisions_regNextWhen <= stage0_dataColisions;
     end
-    if(when_DataCache_l822) begin
+    if(when_DataCache_l827) begin
       stageB_request_wr <= stageA_request_wr;
       stageB_request_size <= stageA_request_size;
       stageB_request_isLrsc <= stageA_request_isLrsc;
@@ -7775,7 +7851,7 @@ module DataCache (
       stageB_request_amoCtrl_alu <= stageA_request_amoCtrl_alu;
       stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
     end
-    if(when_DataCache_l824) begin
+    if(when_DataCache_l829) begin
       stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
       stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
       stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
@@ -7794,27 +7870,27 @@ module DataCache (
       stageB_mmuRsp_ways_3_sel <= io_cpu_memory_mmuRsp_ways_3_sel;
       stageB_mmuRsp_ways_3_physical <= io_cpu_memory_mmuRsp_ways_3_physical;
     end
-    if(when_DataCache_l821) begin
+    if(when_DataCache_l826) begin
       stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
       stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
       stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
     end
-    if(when_DataCache_l821_1) begin
+    if(when_DataCache_l826_1) begin
       stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
     end
-    if(when_DataCache_l820) begin
+    if(when_DataCache_l825) begin
       stageB_wayInvalidate <= stageA_wayInvalidate;
     end
-    if(when_DataCache_l820_1) begin
+    if(when_DataCache_l825_1) begin
       stageB_dataColisions <= stageA_dataColisions;
     end
-    if(when_DataCache_l820_2) begin
+    if(when_DataCache_l825_2) begin
       stageB_unaligned <= ({((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)),((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0))} != 2'b00);
     end
-    if(when_DataCache_l820_3) begin
+    if(when_DataCache_l825_3) begin
       stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
     end
-    if(when_DataCache_l820_4) begin
+    if(when_DataCache_l825_4) begin
       stageB_mask <= stageA_mask;
     end
     stageB_amo_internal_resultRegValid <= io_cpu_writeBack_isStuck;
@@ -7826,7 +7902,7 @@ module DataCache (
     if(reset) begin
       memCmdSent <= 1'b0;
       stageB_flusher_waitDone <= 1'b0;
-      stageB_flusher_counter <= 8'h0;
+      stageB_flusher_counter <= 8'h00;
       stageB_flusher_start <= 1'b1;
       stageB_lrSc_reserved <= 1'b0;
       loader_valid <= 1'b0;
@@ -7838,16 +7914,16 @@ module DataCache (
       if(io_mem_cmd_fire) begin
         memCmdSent <= 1'b1;
       end
-      if(when_DataCache_l686) begin
+      if(when_DataCache_l689) begin
         memCmdSent <= 1'b0;
       end
       if(io_cpu_flush_ready) begin
         stageB_flusher_waitDone <= 1'b0;
       end
-      if(when_DataCache_l850) begin
-        if(when_DataCache_l856) begin
+      if(when_DataCache_l855) begin
+        if(when_DataCache_l861) begin
           stageB_flusher_counter <= (stageB_flusher_counter + 8'h01);
-          if(io_cpu_flush_payload_singleLine) begin
+          if(when_DataCache_l863) begin
             stageB_flusher_counter[7] <= 1'b1;
           end
         end
@@ -7855,12 +7931,12 @@ module DataCache (
       stageB_flusher_start <= (((((((! stageB_flusher_waitDone) && (! stageB_flusher_start)) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
       if(stageB_flusher_start) begin
         stageB_flusher_waitDone <= 1'b1;
-        stageB_flusher_counter <= 8'h0;
-        if(io_cpu_flush_payload_singleLine) begin
+        stageB_flusher_counter <= 8'h00;
+        if(when_DataCache_l877) begin
           stageB_flusher_counter <= {1'b0,io_cpu_flush_payload_lineId};
         end
       end
-      if(when_DataCache_l880) begin
+      if(when_DataCache_l885) begin
         if(stageB_request_isLrsc) begin
           stageB_lrSc_reserved <= 1'b1;
         end
@@ -7868,15 +7944,17 @@ module DataCache (
           stageB_lrSc_reserved <= 1'b0;
         end
       end
-      if(when_DataCache_l1066) begin
-        stageB_lrSc_reserved <= stageB_lrSc_reserved;
+      if(io_cpu_writeBack_isValid) begin
+        if(when_DataCache_l1072) begin
+          stageB_lrSc_reserved <= stageB_lrSc_reserved;
+        end
       end
       `ifndef SYNTHESIS
         `ifdef FORMAL
-          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))); // DataCache.scala:L1077
+          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))); // DataCache.scala:L1084
         `else
           if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-            $display("ERROR writeBack stuck by another plugin is not allowed"); // DataCache.scala:L1077
+            $display("ERROR writeBack stuck by another plugin is not allowed"); // DataCache.scala:L1084
           end
         `endif
       `endif
@@ -7887,7 +7965,7 @@ module DataCache (
       if(loader_kill) begin
         loader_killReg <= 1'b1;
       end
-      if(when_DataCache_l1090) begin
+      if(when_DataCache_l1097) begin
         loader_error <= (loader_error || io_mem_rsp_payload_error);
       end
       if(loader_done) begin
@@ -7895,7 +7973,7 @@ module DataCache (
         loader_error <= 1'b0;
         loader_killReg <= 1'b0;
       end
-      if(when_DataCache_l1118) begin
+      if(when_DataCache_l1125) begin
         loader_waysAllocator <= _zz_loader_waysAllocator[0:0];
       end
     end
@@ -7905,54 +7983,54 @@ module DataCache (
 endmodule
 
 module InstructionCache (
-  input               io_flush,
-  input               io_cpu_prefetch_isValid,
-  output reg          io_cpu_prefetch_haltIt,
-  input      [31:0]   io_cpu_prefetch_pc,
-  input               io_cpu_fetch_isValid,
-  input               io_cpu_fetch_isStuck,
-  input               io_cpu_fetch_isRemoved,
-  input      [31:0]   io_cpu_fetch_pc,
-  output     [31:0]   io_cpu_fetch_data,
-  input      [31:0]   io_cpu_fetch_mmuRsp_physicalAddress,
-  input               io_cpu_fetch_mmuRsp_isIoAccess,
-  input               io_cpu_fetch_mmuRsp_isPaging,
-  input               io_cpu_fetch_mmuRsp_allowRead,
-  input               io_cpu_fetch_mmuRsp_allowWrite,
-  input               io_cpu_fetch_mmuRsp_allowExecute,
-  input               io_cpu_fetch_mmuRsp_exception,
-  input               io_cpu_fetch_mmuRsp_refilling,
-  input               io_cpu_fetch_mmuRsp_bypassTranslation,
-  input               io_cpu_fetch_mmuRsp_ways_0_sel,
-  input      [31:0]   io_cpu_fetch_mmuRsp_ways_0_physical,
-  input               io_cpu_fetch_mmuRsp_ways_1_sel,
-  input      [31:0]   io_cpu_fetch_mmuRsp_ways_1_physical,
-  input               io_cpu_fetch_mmuRsp_ways_2_sel,
-  input      [31:0]   io_cpu_fetch_mmuRsp_ways_2_physical,
-  input               io_cpu_fetch_mmuRsp_ways_3_sel,
-  input      [31:0]   io_cpu_fetch_mmuRsp_ways_3_physical,
-  output     [31:0]   io_cpu_fetch_physicalAddress,
-  input               io_cpu_decode_isValid,
-  input               io_cpu_decode_isStuck,
-  input      [31:0]   io_cpu_decode_pc,
-  output     [31:0]   io_cpu_decode_physicalAddress,
-  output     [31:0]   io_cpu_decode_data,
-  output              io_cpu_decode_cacheMiss,
-  output              io_cpu_decode_error,
-  output              io_cpu_decode_mmuRefilling,
-  output              io_cpu_decode_mmuException,
-  input               io_cpu_decode_isUser,
-  input               io_cpu_fill_valid,
-  input      [31:0]   io_cpu_fill_payload,
-  output              io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output     [31:0]   io_mem_cmd_payload_address,
-  output     [2:0]    io_mem_cmd_payload_size,
-  input               io_mem_rsp_valid,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input               clk,
-  input               reset
+  input  wire          io_flush,
+  input  wire          io_cpu_prefetch_isValid,
+  output reg           io_cpu_prefetch_haltIt,
+  input  wire [31:0]   io_cpu_prefetch_pc,
+  input  wire          io_cpu_fetch_isValid,
+  input  wire          io_cpu_fetch_isStuck,
+  input  wire          io_cpu_fetch_isRemoved,
+  input  wire [31:0]   io_cpu_fetch_pc,
+  output wire [31:0]   io_cpu_fetch_data,
+  input  wire [31:0]   io_cpu_fetch_mmuRsp_physicalAddress,
+  input  wire          io_cpu_fetch_mmuRsp_isIoAccess,
+  input  wire          io_cpu_fetch_mmuRsp_isPaging,
+  input  wire          io_cpu_fetch_mmuRsp_allowRead,
+  input  wire          io_cpu_fetch_mmuRsp_allowWrite,
+  input  wire          io_cpu_fetch_mmuRsp_allowExecute,
+  input  wire          io_cpu_fetch_mmuRsp_exception,
+  input  wire          io_cpu_fetch_mmuRsp_refilling,
+  input  wire          io_cpu_fetch_mmuRsp_bypassTranslation,
+  input  wire          io_cpu_fetch_mmuRsp_ways_0_sel,
+  input  wire [31:0]   io_cpu_fetch_mmuRsp_ways_0_physical,
+  input  wire          io_cpu_fetch_mmuRsp_ways_1_sel,
+  input  wire [31:0]   io_cpu_fetch_mmuRsp_ways_1_physical,
+  input  wire          io_cpu_fetch_mmuRsp_ways_2_sel,
+  input  wire [31:0]   io_cpu_fetch_mmuRsp_ways_2_physical,
+  input  wire          io_cpu_fetch_mmuRsp_ways_3_sel,
+  input  wire [31:0]   io_cpu_fetch_mmuRsp_ways_3_physical,
+  output wire [31:0]   io_cpu_fetch_physicalAddress,
+  input  wire          io_cpu_decode_isValid,
+  input  wire          io_cpu_decode_isStuck,
+  input  wire [31:0]   io_cpu_decode_pc,
+  output wire [31:0]   io_cpu_decode_physicalAddress,
+  output wire [31:0]   io_cpu_decode_data,
+  output wire          io_cpu_decode_cacheMiss,
+  output wire          io_cpu_decode_error,
+  output wire          io_cpu_decode_mmuRefilling,
+  output wire          io_cpu_decode_mmuException,
+  input  wire          io_cpu_decode_isUser,
+  input  wire          io_cpu_fill_valid,
+  input  wire [31:0]   io_cpu_fill_payload,
+  output wire          io_mem_cmd_valid,
+  input  wire          io_mem_cmd_ready,
+  output wire [31:0]   io_mem_cmd_payload_address,
+  output wire [2:0]    io_mem_cmd_payload_size,
+  input  wire          io_mem_rsp_valid,
+  input  wire [31:0]   io_mem_rsp_payload_data,
+  input  wire          io_mem_rsp_payload_error,
+  input  wire          clk,
+  input  wire          reset
 );
 
   reg        [31:0]   _zz_banks_0_port1;
@@ -7972,7 +8050,7 @@ module InstructionCache (
   wire                when_InstructionCache_l351;
   reg                 lineLoader_cmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_Utils_l515;
+  wire                when_Utils_l560;
   reg                 lineLoader_wayToAllocate_willIncrement;
   wire                lineLoader_wayToAllocate_willClear;
   wire                lineLoader_wayToAllocate_willOverflowIfInc;
@@ -8095,12 +8173,12 @@ module InstructionCache (
   assign when_InstructionCache_l351 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
   assign io_mem_cmd_fire = (io_mem_cmd_valid && io_mem_cmd_ready);
   assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
-  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
+  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h00};
   assign io_mem_cmd_payload_size = 3'b101;
-  assign when_Utils_l515 = (! lineLoader_valid);
+  assign when_Utils_l560 = (! lineLoader_valid);
   always @(*) begin
     lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if(when_Utils_l515) begin
+    if(when_Utils_l560) begin
       lineLoader_wayToAllocate_willIncrement = 1'b1;
     end
   end
@@ -8191,7 +8269,7 @@ module InstructionCache (
     end
     _zz_when_InstructionCache_l342 <= lineLoader_flushCounter[7];
     if(when_InstructionCache_l351) begin
-      lineLoader_flushCounter <= 8'h0;
+      lineLoader_flushCounter <= 8'h00;
     end
     if(when_InstructionCache_l435) begin
       io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_Lite.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_Lite.v
@@ -1,38 +1,38 @@
-// Generator : SpinalHDL v1.7.1    git head : 0444bb76ab1d6e19f0ec46bc03c4769776deb7d5
+// Generator : SpinalHDL v1.9.4    git head : 270018552577f3bb8e5339ee2583c9c22d324215
 // Component : VexRiscv
-// Git hash  : 581fcb065adf7ea8b626f939ff51679d4c95872f
+// Git hash  : 63430af99f84cc1d11d58b556debe1cc3f238c67
 
 `timescale 1ns/1ps
 
 module VexRiscv (
-  input      [31:0]   externalResetVector,
-  input               timerInterrupt,
-  input               softwareInterrupt,
-  input      [31:0]   externalInterruptArray,
-  output reg          iBusWishbone_CYC,
-  output reg          iBusWishbone_STB,
-  input               iBusWishbone_ACK,
-  output              iBusWishbone_WE,
-  output     [29:0]   iBusWishbone_ADR,
-  input      [31:0]   iBusWishbone_DAT_MISO,
-  output     [31:0]   iBusWishbone_DAT_MOSI,
-  output     [3:0]    iBusWishbone_SEL,
-  input               iBusWishbone_ERR,
-  output     [2:0]    iBusWishbone_CTI,
-  output     [1:0]    iBusWishbone_BTE,
-  output              dBusWishbone_CYC,
-  output              dBusWishbone_STB,
-  input               dBusWishbone_ACK,
-  output              dBusWishbone_WE,
-  output     [29:0]   dBusWishbone_ADR,
-  input      [31:0]   dBusWishbone_DAT_MISO,
-  output     [31:0]   dBusWishbone_DAT_MOSI,
-  output reg [3:0]    dBusWishbone_SEL,
-  input               dBusWishbone_ERR,
-  output     [2:0]    dBusWishbone_CTI,
-  output     [1:0]    dBusWishbone_BTE,
-  input               clk,
-  input               reset
+  input  wire [31:0]   externalResetVector,
+  input  wire          timerInterrupt,
+  input  wire          softwareInterrupt,
+  input  wire [31:0]   externalInterruptArray,
+  output reg           iBusWishbone_CYC,
+  output reg           iBusWishbone_STB,
+  input  wire          iBusWishbone_ACK,
+  output wire          iBusWishbone_WE,
+  output wire [29:0]   iBusWishbone_ADR,
+  input  wire [31:0]   iBusWishbone_DAT_MISO,
+  output wire [31:0]   iBusWishbone_DAT_MOSI,
+  output wire [3:0]    iBusWishbone_SEL,
+  input  wire          iBusWishbone_ERR,
+  output wire [2:0]    iBusWishbone_CTI,
+  output wire [1:0]    iBusWishbone_BTE,
+  output wire          dBusWishbone_CYC,
+  output wire          dBusWishbone_STB,
+  input  wire          dBusWishbone_ACK,
+  output wire          dBusWishbone_WE,
+  output wire [29:0]   dBusWishbone_ADR,
+  input  wire [31:0]   dBusWishbone_DAT_MISO,
+  output wire [31:0]   dBusWishbone_DAT_MOSI,
+  output reg  [3:0]    dBusWishbone_SEL,
+  input  wire          dBusWishbone_ERR,
+  output wire [2:0]    dBusWishbone_CTI,
+  output wire [1:0]    dBusWishbone_BTE,
+  input  wire          clk,
+  input  wire          reset
 );
   localparam EnvCtrlEnum_NONE = 2'd0;
   localparam EnvCtrlEnum_XRET = 2'd1;
@@ -88,19 +88,18 @@ module VexRiscv (
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_2;
   wire                _zz_decode_LEGAL_INSTRUCTION_3;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_4;
-  wire       [12:0]   _zz_decode_LEGAL_INSTRUCTION_5;
+  wire       [11:0]   _zz_decode_LEGAL_INSTRUCTION_5;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_6;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_7;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_8;
   wire                _zz_decode_LEGAL_INSTRUCTION_9;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_10;
-  wire       [6:0]    _zz_decode_LEGAL_INSTRUCTION_11;
+  wire       [5:0]    _zz_decode_LEGAL_INSTRUCTION_11;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_12;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_13;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_14;
   wire                _zz_decode_LEGAL_INSTRUCTION_15;
-  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_16;
-  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_17;
+  wire                _zz_decode_LEGAL_INSTRUCTION_16;
   wire       [2:0]    _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1;
   reg        [31:0]   _zz_IBusCachedPlugin_jump_pcLoad_payload_4;
   wire       [1:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_5;
@@ -129,120 +128,108 @@ module VexRiscv (
   wire       [31:0]   _zz__zz_decode_IS_DIV_8;
   wire       [24:0]   _zz__zz_decode_IS_DIV_9;
   wire       [0:0]    _zz__zz_decode_IS_DIV_10;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_11;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_12;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_11;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_12;
   wire       [31:0]   _zz__zz_decode_IS_DIV_13;
-  wire       [1:0]    _zz__zz_decode_IS_DIV_14;
+  wire                _zz__zz_decode_IS_DIV_14;
   wire       [31:0]   _zz__zz_decode_IS_DIV_15;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_16;
-  wire                _zz__zz_decode_IS_DIV_17;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_16;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_17;
   wire       [31:0]   _zz__zz_decode_IS_DIV_18;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_19;
+  wire       [20:0]   _zz__zz_decode_IS_DIV_19;
   wire       [0:0]    _zz__zz_decode_IS_DIV_20;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_21;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_22;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_23;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_24;
-  wire       [20:0]   _zz__zz_decode_IS_DIV_25;
-  wire       [2:0]    _zz__zz_decode_IS_DIV_26;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_21;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_22;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_23;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_24;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_25;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_26;
   wire       [31:0]   _zz__zz_decode_IS_DIV_27;
   wire       [31:0]   _zz__zz_decode_IS_DIV_28;
   wire                _zz__zz_decode_IS_DIV_29;
-  wire                _zz__zz_decode_IS_DIV_30;
-  wire                _zz__zz_decode_IS_DIV_31;
-  wire                _zz__zz_decode_IS_DIV_32;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_33;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_34;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_35;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_30;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_31;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_32;
+  wire       [16:0]   _zz__zz_decode_IS_DIV_33;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_34;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_35;
   wire       [31:0]   _zz__zz_decode_IS_DIV_36;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_37;
-  wire                _zz__zz_decode_IS_DIV_38;
-  wire       [17:0]   _zz__zz_decode_IS_DIV_39;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_40;
-  wire                _zz__zz_decode_IS_DIV_41;
-  wire                _zz__zz_decode_IS_DIV_42;
+  wire                _zz__zz_decode_IS_DIV_37;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_38;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_39;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_40;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_41;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_42;
   wire                _zz__zz_decode_IS_DIV_43;
   wire       [0:0]    _zz__zz_decode_IS_DIV_44;
   wire       [0:0]    _zz__zz_decode_IS_DIV_45;
   wire       [31:0]   _zz__zz_decode_IS_DIV_46;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_47;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_48;
-  wire       [14:0]   _zz__zz_decode_IS_DIV_49;
-  wire       [2:0]    _zz__zz_decode_IS_DIV_50;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_51;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_52;
-  wire                _zz__zz_decode_IS_DIV_53;
-  wire                _zz__zz_decode_IS_DIV_54;
+  wire       [13:0]   _zz__zz_decode_IS_DIV_47;
+  wire                _zz__zz_decode_IS_DIV_48;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_49;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_50;
+  wire                _zz__zz_decode_IS_DIV_51;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_52;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_53;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_54;
   wire       [31:0]   _zz__zz_decode_IS_DIV_55;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_56;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_56;
   wire       [0:0]    _zz__zz_decode_IS_DIV_57;
-  wire                _zz__zz_decode_IS_DIV_58;
-  wire       [11:0]   _zz__zz_decode_IS_DIV_59;
-  wire       [2:0]    _zz__zz_decode_IS_DIV_60;
+  wire       [4:0]    _zz__zz_decode_IS_DIV_58;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_59;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_60;
   wire                _zz__zz_decode_IS_DIV_61;
   wire       [31:0]   _zz__zz_decode_IS_DIV_62;
-  wire                _zz__zz_decode_IS_DIV_63;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_63;
   wire       [31:0]   _zz__zz_decode_IS_DIV_64;
-  wire                _zz__zz_decode_IS_DIV_65;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_66;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_67;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_68;
-  wire       [3:0]    _zz__zz_decode_IS_DIV_69;
-  wire                _zz__zz_decode_IS_DIV_70;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_65;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_66;
+  wire                _zz__zz_decode_IS_DIV_67;
+  wire                _zz__zz_decode_IS_DIV_68;
+  wire       [9:0]    _zz__zz_decode_IS_DIV_69;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_70;
   wire       [31:0]   _zz__zz_decode_IS_DIV_71;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_72;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_73;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_74;
-  wire       [1:0]    _zz__zz_decode_IS_DIV_75;
-  wire                _zz__zz_decode_IS_DIV_76;
-  wire                _zz__zz_decode_IS_DIV_77;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_78;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_79;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_72;
+  wire                _zz__zz_decode_IS_DIV_73;
+  wire                _zz__zz_decode_IS_DIV_74;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_75;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_76;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_77;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_78;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_79;
   wire       [0:0]    _zz__zz_decode_IS_DIV_80;
   wire       [31:0]   _zz__zz_decode_IS_DIV_81;
   wire       [31:0]   _zz__zz_decode_IS_DIV_82;
-  wire       [8:0]    _zz__zz_decode_IS_DIV_83;
-  wire       [1:0]    _zz__zz_decode_IS_DIV_84;
-  wire                _zz__zz_decode_IS_DIV_85;
+  wire       [6:0]    _zz__zz_decode_IS_DIV_83;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_84;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_85;
   wire       [31:0]   _zz__zz_decode_IS_DIV_86;
   wire                _zz__zz_decode_IS_DIV_87;
   wire       [0:0]    _zz__zz_decode_IS_DIV_88;
   wire       [31:0]   _zz__zz_decode_IS_DIV_89;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_90;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_91;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_92;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_93;
+  wire       [2:0]    _zz__zz_decode_IS_DIV_90;
+  wire                _zz__zz_decode_IS_DIV_91;
+  wire                _zz__zz_decode_IS_DIV_92;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_93;
   wire       [0:0]    _zz__zz_decode_IS_DIV_94;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_95;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_96;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_97;
-  wire       [5:0]    _zz__zz_decode_IS_DIV_98;
-  wire                _zz__zz_decode_IS_DIV_99;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_100;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_101;
-  wire       [2:0]    _zz__zz_decode_IS_DIV_102;
-  wire                _zz__zz_decode_IS_DIV_103;
-  wire                _zz__zz_decode_IS_DIV_104;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_105;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_95;
+  wire       [3:0]    _zz__zz_decode_IS_DIV_96;
+  wire                _zz__zz_decode_IS_DIV_97;
+  wire                _zz__zz_decode_IS_DIV_98;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_99;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_100;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_101;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_102;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_103;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_104;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_105;
   wire       [0:0]    _zz__zz_decode_IS_DIV_106;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_107;
-  wire       [3:0]    _zz__zz_decode_IS_DIV_108;
-  wire                _zz__zz_decode_IS_DIV_109;
-  wire                _zz__zz_decode_IS_DIV_110;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_107;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_108;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_109;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_110;
   wire       [0:0]    _zz__zz_decode_IS_DIV_111;
   wire       [31:0]   _zz__zz_decode_IS_DIV_112;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_113;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_114;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_115;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_116;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_117;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_118;
-  wire       [1:0]    _zz__zz_decode_IS_DIV_119;
-  wire       [1:0]    _zz__zz_decode_IS_DIV_120;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_121;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_122;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_123;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_124;
   wire                _zz_RegFilePlugin_regFile_port;
   wire                _zz_decode_RegFilePlugin_rs1Data;
   wire                _zz_RegFilePlugin_regFile_port_1;
@@ -250,14 +237,12 @@ module VexRiscv (
   wire       [0:0]    _zz__zz_execute_REGFILE_WRITE_DATA;
   wire       [2:0]    _zz__zz_execute_SRC1;
   wire       [4:0]    _zz__zz_execute_SRC1_1;
-  wire       [11:0]   _zz__zz_execute_SRC2_3;
+  wire       [11:0]   _zz__zz_execute_SRC2_2;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_1;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_2;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_3;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_4;
-  wire       [31:0]   _zz_execute_SrcPlugin_addSub_5;
-  wire       [31:0]   _zz_execute_SrcPlugin_addSub_6;
   wire       [31:0]   _zz__zz_decode_RS2_3;
   wire       [32:0]   _zz__zz_decode_RS2_3_1;
   wire       [19:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_2;
@@ -296,10 +281,10 @@ module VexRiscv (
   wire       [32:0]   _zz_memory_MulDivIterativePlugin_div_result_3;
   wire       [32:0]   _zz_memory_MulDivIterativePlugin_div_result_4;
   wire       [0:0]    _zz_memory_MulDivIterativePlugin_div_result_5;
-  wire       [32:0]   _zz_memory_MulDivIterativePlugin_rs1_3;
-  wire       [0:0]    _zz_memory_MulDivIterativePlugin_rs1_4;
-  wire       [31:0]   _zz_memory_MulDivIterativePlugin_rs2;
-  wire       [0:0]    _zz_memory_MulDivIterativePlugin_rs2_1;
+  wire       [32:0]   _zz_memory_MulDivIterativePlugin_rs1_2;
+  wire       [0:0]    _zz_memory_MulDivIterativePlugin_rs1_3;
+  wire       [31:0]   _zz_memory_MulDivIterativePlugin_rs2_1;
+  wire       [0:0]    _zz_memory_MulDivIterativePlugin_rs2_2;
   wire       [26:0]   _zz_iBusWishbone_ADR_1;
   wire       [31:0]   memory_MEMORY_READ_DATA;
   wire       [31:0]   execute_BRANCH_CALC;
@@ -398,7 +383,7 @@ module VexRiscv (
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_execute_SRC2;
+  wire       [31:0]   _zz_execute_to_memory_PC;
   wire       [1:0]    execute_SRC2_CTRL;
   wire       [1:0]    _zz_execute_SRC2_CTRL;
   wire       [1:0]    execute_SRC1_CTRL;
@@ -545,8 +530,9 @@ module VexRiscv (
   wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
   wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
   wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
-  wire                CsrPlugin_csrMapping_allowCsrSignal;
+  reg                 CsrPlugin_csrMapping_allowCsrSignal;
   wire                CsrPlugin_csrMapping_hazardFree;
+  wire                CsrPlugin_csrMapping_doForceFailCsr;
   wire                CsrPlugin_inWfi /* verilator public */ ;
   wire                CsrPlugin_thirdPartyWake;
   reg                 CsrPlugin_jumpInterface_valid;
@@ -565,6 +551,7 @@ module VexRiscv (
   wire                CsrPlugin_allowInterrupts;
   wire                CsrPlugin_allowException;
   wire                CsrPlugin_allowEbreakException;
+  wire                CsrPlugin_xretAwayFromMachine;
   wire                IBusCachedPlugin_externalFlush;
   wire                IBusCachedPlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
@@ -583,14 +570,13 @@ module VexRiscv (
   reg                 IBusCachedPlugin_fetchPc_pcRegPropagate;
   reg                 IBusCachedPlugin_fetchPc_booted;
   reg                 IBusCachedPlugin_fetchPc_inc;
-  wire                when_Fetcher_l134;
-  wire                IBusCachedPlugin_fetchPc_output_fire_1;
-  wire                when_Fetcher_l134_1;
+  wire                when_Fetcher_l133;
+  wire                when_Fetcher_l133_1;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pc;
   wire                IBusCachedPlugin_fetchPc_redo_valid;
   wire       [31:0]   IBusCachedPlugin_fetchPc_redo_payload;
   reg                 IBusCachedPlugin_fetchPc_flushed;
-  wire                when_Fetcher_l161;
+  wire                when_Fetcher_l160;
   reg                 IBusCachedPlugin_iBusRsp_redoFetch;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_ready;
@@ -618,8 +604,8 @@ module VexRiscv (
   wire                _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready;
   wire                IBusCachedPlugin_iBusRsp_flush;
   wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
-  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
-  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid;
+  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1;
   wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
@@ -632,18 +618,18 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_output_payload_rsp_error;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   wire                IBusCachedPlugin_iBusRsp_output_payload_isRvc;
-  wire                when_Fetcher_l243;
-  wire                when_Fetcher_l323;
+  wire                when_Fetcher_l242;
+  wire                when_Fetcher_l322;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
-  wire                when_Fetcher_l332;
+  wire                when_Fetcher_l331;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
-  wire                when_Fetcher_l332_1;
+  wire                when_Fetcher_l331_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
-  wire                when_Fetcher_l332_2;
+  wire                when_Fetcher_l331_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
-  wire                when_Fetcher_l332_3;
+  wire                when_Fetcher_l331_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                when_Fetcher_l332_4;
+  wire                when_Fetcher_l331_4;
   wire                _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   reg        [18:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1;
   wire                _zz_2;
@@ -669,11 +655,11 @@ module VexRiscv (
   wire                IBusCachedPlugin_rsp_iBusRspOutputHalt;
   wire                IBusCachedPlugin_rsp_issueDetected;
   reg                 IBusCachedPlugin_rsp_redoFetch;
-  wire                when_IBusCachedPlugin_l239;
-  wire                when_IBusCachedPlugin_l244;
+  wire                when_IBusCachedPlugin_l245;
   wire                when_IBusCachedPlugin_l250;
   wire                when_IBusCachedPlugin_l256;
-  wire                when_IBusCachedPlugin_l267;
+  wire                when_IBusCachedPlugin_l262;
+  wire                when_IBusCachedPlugin_l273;
   wire                dBus_cmd_valid;
   wire                dBus_cmd_ready;
   wire                dBus_cmd_payload_wr;
@@ -686,20 +672,20 @@ module VexRiscv (
   wire                _zz_dBus_cmd_valid;
   reg                 execute_DBusSimplePlugin_skipCmd;
   reg        [31:0]   _zz_dBus_cmd_payload_data;
-  wire                when_DBusSimplePlugin_l428;
+  wire                when_DBusSimplePlugin_l436;
   reg        [3:0]    _zz_execute_DBusSimplePlugin_formalMask;
   wire       [3:0]    execute_DBusSimplePlugin_formalMask;
-  wire                when_DBusSimplePlugin_l482;
-  wire                when_DBusSimplePlugin_l489;
-  wire                when_DBusSimplePlugin_l515;
+  wire                when_DBusSimplePlugin_l490;
+  wire                when_DBusSimplePlugin_l497;
+  wire                when_DBusSimplePlugin_l523;
   reg        [31:0]   writeBack_DBusSimplePlugin_rspShifted;
-  wire       [1:0]    switch_Misc_l210;
+  wire       [1:0]    switch_Misc_l232;
   wire                _zz_writeBack_DBusSimplePlugin_rspFormated;
   reg        [31:0]   _zz_writeBack_DBusSimplePlugin_rspFormated_1;
   wire                _zz_writeBack_DBusSimplePlugin_rspFormated_2;
   reg        [31:0]   _zz_writeBack_DBusSimplePlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusSimplePlugin_rspFormated;
-  wire                when_DBusSimplePlugin_l558;
+  wire                when_DBusSimplePlugin_l566;
   wire       [30:0]   _zz_decode_IS_DIV;
   wire                _zz_decode_IS_DIV_1;
   wire                _zz_decode_IS_DIV_2;
@@ -723,15 +709,15 @@ module VexRiscv (
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
   reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
   reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_7;
+  reg                 _zz_10;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
   reg        [31:0]   _zz_execute_REGFILE_WRITE_DATA;
   reg        [31:0]   _zz_execute_SRC1;
-  wire                _zz_execute_SRC2_1;
-  reg        [19:0]   _zz_execute_SRC2_2;
-  wire                _zz_execute_SRC2_3;
-  reg        [19:0]   _zz_execute_SRC2_4;
-  reg        [31:0]   _zz_execute_SRC2_5;
+  wire                _zz_execute_SRC2;
+  reg        [19:0]   _zz_execute_SRC2_1;
+  wire                _zz_execute_SRC2_2;
+  reg        [19:0]   _zz_execute_SRC2_3;
+  reg        [31:0]   _zz_execute_SRC2_4;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   reg                 execute_LightShifterPlugin_isActive;
@@ -774,7 +760,7 @@ module VexRiscv (
   wire                when_HazardSimplePlugin_l108;
   wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    switch_Misc_l210_1;
+  wire       [2:0]    switch_Misc_l232_1;
   reg                 _zz_execute_BRANCH_COND_RESULT;
   reg                 _zz_execute_BRANCH_COND_RESULT_1;
   wire                _zz_execute_BranchPlugin_missAlignedTarget;
@@ -813,9 +799,9 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_mtval;
   reg        [63:0]   CsrPlugin_mcycle;
   reg        [63:0]   CsrPlugin_minstret;
-  wire                _zz_when_CsrPlugin_l965;
-  wire                _zz_when_CsrPlugin_l965_1;
-  wire                _zz_when_CsrPlugin_l965_2;
+  wire                _zz_when_CsrPlugin_l1302;
+  wire                _zz_when_CsrPlugin_l1302_1;
+  wire                _zz_when_CsrPlugin_l1302_2;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -832,56 +818,59 @@ module VexRiscv (
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
   wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_2;
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3;
-  wire                when_CsrPlugin_l922;
-  wire                when_CsrPlugin_l922_1;
-  wire                when_CsrPlugin_l922_2;
-  wire                when_CsrPlugin_l922_3;
-  wire                when_CsrPlugin_l935;
+  wire                when_CsrPlugin_l1259;
+  wire                when_CsrPlugin_l1259_1;
+  wire                when_CsrPlugin_l1259_2;
+  wire                when_CsrPlugin_l1259_3;
+  wire                when_CsrPlugin_l1272;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
-  wire                when_CsrPlugin_l959;
-  wire                when_CsrPlugin_l965;
-  wire                when_CsrPlugin_l965_1;
-  wire                when_CsrPlugin_l965_2;
+  wire                when_CsrPlugin_l1296;
+  wire                when_CsrPlugin_l1302;
+  wire                when_CsrPlugin_l1302_1;
+  wire                when_CsrPlugin_l1302_2;
   wire                CsrPlugin_exception;
   wire                CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
-  wire                when_CsrPlugin_l993;
-  wire                when_CsrPlugin_l993_1;
-  wire                when_CsrPlugin_l993_2;
-  wire                when_CsrPlugin_l998;
+  wire                when_CsrPlugin_l1335;
+  wire                when_CsrPlugin_l1335_1;
+  wire                when_CsrPlugin_l1335_2;
+  wire                when_CsrPlugin_l1340;
   reg                 CsrPlugin_pipelineLiberator_done;
-  wire                when_CsrPlugin_l1004;
+  wire                when_CsrPlugin_l1346;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
+  wire                CsrPlugin_trapCauseEbreakDebug;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
-  wire                when_CsrPlugin_l1032;
-  wire                when_CsrPlugin_l1077;
-  wire       [1:0]    switch_CsrPlugin_l1081;
+  wire                CsrPlugin_trapEnterDebug;
+  wire                when_CsrPlugin_l1390;
+  wire                when_CsrPlugin_l1398;
+  wire                when_CsrPlugin_l1456;
+  wire       [1:0]    switch_CsrPlugin_l1460;
   reg                 execute_CsrPlugin_wfiWake;
-  wire                when_CsrPlugin_l1129;
+  wire                when_CsrPlugin_l1527;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire                when_CsrPlugin_l1149;
-  wire                when_CsrPlugin_l1150;
-  wire                when_CsrPlugin_l1157;
+  wire                when_CsrPlugin_l1547;
+  wire                when_CsrPlugin_l1548;
+  wire                when_CsrPlugin_l1555;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   wire       [31:0]   execute_CsrPlugin_readToWriteData;
-  wire                switch_Misc_l210_2;
+  wire                switch_Misc_l232_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
-  wire                when_CsrPlugin_l1189;
-  wire                when_CsrPlugin_l1193;
+  wire                when_CsrPlugin_l1587;
+  wire                when_CsrPlugin_l1591;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg        [32:0]   memory_MulDivIterativePlugin_rs1;
   reg        [31:0]   memory_MulDivIterativePlugin_rs2;
@@ -919,12 +908,12 @@ module VexRiscv (
   wire                when_MulDivIterativePlugin_l151;
   wire       [31:0]   _zz_memory_MulDivIterativePlugin_div_result;
   wire                when_MulDivIterativePlugin_l162;
+  wire                _zz_memory_MulDivIterativePlugin_rs2;
   wire                _zz_memory_MulDivIterativePlugin_rs1;
-  wire                _zz_memory_MulDivIterativePlugin_rs1_1;
-  reg        [32:0]   _zz_memory_MulDivIterativePlugin_rs1_2;
+  reg        [32:0]   _zz_memory_MulDivIterativePlugin_rs1_1;
   reg        [31:0]   externalInterruptArray_regNext;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit;
-  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
+  wire       [31:0]   _zz_externalInterrupt;
   wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
   wire                when_Pipeline_l124_1;
@@ -1035,25 +1024,26 @@ module VexRiscv (
   wire                when_Pipeline_l154_1;
   wire                when_Pipeline_l151_2;
   wire                when_Pipeline_l154_2;
-  wire                when_CsrPlugin_l1277;
+  wire                when_CsrPlugin_l1669;
   reg                 execute_CsrPlugin_csr_768;
-  wire                when_CsrPlugin_l1277_1;
+  wire                when_CsrPlugin_l1669_1;
   reg                 execute_CsrPlugin_csr_836;
-  wire                when_CsrPlugin_l1277_2;
+  wire                when_CsrPlugin_l1669_2;
   reg                 execute_CsrPlugin_csr_772;
-  wire                when_CsrPlugin_l1277_3;
+  wire                when_CsrPlugin_l1669_3;
   reg                 execute_CsrPlugin_csr_773;
-  wire                when_CsrPlugin_l1277_4;
+  wire                when_CsrPlugin_l1669_4;
   reg                 execute_CsrPlugin_csr_833;
-  wire                when_CsrPlugin_l1277_5;
+  wire                when_CsrPlugin_l1669_5;
   reg                 execute_CsrPlugin_csr_834;
-  wire                when_CsrPlugin_l1277_6;
+  wire                when_CsrPlugin_l1669_6;
   reg                 execute_CsrPlugin_csr_835;
-  wire                when_CsrPlugin_l1277_7;
+  wire                when_CsrPlugin_l1669_7;
   reg                 execute_CsrPlugin_csr_3008;
-  wire                when_CsrPlugin_l1277_8;
+  wire                when_CsrPlugin_l1669_8;
   reg                 execute_CsrPlugin_csr_4032;
-  wire       [1:0]    switch_CsrPlugin_l723;
+  wire       [1:0]    switch_CsrPlugin_l1031;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
@@ -1061,9 +1051,12 @@ module VexRiscv (
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_6;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_8;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
-  wire                when_CsrPlugin_l1310;
-  wire                when_CsrPlugin_l1315;
+  wire                when_CsrPlugin_l1702;
+  wire       [11:0]   _zz_when_CsrPlugin_l1709;
+  wire                when_CsrPlugin_l1709;
+  reg                 when_CsrPlugin_l1719;
+  wire                when_CsrPlugin_l1717;
+  wire                when_CsrPlugin_l1725;
   reg        [2:0]    _zz_iBusWishbone_ADR;
   wire                when_InstructionCache_l239;
   reg                 _zz_iBus_rsp_valid;
@@ -1081,7 +1074,7 @@ module VexRiscv (
   reg        [31:0]   dBus_cmd_rData_data;
   reg        [1:0]    dBus_cmd_rData_size;
   reg        [3:0]    _zz_dBusWishbone_SEL;
-  wire                when_DBusSimplePlugin_l189;
+  wire                when_DBusSimplePlugin_l196;
   `ifndef SYNTHESIS
   reg [39:0] _zz_memory_to_writeBack_ENV_CTRL_string;
   reg [39:0] _zz_memory_to_writeBack_ENV_CTRL_1_string;
@@ -1177,15 +1170,13 @@ module VexRiscv (
   assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
   assign _zz__zz_execute_SRC1 = 3'b100;
   assign _zz__zz_execute_SRC1_1 = execute_INSTRUCTION[19 : 15];
-  assign _zz__zz_execute_SRC2_3 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz__zz_execute_SRC2_2 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
   assign _zz_execute_SrcPlugin_addSub = ($signed(_zz_execute_SrcPlugin_addSub_1) + $signed(_zz_execute_SrcPlugin_addSub_4));
   assign _zz_execute_SrcPlugin_addSub_1 = ($signed(_zz_execute_SrcPlugin_addSub_2) + $signed(_zz_execute_SrcPlugin_addSub_3));
   assign _zz_execute_SrcPlugin_addSub_2 = execute_SRC1;
   assign _zz_execute_SrcPlugin_addSub_3 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? _zz_execute_SrcPlugin_addSub_5 : _zz_execute_SrcPlugin_addSub_6);
-  assign _zz_execute_SrcPlugin_addSub_5 = 32'h00000001;
-  assign _zz_execute_SrcPlugin_addSub_6 = 32'h0;
-  assign _zz__zz_decode_RS2_3 = (_zz__zz_decode_RS2_3_1 >>> 1);
+  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? 32'h00000001 : 32'h00000000);
+  assign _zz__zz_decode_RS2_3 = (_zz__zz_decode_RS2_3_1 >>> 1'd1);
   assign _zz__zz_decode_RS2_3_1 = {((execute_SHIFT_CTRL == ShiftCtrlEnum_SRA_1) && execute_LightShifterPlugin_shiftInput[31]),execute_LightShifterPlugin_shiftInput};
   assign _zz__zz_execute_BranchPlugin_missAlignedTarget_2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
   assign _zz__zz_execute_BranchPlugin_missAlignedTarget_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
@@ -1202,11 +1193,11 @@ module VexRiscv (
   assign _zz_memory_MulDivIterativePlugin_mul_counter_valueNext_1 = memory_MulDivIterativePlugin_mul_counter_willIncrement;
   assign _zz_memory_MulDivIterativePlugin_mul_counter_valueNext = {5'd0, _zz_memory_MulDivIterativePlugin_mul_counter_valueNext_1};
   assign _zz_memory_MulDivIterativePlugin_accumulator = (_zz_memory_MulDivIterativePlugin_accumulator_1 + _zz_memory_MulDivIterativePlugin_accumulator_3);
-  assign _zz_memory_MulDivIterativePlugin_accumulator_2 = (memory_MulDivIterativePlugin_rs2[0] ? memory_MulDivIterativePlugin_rs1 : 33'h0);
+  assign _zz_memory_MulDivIterativePlugin_accumulator_2 = (memory_MulDivIterativePlugin_rs2[0] ? memory_MulDivIterativePlugin_rs1 : 33'h000000000);
   assign _zz_memory_MulDivIterativePlugin_accumulator_1 = {{1{_zz_memory_MulDivIterativePlugin_accumulator_2[32]}}, _zz_memory_MulDivIterativePlugin_accumulator_2};
   assign _zz_memory_MulDivIterativePlugin_accumulator_4 = _zz_memory_MulDivIterativePlugin_accumulator_5;
   assign _zz_memory_MulDivIterativePlugin_accumulator_3 = {{1{_zz_memory_MulDivIterativePlugin_accumulator_4[32]}}, _zz_memory_MulDivIterativePlugin_accumulator_4};
-  assign _zz_memory_MulDivIterativePlugin_accumulator_5 = (memory_MulDivIterativePlugin_accumulator >>> 32);
+  assign _zz_memory_MulDivIterativePlugin_accumulator_5 = (memory_MulDivIterativePlugin_accumulator >>> 6'd32);
   assign _zz_memory_MulDivIterativePlugin_div_counter_valueNext_1 = memory_MulDivIterativePlugin_div_counter_willIncrement;
   assign _zz_memory_MulDivIterativePlugin_div_counter_valueNext = {5'd0, _zz_memory_MulDivIterativePlugin_div_counter_valueNext_1};
   assign _zz_memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator = {1'd0, memory_MulDivIterativePlugin_rs2};
@@ -1218,32 +1209,31 @@ module VexRiscv (
   assign _zz_memory_MulDivIterativePlugin_div_result_3 = ({memory_MulDivIterativePlugin_div_needRevert,(memory_MulDivIterativePlugin_div_needRevert ? (~ _zz_memory_MulDivIterativePlugin_div_result) : _zz_memory_MulDivIterativePlugin_div_result)} + _zz_memory_MulDivIterativePlugin_div_result_4);
   assign _zz_memory_MulDivIterativePlugin_div_result_5 = memory_MulDivIterativePlugin_div_needRevert;
   assign _zz_memory_MulDivIterativePlugin_div_result_4 = {32'd0, _zz_memory_MulDivIterativePlugin_div_result_5};
-  assign _zz_memory_MulDivIterativePlugin_rs1_4 = _zz_memory_MulDivIterativePlugin_rs1_1;
-  assign _zz_memory_MulDivIterativePlugin_rs1_3 = {32'd0, _zz_memory_MulDivIterativePlugin_rs1_4};
-  assign _zz_memory_MulDivIterativePlugin_rs2_1 = _zz_memory_MulDivIterativePlugin_rs1;
-  assign _zz_memory_MulDivIterativePlugin_rs2 = {31'd0, _zz_memory_MulDivIterativePlugin_rs2_1};
-  assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 5);
+  assign _zz_memory_MulDivIterativePlugin_rs1_3 = _zz_memory_MulDivIterativePlugin_rs1;
+  assign _zz_memory_MulDivIterativePlugin_rs1_2 = {32'd0, _zz_memory_MulDivIterativePlugin_rs1_3};
+  assign _zz_memory_MulDivIterativePlugin_rs2_2 = _zz_memory_MulDivIterativePlugin_rs2;
+  assign _zz_memory_MulDivIterativePlugin_rs2_1 = {31'd0, _zz_memory_MulDivIterativePlugin_rs2_2};
+  assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 3'd5);
   assign _zz_decode_RegFilePlugin_rs1Data = 1'b1;
   assign _zz_decode_RegFilePlugin_rs2Data = 1'b1;
   assign _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = {_zz_IBusCachedPlugin_jump_pcLoad_payload_3,_zz_IBusCachedPlugin_jump_pcLoad_payload_2};
-  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000107f;
-  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00002073;
-  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000207f;
+  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000407f);
+  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00004063;
+  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000107f) == 32'h00000013);
   assign _zz_decode_LEGAL_INSTRUCTION_5 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_6) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_7 == _zz_decode_LEGAL_INSTRUCTION_8),{_zz_decode_LEGAL_INSTRUCTION_9,{_zz_decode_LEGAL_INSTRUCTION_10,_zz_decode_LEGAL_INSTRUCTION_11}}}}}};
   assign _zz_decode_LEGAL_INSTRUCTION_6 = 32'h0000505f;
   assign _zz_decode_LEGAL_INSTRUCTION_7 = (decode_INSTRUCTION & 32'h0000707b);
   assign _zz_decode_LEGAL_INSTRUCTION_8 = 32'h00000063;
   assign _zz_decode_LEGAL_INSTRUCTION_9 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
   assign _zz_decode_LEGAL_INSTRUCTION_10 = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
-  assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'hfc00305f) == 32'h00001013),{((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h00005033),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,{_zz_decode_LEGAL_INSTRUCTION_16,_zz_decode_LEGAL_INSTRUCTION_17}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'hbe00705f) == 32'h00005013),{((decode_INSTRUCTION & 32'hfe00305f) == 32'h00001013),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h00000033),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,_zz_decode_LEGAL_INSTRUCTION_16}}}}};
   assign _zz_decode_LEGAL_INSTRUCTION_12 = 32'hbe00707f;
-  assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'hbe00707f);
-  assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h00000033;
-  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
-  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073);
-  assign _zz_decode_LEGAL_INSTRUCTION_17 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073);
+  assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'hdfffffff);
+  assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h10200073;
+  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073);
+  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073);
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_4 = decode_INSTRUCTION[31];
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_5 = decode_INSTRUCTION[31];
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_6 = decode_INSTRUCTION[7];
@@ -1253,125 +1243,113 @@ module VexRiscv (
   assign _zz__zz_decode_IS_DIV_3 = ((decode_INSTRUCTION & 32'h02004074) == 32'h02000030);
   assign _zz__zz_decode_IS_DIV_4 = (|((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_5) == 32'h00000050));
   assign _zz__zz_decode_IS_DIV_6 = (|(_zz__zz_decode_IS_DIV_7 == _zz__zz_decode_IS_DIV_8));
-  assign _zz__zz_decode_IS_DIV_9 = {(|{_zz__zz_decode_IS_DIV_10,_zz__zz_decode_IS_DIV_12}),{(|_zz__zz_decode_IS_DIV_14),{_zz__zz_decode_IS_DIV_17,{_zz__zz_decode_IS_DIV_20,_zz__zz_decode_IS_DIV_25}}}};
+  assign _zz__zz_decode_IS_DIV_9 = {(|{_zz__zz_decode_IS_DIV_10,_zz__zz_decode_IS_DIV_11}),{(|_zz__zz_decode_IS_DIV_12),{_zz__zz_decode_IS_DIV_14,{_zz__zz_decode_IS_DIV_16,_zz__zz_decode_IS_DIV_19}}}};
   assign _zz__zz_decode_IS_DIV_5 = 32'h10003050;
   assign _zz__zz_decode_IS_DIV_7 = (decode_INSTRUCTION & 32'h10403050);
   assign _zz__zz_decode_IS_DIV_8 = 32'h10000050;
-  assign _zz__zz_decode_IS_DIV_10 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_11) == 32'h00001050);
-  assign _zz__zz_decode_IS_DIV_12 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_13) == 32'h00002050);
-  assign _zz__zz_decode_IS_DIV_14 = {_zz_decode_IS_DIV_4,(_zz__zz_decode_IS_DIV_15 == _zz__zz_decode_IS_DIV_16)};
-  assign _zz__zz_decode_IS_DIV_17 = (|(_zz__zz_decode_IS_DIV_18 == _zz__zz_decode_IS_DIV_19));
-  assign _zz__zz_decode_IS_DIV_20 = (|{_zz__zz_decode_IS_DIV_21,_zz__zz_decode_IS_DIV_23});
-  assign _zz__zz_decode_IS_DIV_25 = {(|_zz__zz_decode_IS_DIV_26),{_zz__zz_decode_IS_DIV_31,{_zz__zz_decode_IS_DIV_37,_zz__zz_decode_IS_DIV_39}}};
-  assign _zz__zz_decode_IS_DIV_11 = 32'h00001050;
-  assign _zz__zz_decode_IS_DIV_13 = 32'h00002050;
-  assign _zz__zz_decode_IS_DIV_15 = (decode_INSTRUCTION & 32'h0000001c);
-  assign _zz__zz_decode_IS_DIV_16 = 32'h00000004;
-  assign _zz__zz_decode_IS_DIV_18 = (decode_INSTRUCTION & 32'h00000058);
-  assign _zz__zz_decode_IS_DIV_19 = 32'h00000040;
-  assign _zz__zz_decode_IS_DIV_21 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_22) == 32'h00005010);
-  assign _zz__zz_decode_IS_DIV_23 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_24) == 32'h00005020);
-  assign _zz__zz_decode_IS_DIV_26 = {(_zz__zz_decode_IS_DIV_27 == _zz__zz_decode_IS_DIV_28),{_zz__zz_decode_IS_DIV_29,_zz__zz_decode_IS_DIV_30}};
-  assign _zz__zz_decode_IS_DIV_31 = (|{_zz__zz_decode_IS_DIV_32,{_zz__zz_decode_IS_DIV_33,_zz__zz_decode_IS_DIV_35}});
-  assign _zz__zz_decode_IS_DIV_37 = (|_zz__zz_decode_IS_DIV_38);
-  assign _zz__zz_decode_IS_DIV_39 = {(|_zz__zz_decode_IS_DIV_40),{_zz__zz_decode_IS_DIV_41,{_zz__zz_decode_IS_DIV_44,_zz__zz_decode_IS_DIV_49}}};
-  assign _zz__zz_decode_IS_DIV_22 = 32'h00007034;
-  assign _zz__zz_decode_IS_DIV_24 = 32'h02007064;
-  assign _zz__zz_decode_IS_DIV_27 = (decode_INSTRUCTION & 32'h40003054);
-  assign _zz__zz_decode_IS_DIV_28 = 32'h40001010;
-  assign _zz__zz_decode_IS_DIV_29 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00001010);
-  assign _zz__zz_decode_IS_DIV_30 = ((decode_INSTRUCTION & 32'h02007054) == 32'h00001010);
-  assign _zz__zz_decode_IS_DIV_32 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
-  assign _zz__zz_decode_IS_DIV_33 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_34) == 32'h00001010);
-  assign _zz__zz_decode_IS_DIV_35 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_36) == 32'h00001010);
-  assign _zz__zz_decode_IS_DIV_38 = ((decode_INSTRUCTION & 32'h00001000) == 32'h00001000);
-  assign _zz__zz_decode_IS_DIV_40 = _zz_decode_IS_DIV_5;
-  assign _zz__zz_decode_IS_DIV_41 = (|{_zz__zz_decode_IS_DIV_42,_zz__zz_decode_IS_DIV_43});
-  assign _zz__zz_decode_IS_DIV_44 = (|{_zz__zz_decode_IS_DIV_45,_zz__zz_decode_IS_DIV_47});
-  assign _zz__zz_decode_IS_DIV_49 = {(|_zz__zz_decode_IS_DIV_50),{_zz__zz_decode_IS_DIV_54,{_zz__zz_decode_IS_DIV_57,_zz__zz_decode_IS_DIV_59}}};
-  assign _zz__zz_decode_IS_DIV_34 = 32'h00003034;
-  assign _zz__zz_decode_IS_DIV_36 = 32'h02003054;
-  assign _zz__zz_decode_IS_DIV_42 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
-  assign _zz__zz_decode_IS_DIV_43 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00001000);
-  assign _zz__zz_decode_IS_DIV_45 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_46) == 32'h00000020);
-  assign _zz__zz_decode_IS_DIV_47 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_48) == 32'h00000020);
-  assign _zz__zz_decode_IS_DIV_50 = {(_zz__zz_decode_IS_DIV_51 == _zz__zz_decode_IS_DIV_52),{_zz_decode_IS_DIV_2,_zz__zz_decode_IS_DIV_53}};
-  assign _zz__zz_decode_IS_DIV_54 = (|(_zz__zz_decode_IS_DIV_55 == _zz__zz_decode_IS_DIV_56));
-  assign _zz__zz_decode_IS_DIV_57 = (|_zz__zz_decode_IS_DIV_58);
-  assign _zz__zz_decode_IS_DIV_59 = {(|_zz__zz_decode_IS_DIV_60),{_zz__zz_decode_IS_DIV_65,{_zz__zz_decode_IS_DIV_78,_zz__zz_decode_IS_DIV_83}}};
-  assign _zz__zz_decode_IS_DIV_46 = 32'h00000034;
-  assign _zz__zz_decode_IS_DIV_48 = 32'h00000064;
-  assign _zz__zz_decode_IS_DIV_51 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz__zz_decode_IS_DIV_52 = 32'h00000040;
-  assign _zz__zz_decode_IS_DIV_53 = ((decode_INSTRUCTION & 32'h00403040) == 32'h00000040);
-  assign _zz__zz_decode_IS_DIV_55 = (decode_INSTRUCTION & 32'h00000020);
-  assign _zz__zz_decode_IS_DIV_56 = 32'h00000020;
-  assign _zz__zz_decode_IS_DIV_58 = ((decode_INSTRUCTION & 32'h00000010) == 32'h00000010);
-  assign _zz__zz_decode_IS_DIV_60 = {_zz_decode_IS_DIV_3,{_zz__zz_decode_IS_DIV_61,_zz__zz_decode_IS_DIV_63}};
-  assign _zz__zz_decode_IS_DIV_65 = (|{_zz_decode_IS_DIV_4,{_zz__zz_decode_IS_DIV_66,_zz__zz_decode_IS_DIV_69}});
-  assign _zz__zz_decode_IS_DIV_78 = (|{_zz__zz_decode_IS_DIV_79,_zz__zz_decode_IS_DIV_80});
-  assign _zz__zz_decode_IS_DIV_83 = {(|_zz__zz_decode_IS_DIV_84),{_zz__zz_decode_IS_DIV_87,{_zz__zz_decode_IS_DIV_94,_zz__zz_decode_IS_DIV_98}}};
-  assign _zz__zz_decode_IS_DIV_61 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_62) == 32'h00000010);
-  assign _zz__zz_decode_IS_DIV_63 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_64) == 32'h00000020);
-  assign _zz__zz_decode_IS_DIV_66 = (_zz__zz_decode_IS_DIV_67 == _zz__zz_decode_IS_DIV_68);
-  assign _zz__zz_decode_IS_DIV_69 = {_zz__zz_decode_IS_DIV_70,{_zz__zz_decode_IS_DIV_72,_zz__zz_decode_IS_DIV_75}};
-  assign _zz__zz_decode_IS_DIV_79 = _zz_decode_IS_DIV_3;
+  assign _zz__zz_decode_IS_DIV_10 = ((decode_INSTRUCTION & 32'h00001050) == 32'h00001050);
+  assign _zz__zz_decode_IS_DIV_11 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002050);
+  assign _zz__zz_decode_IS_DIV_12 = {_zz_decode_IS_DIV_4,((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_13) == 32'h00000004)};
+  assign _zz__zz_decode_IS_DIV_14 = (|((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_15) == 32'h00000040));
+  assign _zz__zz_decode_IS_DIV_16 = (|(_zz__zz_decode_IS_DIV_17 == _zz__zz_decode_IS_DIV_18));
+  assign _zz__zz_decode_IS_DIV_19 = {(|{_zz__zz_decode_IS_DIV_20,_zz__zz_decode_IS_DIV_22}),{(|_zz__zz_decode_IS_DIV_24),{_zz__zz_decode_IS_DIV_29,{_zz__zz_decode_IS_DIV_32,_zz__zz_decode_IS_DIV_33}}}};
+  assign _zz__zz_decode_IS_DIV_13 = 32'h0000001c;
+  assign _zz__zz_decode_IS_DIV_15 = 32'h00000058;
+  assign _zz__zz_decode_IS_DIV_17 = (decode_INSTRUCTION & 32'h02007054);
+  assign _zz__zz_decode_IS_DIV_18 = 32'h00005010;
+  assign _zz__zz_decode_IS_DIV_20 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_21) == 32'h40001010);
+  assign _zz__zz_decode_IS_DIV_22 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_23) == 32'h00001010);
+  assign _zz__zz_decode_IS_DIV_24 = {(_zz__zz_decode_IS_DIV_25 == _zz__zz_decode_IS_DIV_26),(_zz__zz_decode_IS_DIV_27 == _zz__zz_decode_IS_DIV_28)};
+  assign _zz__zz_decode_IS_DIV_29 = (|(_zz__zz_decode_IS_DIV_30 == _zz__zz_decode_IS_DIV_31));
+  assign _zz__zz_decode_IS_DIV_32 = (|_zz_decode_IS_DIV_5);
+  assign _zz__zz_decode_IS_DIV_33 = {(|_zz__zz_decode_IS_DIV_34),{_zz__zz_decode_IS_DIV_37,{_zz__zz_decode_IS_DIV_42,_zz__zz_decode_IS_DIV_47}}};
+  assign _zz__zz_decode_IS_DIV_21 = 32'h40003054;
+  assign _zz__zz_decode_IS_DIV_23 = 32'h02007054;
+  assign _zz__zz_decode_IS_DIV_25 = (decode_INSTRUCTION & 32'h00000064);
+  assign _zz__zz_decode_IS_DIV_26 = 32'h00000024;
+  assign _zz__zz_decode_IS_DIV_27 = (decode_INSTRUCTION & 32'h02003054);
+  assign _zz__zz_decode_IS_DIV_28 = 32'h00001010;
+  assign _zz__zz_decode_IS_DIV_30 = (decode_INSTRUCTION & 32'h00001000);
+  assign _zz__zz_decode_IS_DIV_31 = 32'h00001000;
+  assign _zz__zz_decode_IS_DIV_34 = {((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_35) == 32'h00002000),((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_36) == 32'h00001000)};
+  assign _zz__zz_decode_IS_DIV_37 = (|{(_zz__zz_decode_IS_DIV_38 == _zz__zz_decode_IS_DIV_39),(_zz__zz_decode_IS_DIV_40 == _zz__zz_decode_IS_DIV_41)});
+  assign _zz__zz_decode_IS_DIV_42 = (|{_zz__zz_decode_IS_DIV_43,{_zz__zz_decode_IS_DIV_44,_zz__zz_decode_IS_DIV_45}});
+  assign _zz__zz_decode_IS_DIV_47 = {(|_zz__zz_decode_IS_DIV_48),{(|_zz__zz_decode_IS_DIV_49),{_zz__zz_decode_IS_DIV_51,{_zz__zz_decode_IS_DIV_56,_zz__zz_decode_IS_DIV_69}}}};
+  assign _zz__zz_decode_IS_DIV_35 = 32'h00002010;
+  assign _zz__zz_decode_IS_DIV_36 = 32'h00005000;
+  assign _zz__zz_decode_IS_DIV_38 = (decode_INSTRUCTION & 32'h00000034);
+  assign _zz__zz_decode_IS_DIV_39 = 32'h00000020;
+  assign _zz__zz_decode_IS_DIV_40 = (decode_INSTRUCTION & 32'h00000064);
+  assign _zz__zz_decode_IS_DIV_41 = 32'h00000020;
+  assign _zz__zz_decode_IS_DIV_43 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000040);
+  assign _zz__zz_decode_IS_DIV_44 = _zz_decode_IS_DIV_2;
+  assign _zz__zz_decode_IS_DIV_45 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_46) == 32'h00000040);
+  assign _zz__zz_decode_IS_DIV_48 = ((decode_INSTRUCTION & 32'h00000020) == 32'h00000020);
+  assign _zz__zz_decode_IS_DIV_49 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_50) == 32'h00000010);
+  assign _zz__zz_decode_IS_DIV_51 = (|{_zz_decode_IS_DIV_3,{_zz__zz_decode_IS_DIV_52,_zz__zz_decode_IS_DIV_54}});
+  assign _zz__zz_decode_IS_DIV_56 = (|{_zz__zz_decode_IS_DIV_57,_zz__zz_decode_IS_DIV_58});
+  assign _zz__zz_decode_IS_DIV_69 = {(|_zz__zz_decode_IS_DIV_70),{_zz__zz_decode_IS_DIV_73,{_zz__zz_decode_IS_DIV_76,_zz__zz_decode_IS_DIV_83}}};
+  assign _zz__zz_decode_IS_DIV_46 = 32'h00403040;
+  assign _zz__zz_decode_IS_DIV_50 = 32'h00000010;
+  assign _zz__zz_decode_IS_DIV_52 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_53) == 32'h00000010);
+  assign _zz__zz_decode_IS_DIV_54 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_55) == 32'h00000020);
+  assign _zz__zz_decode_IS_DIV_57 = _zz_decode_IS_DIV_4;
+  assign _zz__zz_decode_IS_DIV_58 = {(_zz__zz_decode_IS_DIV_59 == _zz__zz_decode_IS_DIV_60),{_zz__zz_decode_IS_DIV_61,{_zz__zz_decode_IS_DIV_63,_zz__zz_decode_IS_DIV_66}}};
+  assign _zz__zz_decode_IS_DIV_70 = {_zz_decode_IS_DIV_3,(_zz__zz_decode_IS_DIV_71 == _zz__zz_decode_IS_DIV_72)};
+  assign _zz__zz_decode_IS_DIV_73 = (|{_zz_decode_IS_DIV_3,_zz__zz_decode_IS_DIV_74});
+  assign _zz__zz_decode_IS_DIV_76 = (|{_zz__zz_decode_IS_DIV_77,_zz__zz_decode_IS_DIV_80});
+  assign _zz__zz_decode_IS_DIV_83 = {(|_zz__zz_decode_IS_DIV_84),{_zz__zz_decode_IS_DIV_87,{_zz__zz_decode_IS_DIV_93,_zz__zz_decode_IS_DIV_96}}};
+  assign _zz__zz_decode_IS_DIV_53 = 32'h00000030;
+  assign _zz__zz_decode_IS_DIV_55 = 32'h02000060;
+  assign _zz__zz_decode_IS_DIV_59 = (decode_INSTRUCTION & 32'h00001010);
+  assign _zz__zz_decode_IS_DIV_60 = 32'h00001010;
+  assign _zz__zz_decode_IS_DIV_61 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_62) == 32'h00002010);
+  assign _zz__zz_decode_IS_DIV_63 = (_zz__zz_decode_IS_DIV_64 == _zz__zz_decode_IS_DIV_65);
+  assign _zz__zz_decode_IS_DIV_66 = {_zz__zz_decode_IS_DIV_67,_zz__zz_decode_IS_DIV_68};
+  assign _zz__zz_decode_IS_DIV_71 = (decode_INSTRUCTION & 32'h00000070);
+  assign _zz__zz_decode_IS_DIV_72 = 32'h00000020;
+  assign _zz__zz_decode_IS_DIV_74 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_75) == 32'h00000000);
+  assign _zz__zz_decode_IS_DIV_77 = (_zz__zz_decode_IS_DIV_78 == _zz__zz_decode_IS_DIV_79);
   assign _zz__zz_decode_IS_DIV_80 = (_zz__zz_decode_IS_DIV_81 == _zz__zz_decode_IS_DIV_82);
-  assign _zz__zz_decode_IS_DIV_84 = {_zz_decode_IS_DIV_3,_zz__zz_decode_IS_DIV_85};
-  assign _zz__zz_decode_IS_DIV_87 = (|{_zz__zz_decode_IS_DIV_88,_zz__zz_decode_IS_DIV_91});
-  assign _zz__zz_decode_IS_DIV_94 = (|_zz__zz_decode_IS_DIV_95);
-  assign _zz__zz_decode_IS_DIV_98 = {_zz__zz_decode_IS_DIV_99,{_zz__zz_decode_IS_DIV_105,_zz__zz_decode_IS_DIV_108}};
-  assign _zz__zz_decode_IS_DIV_62 = 32'h00000030;
-  assign _zz__zz_decode_IS_DIV_64 = 32'h02000060;
-  assign _zz__zz_decode_IS_DIV_67 = (decode_INSTRUCTION & 32'h00001010);
-  assign _zz__zz_decode_IS_DIV_68 = 32'h00001010;
-  assign _zz__zz_decode_IS_DIV_70 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_71) == 32'h00002010);
-  assign _zz__zz_decode_IS_DIV_72 = (_zz__zz_decode_IS_DIV_73 == _zz__zz_decode_IS_DIV_74);
-  assign _zz__zz_decode_IS_DIV_75 = {_zz__zz_decode_IS_DIV_76,_zz__zz_decode_IS_DIV_77};
-  assign _zz__zz_decode_IS_DIV_81 = (decode_INSTRUCTION & 32'h00000070);
-  assign _zz__zz_decode_IS_DIV_82 = 32'h00000020;
-  assign _zz__zz_decode_IS_DIV_85 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_86) == 32'h0);
-  assign _zz__zz_decode_IS_DIV_88 = (_zz__zz_decode_IS_DIV_89 == _zz__zz_decode_IS_DIV_90);
-  assign _zz__zz_decode_IS_DIV_91 = (_zz__zz_decode_IS_DIV_92 == _zz__zz_decode_IS_DIV_93);
-  assign _zz__zz_decode_IS_DIV_95 = (_zz__zz_decode_IS_DIV_96 == _zz__zz_decode_IS_DIV_97);
-  assign _zz__zz_decode_IS_DIV_99 = (|{_zz__zz_decode_IS_DIV_100,_zz__zz_decode_IS_DIV_102});
-  assign _zz__zz_decode_IS_DIV_105 = (|_zz__zz_decode_IS_DIV_106);
-  assign _zz__zz_decode_IS_DIV_108 = {_zz__zz_decode_IS_DIV_109,{_zz__zz_decode_IS_DIV_115,_zz__zz_decode_IS_DIV_119}};
-  assign _zz__zz_decode_IS_DIV_71 = 32'h00002010;
-  assign _zz__zz_decode_IS_DIV_73 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz__zz_decode_IS_DIV_74 = 32'h00000010;
-  assign _zz__zz_decode_IS_DIV_76 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
-  assign _zz__zz_decode_IS_DIV_77 = ((decode_INSTRUCTION & 32'h00000028) == 32'h0);
-  assign _zz__zz_decode_IS_DIV_86 = 32'h00000020;
-  assign _zz__zz_decode_IS_DIV_89 = (decode_INSTRUCTION & 32'h00006014);
-  assign _zz__zz_decode_IS_DIV_90 = 32'h00006010;
-  assign _zz__zz_decode_IS_DIV_92 = (decode_INSTRUCTION & 32'h00005014);
-  assign _zz__zz_decode_IS_DIV_93 = 32'h00004010;
-  assign _zz__zz_decode_IS_DIV_96 = (decode_INSTRUCTION & 32'h00006014);
-  assign _zz__zz_decode_IS_DIV_97 = 32'h00002010;
-  assign _zz__zz_decode_IS_DIV_100 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_101) == 32'h0);
-  assign _zz__zz_decode_IS_DIV_102 = {_zz_decode_IS_DIV_2,{_zz__zz_decode_IS_DIV_103,_zz__zz_decode_IS_DIV_104}};
-  assign _zz__zz_decode_IS_DIV_106 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_107) == 32'h0);
-  assign _zz__zz_decode_IS_DIV_109 = (|{_zz__zz_decode_IS_DIV_110,{_zz__zz_decode_IS_DIV_111,_zz__zz_decode_IS_DIV_113}});
-  assign _zz__zz_decode_IS_DIV_115 = (|{_zz__zz_decode_IS_DIV_116,_zz__zz_decode_IS_DIV_118});
-  assign _zz__zz_decode_IS_DIV_119 = {(|_zz__zz_decode_IS_DIV_120),(|_zz__zz_decode_IS_DIV_123)};
-  assign _zz__zz_decode_IS_DIV_101 = 32'h00000044;
-  assign _zz__zz_decode_IS_DIV_103 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
-  assign _zz__zz_decode_IS_DIV_104 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
-  assign _zz__zz_decode_IS_DIV_107 = 32'h00000058;
-  assign _zz__zz_decode_IS_DIV_110 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
-  assign _zz__zz_decode_IS_DIV_111 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_112) == 32'h00002010);
-  assign _zz__zz_decode_IS_DIV_113 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_114) == 32'h40000030);
-  assign _zz__zz_decode_IS_DIV_116 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_117) == 32'h00000004);
-  assign _zz__zz_decode_IS_DIV_118 = _zz_decode_IS_DIV_1;
-  assign _zz__zz_decode_IS_DIV_120 = {(_zz__zz_decode_IS_DIV_121 == _zz__zz_decode_IS_DIV_122),_zz_decode_IS_DIV_1};
-  assign _zz__zz_decode_IS_DIV_123 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_124) == 32'h00001008);
-  assign _zz__zz_decode_IS_DIV_112 = 32'h00002014;
-  assign _zz__zz_decode_IS_DIV_114 = 32'h40004034;
-  assign _zz__zz_decode_IS_DIV_117 = 32'h00000014;
-  assign _zz__zz_decode_IS_DIV_121 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz__zz_decode_IS_DIV_122 = 32'h00000004;
-  assign _zz__zz_decode_IS_DIV_124 = 32'h00001048;
+  assign _zz__zz_decode_IS_DIV_84 = (_zz__zz_decode_IS_DIV_85 == _zz__zz_decode_IS_DIV_86);
+  assign _zz__zz_decode_IS_DIV_87 = (|{_zz__zz_decode_IS_DIV_88,_zz__zz_decode_IS_DIV_90});
+  assign _zz__zz_decode_IS_DIV_93 = (|_zz__zz_decode_IS_DIV_94);
+  assign _zz__zz_decode_IS_DIV_96 = {_zz__zz_decode_IS_DIV_97,{_zz__zz_decode_IS_DIV_103,_zz__zz_decode_IS_DIV_107}};
+  assign _zz__zz_decode_IS_DIV_62 = 32'h00002010;
+  assign _zz__zz_decode_IS_DIV_64 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz__zz_decode_IS_DIV_65 = 32'h00000010;
+  assign _zz__zz_decode_IS_DIV_67 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
+  assign _zz__zz_decode_IS_DIV_68 = ((decode_INSTRUCTION & 32'h00000028) == 32'h00000000);
+  assign _zz__zz_decode_IS_DIV_75 = 32'h00000020;
+  assign _zz__zz_decode_IS_DIV_78 = (decode_INSTRUCTION & 32'h00006004);
+  assign _zz__zz_decode_IS_DIV_79 = 32'h00006000;
+  assign _zz__zz_decode_IS_DIV_81 = (decode_INSTRUCTION & 32'h00005014);
+  assign _zz__zz_decode_IS_DIV_82 = 32'h00004010;
+  assign _zz__zz_decode_IS_DIV_85 = (decode_INSTRUCTION & 32'h00006014);
+  assign _zz__zz_decode_IS_DIV_86 = 32'h00002010;
+  assign _zz__zz_decode_IS_DIV_88 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_89) == 32'h00000000);
+  assign _zz__zz_decode_IS_DIV_90 = {_zz_decode_IS_DIV_2,{_zz__zz_decode_IS_DIV_91,_zz__zz_decode_IS_DIV_92}};
+  assign _zz__zz_decode_IS_DIV_94 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_95) == 32'h00000000);
+  assign _zz__zz_decode_IS_DIV_97 = (|{_zz__zz_decode_IS_DIV_98,{_zz__zz_decode_IS_DIV_99,_zz__zz_decode_IS_DIV_101}});
+  assign _zz__zz_decode_IS_DIV_103 = (|{_zz__zz_decode_IS_DIV_104,_zz__zz_decode_IS_DIV_106});
+  assign _zz__zz_decode_IS_DIV_107 = {(|_zz__zz_decode_IS_DIV_108),(|_zz__zz_decode_IS_DIV_111)};
+  assign _zz__zz_decode_IS_DIV_89 = 32'h00000044;
+  assign _zz__zz_decode_IS_DIV_91 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
+  assign _zz__zz_decode_IS_DIV_92 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
+  assign _zz__zz_decode_IS_DIV_95 = 32'h00000058;
+  assign _zz__zz_decode_IS_DIV_98 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
+  assign _zz__zz_decode_IS_DIV_99 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_100) == 32'h00002010);
+  assign _zz__zz_decode_IS_DIV_101 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_102) == 32'h40000030);
+  assign _zz__zz_decode_IS_DIV_104 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_105) == 32'h00000004);
+  assign _zz__zz_decode_IS_DIV_106 = _zz_decode_IS_DIV_1;
+  assign _zz__zz_decode_IS_DIV_108 = {(_zz__zz_decode_IS_DIV_109 == _zz__zz_decode_IS_DIV_110),_zz_decode_IS_DIV_1};
+  assign _zz__zz_decode_IS_DIV_111 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_112) == 32'h00001008);
+  assign _zz__zz_decode_IS_DIV_100 = 32'h00002014;
+  assign _zz__zz_decode_IS_DIV_102 = 32'h40004034;
+  assign _zz__zz_decode_IS_DIV_105 = 32'h00000014;
+  assign _zz__zz_decode_IS_DIV_109 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz__zz_decode_IS_DIV_110 = 32'h00000004;
+  assign _zz__zz_decode_IS_DIV_112 = 32'h00001048;
   assign _zz_execute_BranchPlugin_branch_src2_6 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_7 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_8 = execute_INSTRUCTION[7];
@@ -2074,7 +2052,7 @@ module VexRiscv (
   assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
   assign execute_MEMORY_ADDRESS_LOW = dBus_cmd_payload_address[1 : 0];
   assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
-  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
+  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h00)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h00))));
   assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
   assign decode_IS_DIV = _zz_decode_IS_DIV[30];
@@ -2210,7 +2188,7 @@ module VexRiscv (
     if(when_ShiftPlugins_l169) begin
       _zz_decode_RS2_1 = _zz_decode_RS2_3;
     end
-    if(when_CsrPlugin_l1189) begin
+    if(when_CsrPlugin_l1587) begin
       _zz_decode_RS2_1 = CsrPlugin_csrMapping_readDataSignal;
     end
   end
@@ -2219,7 +2197,7 @@ module VexRiscv (
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_execute_SRC2 = execute_PC;
+  assign _zz_execute_to_memory_PC = execute_PC;
   assign execute_SRC2_CTRL = _zz_execute_SRC2_CTRL;
   assign execute_SRC1_CTRL = _zz_execute_SRC1_CTRL;
   assign decode_SRC_USE_SUB_LESS = _zz_decode_IS_DIV[3];
@@ -2227,7 +2205,7 @@ module VexRiscv (
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
   assign execute_ALU_CTRL = _zz_execute_ALU_CTRL;
-  assign execute_SRC2 = _zz_execute_SRC2_5;
+  assign execute_SRC2 = _zz_execute_SRC2_4;
   assign execute_SRC1 = _zz_execute_SRC1;
   assign execute_ALU_BITWISE_CTRL = _zz_execute_ALU_BITWISE_CTRL;
   assign _zz_lastStageRegFileWrite_payload_address = writeBack_INSTRUCTION;
@@ -2247,10 +2225,10 @@ module VexRiscv (
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00001073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
+  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000107f) == 32'h00001073),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00002073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
   always @(*) begin
     _zz_decode_RS2_2 = writeBack_REGFILE_WRITE_DATA;
-    if(when_DBusSimplePlugin_l558) begin
+    if(when_DBusSimplePlugin_l566) begin
       _zz_decode_RS2_2 = writeBack_DBusSimplePlugin_rspFormated;
     end
   end
@@ -2271,28 +2249,28 @@ module VexRiscv (
   assign decode_FLUSH_ALL = _zz_decode_IS_DIV[0];
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_4 = IBusCachedPlugin_rsp_issueDetected_3;
-    if(when_IBusCachedPlugin_l256) begin
+    if(when_IBusCachedPlugin_l262) begin
       IBusCachedPlugin_rsp_issueDetected_4 = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_3 = IBusCachedPlugin_rsp_issueDetected_2;
-    if(when_IBusCachedPlugin_l250) begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_rsp_issueDetected_3 = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
-    if(when_IBusCachedPlugin_l244) begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
-    if(when_IBusCachedPlugin_l239) begin
+    if(when_IBusCachedPlugin_l245) begin
       IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
@@ -2325,7 +2303,7 @@ module VexRiscv (
     if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(when_CsrPlugin_l1129) begin
+    if(when_CsrPlugin_l1527) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
@@ -2353,7 +2331,7 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(when_DBusSimplePlugin_l428) begin
+    if(when_DBusSimplePlugin_l436) begin
       execute_arbitration_haltItself = 1'b1;
     end
     if(when_ShiftPlugins_l169) begin
@@ -2361,7 +2339,7 @@ module VexRiscv (
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(when_CsrPlugin_l1193) begin
+    if(when_CsrPlugin_l1591) begin
       if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
@@ -2389,7 +2367,7 @@ module VexRiscv (
 
   always @(*) begin
     memory_arbitration_haltItself = 1'b0;
-    if(when_DBusSimplePlugin_l482) begin
+    if(when_DBusSimplePlugin_l490) begin
       memory_arbitration_haltItself = 1'b1;
     end
     if(when_MulDivIterativePlugin_l96) begin
@@ -2441,10 +2419,10 @@ module VexRiscv (
   assign writeBack_arbitration_flushIt = 1'b0;
   always @(*) begin
     writeBack_arbitration_flushNext = 1'b0;
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -2455,13 +2433,13 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @(*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(when_CsrPlugin_l935) begin
+    if(when_CsrPlugin_l1272) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
@@ -2469,33 +2447,43 @@ module VexRiscv (
   assign IBusCachedPlugin_forceNoDecodeCond = 1'b0;
   always @(*) begin
     IBusCachedPlugin_incomingInstruction = 1'b0;
-    if(when_Fetcher_l243) begin
+    if(when_Fetcher_l242) begin
       IBusCachedPlugin_incomingInstruction = 1'b1;
     end
   end
 
   assign BranchPlugin_inDebugNoFetchFlag = 1'b0;
-  assign CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+  always @(*) begin
+    CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+    if(when_CsrPlugin_l1702) begin
+      CsrPlugin_csrMapping_allowCsrSignal = 1'b1;
+    end
+    if(when_CsrPlugin_l1709) begin
+      CsrPlugin_csrMapping_allowCsrSignal = 1'b1;
+    end
+  end
+
+  assign CsrPlugin_csrMapping_doForceFailCsr = 1'b0;
   assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
   assign CsrPlugin_inWfi = 1'b0;
   assign CsrPlugin_thirdPartyWake = 1'b0;
   always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(when_CsrPlugin_l1077) begin
-      case(switch_CsrPlugin_l1081)
+    if(when_CsrPlugin_l1456) begin
+      case(switch_CsrPlugin_l1460)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -2509,6 +2497,7 @@ module VexRiscv (
   assign CsrPlugin_allowInterrupts = 1'b1;
   assign CsrPlugin_allowException = 1'b1;
   assign CsrPlugin_allowEbreakException = 1'b1;
+  assign CsrPlugin_xretAwayFromMachine = 1'b0;
   assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
   assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,IBusCachedPlugin_predictionJumpInterface_valid}} != 3'b000);
   assign _zz_IBusCachedPlugin_jump_pcLoad_payload = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,CsrPlugin_jumpInterface_valid}};
@@ -2535,9 +2524,8 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l134 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
-  assign IBusCachedPlugin_fetchPc_output_fire_1 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
-  assign when_Fetcher_l134_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
+  assign when_Fetcher_l133 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l133_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
   always @(*) begin
     IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_IBusCachedPlugin_fetchPc_pc);
     if(IBusCachedPlugin_fetchPc_redo_valid) begin
@@ -2560,7 +2548,7 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l161 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
+  assign when_Fetcher_l160 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
   assign IBusCachedPlugin_fetchPc_output_valid = ((! IBusCachedPlugin_fetcherHalt) && IBusCachedPlugin_fetchPc_booted);
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
   always @(*) begin
@@ -2597,7 +2585,7 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_1_output_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b0;
-    if(when_IBusCachedPlugin_l267) begin
+    if(when_IBusCachedPlugin_l273) begin
       IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b1;
     end
   end
@@ -2610,9 +2598,9 @@ module VexRiscv (
   assign IBusCachedPlugin_fetchPc_redo_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_iBusRsp_flush = ((decode_arbitration_removeIt || (decode_arbitration_flushNext && (! decode_arbitration_isStuck))) || IBusCachedPlugin_iBusRsp_redoFetch);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
-  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1 = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
   assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid)) || IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready);
   assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
@@ -2622,18 +2610,18 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
   always @(*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
-    if(when_Fetcher_l323) begin
+    if(when_Fetcher_l322) begin
       IBusCachedPlugin_iBusRsp_readyForError = 1'b0;
     end
   end
 
-  assign when_Fetcher_l243 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
-  assign when_Fetcher_l323 = (! IBusCachedPlugin_pcValids_0);
-  assign when_Fetcher_l332 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
-  assign when_Fetcher_l332_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
-  assign when_Fetcher_l332_2 = (! execute_arbitration_isStuck);
-  assign when_Fetcher_l332_3 = (! memory_arbitration_isStuck);
-  assign when_Fetcher_l332_4 = (! writeBack_arbitration_isStuck);
+  assign when_Fetcher_l242 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
+  assign when_Fetcher_l322 = (! IBusCachedPlugin_pcValids_0);
+  assign when_Fetcher_l331 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l331_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
+  assign when_Fetcher_l331_2 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l331_3 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l331_4 = (! writeBack_arbitration_isStuck);
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
@@ -2788,47 +2776,47 @@ module VexRiscv (
   assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
   always @(*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(when_IBusCachedPlugin_l239) begin
+    if(when_IBusCachedPlugin_l245) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(when_IBusCachedPlugin_l250) begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_cache_io_cpu_fill_valid = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
-    if(when_IBusCachedPlugin_l250) begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_cache_io_cpu_fill_valid = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_valid = 1'b0;
-    if(when_IBusCachedPlugin_l244) begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
-    if(when_IBusCachedPlugin_l256) begin
+    if(when_IBusCachedPlugin_l262) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_payload_code = 4'bxxxx;
-    if(when_IBusCachedPlugin_l244) begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b1100;
     end
-    if(when_IBusCachedPlugin_l256) begin
+    if(when_IBusCachedPlugin_l262) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b0001;
     end
   end
 
   assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_2_input_payload[31 : 2],2'b00};
-  assign when_IBusCachedPlugin_l239 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign when_IBusCachedPlugin_l244 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
-  assign when_IBusCachedPlugin_l250 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
-  assign when_IBusCachedPlugin_l256 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
-  assign when_IBusCachedPlugin_l267 = (IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt);
+  assign when_IBusCachedPlugin_l245 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign when_IBusCachedPlugin_l250 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign when_IBusCachedPlugin_l256 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
+  assign when_IBusCachedPlugin_l262 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
+  assign when_IBusCachedPlugin_l273 = (IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt);
   assign IBusCachedPlugin_iBusRsp_output_valid = IBusCachedPlugin_iBusRsp_stages_2_output_valid;
   assign IBusCachedPlugin_iBusRsp_stages_2_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
   assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_decode_data;
@@ -2860,7 +2848,7 @@ module VexRiscv (
   end
 
   assign dBus_cmd_payload_data = _zz_dBus_cmd_payload_data;
-  assign when_DBusSimplePlugin_l428 = ((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! dBus_cmd_ready)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_dBus_cmd_valid));
+  assign when_DBusSimplePlugin_l436 = ((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! dBus_cmd_ready)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_dBus_cmd_valid));
   always @(*) begin
     case(dBus_cmd_payload_size)
       2'b00 : begin
@@ -2877,23 +2865,23 @@ module VexRiscv (
 
   assign execute_DBusSimplePlugin_formalMask = (_zz_execute_DBusSimplePlugin_formalMask <<< dBus_cmd_payload_address[1 : 0]);
   assign dBus_cmd_payload_address = execute_SRC_ADD;
-  assign when_DBusSimplePlugin_l482 = (((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (! memory_MEMORY_STORE)) && ((! dBus_rsp_ready) || 1'b0));
+  assign when_DBusSimplePlugin_l490 = (((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (! memory_MEMORY_STORE)) && ((! dBus_rsp_ready) || 1'b0));
   always @(*) begin
     DBusSimplePlugin_memoryExceptionPort_valid = 1'b0;
-    if(when_DBusSimplePlugin_l489) begin
+    if(when_DBusSimplePlugin_l497) begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b1;
     end
     if(memory_ALIGNEMENT_FAULT) begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b1;
     end
-    if(when_DBusSimplePlugin_l515) begin
+    if(when_DBusSimplePlugin_l523) begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b0;
     end
   end
 
   always @(*) begin
     DBusSimplePlugin_memoryExceptionPort_payload_code = 4'bxxxx;
-    if(when_DBusSimplePlugin_l489) begin
+    if(when_DBusSimplePlugin_l497) begin
       DBusSimplePlugin_memoryExceptionPort_payload_code = 4'b0101;
     end
     if(memory_ALIGNEMENT_FAULT) begin
@@ -2902,8 +2890,8 @@ module VexRiscv (
   end
 
   assign DBusSimplePlugin_memoryExceptionPort_payload_badAddr = memory_REGFILE_WRITE_DATA;
-  assign when_DBusSimplePlugin_l489 = ((dBus_rsp_ready && dBus_rsp_error) && (! memory_MEMORY_STORE));
-  assign when_DBusSimplePlugin_l515 = (! ((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (1'b1 || (! memory_arbitration_isStuckByOthers))));
+  assign when_DBusSimplePlugin_l497 = ((dBus_rsp_ready && dBus_rsp_error) && (! memory_MEMORY_STORE));
+  assign when_DBusSimplePlugin_l523 = (! ((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (1'b1 || (! memory_arbitration_isStuckByOthers))));
   always @(*) begin
     writeBack_DBusSimplePlugin_rspShifted = writeBack_MEMORY_READ_DATA;
     case(writeBack_MEMORY_ADDRESS_LOW)
@@ -2921,7 +2909,7 @@ module VexRiscv (
     endcase
   end
 
-  assign switch_Misc_l210 = writeBack_INSTRUCTION[13 : 12];
+  assign switch_Misc_l232 = writeBack_INSTRUCTION[13 : 12];
   assign _zz_writeBack_DBusSimplePlugin_rspFormated = (writeBack_DBusSimplePlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
   always @(*) begin
     _zz_writeBack_DBusSimplePlugin_rspFormated_1[31] = _zz_writeBack_DBusSimplePlugin_rspFormated;
@@ -2973,7 +2961,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    case(switch_Misc_l210)
+    case(switch_Misc_l232)
       2'b00 : begin
         writeBack_DBusSimplePlugin_rspFormated = _zz_writeBack_DBusSimplePlugin_rspFormated_1;
       end
@@ -2986,7 +2974,7 @@ module VexRiscv (
     endcase
   end
 
-  assign when_DBusSimplePlugin_l558 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusSimplePlugin_l566 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
   assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
@@ -2997,7 +2985,7 @@ module VexRiscv (
   assign IBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign IBusCachedPlugin_mmuBus_busy = 1'b0;
   assign _zz_decode_IS_DIV_1 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_decode_IS_DIV_2 = ((decode_INSTRUCTION & 32'h00000018) == 32'h0);
+  assign _zz_decode_IS_DIV_2 = ((decode_INSTRUCTION & 32'h00000018) == 32'h00000000);
   assign _zz_decode_IS_DIV_3 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
   assign _zz_decode_IS_DIV_4 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
   assign _zz_decode_IS_DIV_5 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
@@ -3021,29 +3009,29 @@ module VexRiscv (
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
-  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h0);
+  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h00);
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
   assign decode_RegFilePlugin_rs1Data = _zz_RegFilePlugin_regFile_port0;
   assign decode_RegFilePlugin_rs2Data = _zz_RegFilePlugin_regFile_port1;
   always @(*) begin
     lastStageRegFileWrite_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
-    if(_zz_7) begin
+    if(_zz_10) begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
   always @(*) begin
     lastStageRegFileWrite_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
-    if(_zz_7) begin
-      lastStageRegFileWrite_payload_address = 5'h0;
+    if(_zz_10) begin
+      lastStageRegFileWrite_payload_address = 5'h00;
     end
   end
 
   always @(*) begin
     lastStageRegFileWrite_payload_data = _zz_decode_RS2_2;
-    if(_zz_7) begin
-      lastStageRegFileWrite_payload_data = 32'h0;
+    if(_zz_10) begin
+      lastStageRegFileWrite_payload_data = 32'h00000000;
     end
   end
 
@@ -3084,7 +3072,7 @@ module VexRiscv (
         _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
       Src1CtrlEnum_IMU : begin
-        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h000};
       end
       default : begin
         _zz_execute_SRC1 = {27'd0, _zz__zz_execute_SRC1_1};
@@ -3092,67 +3080,67 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_execute_SRC2_1 = execute_INSTRUCTION[31];
+  assign _zz_execute_SRC2 = execute_INSTRUCTION[31];
   always @(*) begin
-    _zz_execute_SRC2_2[19] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[18] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[17] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[16] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[15] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[14] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[13] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[12] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[11] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[10] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[9] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[8] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[7] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[6] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[5] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[4] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[3] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[2] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[1] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[0] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_1[19] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[18] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[17] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[16] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[15] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[14] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[13] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[12] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[11] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[10] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[9] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[8] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[7] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[6] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[5] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[4] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[3] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[2] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[1] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[0] = _zz_execute_SRC2;
   end
 
-  assign _zz_execute_SRC2_3 = _zz__zz_execute_SRC2_3[11];
+  assign _zz_execute_SRC2_2 = _zz__zz_execute_SRC2_2[11];
   always @(*) begin
-    _zz_execute_SRC2_4[19] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[18] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[17] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[16] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[15] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[14] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[13] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[12] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[11] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[10] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[9] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[8] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[7] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[6] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[5] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[4] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[3] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[2] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[1] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[0] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_3[19] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[18] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[17] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[16] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[15] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[14] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[13] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[12] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[11] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[10] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[9] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[8] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[7] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[6] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[5] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[4] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[3] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[2] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[1] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[0] = _zz_execute_SRC2_2;
   end
 
   always @(*) begin
     case(execute_SRC2_CTRL)
       Src2CtrlEnum_RS : begin
-        _zz_execute_SRC2_5 = execute_RS2;
+        _zz_execute_SRC2_4 = execute_RS2;
       end
       Src2CtrlEnum_IMI : begin
-        _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
+        _zz_execute_SRC2_4 = {_zz_execute_SRC2_1,execute_INSTRUCTION[31 : 20]};
       end
       Src2CtrlEnum_IMS : begin
-        _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_execute_SRC2_4 = {_zz_execute_SRC2_3,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_execute_SRC2_5 = _zz_execute_SRC2;
+        _zz_execute_SRC2_4 = _zz_execute_to_memory_PC;
       end
     endcase
   end
@@ -3169,7 +3157,7 @@ module VexRiscv (
   assign execute_LightShifterPlugin_amplitude = (execute_LightShifterPlugin_isActive ? execute_LightShifterPlugin_amplitudeReg : execute_SRC2[4 : 0]);
   assign execute_LightShifterPlugin_shiftInput = (execute_LightShifterPlugin_isActive ? memory_REGFILE_WRITE_DATA : execute_SRC1);
   assign execute_LightShifterPlugin_done = (execute_LightShifterPlugin_amplitude[4 : 1] == 4'b0000);
-  assign when_ShiftPlugins_l169 = ((execute_arbitration_isValid && execute_LightShifterPlugin_isShift) && (execute_SRC2[4 : 0] != 5'h0));
+  assign when_ShiftPlugins_l169 = ((execute_arbitration_isValid && execute_LightShifterPlugin_isShift) && (execute_SRC2[4 : 0] != 5'h00));
   always @(*) begin
     case(execute_SHIFT_CTRL)
       ShiftCtrlEnum_SLL_1 : begin
@@ -3264,16 +3252,19 @@ module VexRiscv (
   assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
   assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign switch_Misc_l210_1 = execute_INSTRUCTION[14 : 12];
+  assign switch_Misc_l232_1 = execute_INSTRUCTION[14 : 12];
   always @(*) begin
-    casez(switch_Misc_l210_1)
+    case(switch_Misc_l232_1)
       3'b000 : begin
         _zz_execute_BRANCH_COND_RESULT = execute_BranchPlugin_eq;
       end
       3'b001 : begin
         _zz_execute_BRANCH_COND_RESULT = (! execute_BranchPlugin_eq);
       end
-      3'b1?1 : begin
+      3'b101 : begin
+        _zz_execute_BRANCH_COND_RESULT = (! execute_SRC_LESS);
+      end
+      3'b111 : begin
         _zz_execute_BRANCH_COND_RESULT = (! execute_SRC_LESS);
       end
       default : begin
@@ -3479,9 +3470,9 @@ module VexRiscv (
 
   assign CsrPlugin_misa_base = 2'b01;
   assign CsrPlugin_misa_extensions = 26'h0000042;
-  assign _zz_when_CsrPlugin_l965 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_when_CsrPlugin_l965_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_when_CsrPlugin_l965_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign _zz_when_CsrPlugin_l1302 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l1302_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l1302_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
   assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
@@ -3525,29 +3516,29 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l922 = (! decode_arbitration_isStuck);
-  assign when_CsrPlugin_l922_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l922_2 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l922_3 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l935 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
+  assign when_CsrPlugin_l1259 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l1272 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-  assign when_CsrPlugin_l959 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign when_CsrPlugin_l965 = ((_zz_when_CsrPlugin_l965 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l965_1 = ((_zz_when_CsrPlugin_l965_1 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l965_2 = ((_zz_when_CsrPlugin_l965_2 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1296 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l1302 = ((_zz_when_CsrPlugin_l1302 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1302_1 = ((_zz_when_CsrPlugin_l1302_1 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1302_2 = ((_zz_when_CsrPlugin_l1302_2 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_lastStageWasWfi = 1'b0;
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  assign when_CsrPlugin_l993 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l993_1 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l993_2 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l998 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  assign when_CsrPlugin_l1335 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1335_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l1335_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l1340 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
   always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(when_CsrPlugin_l1004) begin
+    if(when_CsrPlugin_l1346) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException) begin
@@ -3555,7 +3546,7 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l1004 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
+  assign when_CsrPlugin_l1346 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
   always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
@@ -3571,6 +3562,7 @@ module VexRiscv (
     end
   end
 
+  assign CsrPlugin_trapCauseEbreakDebug = 1'b0;
   always @(*) begin
     CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
@@ -3593,11 +3585,13 @@ module VexRiscv (
     endcase
   end
 
-  assign when_CsrPlugin_l1032 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign when_CsrPlugin_l1077 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
-  assign switch_CsrPlugin_l1081 = writeBack_INSTRUCTION[29 : 28];
+  assign CsrPlugin_trapEnterDebug = 1'b0;
+  assign when_CsrPlugin_l1390 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1398 = (! CsrPlugin_trapEnterDebug);
+  assign when_CsrPlugin_l1456 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign switch_CsrPlugin_l1460 = writeBack_INSTRUCTION[29 : 28];
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign when_CsrPlugin_l1129 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
+  assign when_CsrPlugin_l1527 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
   assign execute_CsrPlugin_blockedBySideEffects = ((|{writeBack_arbitration_isValid,memory_arbitration_isValid}) || 1'b0);
   always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
@@ -3639,18 +3633,18 @@ module VexRiscv (
     if(CsrPlugin_csrMapping_allowCsrSignal) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(when_CsrPlugin_l1315) begin
+    if(when_CsrPlugin_l1725) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if(when_CsrPlugin_l1149) begin
-      if(when_CsrPlugin_l1150) begin
+    if(when_CsrPlugin_l1547) begin
+      if(when_CsrPlugin_l1548) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
@@ -3658,14 +3652,14 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(when_CsrPlugin_l1157) begin
+    if(when_CsrPlugin_l1555) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(when_CsrPlugin_l1157) begin
+    if(when_CsrPlugin_l1555) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -3678,19 +3672,19 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  assign when_CsrPlugin_l1149 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
-  assign when_CsrPlugin_l1150 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
-  assign when_CsrPlugin_l1157 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
+  assign when_CsrPlugin_l1547 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign when_CsrPlugin_l1548 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1555 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
   always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -3699,9 +3693,9 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
   assign execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
-  assign switch_Misc_l210_2 = execute_INSTRUCTION[13];
+  assign switch_Misc_l232_2 = execute_INSTRUCTION[13];
   always @(*) begin
-    case(switch_Misc_l210_2)
+    case(switch_Misc_l232_2)
       1'b0 : begin
         _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
@@ -3712,8 +3706,8 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
-  assign when_CsrPlugin_l1189 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign when_CsrPlugin_l1193 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
+  assign when_CsrPlugin_l1587 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1591 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign memory_MulDivIterativePlugin_frontendOk = 1'b1;
   always @(*) begin
@@ -3736,12 +3730,12 @@ module VexRiscv (
   assign memory_MulDivIterativePlugin_mul_counter_willOverflow = (memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc && memory_MulDivIterativePlugin_mul_counter_willIncrement);
   always @(*) begin
     if(memory_MulDivIterativePlugin_mul_counter_willOverflow) begin
-      memory_MulDivIterativePlugin_mul_counter_valueNext = 6'h0;
+      memory_MulDivIterativePlugin_mul_counter_valueNext = 6'h00;
     end else begin
       memory_MulDivIterativePlugin_mul_counter_valueNext = (memory_MulDivIterativePlugin_mul_counter_value + _zz_memory_MulDivIterativePlugin_mul_counter_valueNext);
     end
     if(memory_MulDivIterativePlugin_mul_counter_willClear) begin
-      memory_MulDivIterativePlugin_mul_counter_valueNext = 6'h0;
+      memory_MulDivIterativePlugin_mul_counter_valueNext = 6'h00;
     end
   end
 
@@ -3769,12 +3763,12 @@ module VexRiscv (
   assign memory_MulDivIterativePlugin_div_counter_willOverflow = (memory_MulDivIterativePlugin_div_counter_willOverflowIfInc && memory_MulDivIterativePlugin_div_counter_willIncrement);
   always @(*) begin
     if(memory_MulDivIterativePlugin_div_counter_willOverflow) begin
-      memory_MulDivIterativePlugin_div_counter_valueNext = 6'h0;
+      memory_MulDivIterativePlugin_div_counter_valueNext = 6'h00;
     end else begin
       memory_MulDivIterativePlugin_div_counter_valueNext = (memory_MulDivIterativePlugin_div_counter_value + _zz_memory_MulDivIterativePlugin_div_counter_valueNext);
     end
     if(memory_MulDivIterativePlugin_div_counter_willClear) begin
-      memory_MulDivIterativePlugin_div_counter_valueNext = 6'h0;
+      memory_MulDivIterativePlugin_div_counter_valueNext = 6'h00;
     end
   end
 
@@ -3791,15 +3785,15 @@ module VexRiscv (
   assign when_MulDivIterativePlugin_l151 = (memory_MulDivIterativePlugin_div_counter_value == 6'h20);
   assign _zz_memory_MulDivIterativePlugin_div_result = (memory_INSTRUCTION[13] ? memory_MulDivIterativePlugin_accumulator[31 : 0] : memory_MulDivIterativePlugin_rs1[31 : 0]);
   assign when_MulDivIterativePlugin_l162 = (! memory_arbitration_isStuck);
-  assign _zz_memory_MulDivIterativePlugin_rs1 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
-  assign _zz_memory_MulDivIterativePlugin_rs1_1 = ((execute_IS_MUL && _zz_memory_MulDivIterativePlugin_rs1) || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
+  assign _zz_memory_MulDivIterativePlugin_rs2 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
+  assign _zz_memory_MulDivIterativePlugin_rs1 = ((execute_IS_MUL && _zz_memory_MulDivIterativePlugin_rs2) || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
   always @(*) begin
-    _zz_memory_MulDivIterativePlugin_rs1_2[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
-    _zz_memory_MulDivIterativePlugin_rs1_2[31 : 0] = execute_RS1;
+    _zz_memory_MulDivIterativePlugin_rs1_1[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
+    _zz_memory_MulDivIterativePlugin_rs1_1[31 : 0] = execute_RS1;
   end
 
-  assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
-  assign externalInterrupt = (|_zz_CsrPlugin_csrMapping_readDataInit_1);
+  assign _zz_externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
+  assign externalInterrupt = (|_zz_externalInterrupt);
   assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
@@ -3903,82 +3897,92 @@ module VexRiscv (
   assign when_Pipeline_l154_1 = ((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt));
   assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
   assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
-  assign when_CsrPlugin_l1277 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_2 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_3 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_4 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_5 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_6 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_7 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_8 = (! execute_arbitration_isStuck);
-  assign switch_CsrPlugin_l723 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
+  assign when_CsrPlugin_l1669 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_8 = (! execute_arbitration_isStuck);
+  assign switch_CsrPlugin_l1031 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_1 = 32'h00000000;
     if(execute_CsrPlugin_csr_768) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_2[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_2[3 : 3] = CsrPlugin_mstatus_MIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_2[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_CsrPlugin_csrMapping_readDataInit_1[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_1[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_1[12 : 11] = CsrPlugin_mstatus_MPP;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h00000000;
     if(execute_CsrPlugin_csr_836) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_3[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_3[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_3[3 : 3] = CsrPlugin_mip_MSIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[3 : 3] = CsrPlugin_mip_MSIP;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h00000000;
     if(execute_CsrPlugin_csr_772) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_4[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_4[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_4[3 : 3] = CsrPlugin_mie_MSIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[3 : 3] = CsrPlugin_mie_MSIE;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h00000000;
     if(execute_CsrPlugin_csr_833) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_5[31 : 0] = CsrPlugin_mepc;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[31 : 0] = CsrPlugin_mepc;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h00000000;
     if(execute_CsrPlugin_csr_834) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_6[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_CsrPlugin_csrMapping_readDataInit_6[3 : 0] = CsrPlugin_mcause_exceptionCode;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h00000000;
     if(execute_CsrPlugin_csr_835) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_7[31 : 0] = CsrPlugin_mtval;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[31 : 0] = CsrPlugin_mtval;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h00000000;
     if(execute_CsrPlugin_csr_3008) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_8[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h00000000;
     if(execute_CsrPlugin_csr_4032) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_9[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_1;
+      _zz_CsrPlugin_csrMapping_readDataInit_8[31 : 0] = _zz_externalInterrupt;
     end
   end
 
-  assign CsrPlugin_csrMapping_readDataInit = (((_zz_CsrPlugin_csrMapping_readDataInit_2 | _zz_CsrPlugin_csrMapping_readDataInit_3) | (_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5)) | ((_zz_CsrPlugin_csrMapping_readDataInit_6 | _zz_CsrPlugin_csrMapping_readDataInit_7) | (_zz_CsrPlugin_csrMapping_readDataInit_8 | _zz_CsrPlugin_csrMapping_readDataInit_9)));
-  assign when_CsrPlugin_l1310 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign when_CsrPlugin_l1315 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign CsrPlugin_csrMapping_readDataInit = (((_zz_CsrPlugin_csrMapping_readDataInit_1 | _zz_CsrPlugin_csrMapping_readDataInit_2) | (_zz_CsrPlugin_csrMapping_readDataInit_3 | _zz_CsrPlugin_csrMapping_readDataInit_4)) | ((_zz_CsrPlugin_csrMapping_readDataInit_5 | _zz_CsrPlugin_csrMapping_readDataInit_6) | (_zz_CsrPlugin_csrMapping_readDataInit_7 | _zz_CsrPlugin_csrMapping_readDataInit_8)));
+  assign when_CsrPlugin_l1702 = ((execute_arbitration_isValid && execute_IS_CSR) && (({execute_CsrPlugin_csrAddress[11 : 2],2'b00} == 12'h3a0) || ({execute_CsrPlugin_csrAddress[11 : 4],4'b0000} == 12'h3b0)));
+  assign _zz_when_CsrPlugin_l1709 = (execute_CsrPlugin_csrAddress & 12'hf60);
+  assign when_CsrPlugin_l1709 = (((execute_arbitration_isValid && execute_IS_CSR) && (5'h03 <= execute_CsrPlugin_csrAddress[4 : 0])) && (((_zz_when_CsrPlugin_l1709 == 12'hb00) || (((_zz_when_CsrPlugin_l1709 == 12'hc00) && (! execute_CsrPlugin_writeInstruction)) && (CsrPlugin_privilege == 2'b11))) || ((execute_CsrPlugin_csrAddress & 12'hfe0) == 12'h320)));
+  always @(*) begin
+    when_CsrPlugin_l1719 = CsrPlugin_csrMapping_doForceFailCsr;
+    if(when_CsrPlugin_l1717) begin
+      when_CsrPlugin_l1719 = 1'b1;
+    end
+  end
+
+  assign when_CsrPlugin_l1717 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1725 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
   assign iBusWishbone_ADR = {_zz_iBusWishbone_ADR_1,_zz_iBusWishbone_ADR};
   assign iBusWishbone_CTI = ((_zz_iBusWishbone_ADR == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
@@ -4011,7 +4015,7 @@ module VexRiscv (
   assign dBus_cmd_halfPipe_payload_address = dBus_cmd_rData_address;
   assign dBus_cmd_halfPipe_payload_data = dBus_cmd_rData_data;
   assign dBus_cmd_halfPipe_payload_size = dBus_cmd_rData_size;
-  assign dBusWishbone_ADR = (dBus_cmd_halfPipe_payload_address >>> 2);
+  assign dBusWishbone_ADR = (dBus_cmd_halfPipe_payload_address >>> 2'd2);
   assign dBusWishbone_CTI = 3'b000;
   assign dBusWishbone_BTE = 2'b00;
   always @(*) begin
@@ -4030,12 +4034,12 @@ module VexRiscv (
 
   always @(*) begin
     dBusWishbone_SEL = (_zz_dBusWishbone_SEL <<< dBus_cmd_halfPipe_payload_address[1 : 0]);
-    if(when_DBusSimplePlugin_l189) begin
+    if(when_DBusSimplePlugin_l196) begin
       dBusWishbone_SEL = 4'b1111;
     end
   end
 
-  assign when_DBusSimplePlugin_l189 = (! dBus_cmd_halfPipe_payload_wr);
+  assign when_DBusSimplePlugin_l196 = (! dBus_cmd_halfPipe_payload_wr);
   assign dBusWishbone_WE = dBus_cmd_halfPipe_payload_wr;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_halfPipe_payload_data;
   assign dBus_cmd_halfPipe_ready = (dBus_cmd_halfPipe_valid && dBusWishbone_ACK);
@@ -4050,15 +4054,15 @@ module VexRiscv (
       IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
-      _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+      _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= 1'b0;
       _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= 32'h0;
-      _zz_7 <= 1'b1;
+      IBusCachedPlugin_rspCounter <= 32'h00000000;
+      _zz_10 <= 1'b1;
       execute_LightShifterPlugin_isActive <= 1'b0;
       HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
       CsrPlugin_mstatus_MIE <= 1'b0;
@@ -4067,8 +4071,8 @@ module VexRiscv (
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
-      CsrPlugin_mcycle <= 64'h0;
-      CsrPlugin_minstret <= 64'h0;
+      CsrPlugin_mcycle <= 64'h0000000000000000;
+      CsrPlugin_minstret <= 64'h0000000000000000;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= 1'b0;
@@ -4079,9 +4083,9 @@ module VexRiscv (
       CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
-      memory_MulDivIterativePlugin_mul_counter_value <= 6'h0;
-      memory_MulDivIterativePlugin_div_counter_value <= 6'h0;
-      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h0;
+      memory_MulDivIterativePlugin_mul_counter_value <= 6'h00;
+      memory_MulDivIterativePlugin_div_counter_value <= 6'h00;
+      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h00000000;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
@@ -4096,23 +4100,23 @@ module VexRiscv (
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusCachedPlugin_fetchPc_booted <= 1'b1;
-      if(when_Fetcher_l134) begin
+      if(when_Fetcher_l133) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_output_fire_1) begin
+      if(IBusCachedPlugin_fetchPc_output_fire) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b1;
       end
-      if(when_Fetcher_l134_1) begin
+      if(when_Fetcher_l133_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(when_Fetcher_l161) begin
+      if(when_Fetcher_l160) begin
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
       if(IBusCachedPlugin_iBusRsp_flush) begin
-        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= 1'b0;
       end
       if(_zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready) begin
-        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
       if(IBusCachedPlugin_iBusRsp_flush) begin
         _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
@@ -4123,13 +4127,13 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if(when_Fetcher_l332) begin
+      if(when_Fetcher_l331) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(when_Fetcher_l332_1) begin
+      if(when_Fetcher_l331_1) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= IBusCachedPlugin_injector_nextPcCalc_valids_0;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -4138,7 +4142,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(when_Fetcher_l332_2) begin
+      if(when_Fetcher_l331_2) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= IBusCachedPlugin_injector_nextPcCalc_valids_1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -4147,7 +4151,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(when_Fetcher_l332_3) begin
+      if(when_Fetcher_l331_3) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -4156,7 +4160,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if(when_Fetcher_l332_4) begin
+      if(when_Fetcher_l331_4) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= IBusCachedPlugin_injector_nextPcCalc_valids_3;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -4165,7 +4169,7 @@ module VexRiscv (
       if(iBus_rsp_valid) begin
         IBusCachedPlugin_rspCounter <= (IBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      _zz_7 <= 1'b0;
+      _zz_10 <= 1'b0;
       if(when_ShiftPlugins_l169) begin
         if(when_ShiftPlugins_l175) begin
           execute_LightShifterPlugin_isActive <= 1'b1;
@@ -4182,50 +4186,50 @@ module VexRiscv (
       if(writeBack_arbitration_isFiring) begin
         CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
       end
-      if(when_CsrPlugin_l922) begin
+      if(when_CsrPlugin_l1259) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if(when_CsrPlugin_l922_1) begin
+      if(when_CsrPlugin_l1259_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if(when_CsrPlugin_l922_2) begin
+      if(when_CsrPlugin_l1259_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if(when_CsrPlugin_l922_3) begin
+      if(when_CsrPlugin_l1259_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(when_CsrPlugin_l959) begin
-        if(when_CsrPlugin_l965) begin
+      if(when_CsrPlugin_l1296) begin
+        if(when_CsrPlugin_l1302) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_1) begin
+        if(when_CsrPlugin_l1302_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_2) begin
+        if(when_CsrPlugin_l1302_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
       if(CsrPlugin_pipelineLiberator_active) begin
-        if(when_CsrPlugin_l993) begin
+        if(when_CsrPlugin_l1335) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if(when_CsrPlugin_l993_1) begin
+        if(when_CsrPlugin_l1335_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if(when_CsrPlugin_l993_2) begin
+        if(when_CsrPlugin_l1335_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(when_CsrPlugin_l998) begin
+      if(when_CsrPlugin_l1340) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
@@ -4234,19 +4238,21 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(when_CsrPlugin_l1032) begin
-        case(CsrPlugin_targetPrivilege)
-          2'b11 : begin
-            CsrPlugin_mstatus_MIE <= 1'b0;
-            CsrPlugin_mstatus_MPIE <= CsrPlugin_mstatus_MIE;
-            CsrPlugin_mstatus_MPP <= CsrPlugin_privilege;
-          end
-          default : begin
-          end
-        endcase
+      if(when_CsrPlugin_l1390) begin
+        if(when_CsrPlugin_l1398) begin
+          case(CsrPlugin_targetPrivilege)
+            2'b11 : begin
+              CsrPlugin_mstatus_MIE <= 1'b0;
+              CsrPlugin_mstatus_MPIE <= CsrPlugin_mstatus_MIE;
+              CsrPlugin_mstatus_MPP <= CsrPlugin_privilege;
+            end
+            default : begin
+            end
+          endcase
+        end
       end
-      if(when_CsrPlugin_l1077) begin
-        case(switch_CsrPlugin_l1081)
+      if(when_CsrPlugin_l1456) begin
+        case(switch_CsrPlugin_l1460)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -4256,7 +4262,7 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l965_2,{_zz_when_CsrPlugin_l965_1,_zz_when_CsrPlugin_l965}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l1302_2,{_zz_when_CsrPlugin_l1302_1,_zz_when_CsrPlugin_l1302}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_MulDivIterativePlugin_mul_counter_value <= memory_MulDivIterativePlugin_mul_counter_valueNext;
       memory_MulDivIterativePlugin_div_counter_value <= memory_MulDivIterativePlugin_div_counter_valueNext;
       if(when_Pipeline_l151) begin
@@ -4281,7 +4287,7 @@ module VexRiscv (
         if(execute_CsrPlugin_writeEnable) begin
           CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
           CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
-          case(switch_CsrPlugin_l723)
+          case(switch_CsrPlugin_l1031)
             2'b11 : begin
               CsrPlugin_mstatus_MPP <= 2'b11;
             end
@@ -4349,38 +4355,40 @@ module VexRiscv (
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3 ? DBusSimplePlugin_memoryExceptionPort_payload_code : BranchPlugin_branchExceptionPort_payload_code);
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3 ? DBusSimplePlugin_memoryExceptionPort_payload_badAddr : BranchPlugin_branchExceptionPort_payload_badAddr);
     end
-    if(when_CsrPlugin_l959) begin
-      if(when_CsrPlugin_l965) begin
+    if(when_CsrPlugin_l1296) begin
+      if(when_CsrPlugin_l1302) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l965_1) begin
+      if(when_CsrPlugin_l1302_1) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l965_2) begin
+      if(when_CsrPlugin_l1302_2) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(when_CsrPlugin_l1032) begin
-      case(CsrPlugin_targetPrivilege)
-        2'b11 : begin
-          CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
-          CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
-          CsrPlugin_mepc <= writeBack_PC;
-          if(CsrPlugin_hadException) begin
-            CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
+    if(when_CsrPlugin_l1390) begin
+      if(when_CsrPlugin_l1398) begin
+        case(CsrPlugin_targetPrivilege)
+          2'b11 : begin
+            CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
+            CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
+            CsrPlugin_mepc <= writeBack_PC;
+            if(CsrPlugin_hadException) begin
+              CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
+            end
           end
-        end
-        default : begin
-        end
-      endcase
+          default : begin
+          end
+        endcase
+      end
     end
     if(when_MulDivIterativePlugin_l96) begin
       if(when_MulDivIterativePlugin_l100) begin
         memory_MulDivIterativePlugin_rs2 <= (memory_MulDivIterativePlugin_rs2 >>> 1);
-        memory_MulDivIterativePlugin_accumulator <= ({_zz_memory_MulDivIterativePlugin_accumulator,memory_MulDivIterativePlugin_accumulator[31 : 0]} >>> 1);
+        memory_MulDivIterativePlugin_accumulator <= ({_zz_memory_MulDivIterativePlugin_accumulator,memory_MulDivIterativePlugin_accumulator[31 : 0]} >>> 1'd1);
       end
     end
     if(when_MulDivIterativePlugin_l126) begin
@@ -4399,17 +4407,17 @@ module VexRiscv (
       end
     end
     if(when_MulDivIterativePlugin_l162) begin
-      memory_MulDivIterativePlugin_accumulator <= 65'h0;
-      memory_MulDivIterativePlugin_rs1 <= ((_zz_memory_MulDivIterativePlugin_rs1_1 ? (~ _zz_memory_MulDivIterativePlugin_rs1_2) : _zz_memory_MulDivIterativePlugin_rs1_2) + _zz_memory_MulDivIterativePlugin_rs1_3);
-      memory_MulDivIterativePlugin_rs2 <= ((_zz_memory_MulDivIterativePlugin_rs1 ? (~ execute_RS2) : execute_RS2) + _zz_memory_MulDivIterativePlugin_rs2);
-      memory_MulDivIterativePlugin_div_needRevert <= ((_zz_memory_MulDivIterativePlugin_rs1_1 ^ (_zz_memory_MulDivIterativePlugin_rs1 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
+      memory_MulDivIterativePlugin_accumulator <= 65'h00000000000000000;
+      memory_MulDivIterativePlugin_rs1 <= ((_zz_memory_MulDivIterativePlugin_rs1 ? (~ _zz_memory_MulDivIterativePlugin_rs1_1) : _zz_memory_MulDivIterativePlugin_rs1_1) + _zz_memory_MulDivIterativePlugin_rs1_2);
+      memory_MulDivIterativePlugin_rs2 <= ((_zz_memory_MulDivIterativePlugin_rs2 ? (~ execute_RS2) : execute_RS2) + _zz_memory_MulDivIterativePlugin_rs2_1);
+      memory_MulDivIterativePlugin_div_needRevert <= ((_zz_memory_MulDivIterativePlugin_rs1 ^ (_zz_memory_MulDivIterativePlugin_rs2 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h00000000) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
     end
     externalInterruptArray_regNext <= externalInterruptArray;
     if(when_Pipeline_l124) begin
       decode_to_execute_PC <= decode_PC;
     end
     if(when_Pipeline_l124_1) begin
-      execute_to_memory_PC <= _zz_execute_SRC2;
+      execute_to_memory_PC <= _zz_execute_to_memory_PC;
     end
     if(when_Pipeline_l124_2) begin
       memory_to_writeBack_PC <= memory_PC;
@@ -4561,31 +4569,31 @@ module VexRiscv (
     if(when_Pipeline_l124_51) begin
       memory_to_writeBack_MEMORY_READ_DATA <= memory_MEMORY_READ_DATA;
     end
-    if(when_CsrPlugin_l1277) begin
+    if(when_CsrPlugin_l1669) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if(when_CsrPlugin_l1277_1) begin
+    if(when_CsrPlugin_l1669_1) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if(when_CsrPlugin_l1277_2) begin
+    if(when_CsrPlugin_l1669_2) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if(when_CsrPlugin_l1277_3) begin
+    if(when_CsrPlugin_l1669_3) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if(when_CsrPlugin_l1277_4) begin
+    if(when_CsrPlugin_l1669_4) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if(when_CsrPlugin_l1277_5) begin
+    if(when_CsrPlugin_l1669_5) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if(when_CsrPlugin_l1277_6) begin
+    if(when_CsrPlugin_l1669_6) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if(when_CsrPlugin_l1277_7) begin
+    if(when_CsrPlugin_l1669_7) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if(when_CsrPlugin_l1277_8) begin
+    if(when_CsrPlugin_l1669_8) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
     if(execute_CsrPlugin_csr_836) begin
@@ -4596,7 +4604,6 @@ module VexRiscv (
     if(execute_CsrPlugin_csr_773) begin
       if(execute_CsrPlugin_writeEnable) begin
         CsrPlugin_mtvec_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 2];
-        CsrPlugin_mtvec_mode <= CsrPlugin_csrMapping_writeDataSignal[1 : 0];
       end
     end
     if(execute_CsrPlugin_csr_833) begin
@@ -4617,46 +4624,46 @@ module VexRiscv (
 endmodule
 
 module InstructionCache (
-  input               io_flush,
-  input               io_cpu_prefetch_isValid,
-  output reg          io_cpu_prefetch_haltIt,
-  input      [31:0]   io_cpu_prefetch_pc,
-  input               io_cpu_fetch_isValid,
-  input               io_cpu_fetch_isStuck,
-  input               io_cpu_fetch_isRemoved,
-  input      [31:0]   io_cpu_fetch_pc,
-  output     [31:0]   io_cpu_fetch_data,
-  input      [31:0]   io_cpu_fetch_mmuRsp_physicalAddress,
-  input               io_cpu_fetch_mmuRsp_isIoAccess,
-  input               io_cpu_fetch_mmuRsp_isPaging,
-  input               io_cpu_fetch_mmuRsp_allowRead,
-  input               io_cpu_fetch_mmuRsp_allowWrite,
-  input               io_cpu_fetch_mmuRsp_allowExecute,
-  input               io_cpu_fetch_mmuRsp_exception,
-  input               io_cpu_fetch_mmuRsp_refilling,
-  input               io_cpu_fetch_mmuRsp_bypassTranslation,
-  output     [31:0]   io_cpu_fetch_physicalAddress,
-  input               io_cpu_decode_isValid,
-  input               io_cpu_decode_isStuck,
-  input      [31:0]   io_cpu_decode_pc,
-  output     [31:0]   io_cpu_decode_physicalAddress,
-  output     [31:0]   io_cpu_decode_data,
-  output              io_cpu_decode_cacheMiss,
-  output              io_cpu_decode_error,
-  output              io_cpu_decode_mmuRefilling,
-  output              io_cpu_decode_mmuException,
-  input               io_cpu_decode_isUser,
-  input               io_cpu_fill_valid,
-  input      [31:0]   io_cpu_fill_payload,
-  output              io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output     [31:0]   io_mem_cmd_payload_address,
-  output     [2:0]    io_mem_cmd_payload_size,
-  input               io_mem_rsp_valid,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input               clk,
-  input               reset
+  input  wire          io_flush,
+  input  wire          io_cpu_prefetch_isValid,
+  output reg           io_cpu_prefetch_haltIt,
+  input  wire [31:0]   io_cpu_prefetch_pc,
+  input  wire          io_cpu_fetch_isValid,
+  input  wire          io_cpu_fetch_isStuck,
+  input  wire          io_cpu_fetch_isRemoved,
+  input  wire [31:0]   io_cpu_fetch_pc,
+  output wire [31:0]   io_cpu_fetch_data,
+  input  wire [31:0]   io_cpu_fetch_mmuRsp_physicalAddress,
+  input  wire          io_cpu_fetch_mmuRsp_isIoAccess,
+  input  wire          io_cpu_fetch_mmuRsp_isPaging,
+  input  wire          io_cpu_fetch_mmuRsp_allowRead,
+  input  wire          io_cpu_fetch_mmuRsp_allowWrite,
+  input  wire          io_cpu_fetch_mmuRsp_allowExecute,
+  input  wire          io_cpu_fetch_mmuRsp_exception,
+  input  wire          io_cpu_fetch_mmuRsp_refilling,
+  input  wire          io_cpu_fetch_mmuRsp_bypassTranslation,
+  output wire [31:0]   io_cpu_fetch_physicalAddress,
+  input  wire          io_cpu_decode_isValid,
+  input  wire          io_cpu_decode_isStuck,
+  input  wire [31:0]   io_cpu_decode_pc,
+  output wire [31:0]   io_cpu_decode_physicalAddress,
+  output wire [31:0]   io_cpu_decode_data,
+  output wire          io_cpu_decode_cacheMiss,
+  output wire          io_cpu_decode_error,
+  output wire          io_cpu_decode_mmuRefilling,
+  output wire          io_cpu_decode_mmuException,
+  input  wire          io_cpu_decode_isUser,
+  input  wire          io_cpu_fill_valid,
+  input  wire [31:0]   io_cpu_fill_payload,
+  output wire          io_mem_cmd_valid,
+  input  wire          io_mem_cmd_ready,
+  output wire [31:0]   io_mem_cmd_payload_address,
+  output wire [2:0]    io_mem_cmd_payload_size,
+  input  wire          io_mem_rsp_valid,
+  input  wire [31:0]   io_mem_rsp_payload_data,
+  input  wire          io_mem_rsp_payload_error,
+  input  wire          clk,
+  input  wire          reset
 );
 
   reg        [31:0]   _zz_banks_0_port1;
@@ -4676,7 +4683,7 @@ module InstructionCache (
   wire                when_InstructionCache_l351;
   reg                 lineLoader_cmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_Utils_l515;
+  wire                when_Utils_l560;
   reg                 lineLoader_wayToAllocate_willIncrement;
   wire                lineLoader_wayToAllocate_willClear;
   wire                lineLoader_wayToAllocate_willOverflowIfInc;
@@ -4791,12 +4798,12 @@ module InstructionCache (
   assign when_InstructionCache_l351 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
   assign io_mem_cmd_fire = (io_mem_cmd_valid && io_mem_cmd_ready);
   assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
-  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
+  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h00};
   assign io_mem_cmd_payload_size = 3'b101;
-  assign when_Utils_l515 = (! lineLoader_valid);
+  assign when_Utils_l560 = (! lineLoader_valid);
   always @(*) begin
     lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if(when_Utils_l515) begin
+    if(when_Utils_l560) begin
       lineLoader_wayToAllocate_willIncrement = 1'b1;
     end
   end
@@ -4887,7 +4894,7 @@ module InstructionCache (
     end
     _zz_when_InstructionCache_l342 <= lineLoader_flushCounter[6];
     if(when_InstructionCache_l351) begin
-      lineLoader_flushCounter <= 7'h0;
+      lineLoader_flushCounter <= 7'h00;
     end
     if(when_InstructionCache_l435) begin
       io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_LiteDebug.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_LiteDebug.v
@@ -1,46 +1,46 @@
-// Generator : SpinalHDL v1.7.1    git head : 0444bb76ab1d6e19f0ec46bc03c4769776deb7d5
+// Generator : SpinalHDL v1.9.4    git head : 270018552577f3bb8e5339ee2583c9c22d324215
 // Component : VexRiscv
-// Git hash  : 581fcb065adf7ea8b626f939ff51679d4c95872f
+// Git hash  : 63430af99f84cc1d11d58b556debe1cc3f238c67
 
 `timescale 1ns/1ps
 
 module VexRiscv (
-  input      [31:0]   externalResetVector,
-  input               timerInterrupt,
-  input               softwareInterrupt,
-  input      [31:0]   externalInterruptArray,
-  input               debug_bus_cmd_valid,
-  output reg          debug_bus_cmd_ready,
-  input               debug_bus_cmd_payload_wr,
-  input      [7:0]    debug_bus_cmd_payload_address,
-  input      [31:0]   debug_bus_cmd_payload_data,
-  output reg [31:0]   debug_bus_rsp_data,
-  output              debug_resetOut,
-  output reg          iBusWishbone_CYC,
-  output reg          iBusWishbone_STB,
-  input               iBusWishbone_ACK,
-  output              iBusWishbone_WE,
-  output     [29:0]   iBusWishbone_ADR,
-  input      [31:0]   iBusWishbone_DAT_MISO,
-  output     [31:0]   iBusWishbone_DAT_MOSI,
-  output     [3:0]    iBusWishbone_SEL,
-  input               iBusWishbone_ERR,
-  output     [2:0]    iBusWishbone_CTI,
-  output     [1:0]    iBusWishbone_BTE,
-  output              dBusWishbone_CYC,
-  output              dBusWishbone_STB,
-  input               dBusWishbone_ACK,
-  output              dBusWishbone_WE,
-  output     [29:0]   dBusWishbone_ADR,
-  input      [31:0]   dBusWishbone_DAT_MISO,
-  output     [31:0]   dBusWishbone_DAT_MOSI,
-  output reg [3:0]    dBusWishbone_SEL,
-  input               dBusWishbone_ERR,
-  output     [2:0]    dBusWishbone_CTI,
-  output     [1:0]    dBusWishbone_BTE,
-  input               clk,
-  input               reset,
-  input               debugReset
+  input  wire [31:0]   externalResetVector,
+  input  wire          timerInterrupt,
+  input  wire          softwareInterrupt,
+  input  wire [31:0]   externalInterruptArray,
+  input  wire          debug_bus_cmd_valid,
+  output reg           debug_bus_cmd_ready,
+  input  wire          debug_bus_cmd_payload_wr,
+  input  wire [7:0]    debug_bus_cmd_payload_address,
+  input  wire [31:0]   debug_bus_cmd_payload_data,
+  output reg  [31:0]   debug_bus_rsp_data,
+  output wire          debug_resetOut,
+  output reg           iBusWishbone_CYC,
+  output reg           iBusWishbone_STB,
+  input  wire          iBusWishbone_ACK,
+  output wire          iBusWishbone_WE,
+  output wire [29:0]   iBusWishbone_ADR,
+  input  wire [31:0]   iBusWishbone_DAT_MISO,
+  output wire [31:0]   iBusWishbone_DAT_MOSI,
+  output wire [3:0]    iBusWishbone_SEL,
+  input  wire          iBusWishbone_ERR,
+  output wire [2:0]    iBusWishbone_CTI,
+  output wire [1:0]    iBusWishbone_BTE,
+  output wire          dBusWishbone_CYC,
+  output wire          dBusWishbone_STB,
+  input  wire          dBusWishbone_ACK,
+  output wire          dBusWishbone_WE,
+  output wire [29:0]   dBusWishbone_ADR,
+  input  wire [31:0]   dBusWishbone_DAT_MISO,
+  output wire [31:0]   dBusWishbone_DAT_MOSI,
+  output reg  [3:0]    dBusWishbone_SEL,
+  input  wire          dBusWishbone_ERR,
+  output wire [2:0]    dBusWishbone_CTI,
+  output wire [1:0]    dBusWishbone_BTE,
+  input  wire          clk,
+  input  wire          reset,
+  input  wire          debugReset
 );
   localparam EnvCtrlEnum_NONE = 2'd0;
   localparam EnvCtrlEnum_XRET = 2'd1;
@@ -96,19 +96,18 @@ module VexRiscv (
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_2;
   wire                _zz_decode_LEGAL_INSTRUCTION_3;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_4;
-  wire       [12:0]   _zz_decode_LEGAL_INSTRUCTION_5;
+  wire       [11:0]   _zz_decode_LEGAL_INSTRUCTION_5;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_6;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_7;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_8;
   wire                _zz_decode_LEGAL_INSTRUCTION_9;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_10;
-  wire       [6:0]    _zz_decode_LEGAL_INSTRUCTION_11;
+  wire       [5:0]    _zz_decode_LEGAL_INSTRUCTION_11;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_12;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_13;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_14;
   wire                _zz_decode_LEGAL_INSTRUCTION_15;
-  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_16;
-  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_17;
+  wire                _zz_decode_LEGAL_INSTRUCTION_16;
   wire       [2:0]    _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1;
   reg        [31:0]   _zz_IBusCachedPlugin_jump_pcLoad_payload_4;
   wire       [1:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_5;
@@ -137,120 +136,108 @@ module VexRiscv (
   wire       [31:0]   _zz__zz_decode_IS_DIV_8;
   wire       [24:0]   _zz__zz_decode_IS_DIV_9;
   wire       [0:0]    _zz__zz_decode_IS_DIV_10;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_11;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_12;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_11;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_12;
   wire       [31:0]   _zz__zz_decode_IS_DIV_13;
-  wire       [1:0]    _zz__zz_decode_IS_DIV_14;
+  wire                _zz__zz_decode_IS_DIV_14;
   wire       [31:0]   _zz__zz_decode_IS_DIV_15;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_16;
-  wire                _zz__zz_decode_IS_DIV_17;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_16;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_17;
   wire       [31:0]   _zz__zz_decode_IS_DIV_18;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_19;
+  wire       [20:0]   _zz__zz_decode_IS_DIV_19;
   wire       [0:0]    _zz__zz_decode_IS_DIV_20;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_21;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_22;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_23;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_24;
-  wire       [20:0]   _zz__zz_decode_IS_DIV_25;
-  wire       [2:0]    _zz__zz_decode_IS_DIV_26;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_21;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_22;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_23;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_24;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_25;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_26;
   wire       [31:0]   _zz__zz_decode_IS_DIV_27;
   wire       [31:0]   _zz__zz_decode_IS_DIV_28;
   wire                _zz__zz_decode_IS_DIV_29;
-  wire                _zz__zz_decode_IS_DIV_30;
-  wire                _zz__zz_decode_IS_DIV_31;
-  wire                _zz__zz_decode_IS_DIV_32;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_33;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_34;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_35;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_30;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_31;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_32;
+  wire       [16:0]   _zz__zz_decode_IS_DIV_33;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_34;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_35;
   wire       [31:0]   _zz__zz_decode_IS_DIV_36;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_37;
-  wire                _zz__zz_decode_IS_DIV_38;
-  wire       [17:0]   _zz__zz_decode_IS_DIV_39;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_40;
-  wire                _zz__zz_decode_IS_DIV_41;
-  wire                _zz__zz_decode_IS_DIV_42;
+  wire                _zz__zz_decode_IS_DIV_37;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_38;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_39;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_40;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_41;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_42;
   wire                _zz__zz_decode_IS_DIV_43;
   wire       [0:0]    _zz__zz_decode_IS_DIV_44;
   wire       [0:0]    _zz__zz_decode_IS_DIV_45;
   wire       [31:0]   _zz__zz_decode_IS_DIV_46;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_47;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_48;
-  wire       [14:0]   _zz__zz_decode_IS_DIV_49;
-  wire       [2:0]    _zz__zz_decode_IS_DIV_50;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_51;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_52;
-  wire                _zz__zz_decode_IS_DIV_53;
-  wire                _zz__zz_decode_IS_DIV_54;
+  wire       [13:0]   _zz__zz_decode_IS_DIV_47;
+  wire                _zz__zz_decode_IS_DIV_48;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_49;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_50;
+  wire                _zz__zz_decode_IS_DIV_51;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_52;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_53;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_54;
   wire       [31:0]   _zz__zz_decode_IS_DIV_55;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_56;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_56;
   wire       [0:0]    _zz__zz_decode_IS_DIV_57;
-  wire                _zz__zz_decode_IS_DIV_58;
-  wire       [11:0]   _zz__zz_decode_IS_DIV_59;
-  wire       [2:0]    _zz__zz_decode_IS_DIV_60;
+  wire       [4:0]    _zz__zz_decode_IS_DIV_58;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_59;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_60;
   wire                _zz__zz_decode_IS_DIV_61;
   wire       [31:0]   _zz__zz_decode_IS_DIV_62;
-  wire                _zz__zz_decode_IS_DIV_63;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_63;
   wire       [31:0]   _zz__zz_decode_IS_DIV_64;
-  wire                _zz__zz_decode_IS_DIV_65;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_66;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_67;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_68;
-  wire       [3:0]    _zz__zz_decode_IS_DIV_69;
-  wire                _zz__zz_decode_IS_DIV_70;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_65;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_66;
+  wire                _zz__zz_decode_IS_DIV_67;
+  wire                _zz__zz_decode_IS_DIV_68;
+  wire       [9:0]    _zz__zz_decode_IS_DIV_69;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_70;
   wire       [31:0]   _zz__zz_decode_IS_DIV_71;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_72;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_73;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_74;
-  wire       [1:0]    _zz__zz_decode_IS_DIV_75;
-  wire                _zz__zz_decode_IS_DIV_76;
-  wire                _zz__zz_decode_IS_DIV_77;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_78;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_79;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_72;
+  wire                _zz__zz_decode_IS_DIV_73;
+  wire                _zz__zz_decode_IS_DIV_74;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_75;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_76;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_77;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_78;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_79;
   wire       [0:0]    _zz__zz_decode_IS_DIV_80;
   wire       [31:0]   _zz__zz_decode_IS_DIV_81;
   wire       [31:0]   _zz__zz_decode_IS_DIV_82;
-  wire       [8:0]    _zz__zz_decode_IS_DIV_83;
-  wire       [1:0]    _zz__zz_decode_IS_DIV_84;
-  wire                _zz__zz_decode_IS_DIV_85;
+  wire       [6:0]    _zz__zz_decode_IS_DIV_83;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_84;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_85;
   wire       [31:0]   _zz__zz_decode_IS_DIV_86;
   wire                _zz__zz_decode_IS_DIV_87;
   wire       [0:0]    _zz__zz_decode_IS_DIV_88;
   wire       [31:0]   _zz__zz_decode_IS_DIV_89;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_90;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_91;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_92;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_93;
+  wire       [2:0]    _zz__zz_decode_IS_DIV_90;
+  wire                _zz__zz_decode_IS_DIV_91;
+  wire                _zz__zz_decode_IS_DIV_92;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_93;
   wire       [0:0]    _zz__zz_decode_IS_DIV_94;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_95;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_96;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_97;
-  wire       [5:0]    _zz__zz_decode_IS_DIV_98;
-  wire                _zz__zz_decode_IS_DIV_99;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_100;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_101;
-  wire       [2:0]    _zz__zz_decode_IS_DIV_102;
-  wire                _zz__zz_decode_IS_DIV_103;
-  wire                _zz__zz_decode_IS_DIV_104;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_105;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_95;
+  wire       [3:0]    _zz__zz_decode_IS_DIV_96;
+  wire                _zz__zz_decode_IS_DIV_97;
+  wire                _zz__zz_decode_IS_DIV_98;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_99;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_100;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_101;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_102;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_103;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_104;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_105;
   wire       [0:0]    _zz__zz_decode_IS_DIV_106;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_107;
-  wire       [3:0]    _zz__zz_decode_IS_DIV_108;
-  wire                _zz__zz_decode_IS_DIV_109;
-  wire                _zz__zz_decode_IS_DIV_110;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_107;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_108;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_109;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_110;
   wire       [0:0]    _zz__zz_decode_IS_DIV_111;
   wire       [31:0]   _zz__zz_decode_IS_DIV_112;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_113;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_114;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_115;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_116;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_117;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_118;
-  wire       [1:0]    _zz__zz_decode_IS_DIV_119;
-  wire       [1:0]    _zz__zz_decode_IS_DIV_120;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_121;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_122;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_123;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_124;
   wire                _zz_RegFilePlugin_regFile_port;
   wire                _zz_decode_RegFilePlugin_rs1Data;
   wire                _zz_RegFilePlugin_regFile_port_1;
@@ -258,14 +245,12 @@ module VexRiscv (
   wire       [0:0]    _zz__zz_execute_REGFILE_WRITE_DATA;
   wire       [2:0]    _zz__zz_execute_SRC1;
   wire       [4:0]    _zz__zz_execute_SRC1_1;
-  wire       [11:0]   _zz__zz_execute_SRC2_3;
+  wire       [11:0]   _zz__zz_execute_SRC2_2;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_1;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_2;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_3;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_4;
-  wire       [31:0]   _zz_execute_SrcPlugin_addSub_5;
-  wire       [31:0]   _zz_execute_SrcPlugin_addSub_6;
   wire       [31:0]   _zz__zz_decode_RS2_3;
   wire       [32:0]   _zz__zz_decode_RS2_3_1;
   wire       [19:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_2;
@@ -304,10 +289,10 @@ module VexRiscv (
   wire       [32:0]   _zz_memory_MulDivIterativePlugin_div_result_3;
   wire       [32:0]   _zz_memory_MulDivIterativePlugin_div_result_4;
   wire       [0:0]    _zz_memory_MulDivIterativePlugin_div_result_5;
-  wire       [32:0]   _zz_memory_MulDivIterativePlugin_rs1_3;
-  wire       [0:0]    _zz_memory_MulDivIterativePlugin_rs1_4;
-  wire       [31:0]   _zz_memory_MulDivIterativePlugin_rs2;
-  wire       [0:0]    _zz_memory_MulDivIterativePlugin_rs2_1;
+  wire       [32:0]   _zz_memory_MulDivIterativePlugin_rs1_2;
+  wire       [0:0]    _zz_memory_MulDivIterativePlugin_rs1_3;
+  wire       [31:0]   _zz_memory_MulDivIterativePlugin_rs2_1;
+  wire       [0:0]    _zz_memory_MulDivIterativePlugin_rs2_2;
   wire       [26:0]   _zz_iBusWishbone_ADR_1;
   wire       [31:0]   memory_MEMORY_READ_DATA;
   wire       [31:0]   execute_BRANCH_CALC;
@@ -409,7 +394,7 @@ module VexRiscv (
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_execute_SRC2;
+  wire       [31:0]   _zz_execute_to_memory_PC;
   wire       [1:0]    execute_SRC2_CTRL;
   wire       [1:0]    _zz_execute_SRC2_CTRL;
   wire       [1:0]    execute_SRC1_CTRL;
@@ -556,8 +541,9 @@ module VexRiscv (
   wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
   wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
   wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
-  wire                CsrPlugin_csrMapping_allowCsrSignal;
+  reg                 CsrPlugin_csrMapping_allowCsrSignal;
   wire                CsrPlugin_csrMapping_hazardFree;
+  wire                CsrPlugin_csrMapping_doForceFailCsr;
   wire                CsrPlugin_inWfi /* verilator public */ ;
   reg                 CsrPlugin_thirdPartyWake;
   reg                 CsrPlugin_jumpInterface_valid;
@@ -576,9 +562,10 @@ module VexRiscv (
   reg                 CsrPlugin_allowInterrupts;
   reg                 CsrPlugin_allowException;
   reg                 CsrPlugin_allowEbreakException;
-  reg                 IBusCachedPlugin_injectionPort_valid;
-  reg                 IBusCachedPlugin_injectionPort_ready;
-  wire       [31:0]   IBusCachedPlugin_injectionPort_payload;
+  wire                CsrPlugin_xretAwayFromMachine;
+  reg                 DebugPlugin_injectionPort_valid;
+  reg                 DebugPlugin_injectionPort_ready;
+  wire       [31:0]   DebugPlugin_injectionPort_payload;
   wire                IBusCachedPlugin_externalFlush;
   wire                IBusCachedPlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
@@ -597,14 +584,13 @@ module VexRiscv (
   reg                 IBusCachedPlugin_fetchPc_pcRegPropagate;
   reg                 IBusCachedPlugin_fetchPc_booted;
   reg                 IBusCachedPlugin_fetchPc_inc;
-  wire                when_Fetcher_l134;
-  wire                IBusCachedPlugin_fetchPc_output_fire_1;
-  wire                when_Fetcher_l134_1;
+  wire                when_Fetcher_l133;
+  wire                when_Fetcher_l133_1;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pc;
   wire                IBusCachedPlugin_fetchPc_redo_valid;
   wire       [31:0]   IBusCachedPlugin_fetchPc_redo_payload;
   reg                 IBusCachedPlugin_fetchPc_flushed;
-  wire                when_Fetcher_l161;
+  wire                when_Fetcher_l160;
   reg                 IBusCachedPlugin_iBusRsp_redoFetch;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_ready;
@@ -632,8 +618,8 @@ module VexRiscv (
   wire                _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready;
   wire                IBusCachedPlugin_iBusRsp_flush;
   wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
-  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
-  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid;
+  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1;
   wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
@@ -646,18 +632,18 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_output_payload_rsp_error;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   wire                IBusCachedPlugin_iBusRsp_output_payload_isRvc;
-  wire                when_Fetcher_l243;
-  wire                when_Fetcher_l323;
+  wire                when_Fetcher_l242;
+  wire                when_Fetcher_l322;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
-  wire                when_Fetcher_l332;
+  wire                when_Fetcher_l331;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
-  wire                when_Fetcher_l332_1;
+  wire                when_Fetcher_l331_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
-  wire                when_Fetcher_l332_2;
+  wire                when_Fetcher_l331_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
-  wire                when_Fetcher_l332_3;
+  wire                when_Fetcher_l331_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                when_Fetcher_l332_4;
+  wire                when_Fetcher_l331_4;
   wire                _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   reg        [18:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1;
   wire                _zz_2;
@@ -683,11 +669,11 @@ module VexRiscv (
   wire                IBusCachedPlugin_rsp_iBusRspOutputHalt;
   wire                IBusCachedPlugin_rsp_issueDetected;
   reg                 IBusCachedPlugin_rsp_redoFetch;
-  wire                when_IBusCachedPlugin_l239;
-  wire                when_IBusCachedPlugin_l244;
+  wire                when_IBusCachedPlugin_l245;
   wire                when_IBusCachedPlugin_l250;
   wire                when_IBusCachedPlugin_l256;
-  wire                when_IBusCachedPlugin_l267;
+  wire                when_IBusCachedPlugin_l262;
+  wire                when_IBusCachedPlugin_l273;
   wire                dBus_cmd_valid;
   wire                dBus_cmd_ready;
   wire                dBus_cmd_payload_wr;
@@ -700,20 +686,20 @@ module VexRiscv (
   wire                _zz_dBus_cmd_valid;
   reg                 execute_DBusSimplePlugin_skipCmd;
   reg        [31:0]   _zz_dBus_cmd_payload_data;
-  wire                when_DBusSimplePlugin_l428;
+  wire                when_DBusSimplePlugin_l436;
   reg        [3:0]    _zz_execute_DBusSimplePlugin_formalMask;
   wire       [3:0]    execute_DBusSimplePlugin_formalMask;
-  wire                when_DBusSimplePlugin_l482;
-  wire                when_DBusSimplePlugin_l489;
-  wire                when_DBusSimplePlugin_l515;
+  wire                when_DBusSimplePlugin_l490;
+  wire                when_DBusSimplePlugin_l497;
+  wire                when_DBusSimplePlugin_l523;
   reg        [31:0]   writeBack_DBusSimplePlugin_rspShifted;
-  wire       [1:0]    switch_Misc_l210;
+  wire       [1:0]    switch_Misc_l232;
   wire                _zz_writeBack_DBusSimplePlugin_rspFormated;
   reg        [31:0]   _zz_writeBack_DBusSimplePlugin_rspFormated_1;
   wire                _zz_writeBack_DBusSimplePlugin_rspFormated_2;
   reg        [31:0]   _zz_writeBack_DBusSimplePlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusSimplePlugin_rspFormated;
-  wire                when_DBusSimplePlugin_l558;
+  wire                when_DBusSimplePlugin_l566;
   wire       [31:0]   _zz_decode_IS_DIV;
   wire                _zz_decode_IS_DIV_1;
   wire                _zz_decode_IS_DIV_2;
@@ -737,15 +723,15 @@ module VexRiscv (
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
   reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
   reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_7;
+  reg                 _zz_10;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
   reg        [31:0]   _zz_execute_REGFILE_WRITE_DATA;
   reg        [31:0]   _zz_execute_SRC1;
-  wire                _zz_execute_SRC2_1;
-  reg        [19:0]   _zz_execute_SRC2_2;
-  wire                _zz_execute_SRC2_3;
-  reg        [19:0]   _zz_execute_SRC2_4;
-  reg        [31:0]   _zz_execute_SRC2_5;
+  wire                _zz_execute_SRC2;
+  reg        [19:0]   _zz_execute_SRC2_1;
+  wire                _zz_execute_SRC2_2;
+  reg        [19:0]   _zz_execute_SRC2_3;
+  reg        [31:0]   _zz_execute_SRC2_4;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   reg                 execute_LightShifterPlugin_isActive;
@@ -788,7 +774,7 @@ module VexRiscv (
   wire                when_HazardSimplePlugin_l108;
   wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    switch_Misc_l210_1;
+  wire       [2:0]    switch_Misc_l232_1;
   reg                 _zz_execute_BRANCH_COND_RESULT;
   reg                 _zz_execute_BRANCH_COND_RESULT_1;
   wire                _zz_execute_BranchPlugin_missAlignedTarget;
@@ -827,9 +813,9 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_mtval;
   reg        [63:0]   CsrPlugin_mcycle;
   reg        [63:0]   CsrPlugin_minstret;
-  wire                _zz_when_CsrPlugin_l965;
-  wire                _zz_when_CsrPlugin_l965_1;
-  wire                _zz_when_CsrPlugin_l965_2;
+  wire                _zz_when_CsrPlugin_l1302;
+  wire                _zz_when_CsrPlugin_l1302_1;
+  wire                _zz_when_CsrPlugin_l1302_2;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -846,56 +832,59 @@ module VexRiscv (
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
   wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_2;
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3;
-  wire                when_CsrPlugin_l922;
-  wire                when_CsrPlugin_l922_1;
-  wire                when_CsrPlugin_l922_2;
-  wire                when_CsrPlugin_l922_3;
-  wire                when_CsrPlugin_l935;
+  wire                when_CsrPlugin_l1259;
+  wire                when_CsrPlugin_l1259_1;
+  wire                when_CsrPlugin_l1259_2;
+  wire                when_CsrPlugin_l1259_3;
+  wire                when_CsrPlugin_l1272;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
-  wire                when_CsrPlugin_l959;
-  wire                when_CsrPlugin_l965;
-  wire                when_CsrPlugin_l965_1;
-  wire                when_CsrPlugin_l965_2;
+  wire                when_CsrPlugin_l1296;
+  wire                when_CsrPlugin_l1302;
+  wire                when_CsrPlugin_l1302_1;
+  wire                when_CsrPlugin_l1302_2;
   wire                CsrPlugin_exception;
   wire                CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
-  wire                when_CsrPlugin_l993;
-  wire                when_CsrPlugin_l993_1;
-  wire                when_CsrPlugin_l993_2;
-  wire                when_CsrPlugin_l998;
+  wire                when_CsrPlugin_l1335;
+  wire                when_CsrPlugin_l1335_1;
+  wire                when_CsrPlugin_l1335_2;
+  wire                when_CsrPlugin_l1340;
   reg                 CsrPlugin_pipelineLiberator_done;
-  wire                when_CsrPlugin_l1004;
+  wire                when_CsrPlugin_l1346;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
+  wire                CsrPlugin_trapCauseEbreakDebug;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
-  wire                when_CsrPlugin_l1032;
-  wire                when_CsrPlugin_l1077;
-  wire       [1:0]    switch_CsrPlugin_l1081;
+  wire                CsrPlugin_trapEnterDebug;
+  wire                when_CsrPlugin_l1390;
+  wire                when_CsrPlugin_l1398;
+  wire                when_CsrPlugin_l1456;
+  wire       [1:0]    switch_CsrPlugin_l1460;
   reg                 execute_CsrPlugin_wfiWake;
-  wire                when_CsrPlugin_l1129;
+  wire                when_CsrPlugin_l1527;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire                when_CsrPlugin_l1149;
-  wire                when_CsrPlugin_l1150;
-  wire                when_CsrPlugin_l1157;
+  wire                when_CsrPlugin_l1547;
+  wire                when_CsrPlugin_l1548;
+  wire                when_CsrPlugin_l1555;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   wire       [31:0]   execute_CsrPlugin_readToWriteData;
-  wire                switch_Misc_l210_2;
+  wire                switch_Misc_l232_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
-  wire                when_CsrPlugin_l1189;
-  wire                when_CsrPlugin_l1193;
+  wire                when_CsrPlugin_l1587;
+  wire                when_CsrPlugin_l1591;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg        [32:0]   memory_MulDivIterativePlugin_rs1;
   reg        [31:0]   memory_MulDivIterativePlugin_rs2;
@@ -933,12 +922,12 @@ module VexRiscv (
   wire                when_MulDivIterativePlugin_l151;
   wire       [31:0]   _zz_memory_MulDivIterativePlugin_div_result;
   wire                when_MulDivIterativePlugin_l162;
+  wire                _zz_memory_MulDivIterativePlugin_rs2;
   wire                _zz_memory_MulDivIterativePlugin_rs1;
-  wire                _zz_memory_MulDivIterativePlugin_rs1_1;
-  reg        [32:0]   _zz_memory_MulDivIterativePlugin_rs1_2;
+  reg        [32:0]   _zz_memory_MulDivIterativePlugin_rs1_1;
   reg        [31:0]   externalInterruptArray_regNext;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit;
-  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
+  wire       [31:0]   _zz_externalInterrupt;
   reg                 DebugPlugin_firstCycle;
   reg                 DebugPlugin_secondCycle;
   reg                 DebugPlugin_resetIt;
@@ -946,28 +935,28 @@ module VexRiscv (
   reg                 DebugPlugin_stepIt;
   reg                 DebugPlugin_isPipBusy;
   reg                 DebugPlugin_godmode;
-  wire                when_DebugPlugin_l225;
+  wire                when_DebugPlugin_l238;
   reg                 DebugPlugin_haltedByBreak;
   reg                 DebugPlugin_debugUsed /* verilator public */ ;
   reg                 DebugPlugin_disableEbreak;
   wire                DebugPlugin_allowEBreak;
   reg        [31:0]   DebugPlugin_busReadDataReg;
-  reg                 _zz_when_DebugPlugin_l244;
-  wire                when_DebugPlugin_l244;
-  wire       [5:0]    switch_DebugPlugin_l267;
-  wire                when_DebugPlugin_l271;
-  wire                when_DebugPlugin_l271_1;
-  wire                when_DebugPlugin_l272;
-  wire                when_DebugPlugin_l272_1;
-  wire                when_DebugPlugin_l273;
-  wire                when_DebugPlugin_l274;
-  wire                when_DebugPlugin_l275;
-  wire                when_DebugPlugin_l275_1;
-  wire                when_DebugPlugin_l295;
-  wire                when_DebugPlugin_l298;
+  reg                 _zz_when_DebugPlugin_l257;
+  wire                when_DebugPlugin_l257;
+  wire       [5:0]    switch_DebugPlugin_l280;
+  wire                when_DebugPlugin_l284;
+  wire                when_DebugPlugin_l284_1;
+  wire                when_DebugPlugin_l285;
+  wire                when_DebugPlugin_l285_1;
+  wire                when_DebugPlugin_l286;
+  wire                when_DebugPlugin_l287;
+  wire                when_DebugPlugin_l288;
+  wire                when_DebugPlugin_l288_1;
+  wire                when_DebugPlugin_l308;
   wire                when_DebugPlugin_l311;
+  wire                when_DebugPlugin_l324;
   reg                 DebugPlugin_resetIt_regNext;
-  wire                when_DebugPlugin_l331;
+  wire                when_DebugPlugin_l344;
   wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
   wire                when_Pipeline_l124_1;
@@ -1080,27 +1069,28 @@ module VexRiscv (
   wire                when_Pipeline_l154_1;
   wire                when_Pipeline_l151_2;
   wire                when_Pipeline_l154_2;
-  reg        [2:0]    switch_Fetcher_l365;
-  wire                when_Fetcher_l381;
-  wire                when_CsrPlugin_l1277;
+  reg        [2:0]    IBusCachedPlugin_injector_port_state;
+  wire                when_Fetcher_l391;
+  wire                when_CsrPlugin_l1669;
   reg                 execute_CsrPlugin_csr_768;
-  wire                when_CsrPlugin_l1277_1;
+  wire                when_CsrPlugin_l1669_1;
   reg                 execute_CsrPlugin_csr_836;
-  wire                when_CsrPlugin_l1277_2;
+  wire                when_CsrPlugin_l1669_2;
   reg                 execute_CsrPlugin_csr_772;
-  wire                when_CsrPlugin_l1277_3;
+  wire                when_CsrPlugin_l1669_3;
   reg                 execute_CsrPlugin_csr_773;
-  wire                when_CsrPlugin_l1277_4;
+  wire                when_CsrPlugin_l1669_4;
   reg                 execute_CsrPlugin_csr_833;
-  wire                when_CsrPlugin_l1277_5;
+  wire                when_CsrPlugin_l1669_5;
   reg                 execute_CsrPlugin_csr_834;
-  wire                when_CsrPlugin_l1277_6;
+  wire                when_CsrPlugin_l1669_6;
   reg                 execute_CsrPlugin_csr_835;
-  wire                when_CsrPlugin_l1277_7;
+  wire                when_CsrPlugin_l1669_7;
   reg                 execute_CsrPlugin_csr_3008;
-  wire                when_CsrPlugin_l1277_8;
+  wire                when_CsrPlugin_l1669_8;
   reg                 execute_CsrPlugin_csr_4032;
-  wire       [1:0]    switch_CsrPlugin_l723;
+  wire       [1:0]    switch_CsrPlugin_l1031;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
@@ -1108,9 +1098,12 @@ module VexRiscv (
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_6;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_8;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
-  wire                when_CsrPlugin_l1310;
-  wire                when_CsrPlugin_l1315;
+  wire                when_CsrPlugin_l1702;
+  wire       [11:0]   _zz_when_CsrPlugin_l1709;
+  wire                when_CsrPlugin_l1709;
+  reg                 when_CsrPlugin_l1719;
+  wire                when_CsrPlugin_l1717;
+  wire                when_CsrPlugin_l1725;
   reg        [2:0]    _zz_iBusWishbone_ADR;
   wire                when_InstructionCache_l239;
   reg                 _zz_iBus_rsp_valid;
@@ -1128,7 +1121,7 @@ module VexRiscv (
   reg        [31:0]   dBus_cmd_rData_data;
   reg        [1:0]    dBus_cmd_rData_size;
   reg        [3:0]    _zz_dBusWishbone_SEL;
-  wire                when_DBusSimplePlugin_l189;
+  wire                when_DBusSimplePlugin_l196;
   `ifndef SYNTHESIS
   reg [39:0] _zz_memory_to_writeBack_ENV_CTRL_string;
   reg [39:0] _zz_memory_to_writeBack_ENV_CTRL_1_string;
@@ -1224,15 +1217,13 @@ module VexRiscv (
   assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
   assign _zz__zz_execute_SRC1 = 3'b100;
   assign _zz__zz_execute_SRC1_1 = execute_INSTRUCTION[19 : 15];
-  assign _zz__zz_execute_SRC2_3 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz__zz_execute_SRC2_2 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
   assign _zz_execute_SrcPlugin_addSub = ($signed(_zz_execute_SrcPlugin_addSub_1) + $signed(_zz_execute_SrcPlugin_addSub_4));
   assign _zz_execute_SrcPlugin_addSub_1 = ($signed(_zz_execute_SrcPlugin_addSub_2) + $signed(_zz_execute_SrcPlugin_addSub_3));
   assign _zz_execute_SrcPlugin_addSub_2 = execute_SRC1;
   assign _zz_execute_SrcPlugin_addSub_3 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? _zz_execute_SrcPlugin_addSub_5 : _zz_execute_SrcPlugin_addSub_6);
-  assign _zz_execute_SrcPlugin_addSub_5 = 32'h00000001;
-  assign _zz_execute_SrcPlugin_addSub_6 = 32'h0;
-  assign _zz__zz_decode_RS2_3 = (_zz__zz_decode_RS2_3_1 >>> 1);
+  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? 32'h00000001 : 32'h00000000);
+  assign _zz__zz_decode_RS2_3 = (_zz__zz_decode_RS2_3_1 >>> 1'd1);
   assign _zz__zz_decode_RS2_3_1 = {((execute_SHIFT_CTRL == ShiftCtrlEnum_SRA_1) && execute_LightShifterPlugin_shiftInput[31]),execute_LightShifterPlugin_shiftInput};
   assign _zz__zz_execute_BranchPlugin_missAlignedTarget_2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
   assign _zz__zz_execute_BranchPlugin_missAlignedTarget_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
@@ -1249,11 +1240,11 @@ module VexRiscv (
   assign _zz_memory_MulDivIterativePlugin_mul_counter_valueNext_1 = memory_MulDivIterativePlugin_mul_counter_willIncrement;
   assign _zz_memory_MulDivIterativePlugin_mul_counter_valueNext = {5'd0, _zz_memory_MulDivIterativePlugin_mul_counter_valueNext_1};
   assign _zz_memory_MulDivIterativePlugin_accumulator = (_zz_memory_MulDivIterativePlugin_accumulator_1 + _zz_memory_MulDivIterativePlugin_accumulator_3);
-  assign _zz_memory_MulDivIterativePlugin_accumulator_2 = (memory_MulDivIterativePlugin_rs2[0] ? memory_MulDivIterativePlugin_rs1 : 33'h0);
+  assign _zz_memory_MulDivIterativePlugin_accumulator_2 = (memory_MulDivIterativePlugin_rs2[0] ? memory_MulDivIterativePlugin_rs1 : 33'h000000000);
   assign _zz_memory_MulDivIterativePlugin_accumulator_1 = {{1{_zz_memory_MulDivIterativePlugin_accumulator_2[32]}}, _zz_memory_MulDivIterativePlugin_accumulator_2};
   assign _zz_memory_MulDivIterativePlugin_accumulator_4 = _zz_memory_MulDivIterativePlugin_accumulator_5;
   assign _zz_memory_MulDivIterativePlugin_accumulator_3 = {{1{_zz_memory_MulDivIterativePlugin_accumulator_4[32]}}, _zz_memory_MulDivIterativePlugin_accumulator_4};
-  assign _zz_memory_MulDivIterativePlugin_accumulator_5 = (memory_MulDivIterativePlugin_accumulator >>> 32);
+  assign _zz_memory_MulDivIterativePlugin_accumulator_5 = (memory_MulDivIterativePlugin_accumulator >>> 6'd32);
   assign _zz_memory_MulDivIterativePlugin_div_counter_valueNext_1 = memory_MulDivIterativePlugin_div_counter_willIncrement;
   assign _zz_memory_MulDivIterativePlugin_div_counter_valueNext = {5'd0, _zz_memory_MulDivIterativePlugin_div_counter_valueNext_1};
   assign _zz_memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator = {1'd0, memory_MulDivIterativePlugin_rs2};
@@ -1265,32 +1256,31 @@ module VexRiscv (
   assign _zz_memory_MulDivIterativePlugin_div_result_3 = ({memory_MulDivIterativePlugin_div_needRevert,(memory_MulDivIterativePlugin_div_needRevert ? (~ _zz_memory_MulDivIterativePlugin_div_result) : _zz_memory_MulDivIterativePlugin_div_result)} + _zz_memory_MulDivIterativePlugin_div_result_4);
   assign _zz_memory_MulDivIterativePlugin_div_result_5 = memory_MulDivIterativePlugin_div_needRevert;
   assign _zz_memory_MulDivIterativePlugin_div_result_4 = {32'd0, _zz_memory_MulDivIterativePlugin_div_result_5};
-  assign _zz_memory_MulDivIterativePlugin_rs1_4 = _zz_memory_MulDivIterativePlugin_rs1_1;
-  assign _zz_memory_MulDivIterativePlugin_rs1_3 = {32'd0, _zz_memory_MulDivIterativePlugin_rs1_4};
-  assign _zz_memory_MulDivIterativePlugin_rs2_1 = _zz_memory_MulDivIterativePlugin_rs1;
-  assign _zz_memory_MulDivIterativePlugin_rs2 = {31'd0, _zz_memory_MulDivIterativePlugin_rs2_1};
-  assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 5);
+  assign _zz_memory_MulDivIterativePlugin_rs1_3 = _zz_memory_MulDivIterativePlugin_rs1;
+  assign _zz_memory_MulDivIterativePlugin_rs1_2 = {32'd0, _zz_memory_MulDivIterativePlugin_rs1_3};
+  assign _zz_memory_MulDivIterativePlugin_rs2_2 = _zz_memory_MulDivIterativePlugin_rs2;
+  assign _zz_memory_MulDivIterativePlugin_rs2_1 = {31'd0, _zz_memory_MulDivIterativePlugin_rs2_2};
+  assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 3'd5);
   assign _zz_decode_RegFilePlugin_rs1Data = 1'b1;
   assign _zz_decode_RegFilePlugin_rs2Data = 1'b1;
   assign _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = {_zz_IBusCachedPlugin_jump_pcLoad_payload_3,_zz_IBusCachedPlugin_jump_pcLoad_payload_2};
-  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000107f;
-  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00002073;
-  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000207f;
+  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000407f);
+  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00004063;
+  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000107f) == 32'h00000013);
   assign _zz_decode_LEGAL_INSTRUCTION_5 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_6) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_7 == _zz_decode_LEGAL_INSTRUCTION_8),{_zz_decode_LEGAL_INSTRUCTION_9,{_zz_decode_LEGAL_INSTRUCTION_10,_zz_decode_LEGAL_INSTRUCTION_11}}}}}};
   assign _zz_decode_LEGAL_INSTRUCTION_6 = 32'h0000505f;
   assign _zz_decode_LEGAL_INSTRUCTION_7 = (decode_INSTRUCTION & 32'h0000707b);
   assign _zz_decode_LEGAL_INSTRUCTION_8 = 32'h00000063;
   assign _zz_decode_LEGAL_INSTRUCTION_9 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
   assign _zz_decode_LEGAL_INSTRUCTION_10 = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
-  assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'hfc00305f) == 32'h00001013),{((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h00005033),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,{_zz_decode_LEGAL_INSTRUCTION_16,_zz_decode_LEGAL_INSTRUCTION_17}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'hbe00705f) == 32'h00005013),{((decode_INSTRUCTION & 32'hfe00305f) == 32'h00001013),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h00000033),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,_zz_decode_LEGAL_INSTRUCTION_16}}}}};
   assign _zz_decode_LEGAL_INSTRUCTION_12 = 32'hbe00707f;
-  assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'hbe00707f);
-  assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h00000033;
-  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
-  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hffefffff) == 32'h00000073);
-  assign _zz_decode_LEGAL_INSTRUCTION_17 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073);
+  assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'hdfffffff);
+  assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h10200073;
+  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hffefffff) == 32'h00000073);
+  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073);
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_4 = decode_INSTRUCTION[31];
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_5 = decode_INSTRUCTION[31];
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_6 = decode_INSTRUCTION[7];
@@ -1300,125 +1290,113 @@ module VexRiscv (
   assign _zz__zz_decode_IS_DIV_3 = ((decode_INSTRUCTION & 32'h02004074) == 32'h02000030);
   assign _zz__zz_decode_IS_DIV_4 = (|((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_5) == 32'h00000050));
   assign _zz__zz_decode_IS_DIV_6 = (|(_zz__zz_decode_IS_DIV_7 == _zz__zz_decode_IS_DIV_8));
-  assign _zz__zz_decode_IS_DIV_9 = {(|{_zz__zz_decode_IS_DIV_10,_zz__zz_decode_IS_DIV_12}),{(|_zz__zz_decode_IS_DIV_14),{_zz__zz_decode_IS_DIV_17,{_zz__zz_decode_IS_DIV_20,_zz__zz_decode_IS_DIV_25}}}};
+  assign _zz__zz_decode_IS_DIV_9 = {(|{_zz__zz_decode_IS_DIV_10,_zz__zz_decode_IS_DIV_11}),{(|_zz__zz_decode_IS_DIV_12),{_zz__zz_decode_IS_DIV_14,{_zz__zz_decode_IS_DIV_16,_zz__zz_decode_IS_DIV_19}}}};
   assign _zz__zz_decode_IS_DIV_5 = 32'h10103050;
   assign _zz__zz_decode_IS_DIV_7 = (decode_INSTRUCTION & 32'h10403050);
   assign _zz__zz_decode_IS_DIV_8 = 32'h10000050;
-  assign _zz__zz_decode_IS_DIV_10 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_11) == 32'h00001050);
-  assign _zz__zz_decode_IS_DIV_12 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_13) == 32'h00002050);
-  assign _zz__zz_decode_IS_DIV_14 = {_zz_decode_IS_DIV_4,(_zz__zz_decode_IS_DIV_15 == _zz__zz_decode_IS_DIV_16)};
-  assign _zz__zz_decode_IS_DIV_17 = (|(_zz__zz_decode_IS_DIV_18 == _zz__zz_decode_IS_DIV_19));
-  assign _zz__zz_decode_IS_DIV_20 = (|{_zz__zz_decode_IS_DIV_21,_zz__zz_decode_IS_DIV_23});
-  assign _zz__zz_decode_IS_DIV_25 = {(|_zz__zz_decode_IS_DIV_26),{_zz__zz_decode_IS_DIV_31,{_zz__zz_decode_IS_DIV_37,_zz__zz_decode_IS_DIV_39}}};
-  assign _zz__zz_decode_IS_DIV_11 = 32'h00001050;
-  assign _zz__zz_decode_IS_DIV_13 = 32'h00002050;
-  assign _zz__zz_decode_IS_DIV_15 = (decode_INSTRUCTION & 32'h0000001c);
-  assign _zz__zz_decode_IS_DIV_16 = 32'h00000004;
-  assign _zz__zz_decode_IS_DIV_18 = (decode_INSTRUCTION & 32'h00000058);
-  assign _zz__zz_decode_IS_DIV_19 = 32'h00000040;
-  assign _zz__zz_decode_IS_DIV_21 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_22) == 32'h00005010);
-  assign _zz__zz_decode_IS_DIV_23 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_24) == 32'h00005020);
-  assign _zz__zz_decode_IS_DIV_26 = {(_zz__zz_decode_IS_DIV_27 == _zz__zz_decode_IS_DIV_28),{_zz__zz_decode_IS_DIV_29,_zz__zz_decode_IS_DIV_30}};
-  assign _zz__zz_decode_IS_DIV_31 = (|{_zz__zz_decode_IS_DIV_32,{_zz__zz_decode_IS_DIV_33,_zz__zz_decode_IS_DIV_35}});
-  assign _zz__zz_decode_IS_DIV_37 = (|_zz__zz_decode_IS_DIV_38);
-  assign _zz__zz_decode_IS_DIV_39 = {(|_zz__zz_decode_IS_DIV_40),{_zz__zz_decode_IS_DIV_41,{_zz__zz_decode_IS_DIV_44,_zz__zz_decode_IS_DIV_49}}};
-  assign _zz__zz_decode_IS_DIV_22 = 32'h00007034;
-  assign _zz__zz_decode_IS_DIV_24 = 32'h02007064;
-  assign _zz__zz_decode_IS_DIV_27 = (decode_INSTRUCTION & 32'h40003054);
-  assign _zz__zz_decode_IS_DIV_28 = 32'h40001010;
-  assign _zz__zz_decode_IS_DIV_29 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00001010);
-  assign _zz__zz_decode_IS_DIV_30 = ((decode_INSTRUCTION & 32'h02007054) == 32'h00001010);
-  assign _zz__zz_decode_IS_DIV_32 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
-  assign _zz__zz_decode_IS_DIV_33 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_34) == 32'h00001010);
-  assign _zz__zz_decode_IS_DIV_35 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_36) == 32'h00001010);
-  assign _zz__zz_decode_IS_DIV_38 = ((decode_INSTRUCTION & 32'h00001000) == 32'h00001000);
-  assign _zz__zz_decode_IS_DIV_40 = _zz_decode_IS_DIV_5;
-  assign _zz__zz_decode_IS_DIV_41 = (|{_zz__zz_decode_IS_DIV_42,_zz__zz_decode_IS_DIV_43});
-  assign _zz__zz_decode_IS_DIV_44 = (|{_zz__zz_decode_IS_DIV_45,_zz__zz_decode_IS_DIV_47});
-  assign _zz__zz_decode_IS_DIV_49 = {(|_zz__zz_decode_IS_DIV_50),{_zz__zz_decode_IS_DIV_54,{_zz__zz_decode_IS_DIV_57,_zz__zz_decode_IS_DIV_59}}};
-  assign _zz__zz_decode_IS_DIV_34 = 32'h00003034;
-  assign _zz__zz_decode_IS_DIV_36 = 32'h02003054;
-  assign _zz__zz_decode_IS_DIV_42 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
-  assign _zz__zz_decode_IS_DIV_43 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00001000);
-  assign _zz__zz_decode_IS_DIV_45 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_46) == 32'h00000020);
-  assign _zz__zz_decode_IS_DIV_47 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_48) == 32'h00000020);
-  assign _zz__zz_decode_IS_DIV_50 = {(_zz__zz_decode_IS_DIV_51 == _zz__zz_decode_IS_DIV_52),{_zz_decode_IS_DIV_2,_zz__zz_decode_IS_DIV_53}};
-  assign _zz__zz_decode_IS_DIV_54 = (|(_zz__zz_decode_IS_DIV_55 == _zz__zz_decode_IS_DIV_56));
-  assign _zz__zz_decode_IS_DIV_57 = (|_zz__zz_decode_IS_DIV_58);
-  assign _zz__zz_decode_IS_DIV_59 = {(|_zz__zz_decode_IS_DIV_60),{_zz__zz_decode_IS_DIV_65,{_zz__zz_decode_IS_DIV_78,_zz__zz_decode_IS_DIV_83}}};
-  assign _zz__zz_decode_IS_DIV_46 = 32'h00000034;
-  assign _zz__zz_decode_IS_DIV_48 = 32'h00000064;
-  assign _zz__zz_decode_IS_DIV_51 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz__zz_decode_IS_DIV_52 = 32'h00000040;
-  assign _zz__zz_decode_IS_DIV_53 = ((decode_INSTRUCTION & 32'h00103040) == 32'h00000040);
-  assign _zz__zz_decode_IS_DIV_55 = (decode_INSTRUCTION & 32'h00000020);
-  assign _zz__zz_decode_IS_DIV_56 = 32'h00000020;
-  assign _zz__zz_decode_IS_DIV_58 = ((decode_INSTRUCTION & 32'h00000010) == 32'h00000010);
-  assign _zz__zz_decode_IS_DIV_60 = {_zz_decode_IS_DIV_3,{_zz__zz_decode_IS_DIV_61,_zz__zz_decode_IS_DIV_63}};
-  assign _zz__zz_decode_IS_DIV_65 = (|{_zz_decode_IS_DIV_4,{_zz__zz_decode_IS_DIV_66,_zz__zz_decode_IS_DIV_69}});
-  assign _zz__zz_decode_IS_DIV_78 = (|{_zz__zz_decode_IS_DIV_79,_zz__zz_decode_IS_DIV_80});
-  assign _zz__zz_decode_IS_DIV_83 = {(|_zz__zz_decode_IS_DIV_84),{_zz__zz_decode_IS_DIV_87,{_zz__zz_decode_IS_DIV_94,_zz__zz_decode_IS_DIV_98}}};
-  assign _zz__zz_decode_IS_DIV_61 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_62) == 32'h00000010);
-  assign _zz__zz_decode_IS_DIV_63 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_64) == 32'h00000020);
-  assign _zz__zz_decode_IS_DIV_66 = (_zz__zz_decode_IS_DIV_67 == _zz__zz_decode_IS_DIV_68);
-  assign _zz__zz_decode_IS_DIV_69 = {_zz__zz_decode_IS_DIV_70,{_zz__zz_decode_IS_DIV_72,_zz__zz_decode_IS_DIV_75}};
-  assign _zz__zz_decode_IS_DIV_79 = _zz_decode_IS_DIV_3;
+  assign _zz__zz_decode_IS_DIV_10 = ((decode_INSTRUCTION & 32'h00001050) == 32'h00001050);
+  assign _zz__zz_decode_IS_DIV_11 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002050);
+  assign _zz__zz_decode_IS_DIV_12 = {_zz_decode_IS_DIV_4,((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_13) == 32'h00000004)};
+  assign _zz__zz_decode_IS_DIV_14 = (|((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_15) == 32'h00000040));
+  assign _zz__zz_decode_IS_DIV_16 = (|(_zz__zz_decode_IS_DIV_17 == _zz__zz_decode_IS_DIV_18));
+  assign _zz__zz_decode_IS_DIV_19 = {(|{_zz__zz_decode_IS_DIV_20,_zz__zz_decode_IS_DIV_22}),{(|_zz__zz_decode_IS_DIV_24),{_zz__zz_decode_IS_DIV_29,{_zz__zz_decode_IS_DIV_32,_zz__zz_decode_IS_DIV_33}}}};
+  assign _zz__zz_decode_IS_DIV_13 = 32'h0000001c;
+  assign _zz__zz_decode_IS_DIV_15 = 32'h00000058;
+  assign _zz__zz_decode_IS_DIV_17 = (decode_INSTRUCTION & 32'h02007054);
+  assign _zz__zz_decode_IS_DIV_18 = 32'h00005010;
+  assign _zz__zz_decode_IS_DIV_20 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_21) == 32'h40001010);
+  assign _zz__zz_decode_IS_DIV_22 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_23) == 32'h00001010);
+  assign _zz__zz_decode_IS_DIV_24 = {(_zz__zz_decode_IS_DIV_25 == _zz__zz_decode_IS_DIV_26),(_zz__zz_decode_IS_DIV_27 == _zz__zz_decode_IS_DIV_28)};
+  assign _zz__zz_decode_IS_DIV_29 = (|(_zz__zz_decode_IS_DIV_30 == _zz__zz_decode_IS_DIV_31));
+  assign _zz__zz_decode_IS_DIV_32 = (|_zz_decode_IS_DIV_5);
+  assign _zz__zz_decode_IS_DIV_33 = {(|_zz__zz_decode_IS_DIV_34),{_zz__zz_decode_IS_DIV_37,{_zz__zz_decode_IS_DIV_42,_zz__zz_decode_IS_DIV_47}}};
+  assign _zz__zz_decode_IS_DIV_21 = 32'h40003054;
+  assign _zz__zz_decode_IS_DIV_23 = 32'h02007054;
+  assign _zz__zz_decode_IS_DIV_25 = (decode_INSTRUCTION & 32'h00000064);
+  assign _zz__zz_decode_IS_DIV_26 = 32'h00000024;
+  assign _zz__zz_decode_IS_DIV_27 = (decode_INSTRUCTION & 32'h02003054);
+  assign _zz__zz_decode_IS_DIV_28 = 32'h00001010;
+  assign _zz__zz_decode_IS_DIV_30 = (decode_INSTRUCTION & 32'h00001000);
+  assign _zz__zz_decode_IS_DIV_31 = 32'h00001000;
+  assign _zz__zz_decode_IS_DIV_34 = {((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_35) == 32'h00002000),((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_36) == 32'h00001000)};
+  assign _zz__zz_decode_IS_DIV_37 = (|{(_zz__zz_decode_IS_DIV_38 == _zz__zz_decode_IS_DIV_39),(_zz__zz_decode_IS_DIV_40 == _zz__zz_decode_IS_DIV_41)});
+  assign _zz__zz_decode_IS_DIV_42 = (|{_zz__zz_decode_IS_DIV_43,{_zz__zz_decode_IS_DIV_44,_zz__zz_decode_IS_DIV_45}});
+  assign _zz__zz_decode_IS_DIV_47 = {(|_zz__zz_decode_IS_DIV_48),{(|_zz__zz_decode_IS_DIV_49),{_zz__zz_decode_IS_DIV_51,{_zz__zz_decode_IS_DIV_56,_zz__zz_decode_IS_DIV_69}}}};
+  assign _zz__zz_decode_IS_DIV_35 = 32'h00002010;
+  assign _zz__zz_decode_IS_DIV_36 = 32'h00005000;
+  assign _zz__zz_decode_IS_DIV_38 = (decode_INSTRUCTION & 32'h00000034);
+  assign _zz__zz_decode_IS_DIV_39 = 32'h00000020;
+  assign _zz__zz_decode_IS_DIV_40 = (decode_INSTRUCTION & 32'h00000064);
+  assign _zz__zz_decode_IS_DIV_41 = 32'h00000020;
+  assign _zz__zz_decode_IS_DIV_43 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000040);
+  assign _zz__zz_decode_IS_DIV_44 = _zz_decode_IS_DIV_2;
+  assign _zz__zz_decode_IS_DIV_45 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_46) == 32'h00000040);
+  assign _zz__zz_decode_IS_DIV_48 = ((decode_INSTRUCTION & 32'h00000020) == 32'h00000020);
+  assign _zz__zz_decode_IS_DIV_49 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_50) == 32'h00000010);
+  assign _zz__zz_decode_IS_DIV_51 = (|{_zz_decode_IS_DIV_3,{_zz__zz_decode_IS_DIV_52,_zz__zz_decode_IS_DIV_54}});
+  assign _zz__zz_decode_IS_DIV_56 = (|{_zz__zz_decode_IS_DIV_57,_zz__zz_decode_IS_DIV_58});
+  assign _zz__zz_decode_IS_DIV_69 = {(|_zz__zz_decode_IS_DIV_70),{_zz__zz_decode_IS_DIV_73,{_zz__zz_decode_IS_DIV_76,_zz__zz_decode_IS_DIV_83}}};
+  assign _zz__zz_decode_IS_DIV_46 = 32'h00103040;
+  assign _zz__zz_decode_IS_DIV_50 = 32'h00000010;
+  assign _zz__zz_decode_IS_DIV_52 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_53) == 32'h00000010);
+  assign _zz__zz_decode_IS_DIV_54 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_55) == 32'h00000020);
+  assign _zz__zz_decode_IS_DIV_57 = _zz_decode_IS_DIV_4;
+  assign _zz__zz_decode_IS_DIV_58 = {(_zz__zz_decode_IS_DIV_59 == _zz__zz_decode_IS_DIV_60),{_zz__zz_decode_IS_DIV_61,{_zz__zz_decode_IS_DIV_63,_zz__zz_decode_IS_DIV_66}}};
+  assign _zz__zz_decode_IS_DIV_70 = {_zz_decode_IS_DIV_3,(_zz__zz_decode_IS_DIV_71 == _zz__zz_decode_IS_DIV_72)};
+  assign _zz__zz_decode_IS_DIV_73 = (|{_zz_decode_IS_DIV_3,_zz__zz_decode_IS_DIV_74});
+  assign _zz__zz_decode_IS_DIV_76 = (|{_zz__zz_decode_IS_DIV_77,_zz__zz_decode_IS_DIV_80});
+  assign _zz__zz_decode_IS_DIV_83 = {(|_zz__zz_decode_IS_DIV_84),{_zz__zz_decode_IS_DIV_87,{_zz__zz_decode_IS_DIV_93,_zz__zz_decode_IS_DIV_96}}};
+  assign _zz__zz_decode_IS_DIV_53 = 32'h00000030;
+  assign _zz__zz_decode_IS_DIV_55 = 32'h02000060;
+  assign _zz__zz_decode_IS_DIV_59 = (decode_INSTRUCTION & 32'h00001010);
+  assign _zz__zz_decode_IS_DIV_60 = 32'h00001010;
+  assign _zz__zz_decode_IS_DIV_61 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_62) == 32'h00002010);
+  assign _zz__zz_decode_IS_DIV_63 = (_zz__zz_decode_IS_DIV_64 == _zz__zz_decode_IS_DIV_65);
+  assign _zz__zz_decode_IS_DIV_66 = {_zz__zz_decode_IS_DIV_67,_zz__zz_decode_IS_DIV_68};
+  assign _zz__zz_decode_IS_DIV_71 = (decode_INSTRUCTION & 32'h00000070);
+  assign _zz__zz_decode_IS_DIV_72 = 32'h00000020;
+  assign _zz__zz_decode_IS_DIV_74 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_75) == 32'h00000000);
+  assign _zz__zz_decode_IS_DIV_77 = (_zz__zz_decode_IS_DIV_78 == _zz__zz_decode_IS_DIV_79);
   assign _zz__zz_decode_IS_DIV_80 = (_zz__zz_decode_IS_DIV_81 == _zz__zz_decode_IS_DIV_82);
-  assign _zz__zz_decode_IS_DIV_84 = {_zz_decode_IS_DIV_3,_zz__zz_decode_IS_DIV_85};
-  assign _zz__zz_decode_IS_DIV_87 = (|{_zz__zz_decode_IS_DIV_88,_zz__zz_decode_IS_DIV_91});
-  assign _zz__zz_decode_IS_DIV_94 = (|_zz__zz_decode_IS_DIV_95);
-  assign _zz__zz_decode_IS_DIV_98 = {_zz__zz_decode_IS_DIV_99,{_zz__zz_decode_IS_DIV_105,_zz__zz_decode_IS_DIV_108}};
-  assign _zz__zz_decode_IS_DIV_62 = 32'h00000030;
-  assign _zz__zz_decode_IS_DIV_64 = 32'h02000060;
-  assign _zz__zz_decode_IS_DIV_67 = (decode_INSTRUCTION & 32'h00001010);
-  assign _zz__zz_decode_IS_DIV_68 = 32'h00001010;
-  assign _zz__zz_decode_IS_DIV_70 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_71) == 32'h00002010);
-  assign _zz__zz_decode_IS_DIV_72 = (_zz__zz_decode_IS_DIV_73 == _zz__zz_decode_IS_DIV_74);
-  assign _zz__zz_decode_IS_DIV_75 = {_zz__zz_decode_IS_DIV_76,_zz__zz_decode_IS_DIV_77};
-  assign _zz__zz_decode_IS_DIV_81 = (decode_INSTRUCTION & 32'h00000070);
-  assign _zz__zz_decode_IS_DIV_82 = 32'h00000020;
-  assign _zz__zz_decode_IS_DIV_85 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_86) == 32'h0);
-  assign _zz__zz_decode_IS_DIV_88 = (_zz__zz_decode_IS_DIV_89 == _zz__zz_decode_IS_DIV_90);
-  assign _zz__zz_decode_IS_DIV_91 = (_zz__zz_decode_IS_DIV_92 == _zz__zz_decode_IS_DIV_93);
-  assign _zz__zz_decode_IS_DIV_95 = (_zz__zz_decode_IS_DIV_96 == _zz__zz_decode_IS_DIV_97);
-  assign _zz__zz_decode_IS_DIV_99 = (|{_zz__zz_decode_IS_DIV_100,_zz__zz_decode_IS_DIV_102});
-  assign _zz__zz_decode_IS_DIV_105 = (|_zz__zz_decode_IS_DIV_106);
-  assign _zz__zz_decode_IS_DIV_108 = {_zz__zz_decode_IS_DIV_109,{_zz__zz_decode_IS_DIV_115,_zz__zz_decode_IS_DIV_119}};
-  assign _zz__zz_decode_IS_DIV_71 = 32'h00002010;
-  assign _zz__zz_decode_IS_DIV_73 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz__zz_decode_IS_DIV_74 = 32'h00000010;
-  assign _zz__zz_decode_IS_DIV_76 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
-  assign _zz__zz_decode_IS_DIV_77 = ((decode_INSTRUCTION & 32'h00000028) == 32'h0);
-  assign _zz__zz_decode_IS_DIV_86 = 32'h00000020;
-  assign _zz__zz_decode_IS_DIV_89 = (decode_INSTRUCTION & 32'h00006014);
-  assign _zz__zz_decode_IS_DIV_90 = 32'h00006010;
-  assign _zz__zz_decode_IS_DIV_92 = (decode_INSTRUCTION & 32'h00005014);
-  assign _zz__zz_decode_IS_DIV_93 = 32'h00004010;
-  assign _zz__zz_decode_IS_DIV_96 = (decode_INSTRUCTION & 32'h00006014);
-  assign _zz__zz_decode_IS_DIV_97 = 32'h00002010;
-  assign _zz__zz_decode_IS_DIV_100 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_101) == 32'h0);
-  assign _zz__zz_decode_IS_DIV_102 = {_zz_decode_IS_DIV_2,{_zz__zz_decode_IS_DIV_103,_zz__zz_decode_IS_DIV_104}};
-  assign _zz__zz_decode_IS_DIV_106 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_107) == 32'h0);
-  assign _zz__zz_decode_IS_DIV_109 = (|{_zz__zz_decode_IS_DIV_110,{_zz__zz_decode_IS_DIV_111,_zz__zz_decode_IS_DIV_113}});
-  assign _zz__zz_decode_IS_DIV_115 = (|{_zz__zz_decode_IS_DIV_116,_zz__zz_decode_IS_DIV_118});
-  assign _zz__zz_decode_IS_DIV_119 = {(|_zz__zz_decode_IS_DIV_120),(|_zz__zz_decode_IS_DIV_123)};
-  assign _zz__zz_decode_IS_DIV_101 = 32'h00000044;
-  assign _zz__zz_decode_IS_DIV_103 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
-  assign _zz__zz_decode_IS_DIV_104 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
-  assign _zz__zz_decode_IS_DIV_107 = 32'h00000058;
-  assign _zz__zz_decode_IS_DIV_110 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
-  assign _zz__zz_decode_IS_DIV_111 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_112) == 32'h00002010);
-  assign _zz__zz_decode_IS_DIV_113 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_114) == 32'h40000030);
-  assign _zz__zz_decode_IS_DIV_116 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_117) == 32'h00000004);
-  assign _zz__zz_decode_IS_DIV_118 = _zz_decode_IS_DIV_1;
-  assign _zz__zz_decode_IS_DIV_120 = {(_zz__zz_decode_IS_DIV_121 == _zz__zz_decode_IS_DIV_122),_zz_decode_IS_DIV_1};
-  assign _zz__zz_decode_IS_DIV_123 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_124) == 32'h00001008);
-  assign _zz__zz_decode_IS_DIV_112 = 32'h00002014;
-  assign _zz__zz_decode_IS_DIV_114 = 32'h40004034;
-  assign _zz__zz_decode_IS_DIV_117 = 32'h00000014;
-  assign _zz__zz_decode_IS_DIV_121 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz__zz_decode_IS_DIV_122 = 32'h00000004;
-  assign _zz__zz_decode_IS_DIV_124 = 32'h00001048;
+  assign _zz__zz_decode_IS_DIV_84 = (_zz__zz_decode_IS_DIV_85 == _zz__zz_decode_IS_DIV_86);
+  assign _zz__zz_decode_IS_DIV_87 = (|{_zz__zz_decode_IS_DIV_88,_zz__zz_decode_IS_DIV_90});
+  assign _zz__zz_decode_IS_DIV_93 = (|_zz__zz_decode_IS_DIV_94);
+  assign _zz__zz_decode_IS_DIV_96 = {_zz__zz_decode_IS_DIV_97,{_zz__zz_decode_IS_DIV_103,_zz__zz_decode_IS_DIV_107}};
+  assign _zz__zz_decode_IS_DIV_62 = 32'h00002010;
+  assign _zz__zz_decode_IS_DIV_64 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz__zz_decode_IS_DIV_65 = 32'h00000010;
+  assign _zz__zz_decode_IS_DIV_67 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
+  assign _zz__zz_decode_IS_DIV_68 = ((decode_INSTRUCTION & 32'h00000028) == 32'h00000000);
+  assign _zz__zz_decode_IS_DIV_75 = 32'h00000020;
+  assign _zz__zz_decode_IS_DIV_78 = (decode_INSTRUCTION & 32'h00006004);
+  assign _zz__zz_decode_IS_DIV_79 = 32'h00006000;
+  assign _zz__zz_decode_IS_DIV_81 = (decode_INSTRUCTION & 32'h00005014);
+  assign _zz__zz_decode_IS_DIV_82 = 32'h00004010;
+  assign _zz__zz_decode_IS_DIV_85 = (decode_INSTRUCTION & 32'h00006014);
+  assign _zz__zz_decode_IS_DIV_86 = 32'h00002010;
+  assign _zz__zz_decode_IS_DIV_88 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_89) == 32'h00000000);
+  assign _zz__zz_decode_IS_DIV_90 = {_zz_decode_IS_DIV_2,{_zz__zz_decode_IS_DIV_91,_zz__zz_decode_IS_DIV_92}};
+  assign _zz__zz_decode_IS_DIV_94 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_95) == 32'h00000000);
+  assign _zz__zz_decode_IS_DIV_97 = (|{_zz__zz_decode_IS_DIV_98,{_zz__zz_decode_IS_DIV_99,_zz__zz_decode_IS_DIV_101}});
+  assign _zz__zz_decode_IS_DIV_103 = (|{_zz__zz_decode_IS_DIV_104,_zz__zz_decode_IS_DIV_106});
+  assign _zz__zz_decode_IS_DIV_107 = {(|_zz__zz_decode_IS_DIV_108),(|_zz__zz_decode_IS_DIV_111)};
+  assign _zz__zz_decode_IS_DIV_89 = 32'h00000044;
+  assign _zz__zz_decode_IS_DIV_91 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
+  assign _zz__zz_decode_IS_DIV_92 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
+  assign _zz__zz_decode_IS_DIV_95 = 32'h00000058;
+  assign _zz__zz_decode_IS_DIV_98 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
+  assign _zz__zz_decode_IS_DIV_99 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_100) == 32'h00002010);
+  assign _zz__zz_decode_IS_DIV_101 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_102) == 32'h40000030);
+  assign _zz__zz_decode_IS_DIV_104 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_105) == 32'h00000004);
+  assign _zz__zz_decode_IS_DIV_106 = _zz_decode_IS_DIV_1;
+  assign _zz__zz_decode_IS_DIV_108 = {(_zz__zz_decode_IS_DIV_109 == _zz__zz_decode_IS_DIV_110),_zz_decode_IS_DIV_1};
+  assign _zz__zz_decode_IS_DIV_111 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_112) == 32'h00001008);
+  assign _zz__zz_decode_IS_DIV_100 = 32'h00002014;
+  assign _zz__zz_decode_IS_DIV_102 = 32'h40004034;
+  assign _zz__zz_decode_IS_DIV_105 = 32'h00000014;
+  assign _zz__zz_decode_IS_DIV_109 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz__zz_decode_IS_DIV_110 = 32'h00000004;
+  assign _zz__zz_decode_IS_DIV_112 = 32'h00001048;
   assign _zz_execute_BranchPlugin_branch_src2_6 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_7 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_8 = execute_INSTRUCTION[7];
@@ -1479,8 +1457,8 @@ module VexRiscv (
     .io_mem_rsp_valid                      (iBus_rsp_valid                                            ), //i
     .io_mem_rsp_payload_data               (iBus_rsp_payload_data[31:0]                               ), //i
     .io_mem_rsp_payload_error              (iBus_rsp_payload_error                                    ), //i
-    ._zz_when_Fetcher_l401                 (switch_Fetcher_l365[2:0]                                  ), //i
-    ._zz_io_cpu_fetch_data_regNextWhen     (IBusCachedPlugin_injectionPort_payload[31:0]              ), //i
+    ._zz_when_Fetcher_l411                 (IBusCachedPlugin_injector_port_state[2:0]                 ), //i
+    ._zz_io_cpu_fetch_data_regNextWhen     (DebugPlugin_injectionPort_payload[31:0]                   ), //i
     .clk                                   (clk                                                       ), //i
     .reset                                 (reset                                                     )  //i
   );
@@ -2124,7 +2102,7 @@ module VexRiscv (
   assign execute_MEMORY_ADDRESS_LOW = dBus_cmd_payload_address[1 : 0];
   assign decode_DO_EBREAK = (((! DebugPlugin_haltIt) && (decode_IS_EBREAK || 1'b0)) && DebugPlugin_allowEBreak);
   assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
-  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
+  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h00)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h00))));
   assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
   assign decode_IS_DIV = _zz_decode_IS_DIV[30];
@@ -2262,7 +2240,7 @@ module VexRiscv (
     if(when_ShiftPlugins_l169) begin
       _zz_decode_RS2_1 = _zz_decode_RS2_3;
     end
-    if(when_CsrPlugin_l1189) begin
+    if(when_CsrPlugin_l1587) begin
       _zz_decode_RS2_1 = CsrPlugin_csrMapping_readDataSignal;
     end
   end
@@ -2271,7 +2249,7 @@ module VexRiscv (
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_execute_SRC2 = execute_PC;
+  assign _zz_execute_to_memory_PC = execute_PC;
   assign execute_SRC2_CTRL = _zz_execute_SRC2_CTRL;
   assign execute_SRC1_CTRL = _zz_execute_SRC1_CTRL;
   assign decode_SRC_USE_SUB_LESS = _zz_decode_IS_DIV[3];
@@ -2279,7 +2257,7 @@ module VexRiscv (
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
   assign execute_ALU_CTRL = _zz_execute_ALU_CTRL;
-  assign execute_SRC2 = _zz_execute_SRC2_5;
+  assign execute_SRC2 = _zz_execute_SRC2_4;
   assign execute_SRC1 = _zz_execute_SRC1;
   assign execute_ALU_BITWISE_CTRL = _zz_execute_ALU_BITWISE_CTRL;
   assign _zz_lastStageRegFileWrite_payload_address = writeBack_INSTRUCTION;
@@ -2299,10 +2277,10 @@ module VexRiscv (
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00001073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
+  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000107f) == 32'h00001073),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00002073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
   always @(*) begin
     _zz_decode_RS2_2 = writeBack_REGFILE_WRITE_DATA;
-    if(when_DBusSimplePlugin_l558) begin
+    if(when_DBusSimplePlugin_l566) begin
       _zz_decode_RS2_2 = writeBack_DBusSimplePlugin_rspFormated;
     end
   end
@@ -2323,28 +2301,28 @@ module VexRiscv (
   assign decode_FLUSH_ALL = _zz_decode_IS_DIV[0];
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_4 = IBusCachedPlugin_rsp_issueDetected_3;
-    if(when_IBusCachedPlugin_l256) begin
+    if(when_IBusCachedPlugin_l262) begin
       IBusCachedPlugin_rsp_issueDetected_4 = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_3 = IBusCachedPlugin_rsp_issueDetected_2;
-    if(when_IBusCachedPlugin_l250) begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_rsp_issueDetected_3 = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
-    if(when_IBusCachedPlugin_l244) begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
-    if(when_IBusCachedPlugin_l239) begin
+    if(when_IBusCachedPlugin_l245) begin
       IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
@@ -2370,7 +2348,7 @@ module VexRiscv (
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
   always @(*) begin
     decode_arbitration_haltItself = 1'b0;
-    case(switch_Fetcher_l365)
+    case(IBusCachedPlugin_injector_port_state)
       3'b010 : begin
         decode_arbitration_haltItself = 1'b1;
       end
@@ -2387,7 +2365,7 @@ module VexRiscv (
     if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(when_CsrPlugin_l1129) begin
+    if(when_CsrPlugin_l1527) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
@@ -2415,7 +2393,7 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(when_DBusSimplePlugin_l428) begin
+    if(when_DBusSimplePlugin_l436) begin
       execute_arbitration_haltItself = 1'b1;
     end
     if(when_ShiftPlugins_l169) begin
@@ -2423,7 +2401,7 @@ module VexRiscv (
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(when_CsrPlugin_l1193) begin
+    if(when_CsrPlugin_l1591) begin
       if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
@@ -2432,7 +2410,7 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if(when_DebugPlugin_l295) begin
+    if(when_DebugPlugin_l308) begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
@@ -2449,8 +2427,8 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_flushIt = 1'b0;
-    if(when_DebugPlugin_l295) begin
-      if(when_DebugPlugin_l298) begin
+    if(when_DebugPlugin_l308) begin
+      if(when_DebugPlugin_l311) begin
         execute_arbitration_flushIt = 1'b1;
       end
     end
@@ -2461,8 +2439,8 @@ module VexRiscv (
     if(CsrPlugin_selfException_valid) begin
       execute_arbitration_flushNext = 1'b1;
     end
-    if(when_DebugPlugin_l295) begin
-      if(when_DebugPlugin_l298) begin
+    if(when_DebugPlugin_l308) begin
+      if(when_DebugPlugin_l311) begin
         execute_arbitration_flushNext = 1'b1;
       end
     end
@@ -2470,7 +2448,7 @@ module VexRiscv (
 
   always @(*) begin
     memory_arbitration_haltItself = 1'b0;
-    if(when_DBusSimplePlugin_l482) begin
+    if(when_DBusSimplePlugin_l490) begin
       memory_arbitration_haltItself = 1'b1;
     end
     if(when_MulDivIterativePlugin_l96) begin
@@ -2522,10 +2500,10 @@ module VexRiscv (
   assign writeBack_arbitration_flushIt = 1'b0;
   always @(*) begin
     writeBack_arbitration_flushNext = 1'b0;
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -2536,24 +2514,24 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @(*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(when_CsrPlugin_l935) begin
+    if(when_CsrPlugin_l1272) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_DebugPlugin_l295) begin
-      if(when_DebugPlugin_l298) begin
+    if(when_DebugPlugin_l308) begin
+      if(when_DebugPlugin_l311) begin
         IBusCachedPlugin_fetcherHalt = 1'b1;
       end
     end
     if(DebugPlugin_haltIt) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_DebugPlugin_l311) begin
+    if(when_DebugPlugin_l324) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
@@ -2561,7 +2539,7 @@ module VexRiscv (
   assign IBusCachedPlugin_forceNoDecodeCond = 1'b0;
   always @(*) begin
     IBusCachedPlugin_incomingInstruction = 1'b0;
-    if(when_Fetcher_l243) begin
+    if(when_Fetcher_l242) begin
       IBusCachedPlugin_incomingInstruction = 1'b1;
     end
   end
@@ -2573,7 +2551,17 @@ module VexRiscv (
     end
   end
 
-  assign CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+  always @(*) begin
+    CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+    if(when_CsrPlugin_l1702) begin
+      CsrPlugin_csrMapping_allowCsrSignal = 1'b1;
+    end
+    if(when_CsrPlugin_l1709) begin
+      CsrPlugin_csrMapping_allowCsrSignal = 1'b1;
+    end
+  end
+
+  assign CsrPlugin_csrMapping_doForceFailCsr = 1'b0;
   assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
   assign CsrPlugin_inWfi = 1'b0;
   always @(*) begin
@@ -2585,21 +2573,21 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(when_CsrPlugin_l1077) begin
-      case(switch_CsrPlugin_l1081)
+    if(when_CsrPlugin_l1456) begin
+      case(switch_CsrPlugin_l1460)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -2618,7 +2606,7 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_allowInterrupts = 1'b1;
-    if(when_DebugPlugin_l331) begin
+    if(when_DebugPlugin_l344) begin
       CsrPlugin_allowInterrupts = 1'b0;
     end
   end
@@ -2637,6 +2625,7 @@ module VexRiscv (
     end
   end
 
+  assign CsrPlugin_xretAwayFromMachine = 1'b0;
   assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
   assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,IBusCachedPlugin_predictionJumpInterface_valid}} != 3'b000);
   assign _zz_IBusCachedPlugin_jump_pcLoad_payload = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,CsrPlugin_jumpInterface_valid}};
@@ -2663,9 +2652,8 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l134 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
-  assign IBusCachedPlugin_fetchPc_output_fire_1 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
-  assign when_Fetcher_l134_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
+  assign when_Fetcher_l133 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l133_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
   always @(*) begin
     IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_IBusCachedPlugin_fetchPc_pc);
     if(IBusCachedPlugin_fetchPc_redo_valid) begin
@@ -2688,7 +2676,7 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l161 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
+  assign when_Fetcher_l160 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
   assign IBusCachedPlugin_fetchPc_output_valid = ((! IBusCachedPlugin_fetcherHalt) && IBusCachedPlugin_fetchPc_booted);
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
   always @(*) begin
@@ -2725,7 +2713,7 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_1_output_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b0;
-    if(when_IBusCachedPlugin_l267) begin
+    if(when_IBusCachedPlugin_l273) begin
       IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b1;
     end
   end
@@ -2738,9 +2726,9 @@ module VexRiscv (
   assign IBusCachedPlugin_fetchPc_redo_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_iBusRsp_flush = ((decode_arbitration_removeIt || (decode_arbitration_flushNext && (! decode_arbitration_isStuck))) || IBusCachedPlugin_iBusRsp_redoFetch);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
-  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1 = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
   assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid)) || IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready);
   assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
@@ -2750,18 +2738,18 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
   always @(*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
-    if(when_Fetcher_l323) begin
+    if(when_Fetcher_l322) begin
       IBusCachedPlugin_iBusRsp_readyForError = 1'b0;
     end
   end
 
-  assign when_Fetcher_l243 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
-  assign when_Fetcher_l323 = (! IBusCachedPlugin_pcValids_0);
-  assign when_Fetcher_l332 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
-  assign when_Fetcher_l332_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
-  assign when_Fetcher_l332_2 = (! execute_arbitration_isStuck);
-  assign when_Fetcher_l332_3 = (! memory_arbitration_isStuck);
-  assign when_Fetcher_l332_4 = (! writeBack_arbitration_isStuck);
+  assign when_Fetcher_l242 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
+  assign when_Fetcher_l322 = (! IBusCachedPlugin_pcValids_0);
+  assign when_Fetcher_l331 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l331_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
+  assign when_Fetcher_l331_2 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l331_3 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l331_4 = (! writeBack_arbitration_isStuck);
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
@@ -2769,7 +2757,7 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
   always @(*) begin
     decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
-    case(switch_Fetcher_l365)
+    case(IBusCachedPlugin_injector_port_state)
       3'b010 : begin
         decode_arbitration_isValid = 1'b1;
       end
@@ -2926,47 +2914,47 @@ module VexRiscv (
   assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
   always @(*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(when_IBusCachedPlugin_l239) begin
+    if(when_IBusCachedPlugin_l245) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(when_IBusCachedPlugin_l250) begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_cache_io_cpu_fill_valid = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
-    if(when_IBusCachedPlugin_l250) begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_cache_io_cpu_fill_valid = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_valid = 1'b0;
-    if(when_IBusCachedPlugin_l244) begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
-    if(when_IBusCachedPlugin_l256) begin
+    if(when_IBusCachedPlugin_l262) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_payload_code = 4'bxxxx;
-    if(when_IBusCachedPlugin_l244) begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b1100;
     end
-    if(when_IBusCachedPlugin_l256) begin
+    if(when_IBusCachedPlugin_l262) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b0001;
     end
   end
 
   assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_2_input_payload[31 : 2],2'b00};
-  assign when_IBusCachedPlugin_l239 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign when_IBusCachedPlugin_l244 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
-  assign when_IBusCachedPlugin_l250 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
-  assign when_IBusCachedPlugin_l256 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
-  assign when_IBusCachedPlugin_l267 = (IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt);
+  assign when_IBusCachedPlugin_l245 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign when_IBusCachedPlugin_l250 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign when_IBusCachedPlugin_l256 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
+  assign when_IBusCachedPlugin_l262 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
+  assign when_IBusCachedPlugin_l273 = (IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt);
   assign IBusCachedPlugin_iBusRsp_output_valid = IBusCachedPlugin_iBusRsp_stages_2_output_valid;
   assign IBusCachedPlugin_iBusRsp_stages_2_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
   assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_decode_data;
@@ -2998,7 +2986,7 @@ module VexRiscv (
   end
 
   assign dBus_cmd_payload_data = _zz_dBus_cmd_payload_data;
-  assign when_DBusSimplePlugin_l428 = ((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! dBus_cmd_ready)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_dBus_cmd_valid));
+  assign when_DBusSimplePlugin_l436 = ((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! dBus_cmd_ready)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_dBus_cmd_valid));
   always @(*) begin
     case(dBus_cmd_payload_size)
       2'b00 : begin
@@ -3015,23 +3003,23 @@ module VexRiscv (
 
   assign execute_DBusSimplePlugin_formalMask = (_zz_execute_DBusSimplePlugin_formalMask <<< dBus_cmd_payload_address[1 : 0]);
   assign dBus_cmd_payload_address = execute_SRC_ADD;
-  assign when_DBusSimplePlugin_l482 = (((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (! memory_MEMORY_STORE)) && ((! dBus_rsp_ready) || 1'b0));
+  assign when_DBusSimplePlugin_l490 = (((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (! memory_MEMORY_STORE)) && ((! dBus_rsp_ready) || 1'b0));
   always @(*) begin
     DBusSimplePlugin_memoryExceptionPort_valid = 1'b0;
-    if(when_DBusSimplePlugin_l489) begin
+    if(when_DBusSimplePlugin_l497) begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b1;
     end
     if(memory_ALIGNEMENT_FAULT) begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b1;
     end
-    if(when_DBusSimplePlugin_l515) begin
+    if(when_DBusSimplePlugin_l523) begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b0;
     end
   end
 
   always @(*) begin
     DBusSimplePlugin_memoryExceptionPort_payload_code = 4'bxxxx;
-    if(when_DBusSimplePlugin_l489) begin
+    if(when_DBusSimplePlugin_l497) begin
       DBusSimplePlugin_memoryExceptionPort_payload_code = 4'b0101;
     end
     if(memory_ALIGNEMENT_FAULT) begin
@@ -3040,8 +3028,8 @@ module VexRiscv (
   end
 
   assign DBusSimplePlugin_memoryExceptionPort_payload_badAddr = memory_REGFILE_WRITE_DATA;
-  assign when_DBusSimplePlugin_l489 = ((dBus_rsp_ready && dBus_rsp_error) && (! memory_MEMORY_STORE));
-  assign when_DBusSimplePlugin_l515 = (! ((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (1'b1 || (! memory_arbitration_isStuckByOthers))));
+  assign when_DBusSimplePlugin_l497 = ((dBus_rsp_ready && dBus_rsp_error) && (! memory_MEMORY_STORE));
+  assign when_DBusSimplePlugin_l523 = (! ((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (1'b1 || (! memory_arbitration_isStuckByOthers))));
   always @(*) begin
     writeBack_DBusSimplePlugin_rspShifted = writeBack_MEMORY_READ_DATA;
     case(writeBack_MEMORY_ADDRESS_LOW)
@@ -3059,7 +3047,7 @@ module VexRiscv (
     endcase
   end
 
-  assign switch_Misc_l210 = writeBack_INSTRUCTION[13 : 12];
+  assign switch_Misc_l232 = writeBack_INSTRUCTION[13 : 12];
   assign _zz_writeBack_DBusSimplePlugin_rspFormated = (writeBack_DBusSimplePlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
   always @(*) begin
     _zz_writeBack_DBusSimplePlugin_rspFormated_1[31] = _zz_writeBack_DBusSimplePlugin_rspFormated;
@@ -3111,7 +3099,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    case(switch_Misc_l210)
+    case(switch_Misc_l232)
       2'b00 : begin
         writeBack_DBusSimplePlugin_rspFormated = _zz_writeBack_DBusSimplePlugin_rspFormated_1;
       end
@@ -3124,7 +3112,7 @@ module VexRiscv (
     endcase
   end
 
-  assign when_DBusSimplePlugin_l558 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusSimplePlugin_l566 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
   assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
@@ -3135,7 +3123,7 @@ module VexRiscv (
   assign IBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign IBusCachedPlugin_mmuBus_busy = 1'b0;
   assign _zz_decode_IS_DIV_1 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_decode_IS_DIV_2 = ((decode_INSTRUCTION & 32'h00000018) == 32'h0);
+  assign _zz_decode_IS_DIV_2 = ((decode_INSTRUCTION & 32'h00000018) == 32'h00000000);
   assign _zz_decode_IS_DIV_3 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
   assign _zz_decode_IS_DIV_4 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
   assign _zz_decode_IS_DIV_5 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
@@ -3159,29 +3147,29 @@ module VexRiscv (
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
-  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h0);
+  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h00);
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
   assign decode_RegFilePlugin_rs1Data = _zz_RegFilePlugin_regFile_port0;
   assign decode_RegFilePlugin_rs2Data = _zz_RegFilePlugin_regFile_port1;
   always @(*) begin
     lastStageRegFileWrite_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
-    if(_zz_7) begin
+    if(_zz_10) begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
   always @(*) begin
     lastStageRegFileWrite_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
-    if(_zz_7) begin
-      lastStageRegFileWrite_payload_address = 5'h0;
+    if(_zz_10) begin
+      lastStageRegFileWrite_payload_address = 5'h00;
     end
   end
 
   always @(*) begin
     lastStageRegFileWrite_payload_data = _zz_decode_RS2_2;
-    if(_zz_7) begin
-      lastStageRegFileWrite_payload_data = 32'h0;
+    if(_zz_10) begin
+      lastStageRegFileWrite_payload_data = 32'h00000000;
     end
   end
 
@@ -3222,7 +3210,7 @@ module VexRiscv (
         _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
       Src1CtrlEnum_IMU : begin
-        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h000};
       end
       default : begin
         _zz_execute_SRC1 = {27'd0, _zz__zz_execute_SRC1_1};
@@ -3230,67 +3218,67 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_execute_SRC2_1 = execute_INSTRUCTION[31];
+  assign _zz_execute_SRC2 = execute_INSTRUCTION[31];
   always @(*) begin
-    _zz_execute_SRC2_2[19] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[18] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[17] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[16] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[15] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[14] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[13] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[12] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[11] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[10] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[9] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[8] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[7] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[6] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[5] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[4] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[3] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[2] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[1] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[0] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_1[19] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[18] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[17] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[16] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[15] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[14] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[13] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[12] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[11] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[10] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[9] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[8] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[7] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[6] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[5] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[4] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[3] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[2] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[1] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[0] = _zz_execute_SRC2;
   end
 
-  assign _zz_execute_SRC2_3 = _zz__zz_execute_SRC2_3[11];
+  assign _zz_execute_SRC2_2 = _zz__zz_execute_SRC2_2[11];
   always @(*) begin
-    _zz_execute_SRC2_4[19] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[18] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[17] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[16] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[15] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[14] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[13] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[12] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[11] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[10] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[9] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[8] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[7] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[6] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[5] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[4] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[3] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[2] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[1] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[0] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_3[19] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[18] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[17] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[16] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[15] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[14] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[13] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[12] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[11] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[10] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[9] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[8] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[7] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[6] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[5] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[4] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[3] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[2] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[1] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[0] = _zz_execute_SRC2_2;
   end
 
   always @(*) begin
     case(execute_SRC2_CTRL)
       Src2CtrlEnum_RS : begin
-        _zz_execute_SRC2_5 = execute_RS2;
+        _zz_execute_SRC2_4 = execute_RS2;
       end
       Src2CtrlEnum_IMI : begin
-        _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
+        _zz_execute_SRC2_4 = {_zz_execute_SRC2_1,execute_INSTRUCTION[31 : 20]};
       end
       Src2CtrlEnum_IMS : begin
-        _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_execute_SRC2_4 = {_zz_execute_SRC2_3,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_execute_SRC2_5 = _zz_execute_SRC2;
+        _zz_execute_SRC2_4 = _zz_execute_to_memory_PC;
       end
     endcase
   end
@@ -3307,7 +3295,7 @@ module VexRiscv (
   assign execute_LightShifterPlugin_amplitude = (execute_LightShifterPlugin_isActive ? execute_LightShifterPlugin_amplitudeReg : execute_SRC2[4 : 0]);
   assign execute_LightShifterPlugin_shiftInput = (execute_LightShifterPlugin_isActive ? memory_REGFILE_WRITE_DATA : execute_SRC1);
   assign execute_LightShifterPlugin_done = (execute_LightShifterPlugin_amplitude[4 : 1] == 4'b0000);
-  assign when_ShiftPlugins_l169 = ((execute_arbitration_isValid && execute_LightShifterPlugin_isShift) && (execute_SRC2[4 : 0] != 5'h0));
+  assign when_ShiftPlugins_l169 = ((execute_arbitration_isValid && execute_LightShifterPlugin_isShift) && (execute_SRC2[4 : 0] != 5'h00));
   always @(*) begin
     case(execute_SHIFT_CTRL)
       ShiftCtrlEnum_SLL_1 : begin
@@ -3402,16 +3390,19 @@ module VexRiscv (
   assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
   assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign switch_Misc_l210_1 = execute_INSTRUCTION[14 : 12];
+  assign switch_Misc_l232_1 = execute_INSTRUCTION[14 : 12];
   always @(*) begin
-    casez(switch_Misc_l210_1)
+    case(switch_Misc_l232_1)
       3'b000 : begin
         _zz_execute_BRANCH_COND_RESULT = execute_BranchPlugin_eq;
       end
       3'b001 : begin
         _zz_execute_BRANCH_COND_RESULT = (! execute_BranchPlugin_eq);
       end
-      3'b1?1 : begin
+      3'b101 : begin
+        _zz_execute_BRANCH_COND_RESULT = (! execute_SRC_LESS);
+      end
+      3'b111 : begin
         _zz_execute_BRANCH_COND_RESULT = (! execute_SRC_LESS);
       end
       default : begin
@@ -3617,9 +3608,9 @@ module VexRiscv (
 
   assign CsrPlugin_misa_base = 2'b01;
   assign CsrPlugin_misa_extensions = 26'h0000042;
-  assign _zz_when_CsrPlugin_l965 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_when_CsrPlugin_l965_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_when_CsrPlugin_l965_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign _zz_when_CsrPlugin_l1302 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l1302_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l1302_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
   assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
@@ -3663,29 +3654,29 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l922 = (! decode_arbitration_isStuck);
-  assign when_CsrPlugin_l922_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l922_2 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l922_3 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l935 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
+  assign when_CsrPlugin_l1259 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l1272 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-  assign when_CsrPlugin_l959 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign when_CsrPlugin_l965 = ((_zz_when_CsrPlugin_l965 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l965_1 = ((_zz_when_CsrPlugin_l965_1 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l965_2 = ((_zz_when_CsrPlugin_l965_2 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1296 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l1302 = ((_zz_when_CsrPlugin_l1302 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1302_1 = ((_zz_when_CsrPlugin_l1302_1 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1302_2 = ((_zz_when_CsrPlugin_l1302_2 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_lastStageWasWfi = 1'b0;
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  assign when_CsrPlugin_l993 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l993_1 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l993_2 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l998 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  assign when_CsrPlugin_l1335 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1335_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l1335_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l1340 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
   always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(when_CsrPlugin_l1004) begin
+    if(when_CsrPlugin_l1346) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException) begin
@@ -3693,7 +3684,7 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l1004 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
+  assign when_CsrPlugin_l1346 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
   always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
@@ -3709,6 +3700,7 @@ module VexRiscv (
     end
   end
 
+  assign CsrPlugin_trapCauseEbreakDebug = 1'b0;
   always @(*) begin
     CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
@@ -3731,11 +3723,13 @@ module VexRiscv (
     endcase
   end
 
-  assign when_CsrPlugin_l1032 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign when_CsrPlugin_l1077 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
-  assign switch_CsrPlugin_l1081 = writeBack_INSTRUCTION[29 : 28];
+  assign CsrPlugin_trapEnterDebug = 1'b0;
+  assign when_CsrPlugin_l1390 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1398 = (! CsrPlugin_trapEnterDebug);
+  assign when_CsrPlugin_l1456 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign switch_CsrPlugin_l1460 = writeBack_INSTRUCTION[29 : 28];
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign when_CsrPlugin_l1129 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
+  assign when_CsrPlugin_l1527 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
   assign execute_CsrPlugin_blockedBySideEffects = ((|{writeBack_arbitration_isValid,memory_arbitration_isValid}) || 1'b0);
   always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
@@ -3777,18 +3771,18 @@ module VexRiscv (
     if(CsrPlugin_csrMapping_allowCsrSignal) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(when_CsrPlugin_l1315) begin
+    if(when_CsrPlugin_l1725) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if(when_CsrPlugin_l1149) begin
-      if(when_CsrPlugin_l1150) begin
+    if(when_CsrPlugin_l1547) begin
+      if(when_CsrPlugin_l1548) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
@@ -3796,14 +3790,14 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(when_CsrPlugin_l1157) begin
+    if(when_CsrPlugin_l1555) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(when_CsrPlugin_l1157) begin
+    if(when_CsrPlugin_l1555) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -3816,19 +3810,19 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  assign when_CsrPlugin_l1149 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
-  assign when_CsrPlugin_l1150 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
-  assign when_CsrPlugin_l1157 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
+  assign when_CsrPlugin_l1547 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign when_CsrPlugin_l1548 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1555 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
   always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -3837,9 +3831,9 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
   assign execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
-  assign switch_Misc_l210_2 = execute_INSTRUCTION[13];
+  assign switch_Misc_l232_2 = execute_INSTRUCTION[13];
   always @(*) begin
-    case(switch_Misc_l210_2)
+    case(switch_Misc_l232_2)
       1'b0 : begin
         _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
@@ -3850,8 +3844,8 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
-  assign when_CsrPlugin_l1189 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign when_CsrPlugin_l1193 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
+  assign when_CsrPlugin_l1587 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1591 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign memory_MulDivIterativePlugin_frontendOk = 1'b1;
   always @(*) begin
@@ -3874,12 +3868,12 @@ module VexRiscv (
   assign memory_MulDivIterativePlugin_mul_counter_willOverflow = (memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc && memory_MulDivIterativePlugin_mul_counter_willIncrement);
   always @(*) begin
     if(memory_MulDivIterativePlugin_mul_counter_willOverflow) begin
-      memory_MulDivIterativePlugin_mul_counter_valueNext = 6'h0;
+      memory_MulDivIterativePlugin_mul_counter_valueNext = 6'h00;
     end else begin
       memory_MulDivIterativePlugin_mul_counter_valueNext = (memory_MulDivIterativePlugin_mul_counter_value + _zz_memory_MulDivIterativePlugin_mul_counter_valueNext);
     end
     if(memory_MulDivIterativePlugin_mul_counter_willClear) begin
-      memory_MulDivIterativePlugin_mul_counter_valueNext = 6'h0;
+      memory_MulDivIterativePlugin_mul_counter_valueNext = 6'h00;
     end
   end
 
@@ -3907,12 +3901,12 @@ module VexRiscv (
   assign memory_MulDivIterativePlugin_div_counter_willOverflow = (memory_MulDivIterativePlugin_div_counter_willOverflowIfInc && memory_MulDivIterativePlugin_div_counter_willIncrement);
   always @(*) begin
     if(memory_MulDivIterativePlugin_div_counter_willOverflow) begin
-      memory_MulDivIterativePlugin_div_counter_valueNext = 6'h0;
+      memory_MulDivIterativePlugin_div_counter_valueNext = 6'h00;
     end else begin
       memory_MulDivIterativePlugin_div_counter_valueNext = (memory_MulDivIterativePlugin_div_counter_value + _zz_memory_MulDivIterativePlugin_div_counter_valueNext);
     end
     if(memory_MulDivIterativePlugin_div_counter_willClear) begin
-      memory_MulDivIterativePlugin_div_counter_valueNext = 6'h0;
+      memory_MulDivIterativePlugin_div_counter_valueNext = 6'h00;
     end
   end
 
@@ -3929,24 +3923,24 @@ module VexRiscv (
   assign when_MulDivIterativePlugin_l151 = (memory_MulDivIterativePlugin_div_counter_value == 6'h20);
   assign _zz_memory_MulDivIterativePlugin_div_result = (memory_INSTRUCTION[13] ? memory_MulDivIterativePlugin_accumulator[31 : 0] : memory_MulDivIterativePlugin_rs1[31 : 0]);
   assign when_MulDivIterativePlugin_l162 = (! memory_arbitration_isStuck);
-  assign _zz_memory_MulDivIterativePlugin_rs1 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
-  assign _zz_memory_MulDivIterativePlugin_rs1_1 = ((execute_IS_MUL && _zz_memory_MulDivIterativePlugin_rs1) || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
+  assign _zz_memory_MulDivIterativePlugin_rs2 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
+  assign _zz_memory_MulDivIterativePlugin_rs1 = ((execute_IS_MUL && _zz_memory_MulDivIterativePlugin_rs2) || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
   always @(*) begin
-    _zz_memory_MulDivIterativePlugin_rs1_2[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
-    _zz_memory_MulDivIterativePlugin_rs1_2[31 : 0] = execute_RS1;
+    _zz_memory_MulDivIterativePlugin_rs1_1[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
+    _zz_memory_MulDivIterativePlugin_rs1_1[31 : 0] = execute_RS1;
   end
 
-  assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
-  assign externalInterrupt = (|_zz_CsrPlugin_csrMapping_readDataInit_1);
-  assign when_DebugPlugin_l225 = (DebugPlugin_haltIt && (! DebugPlugin_isPipBusy));
+  assign _zz_externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
+  assign externalInterrupt = (|_zz_externalInterrupt);
+  assign when_DebugPlugin_l238 = (DebugPlugin_haltIt && (! DebugPlugin_isPipBusy));
   assign DebugPlugin_allowEBreak = (DebugPlugin_debugUsed && (! DebugPlugin_disableEbreak));
   always @(*) begin
     debug_bus_cmd_ready = 1'b1;
     if(debug_bus_cmd_valid) begin
-      case(switch_DebugPlugin_l267)
+      case(switch_DebugPlugin_l280)
         6'h01 : begin
           if(debug_bus_cmd_payload_wr) begin
-            debug_bus_cmd_ready = IBusCachedPlugin_injectionPort_ready;
+            debug_bus_cmd_ready = DebugPlugin_injectionPort_ready;
           end
         end
         default : begin
@@ -3957,7 +3951,7 @@ module VexRiscv (
 
   always @(*) begin
     debug_bus_rsp_data = DebugPlugin_busReadDataReg;
-    if(when_DebugPlugin_l244) begin
+    if(when_DebugPlugin_l257) begin
       debug_bus_rsp_data[0] = DebugPlugin_resetIt;
       debug_bus_rsp_data[1] = DebugPlugin_haltIt;
       debug_bus_rsp_data[2] = DebugPlugin_isPipBusy;
@@ -3966,14 +3960,14 @@ module VexRiscv (
     end
   end
 
-  assign when_DebugPlugin_l244 = (! _zz_when_DebugPlugin_l244);
+  assign when_DebugPlugin_l257 = (! _zz_when_DebugPlugin_l257);
   always @(*) begin
-    IBusCachedPlugin_injectionPort_valid = 1'b0;
+    DebugPlugin_injectionPort_valid = 1'b0;
     if(debug_bus_cmd_valid) begin
-      case(switch_DebugPlugin_l267)
+      case(switch_DebugPlugin_l280)
         6'h01 : begin
           if(debug_bus_cmd_payload_wr) begin
-            IBusCachedPlugin_injectionPort_valid = 1'b1;
+            DebugPlugin_injectionPort_valid = 1'b1;
           end
         end
         default : begin
@@ -3982,21 +3976,21 @@ module VexRiscv (
     end
   end
 
-  assign IBusCachedPlugin_injectionPort_payload = debug_bus_cmd_payload_data;
-  assign switch_DebugPlugin_l267 = debug_bus_cmd_payload_address[7 : 2];
-  assign when_DebugPlugin_l271 = debug_bus_cmd_payload_data[16];
-  assign when_DebugPlugin_l271_1 = debug_bus_cmd_payload_data[24];
-  assign when_DebugPlugin_l272 = debug_bus_cmd_payload_data[17];
-  assign when_DebugPlugin_l272_1 = debug_bus_cmd_payload_data[25];
-  assign when_DebugPlugin_l273 = debug_bus_cmd_payload_data[25];
-  assign when_DebugPlugin_l274 = debug_bus_cmd_payload_data[25];
-  assign when_DebugPlugin_l275 = debug_bus_cmd_payload_data[18];
-  assign when_DebugPlugin_l275_1 = debug_bus_cmd_payload_data[26];
-  assign when_DebugPlugin_l295 = (execute_arbitration_isValid && execute_DO_EBREAK);
-  assign when_DebugPlugin_l298 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
-  assign when_DebugPlugin_l311 = (DebugPlugin_stepIt && IBusCachedPlugin_incomingInstruction);
+  assign DebugPlugin_injectionPort_payload = debug_bus_cmd_payload_data;
+  assign switch_DebugPlugin_l280 = debug_bus_cmd_payload_address[7 : 2];
+  assign when_DebugPlugin_l284 = debug_bus_cmd_payload_data[16];
+  assign when_DebugPlugin_l284_1 = debug_bus_cmd_payload_data[24];
+  assign when_DebugPlugin_l285 = debug_bus_cmd_payload_data[17];
+  assign when_DebugPlugin_l285_1 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l286 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l287 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l288 = debug_bus_cmd_payload_data[18];
+  assign when_DebugPlugin_l288_1 = debug_bus_cmd_payload_data[26];
+  assign when_DebugPlugin_l308 = (execute_arbitration_isValid && execute_DO_EBREAK);
+  assign when_DebugPlugin_l311 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
+  assign when_DebugPlugin_l324 = (DebugPlugin_stepIt && IBusCachedPlugin_incomingInstruction);
   assign debug_resetOut = DebugPlugin_resetIt_regNext;
-  assign when_DebugPlugin_l331 = (DebugPlugin_haltIt || DebugPlugin_stepIt);
+  assign when_DebugPlugin_l344 = (DebugPlugin_haltIt || DebugPlugin_stepIt);
   assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
@@ -4102,93 +4096,103 @@ module VexRiscv (
   assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
   assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
   always @(*) begin
-    IBusCachedPlugin_injectionPort_ready = 1'b0;
-    case(switch_Fetcher_l365)
+    DebugPlugin_injectionPort_ready = 1'b0;
+    case(IBusCachedPlugin_injector_port_state)
       3'b100 : begin
-        IBusCachedPlugin_injectionPort_ready = 1'b1;
+        DebugPlugin_injectionPort_ready = 1'b1;
       end
       default : begin
       end
     endcase
   end
 
-  assign when_Fetcher_l381 = (! decode_arbitration_isStuck);
-  assign when_CsrPlugin_l1277 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_2 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_3 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_4 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_5 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_6 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_7 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_8 = (! execute_arbitration_isStuck);
-  assign switch_CsrPlugin_l723 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
+  assign when_Fetcher_l391 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l1669 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_8 = (! execute_arbitration_isStuck);
+  assign switch_CsrPlugin_l1031 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_1 = 32'h00000000;
     if(execute_CsrPlugin_csr_768) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_2[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_2[3 : 3] = CsrPlugin_mstatus_MIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_2[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_CsrPlugin_csrMapping_readDataInit_1[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_1[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_1[12 : 11] = CsrPlugin_mstatus_MPP;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h00000000;
     if(execute_CsrPlugin_csr_836) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_3[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_3[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_3[3 : 3] = CsrPlugin_mip_MSIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[3 : 3] = CsrPlugin_mip_MSIP;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h00000000;
     if(execute_CsrPlugin_csr_772) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_4[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_4[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_4[3 : 3] = CsrPlugin_mie_MSIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[3 : 3] = CsrPlugin_mie_MSIE;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h00000000;
     if(execute_CsrPlugin_csr_833) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_5[31 : 0] = CsrPlugin_mepc;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[31 : 0] = CsrPlugin_mepc;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h00000000;
     if(execute_CsrPlugin_csr_834) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_6[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_CsrPlugin_csrMapping_readDataInit_6[3 : 0] = CsrPlugin_mcause_exceptionCode;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h00000000;
     if(execute_CsrPlugin_csr_835) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_7[31 : 0] = CsrPlugin_mtval;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[31 : 0] = CsrPlugin_mtval;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h00000000;
     if(execute_CsrPlugin_csr_3008) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_8[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h00000000;
     if(execute_CsrPlugin_csr_4032) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_9[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_1;
+      _zz_CsrPlugin_csrMapping_readDataInit_8[31 : 0] = _zz_externalInterrupt;
     end
   end
 
-  assign CsrPlugin_csrMapping_readDataInit = (((_zz_CsrPlugin_csrMapping_readDataInit_2 | _zz_CsrPlugin_csrMapping_readDataInit_3) | (_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5)) | ((_zz_CsrPlugin_csrMapping_readDataInit_6 | _zz_CsrPlugin_csrMapping_readDataInit_7) | (_zz_CsrPlugin_csrMapping_readDataInit_8 | _zz_CsrPlugin_csrMapping_readDataInit_9)));
-  assign when_CsrPlugin_l1310 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign when_CsrPlugin_l1315 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign CsrPlugin_csrMapping_readDataInit = (((_zz_CsrPlugin_csrMapping_readDataInit_1 | _zz_CsrPlugin_csrMapping_readDataInit_2) | (_zz_CsrPlugin_csrMapping_readDataInit_3 | _zz_CsrPlugin_csrMapping_readDataInit_4)) | ((_zz_CsrPlugin_csrMapping_readDataInit_5 | _zz_CsrPlugin_csrMapping_readDataInit_6) | (_zz_CsrPlugin_csrMapping_readDataInit_7 | _zz_CsrPlugin_csrMapping_readDataInit_8)));
+  assign when_CsrPlugin_l1702 = ((execute_arbitration_isValid && execute_IS_CSR) && (({execute_CsrPlugin_csrAddress[11 : 2],2'b00} == 12'h3a0) || ({execute_CsrPlugin_csrAddress[11 : 4],4'b0000} == 12'h3b0)));
+  assign _zz_when_CsrPlugin_l1709 = (execute_CsrPlugin_csrAddress & 12'hf60);
+  assign when_CsrPlugin_l1709 = (((execute_arbitration_isValid && execute_IS_CSR) && (5'h03 <= execute_CsrPlugin_csrAddress[4 : 0])) && (((_zz_when_CsrPlugin_l1709 == 12'hb00) || (((_zz_when_CsrPlugin_l1709 == 12'hc00) && (! execute_CsrPlugin_writeInstruction)) && (CsrPlugin_privilege == 2'b11))) || ((execute_CsrPlugin_csrAddress & 12'hfe0) == 12'h320)));
+  always @(*) begin
+    when_CsrPlugin_l1719 = CsrPlugin_csrMapping_doForceFailCsr;
+    if(when_CsrPlugin_l1717) begin
+      when_CsrPlugin_l1719 = 1'b1;
+    end
+  end
+
+  assign when_CsrPlugin_l1717 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1725 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
   assign iBusWishbone_ADR = {_zz_iBusWishbone_ADR_1,_zz_iBusWishbone_ADR};
   assign iBusWishbone_CTI = ((_zz_iBusWishbone_ADR == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
@@ -4221,7 +4225,7 @@ module VexRiscv (
   assign dBus_cmd_halfPipe_payload_address = dBus_cmd_rData_address;
   assign dBus_cmd_halfPipe_payload_data = dBus_cmd_rData_data;
   assign dBus_cmd_halfPipe_payload_size = dBus_cmd_rData_size;
-  assign dBusWishbone_ADR = (dBus_cmd_halfPipe_payload_address >>> 2);
+  assign dBusWishbone_ADR = (dBus_cmd_halfPipe_payload_address >>> 2'd2);
   assign dBusWishbone_CTI = 3'b000;
   assign dBusWishbone_BTE = 2'b00;
   always @(*) begin
@@ -4240,12 +4244,12 @@ module VexRiscv (
 
   always @(*) begin
     dBusWishbone_SEL = (_zz_dBusWishbone_SEL <<< dBus_cmd_halfPipe_payload_address[1 : 0]);
-    if(when_DBusSimplePlugin_l189) begin
+    if(when_DBusSimplePlugin_l196) begin
       dBusWishbone_SEL = 4'b1111;
     end
   end
 
-  assign when_DBusSimplePlugin_l189 = (! dBus_cmd_halfPipe_payload_wr);
+  assign when_DBusSimplePlugin_l196 = (! dBus_cmd_halfPipe_payload_wr);
   assign dBusWishbone_WE = dBus_cmd_halfPipe_payload_wr;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_halfPipe_payload_data;
   assign dBus_cmd_halfPipe_ready = (dBus_cmd_halfPipe_valid && dBusWishbone_ACK);
@@ -4260,15 +4264,15 @@ module VexRiscv (
       IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
-      _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+      _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= 1'b0;
       _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= 32'h0;
-      _zz_7 <= 1'b1;
+      IBusCachedPlugin_rspCounter <= 32'h00000000;
+      _zz_10 <= 1'b1;
       execute_LightShifterPlugin_isActive <= 1'b0;
       HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
       CsrPlugin_mstatus_MIE <= 1'b0;
@@ -4277,8 +4281,8 @@ module VexRiscv (
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
-      CsrPlugin_mcycle <= 64'h0;
-      CsrPlugin_minstret <= 64'h0;
+      CsrPlugin_mcycle <= 64'h0000000000000000;
+      CsrPlugin_minstret <= 64'h0000000000000000;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= 1'b0;
@@ -4289,13 +4293,13 @@ module VexRiscv (
       CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
-      memory_MulDivIterativePlugin_mul_counter_value <= 6'h0;
-      memory_MulDivIterativePlugin_div_counter_value <= 6'h0;
-      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h0;
+      memory_MulDivIterativePlugin_mul_counter_value <= 6'h00;
+      memory_MulDivIterativePlugin_div_counter_value <= 6'h00;
+      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h00000000;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
-      switch_Fetcher_l365 <= 3'b000;
+      IBusCachedPlugin_injector_port_state <= 3'b000;
       _zz_iBusWishbone_ADR <= 3'b000;
       _zz_iBus_rsp_valid <= 1'b0;
       dBus_cmd_rValid <= 1'b0;
@@ -4307,23 +4311,23 @@ module VexRiscv (
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusCachedPlugin_fetchPc_booted <= 1'b1;
-      if(when_Fetcher_l134) begin
+      if(when_Fetcher_l133) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_output_fire_1) begin
+      if(IBusCachedPlugin_fetchPc_output_fire) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b1;
       end
-      if(when_Fetcher_l134_1) begin
+      if(when_Fetcher_l133_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(when_Fetcher_l161) begin
+      if(when_Fetcher_l160) begin
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
       if(IBusCachedPlugin_iBusRsp_flush) begin
-        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= 1'b0;
       end
       if(_zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready) begin
-        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
       if(IBusCachedPlugin_iBusRsp_flush) begin
         _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
@@ -4334,13 +4338,13 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if(when_Fetcher_l332) begin
+      if(when_Fetcher_l331) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(when_Fetcher_l332_1) begin
+      if(when_Fetcher_l331_1) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= IBusCachedPlugin_injector_nextPcCalc_valids_0;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -4349,7 +4353,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(when_Fetcher_l332_2) begin
+      if(when_Fetcher_l331_2) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= IBusCachedPlugin_injector_nextPcCalc_valids_1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -4358,7 +4362,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(when_Fetcher_l332_3) begin
+      if(when_Fetcher_l331_3) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -4367,7 +4371,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if(when_Fetcher_l332_4) begin
+      if(when_Fetcher_l331_4) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= IBusCachedPlugin_injector_nextPcCalc_valids_3;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -4376,7 +4380,7 @@ module VexRiscv (
       if(iBus_rsp_valid) begin
         IBusCachedPlugin_rspCounter <= (IBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      _zz_7 <= 1'b0;
+      _zz_10 <= 1'b0;
       if(when_ShiftPlugins_l169) begin
         if(when_ShiftPlugins_l175) begin
           execute_LightShifterPlugin_isActive <= 1'b1;
@@ -4393,50 +4397,50 @@ module VexRiscv (
       if(writeBack_arbitration_isFiring) begin
         CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
       end
-      if(when_CsrPlugin_l922) begin
+      if(when_CsrPlugin_l1259) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if(when_CsrPlugin_l922_1) begin
+      if(when_CsrPlugin_l1259_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if(when_CsrPlugin_l922_2) begin
+      if(when_CsrPlugin_l1259_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if(when_CsrPlugin_l922_3) begin
+      if(when_CsrPlugin_l1259_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(when_CsrPlugin_l959) begin
-        if(when_CsrPlugin_l965) begin
+      if(when_CsrPlugin_l1296) begin
+        if(when_CsrPlugin_l1302) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_1) begin
+        if(when_CsrPlugin_l1302_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_2) begin
+        if(when_CsrPlugin_l1302_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
       if(CsrPlugin_pipelineLiberator_active) begin
-        if(when_CsrPlugin_l993) begin
+        if(when_CsrPlugin_l1335) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if(when_CsrPlugin_l993_1) begin
+        if(when_CsrPlugin_l1335_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if(when_CsrPlugin_l993_2) begin
+        if(when_CsrPlugin_l1335_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(when_CsrPlugin_l998) begin
+      if(when_CsrPlugin_l1340) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
@@ -4445,19 +4449,21 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(when_CsrPlugin_l1032) begin
-        case(CsrPlugin_targetPrivilege)
-          2'b11 : begin
-            CsrPlugin_mstatus_MIE <= 1'b0;
-            CsrPlugin_mstatus_MPIE <= CsrPlugin_mstatus_MIE;
-            CsrPlugin_mstatus_MPP <= CsrPlugin_privilege;
-          end
-          default : begin
-          end
-        endcase
+      if(when_CsrPlugin_l1390) begin
+        if(when_CsrPlugin_l1398) begin
+          case(CsrPlugin_targetPrivilege)
+            2'b11 : begin
+              CsrPlugin_mstatus_MIE <= 1'b0;
+              CsrPlugin_mstatus_MPIE <= CsrPlugin_mstatus_MIE;
+              CsrPlugin_mstatus_MPP <= CsrPlugin_privilege;
+            end
+            default : begin
+            end
+          endcase
+        end
       end
-      if(when_CsrPlugin_l1077) begin
-        case(switch_CsrPlugin_l1081)
+      if(when_CsrPlugin_l1456) begin
+        case(switch_CsrPlugin_l1460)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -4467,7 +4473,7 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l965_2,{_zz_when_CsrPlugin_l965_1,_zz_when_CsrPlugin_l965}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l1302_2,{_zz_when_CsrPlugin_l1302_1,_zz_when_CsrPlugin_l1302}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_MulDivIterativePlugin_mul_counter_value <= memory_MulDivIterativePlugin_mul_counter_valueNext;
       memory_MulDivIterativePlugin_div_counter_value <= memory_MulDivIterativePlugin_div_counter_valueNext;
       if(when_Pipeline_l151) begin
@@ -4488,25 +4494,25 @@ module VexRiscv (
       if(when_Pipeline_l154_2) begin
         writeBack_arbitration_isValid <= memory_arbitration_isValid;
       end
-      case(switch_Fetcher_l365)
+      case(IBusCachedPlugin_injector_port_state)
         3'b000 : begin
-          if(IBusCachedPlugin_injectionPort_valid) begin
-            switch_Fetcher_l365 <= 3'b001;
+          if(DebugPlugin_injectionPort_valid) begin
+            IBusCachedPlugin_injector_port_state <= 3'b001;
           end
         end
         3'b001 : begin
-          switch_Fetcher_l365 <= 3'b010;
+          IBusCachedPlugin_injector_port_state <= 3'b010;
         end
         3'b010 : begin
-          switch_Fetcher_l365 <= 3'b011;
+          IBusCachedPlugin_injector_port_state <= 3'b011;
         end
         3'b011 : begin
-          if(when_Fetcher_l381) begin
-            switch_Fetcher_l365 <= 3'b100;
+          if(when_Fetcher_l391) begin
+            IBusCachedPlugin_injector_port_state <= 3'b100;
           end
         end
         3'b100 : begin
-          switch_Fetcher_l365 <= 3'b000;
+          IBusCachedPlugin_injector_port_state <= 3'b000;
         end
         default : begin
         end
@@ -4515,7 +4521,7 @@ module VexRiscv (
         if(execute_CsrPlugin_writeEnable) begin
           CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
           CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
-          case(switch_CsrPlugin_l723)
+          case(switch_CsrPlugin_l1031)
             2'b11 : begin
               CsrPlugin_mstatus_MPP <= 2'b11;
             end
@@ -4583,38 +4589,40 @@ module VexRiscv (
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3 ? DBusSimplePlugin_memoryExceptionPort_payload_code : BranchPlugin_branchExceptionPort_payload_code);
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3 ? DBusSimplePlugin_memoryExceptionPort_payload_badAddr : BranchPlugin_branchExceptionPort_payload_badAddr);
     end
-    if(when_CsrPlugin_l959) begin
-      if(when_CsrPlugin_l965) begin
+    if(when_CsrPlugin_l1296) begin
+      if(when_CsrPlugin_l1302) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l965_1) begin
+      if(when_CsrPlugin_l1302_1) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l965_2) begin
+      if(when_CsrPlugin_l1302_2) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(when_CsrPlugin_l1032) begin
-      case(CsrPlugin_targetPrivilege)
-        2'b11 : begin
-          CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
-          CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
-          CsrPlugin_mepc <= writeBack_PC;
-          if(CsrPlugin_hadException) begin
-            CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
+    if(when_CsrPlugin_l1390) begin
+      if(when_CsrPlugin_l1398) begin
+        case(CsrPlugin_targetPrivilege)
+          2'b11 : begin
+            CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
+            CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
+            CsrPlugin_mepc <= writeBack_PC;
+            if(CsrPlugin_hadException) begin
+              CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
+            end
           end
-        end
-        default : begin
-        end
-      endcase
+          default : begin
+          end
+        endcase
+      end
     end
     if(when_MulDivIterativePlugin_l96) begin
       if(when_MulDivIterativePlugin_l100) begin
         memory_MulDivIterativePlugin_rs2 <= (memory_MulDivIterativePlugin_rs2 >>> 1);
-        memory_MulDivIterativePlugin_accumulator <= ({_zz_memory_MulDivIterativePlugin_accumulator,memory_MulDivIterativePlugin_accumulator[31 : 0]} >>> 1);
+        memory_MulDivIterativePlugin_accumulator <= ({_zz_memory_MulDivIterativePlugin_accumulator,memory_MulDivIterativePlugin_accumulator[31 : 0]} >>> 1'd1);
       end
     end
     if(when_MulDivIterativePlugin_l126) begin
@@ -4633,17 +4641,17 @@ module VexRiscv (
       end
     end
     if(when_MulDivIterativePlugin_l162) begin
-      memory_MulDivIterativePlugin_accumulator <= 65'h0;
-      memory_MulDivIterativePlugin_rs1 <= ((_zz_memory_MulDivIterativePlugin_rs1_1 ? (~ _zz_memory_MulDivIterativePlugin_rs1_2) : _zz_memory_MulDivIterativePlugin_rs1_2) + _zz_memory_MulDivIterativePlugin_rs1_3);
-      memory_MulDivIterativePlugin_rs2 <= ((_zz_memory_MulDivIterativePlugin_rs1 ? (~ execute_RS2) : execute_RS2) + _zz_memory_MulDivIterativePlugin_rs2);
-      memory_MulDivIterativePlugin_div_needRevert <= ((_zz_memory_MulDivIterativePlugin_rs1_1 ^ (_zz_memory_MulDivIterativePlugin_rs1 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
+      memory_MulDivIterativePlugin_accumulator <= 65'h00000000000000000;
+      memory_MulDivIterativePlugin_rs1 <= ((_zz_memory_MulDivIterativePlugin_rs1 ? (~ _zz_memory_MulDivIterativePlugin_rs1_1) : _zz_memory_MulDivIterativePlugin_rs1_1) + _zz_memory_MulDivIterativePlugin_rs1_2);
+      memory_MulDivIterativePlugin_rs2 <= ((_zz_memory_MulDivIterativePlugin_rs2 ? (~ execute_RS2) : execute_RS2) + _zz_memory_MulDivIterativePlugin_rs2_1);
+      memory_MulDivIterativePlugin_div_needRevert <= ((_zz_memory_MulDivIterativePlugin_rs1 ^ (_zz_memory_MulDivIterativePlugin_rs2 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h00000000) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
     end
     externalInterruptArray_regNext <= externalInterruptArray;
     if(when_Pipeline_l124) begin
       decode_to_execute_PC <= decode_PC;
     end
     if(when_Pipeline_l124_1) begin
-      execute_to_memory_PC <= _zz_execute_SRC2;
+      execute_to_memory_PC <= _zz_execute_to_memory_PC;
     end
     if(when_Pipeline_l124_2) begin
       memory_to_writeBack_PC <= memory_PC;
@@ -4798,31 +4806,31 @@ module VexRiscv (
     if(when_Pipeline_l124_52) begin
       memory_to_writeBack_MEMORY_READ_DATA <= memory_MEMORY_READ_DATA;
     end
-    if(when_CsrPlugin_l1277) begin
+    if(when_CsrPlugin_l1669) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if(when_CsrPlugin_l1277_1) begin
+    if(when_CsrPlugin_l1669_1) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if(when_CsrPlugin_l1277_2) begin
+    if(when_CsrPlugin_l1669_2) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if(when_CsrPlugin_l1277_3) begin
+    if(when_CsrPlugin_l1669_3) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if(when_CsrPlugin_l1277_4) begin
+    if(when_CsrPlugin_l1669_4) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if(when_CsrPlugin_l1277_5) begin
+    if(when_CsrPlugin_l1669_5) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if(when_CsrPlugin_l1277_6) begin
+    if(when_CsrPlugin_l1669_6) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if(when_CsrPlugin_l1277_7) begin
+    if(when_CsrPlugin_l1669_7) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if(when_CsrPlugin_l1277_8) begin
+    if(when_CsrPlugin_l1669_8) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
     if(execute_CsrPlugin_csr_836) begin
@@ -4833,7 +4841,6 @@ module VexRiscv (
     if(execute_CsrPlugin_csr_773) begin
       if(execute_CsrPlugin_writeEnable) begin
         CsrPlugin_mtvec_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 2];
-        CsrPlugin_mtvec_mode <= CsrPlugin_csrMapping_writeDataSignal[1 : 0];
       end
     end
     if(execute_CsrPlugin_csr_833) begin
@@ -4860,8 +4867,8 @@ module VexRiscv (
     if(writeBack_arbitration_isValid) begin
       DebugPlugin_busReadDataReg <= _zz_decode_RS2_2;
     end
-    _zz_when_DebugPlugin_l244 <= debug_bus_cmd_payload_address[2];
-    if(when_DebugPlugin_l295) begin
+    _zz_when_DebugPlugin_l257 <= debug_bus_cmd_payload_address[2];
+    if(when_DebugPlugin_l308) begin
       DebugPlugin_busReadDataReg <= execute_PC;
     end
     DebugPlugin_resetIt_regNext <= DebugPlugin_resetIt;
@@ -4877,39 +4884,39 @@ module VexRiscv (
       DebugPlugin_debugUsed <= 1'b0;
       DebugPlugin_disableEbreak <= 1'b0;
     end else begin
-      if(when_DebugPlugin_l225) begin
+      if(when_DebugPlugin_l238) begin
         DebugPlugin_godmode <= 1'b1;
       end
       if(debug_bus_cmd_valid) begin
         DebugPlugin_debugUsed <= 1'b1;
       end
       if(debug_bus_cmd_valid) begin
-        case(switch_DebugPlugin_l267)
-          6'h0 : begin
+        case(switch_DebugPlugin_l280)
+          6'h00 : begin
             if(debug_bus_cmd_payload_wr) begin
               DebugPlugin_stepIt <= debug_bus_cmd_payload_data[4];
-              if(when_DebugPlugin_l271) begin
+              if(when_DebugPlugin_l284) begin
                 DebugPlugin_resetIt <= 1'b1;
               end
-              if(when_DebugPlugin_l271_1) begin
+              if(when_DebugPlugin_l284_1) begin
                 DebugPlugin_resetIt <= 1'b0;
               end
-              if(when_DebugPlugin_l272) begin
+              if(when_DebugPlugin_l285) begin
                 DebugPlugin_haltIt <= 1'b1;
               end
-              if(when_DebugPlugin_l272_1) begin
+              if(when_DebugPlugin_l285_1) begin
                 DebugPlugin_haltIt <= 1'b0;
               end
-              if(when_DebugPlugin_l273) begin
+              if(when_DebugPlugin_l286) begin
                 DebugPlugin_haltedByBreak <= 1'b0;
               end
-              if(when_DebugPlugin_l274) begin
+              if(when_DebugPlugin_l287) begin
                 DebugPlugin_godmode <= 1'b0;
               end
-              if(when_DebugPlugin_l275) begin
+              if(when_DebugPlugin_l288) begin
                 DebugPlugin_disableEbreak <= 1'b1;
               end
-              if(when_DebugPlugin_l275_1) begin
+              if(when_DebugPlugin_l288_1) begin
                 DebugPlugin_disableEbreak <= 1'b0;
               end
             end
@@ -4918,13 +4925,13 @@ module VexRiscv (
           end
         endcase
       end
-      if(when_DebugPlugin_l295) begin
-        if(when_DebugPlugin_l298) begin
+      if(when_DebugPlugin_l308) begin
+        if(when_DebugPlugin_l311) begin
           DebugPlugin_haltIt <= 1'b1;
           DebugPlugin_haltedByBreak <= 1'b1;
         end
       end
-      if(when_DebugPlugin_l311) begin
+      if(when_DebugPlugin_l324) begin
         if(decode_arbitration_isValid) begin
           DebugPlugin_haltIt <= 1'b1;
         end
@@ -4936,48 +4943,48 @@ module VexRiscv (
 endmodule
 
 module InstructionCache (
-  input               io_flush,
-  input               io_cpu_prefetch_isValid,
-  output reg          io_cpu_prefetch_haltIt,
-  input      [31:0]   io_cpu_prefetch_pc,
-  input               io_cpu_fetch_isValid,
-  input               io_cpu_fetch_isStuck,
-  input               io_cpu_fetch_isRemoved,
-  input      [31:0]   io_cpu_fetch_pc,
-  output     [31:0]   io_cpu_fetch_data,
-  input      [31:0]   io_cpu_fetch_mmuRsp_physicalAddress,
-  input               io_cpu_fetch_mmuRsp_isIoAccess,
-  input               io_cpu_fetch_mmuRsp_isPaging,
-  input               io_cpu_fetch_mmuRsp_allowRead,
-  input               io_cpu_fetch_mmuRsp_allowWrite,
-  input               io_cpu_fetch_mmuRsp_allowExecute,
-  input               io_cpu_fetch_mmuRsp_exception,
-  input               io_cpu_fetch_mmuRsp_refilling,
-  input               io_cpu_fetch_mmuRsp_bypassTranslation,
-  output     [31:0]   io_cpu_fetch_physicalAddress,
-  input               io_cpu_decode_isValid,
-  input               io_cpu_decode_isStuck,
-  input      [31:0]   io_cpu_decode_pc,
-  output     [31:0]   io_cpu_decode_physicalAddress,
-  output     [31:0]   io_cpu_decode_data,
-  output              io_cpu_decode_cacheMiss,
-  output              io_cpu_decode_error,
-  output              io_cpu_decode_mmuRefilling,
-  output              io_cpu_decode_mmuException,
-  input               io_cpu_decode_isUser,
-  input               io_cpu_fill_valid,
-  input      [31:0]   io_cpu_fill_payload,
-  output              io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output     [31:0]   io_mem_cmd_payload_address,
-  output     [2:0]    io_mem_cmd_payload_size,
-  input               io_mem_rsp_valid,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input      [2:0]    _zz_when_Fetcher_l401,
-  input      [31:0]   _zz_io_cpu_fetch_data_regNextWhen,
-  input               clk,
-  input               reset
+  input  wire          io_flush,
+  input  wire          io_cpu_prefetch_isValid,
+  output reg           io_cpu_prefetch_haltIt,
+  input  wire [31:0]   io_cpu_prefetch_pc,
+  input  wire          io_cpu_fetch_isValid,
+  input  wire          io_cpu_fetch_isStuck,
+  input  wire          io_cpu_fetch_isRemoved,
+  input  wire [31:0]   io_cpu_fetch_pc,
+  output wire [31:0]   io_cpu_fetch_data,
+  input  wire [31:0]   io_cpu_fetch_mmuRsp_physicalAddress,
+  input  wire          io_cpu_fetch_mmuRsp_isIoAccess,
+  input  wire          io_cpu_fetch_mmuRsp_isPaging,
+  input  wire          io_cpu_fetch_mmuRsp_allowRead,
+  input  wire          io_cpu_fetch_mmuRsp_allowWrite,
+  input  wire          io_cpu_fetch_mmuRsp_allowExecute,
+  input  wire          io_cpu_fetch_mmuRsp_exception,
+  input  wire          io_cpu_fetch_mmuRsp_refilling,
+  input  wire          io_cpu_fetch_mmuRsp_bypassTranslation,
+  output wire [31:0]   io_cpu_fetch_physicalAddress,
+  input  wire          io_cpu_decode_isValid,
+  input  wire          io_cpu_decode_isStuck,
+  input  wire [31:0]   io_cpu_decode_pc,
+  output wire [31:0]   io_cpu_decode_physicalAddress,
+  output wire [31:0]   io_cpu_decode_data,
+  output wire          io_cpu_decode_cacheMiss,
+  output wire          io_cpu_decode_error,
+  output wire          io_cpu_decode_mmuRefilling,
+  output wire          io_cpu_decode_mmuException,
+  input  wire          io_cpu_decode_isUser,
+  input  wire          io_cpu_fill_valid,
+  input  wire [31:0]   io_cpu_fill_payload,
+  output wire          io_mem_cmd_valid,
+  input  wire          io_mem_cmd_ready,
+  output wire [31:0]   io_mem_cmd_payload_address,
+  output wire [2:0]    io_mem_cmd_payload_size,
+  input  wire          io_mem_rsp_valid,
+  input  wire [31:0]   io_mem_rsp_payload_data,
+  input  wire          io_mem_rsp_payload_error,
+  input  wire [2:0]    _zz_when_Fetcher_l411,
+  input  wire [31:0]   _zz_io_cpu_fetch_data_regNextWhen,
+  input  wire          clk,
+  input  wire          reset
 );
 
   reg        [31:0]   _zz_banks_0_port1;
@@ -4997,7 +5004,7 @@ module InstructionCache (
   wire                when_InstructionCache_l351;
   reg                 lineLoader_cmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_Utils_l515;
+  wire                when_Utils_l560;
   reg                 lineLoader_wayToAllocate_willIncrement;
   wire                lineLoader_wayToAllocate_willClear;
   wire                lineLoader_wayToAllocate_willOverflowIfInc;
@@ -5043,7 +5050,7 @@ module InstructionCache (
   reg                 decodeStage_hit_valid;
   wire                when_InstructionCache_l459_2;
   reg                 decodeStage_hit_error;
-  wire                when_Fetcher_l401;
+  wire                when_Fetcher_l411;
   (* no_rw_check , ram_style = "block" *) reg [31:0] banks_0 [0:511];
   (* no_rw_check , ram_style = "block" *) reg [22:0] ways_0_tags [0:63];
 
@@ -5113,12 +5120,12 @@ module InstructionCache (
   assign when_InstructionCache_l351 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
   assign io_mem_cmd_fire = (io_mem_cmd_valid && io_mem_cmd_ready);
   assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
-  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
+  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h00};
   assign io_mem_cmd_payload_size = 3'b101;
-  assign when_Utils_l515 = (! lineLoader_valid);
+  assign when_Utils_l560 = (! lineLoader_valid);
   always @(*) begin
     lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if(when_Utils_l515) begin
+    if(when_Utils_l560) begin
       lineLoader_wayToAllocate_willIncrement = 1'b1;
     end
   end
@@ -5162,7 +5169,7 @@ module InstructionCache (
   assign io_cpu_decode_mmuRefilling = decodeStage_mmuRsp_refilling;
   assign io_cpu_decode_mmuException = (((! decodeStage_mmuRsp_refilling) && decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute)));
   assign io_cpu_decode_physicalAddress = decodeStage_mmuRsp_physicalAddress;
-  assign when_Fetcher_l401 = (_zz_when_Fetcher_l401 != 3'b000);
+  assign when_Fetcher_l411 = (_zz_when_Fetcher_l411 != 3'b000);
   always @(posedge clk) begin
     if(reset) begin
       lineLoader_valid <= 1'b0;
@@ -5210,7 +5217,7 @@ module InstructionCache (
     end
     _zz_when_InstructionCache_l342 <= lineLoader_flushCounter[6];
     if(when_InstructionCache_l351) begin
-      lineLoader_flushCounter <= 7'h0;
+      lineLoader_flushCounter <= 7'h00;
     end
     if(when_InstructionCache_l435) begin
       io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;
@@ -5232,7 +5239,7 @@ module InstructionCache (
     if(when_InstructionCache_l459_2) begin
       decodeStage_hit_error <= fetchStage_hit_error;
     end
-    if(when_Fetcher_l401) begin
+    if(when_Fetcher_l411) begin
       io_cpu_fetch_data_regNextWhen <= _zz_io_cpu_fetch_data_regNextWhen;
     end
   end

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_LiteDebugHwBP.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_LiteDebugHwBP.v
@@ -1,46 +1,46 @@
-// Generator : SpinalHDL v1.7.1    git head : 0444bb76ab1d6e19f0ec46bc03c4769776deb7d5
+// Generator : SpinalHDL v1.9.4    git head : 270018552577f3bb8e5339ee2583c9c22d324215
 // Component : VexRiscv
-// Git hash  : 581fcb065adf7ea8b626f939ff51679d4c95872f
+// Git hash  : 63430af99f84cc1d11d58b556debe1cc3f238c67
 
 `timescale 1ns/1ps
 
 module VexRiscv (
-  input      [31:0]   externalResetVector,
-  input               timerInterrupt,
-  input               softwareInterrupt,
-  input      [31:0]   externalInterruptArray,
-  input               debug_bus_cmd_valid,
-  output reg          debug_bus_cmd_ready,
-  input               debug_bus_cmd_payload_wr,
-  input      [7:0]    debug_bus_cmd_payload_address,
-  input      [31:0]   debug_bus_cmd_payload_data,
-  output reg [31:0]   debug_bus_rsp_data,
-  output              debug_resetOut,
-  output reg          iBusWishbone_CYC,
-  output reg          iBusWishbone_STB,
-  input               iBusWishbone_ACK,
-  output              iBusWishbone_WE,
-  output     [29:0]   iBusWishbone_ADR,
-  input      [31:0]   iBusWishbone_DAT_MISO,
-  output     [31:0]   iBusWishbone_DAT_MOSI,
-  output     [3:0]    iBusWishbone_SEL,
-  input               iBusWishbone_ERR,
-  output     [2:0]    iBusWishbone_CTI,
-  output     [1:0]    iBusWishbone_BTE,
-  output              dBusWishbone_CYC,
-  output              dBusWishbone_STB,
-  input               dBusWishbone_ACK,
-  output              dBusWishbone_WE,
-  output     [29:0]   dBusWishbone_ADR,
-  input      [31:0]   dBusWishbone_DAT_MISO,
-  output     [31:0]   dBusWishbone_DAT_MOSI,
-  output reg [3:0]    dBusWishbone_SEL,
-  input               dBusWishbone_ERR,
-  output     [2:0]    dBusWishbone_CTI,
-  output     [1:0]    dBusWishbone_BTE,
-  input               clk,
-  input               reset,
-  input               debugReset
+  input  wire [31:0]   externalResetVector,
+  input  wire          timerInterrupt,
+  input  wire          softwareInterrupt,
+  input  wire [31:0]   externalInterruptArray,
+  input  wire          debug_bus_cmd_valid,
+  output reg           debug_bus_cmd_ready,
+  input  wire          debug_bus_cmd_payload_wr,
+  input  wire [7:0]    debug_bus_cmd_payload_address,
+  input  wire [31:0]   debug_bus_cmd_payload_data,
+  output reg  [31:0]   debug_bus_rsp_data,
+  output wire          debug_resetOut,
+  output reg           iBusWishbone_CYC,
+  output reg           iBusWishbone_STB,
+  input  wire          iBusWishbone_ACK,
+  output wire          iBusWishbone_WE,
+  output wire [29:0]   iBusWishbone_ADR,
+  input  wire [31:0]   iBusWishbone_DAT_MISO,
+  output wire [31:0]   iBusWishbone_DAT_MOSI,
+  output wire [3:0]    iBusWishbone_SEL,
+  input  wire          iBusWishbone_ERR,
+  output wire [2:0]    iBusWishbone_CTI,
+  output wire [1:0]    iBusWishbone_BTE,
+  output wire          dBusWishbone_CYC,
+  output wire          dBusWishbone_STB,
+  input  wire          dBusWishbone_ACK,
+  output wire          dBusWishbone_WE,
+  output wire [29:0]   dBusWishbone_ADR,
+  input  wire [31:0]   dBusWishbone_DAT_MISO,
+  output wire [31:0]   dBusWishbone_DAT_MOSI,
+  output reg  [3:0]    dBusWishbone_SEL,
+  input  wire          dBusWishbone_ERR,
+  output wire [2:0]    dBusWishbone_CTI,
+  output wire [1:0]    dBusWishbone_BTE,
+  input  wire          clk,
+  input  wire          reset,
+  input  wire          debugReset
 );
   localparam EnvCtrlEnum_NONE = 2'd0;
   localparam EnvCtrlEnum_XRET = 2'd1;
@@ -98,19 +98,18 @@ module VexRiscv (
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_2;
   wire                _zz_decode_LEGAL_INSTRUCTION_3;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_4;
-  wire       [12:0]   _zz_decode_LEGAL_INSTRUCTION_5;
+  wire       [11:0]   _zz_decode_LEGAL_INSTRUCTION_5;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_6;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_7;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_8;
   wire                _zz_decode_LEGAL_INSTRUCTION_9;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_10;
-  wire       [6:0]    _zz_decode_LEGAL_INSTRUCTION_11;
+  wire       [5:0]    _zz_decode_LEGAL_INSTRUCTION_11;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_12;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_13;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_14;
   wire                _zz_decode_LEGAL_INSTRUCTION_15;
-  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_16;
-  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_17;
+  wire                _zz_decode_LEGAL_INSTRUCTION_16;
   wire       [2:0]    _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1;
   reg        [31:0]   _zz_IBusCachedPlugin_jump_pcLoad_payload_4;
   wire       [1:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_5;
@@ -139,120 +138,108 @@ module VexRiscv (
   wire       [31:0]   _zz__zz_decode_IS_DIV_8;
   wire       [24:0]   _zz__zz_decode_IS_DIV_9;
   wire       [0:0]    _zz__zz_decode_IS_DIV_10;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_11;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_12;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_11;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_12;
   wire       [31:0]   _zz__zz_decode_IS_DIV_13;
-  wire       [1:0]    _zz__zz_decode_IS_DIV_14;
+  wire                _zz__zz_decode_IS_DIV_14;
   wire       [31:0]   _zz__zz_decode_IS_DIV_15;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_16;
-  wire                _zz__zz_decode_IS_DIV_17;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_16;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_17;
   wire       [31:0]   _zz__zz_decode_IS_DIV_18;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_19;
+  wire       [20:0]   _zz__zz_decode_IS_DIV_19;
   wire       [0:0]    _zz__zz_decode_IS_DIV_20;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_21;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_22;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_23;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_24;
-  wire       [20:0]   _zz__zz_decode_IS_DIV_25;
-  wire       [2:0]    _zz__zz_decode_IS_DIV_26;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_21;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_22;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_23;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_24;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_25;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_26;
   wire       [31:0]   _zz__zz_decode_IS_DIV_27;
   wire       [31:0]   _zz__zz_decode_IS_DIV_28;
   wire                _zz__zz_decode_IS_DIV_29;
-  wire                _zz__zz_decode_IS_DIV_30;
-  wire                _zz__zz_decode_IS_DIV_31;
-  wire                _zz__zz_decode_IS_DIV_32;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_33;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_34;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_35;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_30;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_31;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_32;
+  wire       [16:0]   _zz__zz_decode_IS_DIV_33;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_34;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_35;
   wire       [31:0]   _zz__zz_decode_IS_DIV_36;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_37;
-  wire                _zz__zz_decode_IS_DIV_38;
-  wire       [17:0]   _zz__zz_decode_IS_DIV_39;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_40;
-  wire                _zz__zz_decode_IS_DIV_41;
-  wire                _zz__zz_decode_IS_DIV_42;
+  wire                _zz__zz_decode_IS_DIV_37;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_38;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_39;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_40;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_41;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_42;
   wire                _zz__zz_decode_IS_DIV_43;
   wire       [0:0]    _zz__zz_decode_IS_DIV_44;
   wire       [0:0]    _zz__zz_decode_IS_DIV_45;
   wire       [31:0]   _zz__zz_decode_IS_DIV_46;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_47;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_48;
-  wire       [14:0]   _zz__zz_decode_IS_DIV_49;
-  wire       [2:0]    _zz__zz_decode_IS_DIV_50;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_51;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_52;
-  wire                _zz__zz_decode_IS_DIV_53;
-  wire                _zz__zz_decode_IS_DIV_54;
+  wire       [13:0]   _zz__zz_decode_IS_DIV_47;
+  wire                _zz__zz_decode_IS_DIV_48;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_49;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_50;
+  wire                _zz__zz_decode_IS_DIV_51;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_52;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_53;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_54;
   wire       [31:0]   _zz__zz_decode_IS_DIV_55;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_56;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_56;
   wire       [0:0]    _zz__zz_decode_IS_DIV_57;
-  wire                _zz__zz_decode_IS_DIV_58;
-  wire       [11:0]   _zz__zz_decode_IS_DIV_59;
-  wire       [2:0]    _zz__zz_decode_IS_DIV_60;
+  wire       [4:0]    _zz__zz_decode_IS_DIV_58;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_59;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_60;
   wire                _zz__zz_decode_IS_DIV_61;
   wire       [31:0]   _zz__zz_decode_IS_DIV_62;
-  wire                _zz__zz_decode_IS_DIV_63;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_63;
   wire       [31:0]   _zz__zz_decode_IS_DIV_64;
-  wire                _zz__zz_decode_IS_DIV_65;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_66;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_67;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_68;
-  wire       [3:0]    _zz__zz_decode_IS_DIV_69;
-  wire                _zz__zz_decode_IS_DIV_70;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_65;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_66;
+  wire                _zz__zz_decode_IS_DIV_67;
+  wire                _zz__zz_decode_IS_DIV_68;
+  wire       [9:0]    _zz__zz_decode_IS_DIV_69;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_70;
   wire       [31:0]   _zz__zz_decode_IS_DIV_71;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_72;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_73;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_74;
-  wire       [1:0]    _zz__zz_decode_IS_DIV_75;
-  wire                _zz__zz_decode_IS_DIV_76;
-  wire                _zz__zz_decode_IS_DIV_77;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_78;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_79;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_72;
+  wire                _zz__zz_decode_IS_DIV_73;
+  wire                _zz__zz_decode_IS_DIV_74;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_75;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_76;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_77;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_78;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_79;
   wire       [0:0]    _zz__zz_decode_IS_DIV_80;
   wire       [31:0]   _zz__zz_decode_IS_DIV_81;
   wire       [31:0]   _zz__zz_decode_IS_DIV_82;
-  wire       [8:0]    _zz__zz_decode_IS_DIV_83;
-  wire       [1:0]    _zz__zz_decode_IS_DIV_84;
-  wire                _zz__zz_decode_IS_DIV_85;
+  wire       [6:0]    _zz__zz_decode_IS_DIV_83;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_84;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_85;
   wire       [31:0]   _zz__zz_decode_IS_DIV_86;
   wire                _zz__zz_decode_IS_DIV_87;
   wire       [0:0]    _zz__zz_decode_IS_DIV_88;
   wire       [31:0]   _zz__zz_decode_IS_DIV_89;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_90;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_91;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_92;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_93;
+  wire       [2:0]    _zz__zz_decode_IS_DIV_90;
+  wire                _zz__zz_decode_IS_DIV_91;
+  wire                _zz__zz_decode_IS_DIV_92;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_93;
   wire       [0:0]    _zz__zz_decode_IS_DIV_94;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_95;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_96;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_97;
-  wire       [5:0]    _zz__zz_decode_IS_DIV_98;
-  wire                _zz__zz_decode_IS_DIV_99;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_100;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_101;
-  wire       [2:0]    _zz__zz_decode_IS_DIV_102;
-  wire                _zz__zz_decode_IS_DIV_103;
-  wire                _zz__zz_decode_IS_DIV_104;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_105;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_95;
+  wire       [3:0]    _zz__zz_decode_IS_DIV_96;
+  wire                _zz__zz_decode_IS_DIV_97;
+  wire                _zz__zz_decode_IS_DIV_98;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_99;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_100;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_101;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_102;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_103;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_104;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_105;
   wire       [0:0]    _zz__zz_decode_IS_DIV_106;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_107;
-  wire       [3:0]    _zz__zz_decode_IS_DIV_108;
-  wire                _zz__zz_decode_IS_DIV_109;
-  wire                _zz__zz_decode_IS_DIV_110;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_107;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_108;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_109;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_110;
   wire       [0:0]    _zz__zz_decode_IS_DIV_111;
   wire       [31:0]   _zz__zz_decode_IS_DIV_112;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_113;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_114;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_115;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_116;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_117;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_118;
-  wire       [1:0]    _zz__zz_decode_IS_DIV_119;
-  wire       [1:0]    _zz__zz_decode_IS_DIV_120;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_121;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_122;
-  wire       [0:0]    _zz__zz_decode_IS_DIV_123;
-  wire       [31:0]   _zz__zz_decode_IS_DIV_124;
   wire                _zz_RegFilePlugin_regFile_port;
   wire                _zz_decode_RegFilePlugin_rs1Data;
   wire                _zz_RegFilePlugin_regFile_port_1;
@@ -260,14 +247,12 @@ module VexRiscv (
   wire       [0:0]    _zz__zz_execute_REGFILE_WRITE_DATA;
   wire       [2:0]    _zz__zz_execute_SRC1;
   wire       [4:0]    _zz__zz_execute_SRC1_1;
-  wire       [11:0]   _zz__zz_execute_SRC2_3;
+  wire       [11:0]   _zz__zz_execute_SRC2_2;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_1;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_2;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_3;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_4;
-  wire       [31:0]   _zz_execute_SrcPlugin_addSub_5;
-  wire       [31:0]   _zz_execute_SrcPlugin_addSub_6;
   wire       [31:0]   _zz__zz_decode_RS2_3;
   wire       [32:0]   _zz__zz_decode_RS2_3_1;
   wire       [19:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_2;
@@ -306,10 +291,10 @@ module VexRiscv (
   wire       [32:0]   _zz_memory_MulDivIterativePlugin_div_result_3;
   wire       [32:0]   _zz_memory_MulDivIterativePlugin_div_result_4;
   wire       [0:0]    _zz_memory_MulDivIterativePlugin_div_result_5;
-  wire       [32:0]   _zz_memory_MulDivIterativePlugin_rs1_3;
-  wire       [0:0]    _zz_memory_MulDivIterativePlugin_rs1_4;
-  wire       [31:0]   _zz_memory_MulDivIterativePlugin_rs2;
-  wire       [0:0]    _zz_memory_MulDivIterativePlugin_rs2_1;
+  wire       [32:0]   _zz_memory_MulDivIterativePlugin_rs1_2;
+  wire       [0:0]    _zz_memory_MulDivIterativePlugin_rs1_3;
+  wire       [31:0]   _zz_memory_MulDivIterativePlugin_rs2_1;
+  wire       [0:0]    _zz_memory_MulDivIterativePlugin_rs2_2;
   wire       [26:0]   _zz_iBusWishbone_ADR_1;
   wire       [31:0]   memory_MEMORY_READ_DATA;
   wire       [31:0]   execute_BRANCH_CALC;
@@ -411,7 +396,7 @@ module VexRiscv (
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_execute_SRC2;
+  wire       [31:0]   _zz_execute_to_memory_PC;
   wire       [1:0]    execute_SRC2_CTRL;
   wire       [1:0]    _zz_execute_SRC2_CTRL;
   wire       [1:0]    execute_SRC1_CTRL;
@@ -558,8 +543,9 @@ module VexRiscv (
   wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
   wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
   wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
-  wire                CsrPlugin_csrMapping_allowCsrSignal;
+  reg                 CsrPlugin_csrMapping_allowCsrSignal;
   wire                CsrPlugin_csrMapping_hazardFree;
+  wire                CsrPlugin_csrMapping_doForceFailCsr;
   wire                CsrPlugin_inWfi /* verilator public */ ;
   reg                 CsrPlugin_thirdPartyWake;
   reg                 CsrPlugin_jumpInterface_valid;
@@ -578,9 +564,10 @@ module VexRiscv (
   reg                 CsrPlugin_allowInterrupts;
   reg                 CsrPlugin_allowException;
   reg                 CsrPlugin_allowEbreakException;
-  reg                 IBusCachedPlugin_injectionPort_valid;
-  reg                 IBusCachedPlugin_injectionPort_ready;
-  wire       [31:0]   IBusCachedPlugin_injectionPort_payload;
+  wire                CsrPlugin_xretAwayFromMachine;
+  reg                 DebugPlugin_injectionPort_valid;
+  reg                 DebugPlugin_injectionPort_ready;
+  wire       [31:0]   DebugPlugin_injectionPort_payload;
   wire                IBusCachedPlugin_externalFlush;
   wire                IBusCachedPlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
@@ -599,14 +586,13 @@ module VexRiscv (
   reg                 IBusCachedPlugin_fetchPc_pcRegPropagate;
   reg                 IBusCachedPlugin_fetchPc_booted;
   reg                 IBusCachedPlugin_fetchPc_inc;
-  wire                when_Fetcher_l134;
-  wire                IBusCachedPlugin_fetchPc_output_fire_1;
-  wire                when_Fetcher_l134_1;
+  wire                when_Fetcher_l133;
+  wire                when_Fetcher_l133_1;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pc;
   wire                IBusCachedPlugin_fetchPc_redo_valid;
   wire       [31:0]   IBusCachedPlugin_fetchPc_redo_payload;
   reg                 IBusCachedPlugin_fetchPc_flushed;
-  wire                when_Fetcher_l161;
+  wire                when_Fetcher_l160;
   reg                 IBusCachedPlugin_iBusRsp_redoFetch;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_ready;
@@ -634,8 +620,8 @@ module VexRiscv (
   wire                _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready;
   wire                IBusCachedPlugin_iBusRsp_flush;
   wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
-  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
-  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid;
+  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1;
   wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
@@ -648,18 +634,18 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_output_payload_rsp_error;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   wire                IBusCachedPlugin_iBusRsp_output_payload_isRvc;
-  wire                when_Fetcher_l243;
-  wire                when_Fetcher_l323;
+  wire                when_Fetcher_l242;
+  wire                when_Fetcher_l322;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
-  wire                when_Fetcher_l332;
+  wire                when_Fetcher_l331;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
-  wire                when_Fetcher_l332_1;
+  wire                when_Fetcher_l331_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
-  wire                when_Fetcher_l332_2;
+  wire                when_Fetcher_l331_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
-  wire                when_Fetcher_l332_3;
+  wire                when_Fetcher_l331_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                when_Fetcher_l332_4;
+  wire                when_Fetcher_l331_4;
   wire                _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   reg        [18:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1;
   wire                _zz_2;
@@ -685,11 +671,11 @@ module VexRiscv (
   wire                IBusCachedPlugin_rsp_iBusRspOutputHalt;
   wire                IBusCachedPlugin_rsp_issueDetected;
   reg                 IBusCachedPlugin_rsp_redoFetch;
-  wire                when_IBusCachedPlugin_l239;
-  wire                when_IBusCachedPlugin_l244;
+  wire                when_IBusCachedPlugin_l245;
   wire                when_IBusCachedPlugin_l250;
   wire                when_IBusCachedPlugin_l256;
-  wire                when_IBusCachedPlugin_l267;
+  wire                when_IBusCachedPlugin_l262;
+  wire                when_IBusCachedPlugin_l273;
   wire                dBus_cmd_valid;
   wire                dBus_cmd_ready;
   wire                dBus_cmd_payload_wr;
@@ -702,20 +688,20 @@ module VexRiscv (
   wire                _zz_dBus_cmd_valid;
   reg                 execute_DBusSimplePlugin_skipCmd;
   reg        [31:0]   _zz_dBus_cmd_payload_data;
-  wire                when_DBusSimplePlugin_l428;
+  wire                when_DBusSimplePlugin_l436;
   reg        [3:0]    _zz_execute_DBusSimplePlugin_formalMask;
   wire       [3:0]    execute_DBusSimplePlugin_formalMask;
-  wire                when_DBusSimplePlugin_l482;
-  wire                when_DBusSimplePlugin_l489;
-  wire                when_DBusSimplePlugin_l515;
+  wire                when_DBusSimplePlugin_l490;
+  wire                when_DBusSimplePlugin_l497;
+  wire                when_DBusSimplePlugin_l523;
   reg        [31:0]   writeBack_DBusSimplePlugin_rspShifted;
-  wire       [1:0]    switch_Misc_l210;
+  wire       [1:0]    switch_Misc_l232;
   wire                _zz_writeBack_DBusSimplePlugin_rspFormated;
   reg        [31:0]   _zz_writeBack_DBusSimplePlugin_rspFormated_1;
   wire                _zz_writeBack_DBusSimplePlugin_rspFormated_2;
   reg        [31:0]   _zz_writeBack_DBusSimplePlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusSimplePlugin_rspFormated;
-  wire                when_DBusSimplePlugin_l558;
+  wire                when_DBusSimplePlugin_l566;
   wire       [31:0]   _zz_decode_IS_DIV;
   wire                _zz_decode_IS_DIV_1;
   wire                _zz_decode_IS_DIV_2;
@@ -739,15 +725,15 @@ module VexRiscv (
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
   reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
   reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_7;
+  reg                 _zz_10;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
   reg        [31:0]   _zz_execute_REGFILE_WRITE_DATA;
   reg        [31:0]   _zz_execute_SRC1;
-  wire                _zz_execute_SRC2_1;
-  reg        [19:0]   _zz_execute_SRC2_2;
-  wire                _zz_execute_SRC2_3;
-  reg        [19:0]   _zz_execute_SRC2_4;
-  reg        [31:0]   _zz_execute_SRC2_5;
+  wire                _zz_execute_SRC2;
+  reg        [19:0]   _zz_execute_SRC2_1;
+  wire                _zz_execute_SRC2_2;
+  reg        [19:0]   _zz_execute_SRC2_3;
+  reg        [31:0]   _zz_execute_SRC2_4;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   reg                 execute_LightShifterPlugin_isActive;
@@ -790,7 +776,7 @@ module VexRiscv (
   wire                when_HazardSimplePlugin_l108;
   wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    switch_Misc_l210_1;
+  wire       [2:0]    switch_Misc_l232_1;
   reg                 _zz_execute_BRANCH_COND_RESULT;
   reg                 _zz_execute_BRANCH_COND_RESULT_1;
   wire                _zz_execute_BranchPlugin_missAlignedTarget;
@@ -829,9 +815,9 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_mtval;
   reg        [63:0]   CsrPlugin_mcycle;
   reg        [63:0]   CsrPlugin_minstret;
-  wire                _zz_when_CsrPlugin_l965;
-  wire                _zz_when_CsrPlugin_l965_1;
-  wire                _zz_when_CsrPlugin_l965_2;
+  wire                _zz_when_CsrPlugin_l1302;
+  wire                _zz_when_CsrPlugin_l1302_1;
+  wire                _zz_when_CsrPlugin_l1302_2;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -848,56 +834,59 @@ module VexRiscv (
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
   wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_2;
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3;
-  wire                when_CsrPlugin_l922;
-  wire                when_CsrPlugin_l922_1;
-  wire                when_CsrPlugin_l922_2;
-  wire                when_CsrPlugin_l922_3;
-  wire                when_CsrPlugin_l935;
+  wire                when_CsrPlugin_l1259;
+  wire                when_CsrPlugin_l1259_1;
+  wire                when_CsrPlugin_l1259_2;
+  wire                when_CsrPlugin_l1259_3;
+  wire                when_CsrPlugin_l1272;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
-  wire                when_CsrPlugin_l959;
-  wire                when_CsrPlugin_l965;
-  wire                when_CsrPlugin_l965_1;
-  wire                when_CsrPlugin_l965_2;
+  wire                when_CsrPlugin_l1296;
+  wire                when_CsrPlugin_l1302;
+  wire                when_CsrPlugin_l1302_1;
+  wire                when_CsrPlugin_l1302_2;
   wire                CsrPlugin_exception;
   wire                CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
-  wire                when_CsrPlugin_l993;
-  wire                when_CsrPlugin_l993_1;
-  wire                when_CsrPlugin_l993_2;
-  wire                when_CsrPlugin_l998;
+  wire                when_CsrPlugin_l1335;
+  wire                when_CsrPlugin_l1335_1;
+  wire                when_CsrPlugin_l1335_2;
+  wire                when_CsrPlugin_l1340;
   reg                 CsrPlugin_pipelineLiberator_done;
-  wire                when_CsrPlugin_l1004;
+  wire                when_CsrPlugin_l1346;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
+  wire                CsrPlugin_trapCauseEbreakDebug;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
-  wire                when_CsrPlugin_l1032;
-  wire                when_CsrPlugin_l1077;
-  wire       [1:0]    switch_CsrPlugin_l1081;
+  wire                CsrPlugin_trapEnterDebug;
+  wire                when_CsrPlugin_l1390;
+  wire                when_CsrPlugin_l1398;
+  wire                when_CsrPlugin_l1456;
+  wire       [1:0]    switch_CsrPlugin_l1460;
   reg                 execute_CsrPlugin_wfiWake;
-  wire                when_CsrPlugin_l1129;
+  wire                when_CsrPlugin_l1527;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire                when_CsrPlugin_l1149;
-  wire                when_CsrPlugin_l1150;
-  wire                when_CsrPlugin_l1157;
+  wire                when_CsrPlugin_l1547;
+  wire                when_CsrPlugin_l1548;
+  wire                when_CsrPlugin_l1555;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   wire       [31:0]   execute_CsrPlugin_readToWriteData;
-  wire                switch_Misc_l210_2;
+  wire                switch_Misc_l232_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
-  wire                when_CsrPlugin_l1189;
-  wire                when_CsrPlugin_l1193;
+  wire                when_CsrPlugin_l1587;
+  wire                when_CsrPlugin_l1591;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg        [32:0]   memory_MulDivIterativePlugin_rs1;
   reg        [31:0]   memory_MulDivIterativePlugin_rs2;
@@ -935,12 +924,12 @@ module VexRiscv (
   wire                when_MulDivIterativePlugin_l151;
   wire       [31:0]   _zz_memory_MulDivIterativePlugin_div_result;
   wire                when_MulDivIterativePlugin_l162;
+  wire                _zz_memory_MulDivIterativePlugin_rs2;
   wire                _zz_memory_MulDivIterativePlugin_rs1;
-  wire                _zz_memory_MulDivIterativePlugin_rs1_1;
-  reg        [32:0]   _zz_memory_MulDivIterativePlugin_rs1_2;
+  reg        [32:0]   _zz_memory_MulDivIterativePlugin_rs1_1;
   reg        [31:0]   externalInterruptArray_regNext;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit;
-  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
+  wire       [31:0]   _zz_externalInterrupt;
   reg                 DebugPlugin_firstCycle;
   reg                 DebugPlugin_secondCycle;
   reg                 DebugPlugin_resetIt;
@@ -948,7 +937,7 @@ module VexRiscv (
   reg                 DebugPlugin_stepIt;
   reg                 DebugPlugin_isPipBusy;
   reg                 DebugPlugin_godmode;
-  wire                when_DebugPlugin_l225;
+  wire                when_DebugPlugin_l238;
   reg                 DebugPlugin_haltedByBreak;
   reg                 DebugPlugin_debugUsed /* verilator public */ ;
   reg                 DebugPlugin_disableEbreak;
@@ -958,22 +947,22 @@ module VexRiscv (
   reg                 DebugPlugin_hardwareBreakpoints_1_valid;
   reg        [30:0]   DebugPlugin_hardwareBreakpoints_1_pc;
   reg        [31:0]   DebugPlugin_busReadDataReg;
-  reg                 _zz_when_DebugPlugin_l244;
-  wire                when_DebugPlugin_l244;
-  wire       [5:0]    switch_DebugPlugin_l267;
-  wire                when_DebugPlugin_l271;
-  wire                when_DebugPlugin_l271_1;
-  wire                when_DebugPlugin_l272;
-  wire                when_DebugPlugin_l272_1;
-  wire                when_DebugPlugin_l273;
-  wire                when_DebugPlugin_l274;
-  wire                when_DebugPlugin_l275;
-  wire                when_DebugPlugin_l275_1;
-  wire                when_DebugPlugin_l295;
-  wire                when_DebugPlugin_l298;
+  reg                 _zz_when_DebugPlugin_l257;
+  wire                when_DebugPlugin_l257;
+  wire       [5:0]    switch_DebugPlugin_l280;
+  wire                when_DebugPlugin_l284;
+  wire                when_DebugPlugin_l284_1;
+  wire                when_DebugPlugin_l285;
+  wire                when_DebugPlugin_l285_1;
+  wire                when_DebugPlugin_l286;
+  wire                when_DebugPlugin_l287;
+  wire                when_DebugPlugin_l288;
+  wire                when_DebugPlugin_l288_1;
+  wire                when_DebugPlugin_l308;
   wire                when_DebugPlugin_l311;
+  wire                when_DebugPlugin_l324;
   reg                 DebugPlugin_resetIt_regNext;
-  wire                when_DebugPlugin_l331;
+  wire                when_DebugPlugin_l344;
   wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
   wire                when_Pipeline_l124_1;
@@ -1086,27 +1075,28 @@ module VexRiscv (
   wire                when_Pipeline_l154_1;
   wire                when_Pipeline_l151_2;
   wire                when_Pipeline_l154_2;
-  reg        [2:0]    switch_Fetcher_l365;
-  wire                when_Fetcher_l381;
-  wire                when_CsrPlugin_l1277;
+  reg        [2:0]    IBusCachedPlugin_injector_port_state;
+  wire                when_Fetcher_l391;
+  wire                when_CsrPlugin_l1669;
   reg                 execute_CsrPlugin_csr_768;
-  wire                when_CsrPlugin_l1277_1;
+  wire                when_CsrPlugin_l1669_1;
   reg                 execute_CsrPlugin_csr_836;
-  wire                when_CsrPlugin_l1277_2;
+  wire                when_CsrPlugin_l1669_2;
   reg                 execute_CsrPlugin_csr_772;
-  wire                when_CsrPlugin_l1277_3;
+  wire                when_CsrPlugin_l1669_3;
   reg                 execute_CsrPlugin_csr_773;
-  wire                when_CsrPlugin_l1277_4;
+  wire                when_CsrPlugin_l1669_4;
   reg                 execute_CsrPlugin_csr_833;
-  wire                when_CsrPlugin_l1277_5;
+  wire                when_CsrPlugin_l1669_5;
   reg                 execute_CsrPlugin_csr_834;
-  wire                when_CsrPlugin_l1277_6;
+  wire                when_CsrPlugin_l1669_6;
   reg                 execute_CsrPlugin_csr_835;
-  wire                when_CsrPlugin_l1277_7;
+  wire                when_CsrPlugin_l1669_7;
   reg                 execute_CsrPlugin_csr_3008;
-  wire                when_CsrPlugin_l1277_8;
+  wire                when_CsrPlugin_l1669_8;
   reg                 execute_CsrPlugin_csr_4032;
-  wire       [1:0]    switch_CsrPlugin_l723;
+  wire       [1:0]    switch_CsrPlugin_l1031;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
@@ -1114,9 +1104,12 @@ module VexRiscv (
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_6;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_8;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
-  wire                when_CsrPlugin_l1310;
-  wire                when_CsrPlugin_l1315;
+  wire                when_CsrPlugin_l1702;
+  wire       [11:0]   _zz_when_CsrPlugin_l1709;
+  wire                when_CsrPlugin_l1709;
+  reg                 when_CsrPlugin_l1719;
+  wire                when_CsrPlugin_l1717;
+  wire                when_CsrPlugin_l1725;
   reg        [2:0]    _zz_iBusWishbone_ADR;
   wire                when_InstructionCache_l239;
   reg                 _zz_iBus_rsp_valid;
@@ -1134,7 +1127,7 @@ module VexRiscv (
   reg        [31:0]   dBus_cmd_rData_data;
   reg        [1:0]    dBus_cmd_rData_size;
   reg        [3:0]    _zz_dBusWishbone_SEL;
-  wire                when_DBusSimplePlugin_l189;
+  wire                when_DBusSimplePlugin_l196;
   `ifndef SYNTHESIS
   reg [39:0] _zz_memory_to_writeBack_ENV_CTRL_string;
   reg [39:0] _zz_memory_to_writeBack_ENV_CTRL_1_string;
@@ -1215,8 +1208,8 @@ module VexRiscv (
 
   assign _zz_when = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
   assign _zz_when_1 = ({BranchPlugin_branchExceptionPort_valid,DBusSimplePlugin_memoryExceptionPort_valid} != 2'b00);
-  assign _zz_decode_DO_EBREAK = (decode_PC >>> 1);
-  assign _zz_decode_DO_EBREAK_1 = (decode_PC >>> 1);
+  assign _zz_decode_DO_EBREAK = (decode_PC >>> 1'd1);
+  assign _zz_decode_DO_EBREAK_1 = (decode_PC >>> 1'd1);
   assign _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload - 3'b001);
   assign _zz_IBusCachedPlugin_fetchPc_pc_1 = {IBusCachedPlugin_fetchPc_inc,2'b00};
   assign _zz_IBusCachedPlugin_fetchPc_pc = {29'd0, _zz_IBusCachedPlugin_fetchPc_pc_1};
@@ -1232,15 +1225,13 @@ module VexRiscv (
   assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
   assign _zz__zz_execute_SRC1 = 3'b100;
   assign _zz__zz_execute_SRC1_1 = execute_INSTRUCTION[19 : 15];
-  assign _zz__zz_execute_SRC2_3 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz__zz_execute_SRC2_2 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
   assign _zz_execute_SrcPlugin_addSub = ($signed(_zz_execute_SrcPlugin_addSub_1) + $signed(_zz_execute_SrcPlugin_addSub_4));
   assign _zz_execute_SrcPlugin_addSub_1 = ($signed(_zz_execute_SrcPlugin_addSub_2) + $signed(_zz_execute_SrcPlugin_addSub_3));
   assign _zz_execute_SrcPlugin_addSub_2 = execute_SRC1;
   assign _zz_execute_SrcPlugin_addSub_3 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? _zz_execute_SrcPlugin_addSub_5 : _zz_execute_SrcPlugin_addSub_6);
-  assign _zz_execute_SrcPlugin_addSub_5 = 32'h00000001;
-  assign _zz_execute_SrcPlugin_addSub_6 = 32'h0;
-  assign _zz__zz_decode_RS2_3 = (_zz__zz_decode_RS2_3_1 >>> 1);
+  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? 32'h00000001 : 32'h00000000);
+  assign _zz__zz_decode_RS2_3 = (_zz__zz_decode_RS2_3_1 >>> 1'd1);
   assign _zz__zz_decode_RS2_3_1 = {((execute_SHIFT_CTRL == ShiftCtrlEnum_SRA_1) && execute_LightShifterPlugin_shiftInput[31]),execute_LightShifterPlugin_shiftInput};
   assign _zz__zz_execute_BranchPlugin_missAlignedTarget_2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
   assign _zz__zz_execute_BranchPlugin_missAlignedTarget_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
@@ -1257,11 +1248,11 @@ module VexRiscv (
   assign _zz_memory_MulDivIterativePlugin_mul_counter_valueNext_1 = memory_MulDivIterativePlugin_mul_counter_willIncrement;
   assign _zz_memory_MulDivIterativePlugin_mul_counter_valueNext = {5'd0, _zz_memory_MulDivIterativePlugin_mul_counter_valueNext_1};
   assign _zz_memory_MulDivIterativePlugin_accumulator = (_zz_memory_MulDivIterativePlugin_accumulator_1 + _zz_memory_MulDivIterativePlugin_accumulator_3);
-  assign _zz_memory_MulDivIterativePlugin_accumulator_2 = (memory_MulDivIterativePlugin_rs2[0] ? memory_MulDivIterativePlugin_rs1 : 33'h0);
+  assign _zz_memory_MulDivIterativePlugin_accumulator_2 = (memory_MulDivIterativePlugin_rs2[0] ? memory_MulDivIterativePlugin_rs1 : 33'h000000000);
   assign _zz_memory_MulDivIterativePlugin_accumulator_1 = {{1{_zz_memory_MulDivIterativePlugin_accumulator_2[32]}}, _zz_memory_MulDivIterativePlugin_accumulator_2};
   assign _zz_memory_MulDivIterativePlugin_accumulator_4 = _zz_memory_MulDivIterativePlugin_accumulator_5;
   assign _zz_memory_MulDivIterativePlugin_accumulator_3 = {{1{_zz_memory_MulDivIterativePlugin_accumulator_4[32]}}, _zz_memory_MulDivIterativePlugin_accumulator_4};
-  assign _zz_memory_MulDivIterativePlugin_accumulator_5 = (memory_MulDivIterativePlugin_accumulator >>> 32);
+  assign _zz_memory_MulDivIterativePlugin_accumulator_5 = (memory_MulDivIterativePlugin_accumulator >>> 6'd32);
   assign _zz_memory_MulDivIterativePlugin_div_counter_valueNext_1 = memory_MulDivIterativePlugin_div_counter_willIncrement;
   assign _zz_memory_MulDivIterativePlugin_div_counter_valueNext = {5'd0, _zz_memory_MulDivIterativePlugin_div_counter_valueNext_1};
   assign _zz_memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator = {1'd0, memory_MulDivIterativePlugin_rs2};
@@ -1273,32 +1264,31 @@ module VexRiscv (
   assign _zz_memory_MulDivIterativePlugin_div_result_3 = ({memory_MulDivIterativePlugin_div_needRevert,(memory_MulDivIterativePlugin_div_needRevert ? (~ _zz_memory_MulDivIterativePlugin_div_result) : _zz_memory_MulDivIterativePlugin_div_result)} + _zz_memory_MulDivIterativePlugin_div_result_4);
   assign _zz_memory_MulDivIterativePlugin_div_result_5 = memory_MulDivIterativePlugin_div_needRevert;
   assign _zz_memory_MulDivIterativePlugin_div_result_4 = {32'd0, _zz_memory_MulDivIterativePlugin_div_result_5};
-  assign _zz_memory_MulDivIterativePlugin_rs1_4 = _zz_memory_MulDivIterativePlugin_rs1_1;
-  assign _zz_memory_MulDivIterativePlugin_rs1_3 = {32'd0, _zz_memory_MulDivIterativePlugin_rs1_4};
-  assign _zz_memory_MulDivIterativePlugin_rs2_1 = _zz_memory_MulDivIterativePlugin_rs1;
-  assign _zz_memory_MulDivIterativePlugin_rs2 = {31'd0, _zz_memory_MulDivIterativePlugin_rs2_1};
-  assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 5);
+  assign _zz_memory_MulDivIterativePlugin_rs1_3 = _zz_memory_MulDivIterativePlugin_rs1;
+  assign _zz_memory_MulDivIterativePlugin_rs1_2 = {32'd0, _zz_memory_MulDivIterativePlugin_rs1_3};
+  assign _zz_memory_MulDivIterativePlugin_rs2_2 = _zz_memory_MulDivIterativePlugin_rs2;
+  assign _zz_memory_MulDivIterativePlugin_rs2_1 = {31'd0, _zz_memory_MulDivIterativePlugin_rs2_2};
+  assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 3'd5);
   assign _zz_decode_RegFilePlugin_rs1Data = 1'b1;
   assign _zz_decode_RegFilePlugin_rs2Data = 1'b1;
   assign _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = {_zz_IBusCachedPlugin_jump_pcLoad_payload_3,_zz_IBusCachedPlugin_jump_pcLoad_payload_2};
-  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000107f;
-  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00002073;
-  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000207f;
+  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000407f);
+  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00004063;
+  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000107f) == 32'h00000013);
   assign _zz_decode_LEGAL_INSTRUCTION_5 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_6) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_7 == _zz_decode_LEGAL_INSTRUCTION_8),{_zz_decode_LEGAL_INSTRUCTION_9,{_zz_decode_LEGAL_INSTRUCTION_10,_zz_decode_LEGAL_INSTRUCTION_11}}}}}};
   assign _zz_decode_LEGAL_INSTRUCTION_6 = 32'h0000505f;
   assign _zz_decode_LEGAL_INSTRUCTION_7 = (decode_INSTRUCTION & 32'h0000707b);
   assign _zz_decode_LEGAL_INSTRUCTION_8 = 32'h00000063;
   assign _zz_decode_LEGAL_INSTRUCTION_9 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
   assign _zz_decode_LEGAL_INSTRUCTION_10 = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
-  assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'hfc00305f) == 32'h00001013),{((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h00005033),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,{_zz_decode_LEGAL_INSTRUCTION_16,_zz_decode_LEGAL_INSTRUCTION_17}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'hbe00705f) == 32'h00005013),{((decode_INSTRUCTION & 32'hfe00305f) == 32'h00001013),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h00000033),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,_zz_decode_LEGAL_INSTRUCTION_16}}}}};
   assign _zz_decode_LEGAL_INSTRUCTION_12 = 32'hbe00707f;
-  assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'hbe00707f);
-  assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h00000033;
-  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
-  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hffefffff) == 32'h00000073);
-  assign _zz_decode_LEGAL_INSTRUCTION_17 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073);
+  assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'hdfffffff);
+  assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h10200073;
+  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hffefffff) == 32'h00000073);
+  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073);
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_4 = decode_INSTRUCTION[31];
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_5 = decode_INSTRUCTION[31];
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_6 = decode_INSTRUCTION[7];
@@ -1308,125 +1298,113 @@ module VexRiscv (
   assign _zz__zz_decode_IS_DIV_3 = ((decode_INSTRUCTION & 32'h02004074) == 32'h02000030);
   assign _zz__zz_decode_IS_DIV_4 = (|((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_5) == 32'h00000050));
   assign _zz__zz_decode_IS_DIV_6 = (|(_zz__zz_decode_IS_DIV_7 == _zz__zz_decode_IS_DIV_8));
-  assign _zz__zz_decode_IS_DIV_9 = {(|{_zz__zz_decode_IS_DIV_10,_zz__zz_decode_IS_DIV_12}),{(|_zz__zz_decode_IS_DIV_14),{_zz__zz_decode_IS_DIV_17,{_zz__zz_decode_IS_DIV_20,_zz__zz_decode_IS_DIV_25}}}};
+  assign _zz__zz_decode_IS_DIV_9 = {(|{_zz__zz_decode_IS_DIV_10,_zz__zz_decode_IS_DIV_11}),{(|_zz__zz_decode_IS_DIV_12),{_zz__zz_decode_IS_DIV_14,{_zz__zz_decode_IS_DIV_16,_zz__zz_decode_IS_DIV_19}}}};
   assign _zz__zz_decode_IS_DIV_5 = 32'h10103050;
   assign _zz__zz_decode_IS_DIV_7 = (decode_INSTRUCTION & 32'h10403050);
   assign _zz__zz_decode_IS_DIV_8 = 32'h10000050;
-  assign _zz__zz_decode_IS_DIV_10 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_11) == 32'h00001050);
-  assign _zz__zz_decode_IS_DIV_12 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_13) == 32'h00002050);
-  assign _zz__zz_decode_IS_DIV_14 = {_zz_decode_IS_DIV_4,(_zz__zz_decode_IS_DIV_15 == _zz__zz_decode_IS_DIV_16)};
-  assign _zz__zz_decode_IS_DIV_17 = (|(_zz__zz_decode_IS_DIV_18 == _zz__zz_decode_IS_DIV_19));
-  assign _zz__zz_decode_IS_DIV_20 = (|{_zz__zz_decode_IS_DIV_21,_zz__zz_decode_IS_DIV_23});
-  assign _zz__zz_decode_IS_DIV_25 = {(|_zz__zz_decode_IS_DIV_26),{_zz__zz_decode_IS_DIV_31,{_zz__zz_decode_IS_DIV_37,_zz__zz_decode_IS_DIV_39}}};
-  assign _zz__zz_decode_IS_DIV_11 = 32'h00001050;
-  assign _zz__zz_decode_IS_DIV_13 = 32'h00002050;
-  assign _zz__zz_decode_IS_DIV_15 = (decode_INSTRUCTION & 32'h0000001c);
-  assign _zz__zz_decode_IS_DIV_16 = 32'h00000004;
-  assign _zz__zz_decode_IS_DIV_18 = (decode_INSTRUCTION & 32'h00000058);
-  assign _zz__zz_decode_IS_DIV_19 = 32'h00000040;
-  assign _zz__zz_decode_IS_DIV_21 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_22) == 32'h00005010);
-  assign _zz__zz_decode_IS_DIV_23 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_24) == 32'h00005020);
-  assign _zz__zz_decode_IS_DIV_26 = {(_zz__zz_decode_IS_DIV_27 == _zz__zz_decode_IS_DIV_28),{_zz__zz_decode_IS_DIV_29,_zz__zz_decode_IS_DIV_30}};
-  assign _zz__zz_decode_IS_DIV_31 = (|{_zz__zz_decode_IS_DIV_32,{_zz__zz_decode_IS_DIV_33,_zz__zz_decode_IS_DIV_35}});
-  assign _zz__zz_decode_IS_DIV_37 = (|_zz__zz_decode_IS_DIV_38);
-  assign _zz__zz_decode_IS_DIV_39 = {(|_zz__zz_decode_IS_DIV_40),{_zz__zz_decode_IS_DIV_41,{_zz__zz_decode_IS_DIV_44,_zz__zz_decode_IS_DIV_49}}};
-  assign _zz__zz_decode_IS_DIV_22 = 32'h00007034;
-  assign _zz__zz_decode_IS_DIV_24 = 32'h02007064;
-  assign _zz__zz_decode_IS_DIV_27 = (decode_INSTRUCTION & 32'h40003054);
-  assign _zz__zz_decode_IS_DIV_28 = 32'h40001010;
-  assign _zz__zz_decode_IS_DIV_29 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00001010);
-  assign _zz__zz_decode_IS_DIV_30 = ((decode_INSTRUCTION & 32'h02007054) == 32'h00001010);
-  assign _zz__zz_decode_IS_DIV_32 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
-  assign _zz__zz_decode_IS_DIV_33 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_34) == 32'h00001010);
-  assign _zz__zz_decode_IS_DIV_35 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_36) == 32'h00001010);
-  assign _zz__zz_decode_IS_DIV_38 = ((decode_INSTRUCTION & 32'h00001000) == 32'h00001000);
-  assign _zz__zz_decode_IS_DIV_40 = _zz_decode_IS_DIV_5;
-  assign _zz__zz_decode_IS_DIV_41 = (|{_zz__zz_decode_IS_DIV_42,_zz__zz_decode_IS_DIV_43});
-  assign _zz__zz_decode_IS_DIV_44 = (|{_zz__zz_decode_IS_DIV_45,_zz__zz_decode_IS_DIV_47});
-  assign _zz__zz_decode_IS_DIV_49 = {(|_zz__zz_decode_IS_DIV_50),{_zz__zz_decode_IS_DIV_54,{_zz__zz_decode_IS_DIV_57,_zz__zz_decode_IS_DIV_59}}};
-  assign _zz__zz_decode_IS_DIV_34 = 32'h00003034;
-  assign _zz__zz_decode_IS_DIV_36 = 32'h02003054;
-  assign _zz__zz_decode_IS_DIV_42 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
-  assign _zz__zz_decode_IS_DIV_43 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00001000);
-  assign _zz__zz_decode_IS_DIV_45 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_46) == 32'h00000020);
-  assign _zz__zz_decode_IS_DIV_47 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_48) == 32'h00000020);
-  assign _zz__zz_decode_IS_DIV_50 = {(_zz__zz_decode_IS_DIV_51 == _zz__zz_decode_IS_DIV_52),{_zz_decode_IS_DIV_2,_zz__zz_decode_IS_DIV_53}};
-  assign _zz__zz_decode_IS_DIV_54 = (|(_zz__zz_decode_IS_DIV_55 == _zz__zz_decode_IS_DIV_56));
-  assign _zz__zz_decode_IS_DIV_57 = (|_zz__zz_decode_IS_DIV_58);
-  assign _zz__zz_decode_IS_DIV_59 = {(|_zz__zz_decode_IS_DIV_60),{_zz__zz_decode_IS_DIV_65,{_zz__zz_decode_IS_DIV_78,_zz__zz_decode_IS_DIV_83}}};
-  assign _zz__zz_decode_IS_DIV_46 = 32'h00000034;
-  assign _zz__zz_decode_IS_DIV_48 = 32'h00000064;
-  assign _zz__zz_decode_IS_DIV_51 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz__zz_decode_IS_DIV_52 = 32'h00000040;
-  assign _zz__zz_decode_IS_DIV_53 = ((decode_INSTRUCTION & 32'h00103040) == 32'h00000040);
-  assign _zz__zz_decode_IS_DIV_55 = (decode_INSTRUCTION & 32'h00000020);
-  assign _zz__zz_decode_IS_DIV_56 = 32'h00000020;
-  assign _zz__zz_decode_IS_DIV_58 = ((decode_INSTRUCTION & 32'h00000010) == 32'h00000010);
-  assign _zz__zz_decode_IS_DIV_60 = {_zz_decode_IS_DIV_3,{_zz__zz_decode_IS_DIV_61,_zz__zz_decode_IS_DIV_63}};
-  assign _zz__zz_decode_IS_DIV_65 = (|{_zz_decode_IS_DIV_4,{_zz__zz_decode_IS_DIV_66,_zz__zz_decode_IS_DIV_69}});
-  assign _zz__zz_decode_IS_DIV_78 = (|{_zz__zz_decode_IS_DIV_79,_zz__zz_decode_IS_DIV_80});
-  assign _zz__zz_decode_IS_DIV_83 = {(|_zz__zz_decode_IS_DIV_84),{_zz__zz_decode_IS_DIV_87,{_zz__zz_decode_IS_DIV_94,_zz__zz_decode_IS_DIV_98}}};
-  assign _zz__zz_decode_IS_DIV_61 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_62) == 32'h00000010);
-  assign _zz__zz_decode_IS_DIV_63 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_64) == 32'h00000020);
-  assign _zz__zz_decode_IS_DIV_66 = (_zz__zz_decode_IS_DIV_67 == _zz__zz_decode_IS_DIV_68);
-  assign _zz__zz_decode_IS_DIV_69 = {_zz__zz_decode_IS_DIV_70,{_zz__zz_decode_IS_DIV_72,_zz__zz_decode_IS_DIV_75}};
-  assign _zz__zz_decode_IS_DIV_79 = _zz_decode_IS_DIV_3;
+  assign _zz__zz_decode_IS_DIV_10 = ((decode_INSTRUCTION & 32'h00001050) == 32'h00001050);
+  assign _zz__zz_decode_IS_DIV_11 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002050);
+  assign _zz__zz_decode_IS_DIV_12 = {_zz_decode_IS_DIV_4,((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_13) == 32'h00000004)};
+  assign _zz__zz_decode_IS_DIV_14 = (|((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_15) == 32'h00000040));
+  assign _zz__zz_decode_IS_DIV_16 = (|(_zz__zz_decode_IS_DIV_17 == _zz__zz_decode_IS_DIV_18));
+  assign _zz__zz_decode_IS_DIV_19 = {(|{_zz__zz_decode_IS_DIV_20,_zz__zz_decode_IS_DIV_22}),{(|_zz__zz_decode_IS_DIV_24),{_zz__zz_decode_IS_DIV_29,{_zz__zz_decode_IS_DIV_32,_zz__zz_decode_IS_DIV_33}}}};
+  assign _zz__zz_decode_IS_DIV_13 = 32'h0000001c;
+  assign _zz__zz_decode_IS_DIV_15 = 32'h00000058;
+  assign _zz__zz_decode_IS_DIV_17 = (decode_INSTRUCTION & 32'h02007054);
+  assign _zz__zz_decode_IS_DIV_18 = 32'h00005010;
+  assign _zz__zz_decode_IS_DIV_20 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_21) == 32'h40001010);
+  assign _zz__zz_decode_IS_DIV_22 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_23) == 32'h00001010);
+  assign _zz__zz_decode_IS_DIV_24 = {(_zz__zz_decode_IS_DIV_25 == _zz__zz_decode_IS_DIV_26),(_zz__zz_decode_IS_DIV_27 == _zz__zz_decode_IS_DIV_28)};
+  assign _zz__zz_decode_IS_DIV_29 = (|(_zz__zz_decode_IS_DIV_30 == _zz__zz_decode_IS_DIV_31));
+  assign _zz__zz_decode_IS_DIV_32 = (|_zz_decode_IS_DIV_5);
+  assign _zz__zz_decode_IS_DIV_33 = {(|_zz__zz_decode_IS_DIV_34),{_zz__zz_decode_IS_DIV_37,{_zz__zz_decode_IS_DIV_42,_zz__zz_decode_IS_DIV_47}}};
+  assign _zz__zz_decode_IS_DIV_21 = 32'h40003054;
+  assign _zz__zz_decode_IS_DIV_23 = 32'h02007054;
+  assign _zz__zz_decode_IS_DIV_25 = (decode_INSTRUCTION & 32'h00000064);
+  assign _zz__zz_decode_IS_DIV_26 = 32'h00000024;
+  assign _zz__zz_decode_IS_DIV_27 = (decode_INSTRUCTION & 32'h02003054);
+  assign _zz__zz_decode_IS_DIV_28 = 32'h00001010;
+  assign _zz__zz_decode_IS_DIV_30 = (decode_INSTRUCTION & 32'h00001000);
+  assign _zz__zz_decode_IS_DIV_31 = 32'h00001000;
+  assign _zz__zz_decode_IS_DIV_34 = {((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_35) == 32'h00002000),((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_36) == 32'h00001000)};
+  assign _zz__zz_decode_IS_DIV_37 = (|{(_zz__zz_decode_IS_DIV_38 == _zz__zz_decode_IS_DIV_39),(_zz__zz_decode_IS_DIV_40 == _zz__zz_decode_IS_DIV_41)});
+  assign _zz__zz_decode_IS_DIV_42 = (|{_zz__zz_decode_IS_DIV_43,{_zz__zz_decode_IS_DIV_44,_zz__zz_decode_IS_DIV_45}});
+  assign _zz__zz_decode_IS_DIV_47 = {(|_zz__zz_decode_IS_DIV_48),{(|_zz__zz_decode_IS_DIV_49),{_zz__zz_decode_IS_DIV_51,{_zz__zz_decode_IS_DIV_56,_zz__zz_decode_IS_DIV_69}}}};
+  assign _zz__zz_decode_IS_DIV_35 = 32'h00002010;
+  assign _zz__zz_decode_IS_DIV_36 = 32'h00005000;
+  assign _zz__zz_decode_IS_DIV_38 = (decode_INSTRUCTION & 32'h00000034);
+  assign _zz__zz_decode_IS_DIV_39 = 32'h00000020;
+  assign _zz__zz_decode_IS_DIV_40 = (decode_INSTRUCTION & 32'h00000064);
+  assign _zz__zz_decode_IS_DIV_41 = 32'h00000020;
+  assign _zz__zz_decode_IS_DIV_43 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000040);
+  assign _zz__zz_decode_IS_DIV_44 = _zz_decode_IS_DIV_2;
+  assign _zz__zz_decode_IS_DIV_45 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_46) == 32'h00000040);
+  assign _zz__zz_decode_IS_DIV_48 = ((decode_INSTRUCTION & 32'h00000020) == 32'h00000020);
+  assign _zz__zz_decode_IS_DIV_49 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_50) == 32'h00000010);
+  assign _zz__zz_decode_IS_DIV_51 = (|{_zz_decode_IS_DIV_3,{_zz__zz_decode_IS_DIV_52,_zz__zz_decode_IS_DIV_54}});
+  assign _zz__zz_decode_IS_DIV_56 = (|{_zz__zz_decode_IS_DIV_57,_zz__zz_decode_IS_DIV_58});
+  assign _zz__zz_decode_IS_DIV_69 = {(|_zz__zz_decode_IS_DIV_70),{_zz__zz_decode_IS_DIV_73,{_zz__zz_decode_IS_DIV_76,_zz__zz_decode_IS_DIV_83}}};
+  assign _zz__zz_decode_IS_DIV_46 = 32'h00103040;
+  assign _zz__zz_decode_IS_DIV_50 = 32'h00000010;
+  assign _zz__zz_decode_IS_DIV_52 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_53) == 32'h00000010);
+  assign _zz__zz_decode_IS_DIV_54 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_55) == 32'h00000020);
+  assign _zz__zz_decode_IS_DIV_57 = _zz_decode_IS_DIV_4;
+  assign _zz__zz_decode_IS_DIV_58 = {(_zz__zz_decode_IS_DIV_59 == _zz__zz_decode_IS_DIV_60),{_zz__zz_decode_IS_DIV_61,{_zz__zz_decode_IS_DIV_63,_zz__zz_decode_IS_DIV_66}}};
+  assign _zz__zz_decode_IS_DIV_70 = {_zz_decode_IS_DIV_3,(_zz__zz_decode_IS_DIV_71 == _zz__zz_decode_IS_DIV_72)};
+  assign _zz__zz_decode_IS_DIV_73 = (|{_zz_decode_IS_DIV_3,_zz__zz_decode_IS_DIV_74});
+  assign _zz__zz_decode_IS_DIV_76 = (|{_zz__zz_decode_IS_DIV_77,_zz__zz_decode_IS_DIV_80});
+  assign _zz__zz_decode_IS_DIV_83 = {(|_zz__zz_decode_IS_DIV_84),{_zz__zz_decode_IS_DIV_87,{_zz__zz_decode_IS_DIV_93,_zz__zz_decode_IS_DIV_96}}};
+  assign _zz__zz_decode_IS_DIV_53 = 32'h00000030;
+  assign _zz__zz_decode_IS_DIV_55 = 32'h02000060;
+  assign _zz__zz_decode_IS_DIV_59 = (decode_INSTRUCTION & 32'h00001010);
+  assign _zz__zz_decode_IS_DIV_60 = 32'h00001010;
+  assign _zz__zz_decode_IS_DIV_61 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_62) == 32'h00002010);
+  assign _zz__zz_decode_IS_DIV_63 = (_zz__zz_decode_IS_DIV_64 == _zz__zz_decode_IS_DIV_65);
+  assign _zz__zz_decode_IS_DIV_66 = {_zz__zz_decode_IS_DIV_67,_zz__zz_decode_IS_DIV_68};
+  assign _zz__zz_decode_IS_DIV_71 = (decode_INSTRUCTION & 32'h00000070);
+  assign _zz__zz_decode_IS_DIV_72 = 32'h00000020;
+  assign _zz__zz_decode_IS_DIV_74 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_75) == 32'h00000000);
+  assign _zz__zz_decode_IS_DIV_77 = (_zz__zz_decode_IS_DIV_78 == _zz__zz_decode_IS_DIV_79);
   assign _zz__zz_decode_IS_DIV_80 = (_zz__zz_decode_IS_DIV_81 == _zz__zz_decode_IS_DIV_82);
-  assign _zz__zz_decode_IS_DIV_84 = {_zz_decode_IS_DIV_3,_zz__zz_decode_IS_DIV_85};
-  assign _zz__zz_decode_IS_DIV_87 = (|{_zz__zz_decode_IS_DIV_88,_zz__zz_decode_IS_DIV_91});
-  assign _zz__zz_decode_IS_DIV_94 = (|_zz__zz_decode_IS_DIV_95);
-  assign _zz__zz_decode_IS_DIV_98 = {_zz__zz_decode_IS_DIV_99,{_zz__zz_decode_IS_DIV_105,_zz__zz_decode_IS_DIV_108}};
-  assign _zz__zz_decode_IS_DIV_62 = 32'h00000030;
-  assign _zz__zz_decode_IS_DIV_64 = 32'h02000060;
-  assign _zz__zz_decode_IS_DIV_67 = (decode_INSTRUCTION & 32'h00001010);
-  assign _zz__zz_decode_IS_DIV_68 = 32'h00001010;
-  assign _zz__zz_decode_IS_DIV_70 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_71) == 32'h00002010);
-  assign _zz__zz_decode_IS_DIV_72 = (_zz__zz_decode_IS_DIV_73 == _zz__zz_decode_IS_DIV_74);
-  assign _zz__zz_decode_IS_DIV_75 = {_zz__zz_decode_IS_DIV_76,_zz__zz_decode_IS_DIV_77};
-  assign _zz__zz_decode_IS_DIV_81 = (decode_INSTRUCTION & 32'h00000070);
-  assign _zz__zz_decode_IS_DIV_82 = 32'h00000020;
-  assign _zz__zz_decode_IS_DIV_85 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_86) == 32'h0);
-  assign _zz__zz_decode_IS_DIV_88 = (_zz__zz_decode_IS_DIV_89 == _zz__zz_decode_IS_DIV_90);
-  assign _zz__zz_decode_IS_DIV_91 = (_zz__zz_decode_IS_DIV_92 == _zz__zz_decode_IS_DIV_93);
-  assign _zz__zz_decode_IS_DIV_95 = (_zz__zz_decode_IS_DIV_96 == _zz__zz_decode_IS_DIV_97);
-  assign _zz__zz_decode_IS_DIV_99 = (|{_zz__zz_decode_IS_DIV_100,_zz__zz_decode_IS_DIV_102});
-  assign _zz__zz_decode_IS_DIV_105 = (|_zz__zz_decode_IS_DIV_106);
-  assign _zz__zz_decode_IS_DIV_108 = {_zz__zz_decode_IS_DIV_109,{_zz__zz_decode_IS_DIV_115,_zz__zz_decode_IS_DIV_119}};
-  assign _zz__zz_decode_IS_DIV_71 = 32'h00002010;
-  assign _zz__zz_decode_IS_DIV_73 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz__zz_decode_IS_DIV_74 = 32'h00000010;
-  assign _zz__zz_decode_IS_DIV_76 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
-  assign _zz__zz_decode_IS_DIV_77 = ((decode_INSTRUCTION & 32'h00000028) == 32'h0);
-  assign _zz__zz_decode_IS_DIV_86 = 32'h00000020;
-  assign _zz__zz_decode_IS_DIV_89 = (decode_INSTRUCTION & 32'h00006014);
-  assign _zz__zz_decode_IS_DIV_90 = 32'h00006010;
-  assign _zz__zz_decode_IS_DIV_92 = (decode_INSTRUCTION & 32'h00005014);
-  assign _zz__zz_decode_IS_DIV_93 = 32'h00004010;
-  assign _zz__zz_decode_IS_DIV_96 = (decode_INSTRUCTION & 32'h00006014);
-  assign _zz__zz_decode_IS_DIV_97 = 32'h00002010;
-  assign _zz__zz_decode_IS_DIV_100 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_101) == 32'h0);
-  assign _zz__zz_decode_IS_DIV_102 = {_zz_decode_IS_DIV_2,{_zz__zz_decode_IS_DIV_103,_zz__zz_decode_IS_DIV_104}};
-  assign _zz__zz_decode_IS_DIV_106 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_107) == 32'h0);
-  assign _zz__zz_decode_IS_DIV_109 = (|{_zz__zz_decode_IS_DIV_110,{_zz__zz_decode_IS_DIV_111,_zz__zz_decode_IS_DIV_113}});
-  assign _zz__zz_decode_IS_DIV_115 = (|{_zz__zz_decode_IS_DIV_116,_zz__zz_decode_IS_DIV_118});
-  assign _zz__zz_decode_IS_DIV_119 = {(|_zz__zz_decode_IS_DIV_120),(|_zz__zz_decode_IS_DIV_123)};
-  assign _zz__zz_decode_IS_DIV_101 = 32'h00000044;
-  assign _zz__zz_decode_IS_DIV_103 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
-  assign _zz__zz_decode_IS_DIV_104 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
-  assign _zz__zz_decode_IS_DIV_107 = 32'h00000058;
-  assign _zz__zz_decode_IS_DIV_110 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
-  assign _zz__zz_decode_IS_DIV_111 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_112) == 32'h00002010);
-  assign _zz__zz_decode_IS_DIV_113 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_114) == 32'h40000030);
-  assign _zz__zz_decode_IS_DIV_116 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_117) == 32'h00000004);
-  assign _zz__zz_decode_IS_DIV_118 = _zz_decode_IS_DIV_1;
-  assign _zz__zz_decode_IS_DIV_120 = {(_zz__zz_decode_IS_DIV_121 == _zz__zz_decode_IS_DIV_122),_zz_decode_IS_DIV_1};
-  assign _zz__zz_decode_IS_DIV_123 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_124) == 32'h00001008);
-  assign _zz__zz_decode_IS_DIV_112 = 32'h00002014;
-  assign _zz__zz_decode_IS_DIV_114 = 32'h40004034;
-  assign _zz__zz_decode_IS_DIV_117 = 32'h00000014;
-  assign _zz__zz_decode_IS_DIV_121 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz__zz_decode_IS_DIV_122 = 32'h00000004;
-  assign _zz__zz_decode_IS_DIV_124 = 32'h00001048;
+  assign _zz__zz_decode_IS_DIV_84 = (_zz__zz_decode_IS_DIV_85 == _zz__zz_decode_IS_DIV_86);
+  assign _zz__zz_decode_IS_DIV_87 = (|{_zz__zz_decode_IS_DIV_88,_zz__zz_decode_IS_DIV_90});
+  assign _zz__zz_decode_IS_DIV_93 = (|_zz__zz_decode_IS_DIV_94);
+  assign _zz__zz_decode_IS_DIV_96 = {_zz__zz_decode_IS_DIV_97,{_zz__zz_decode_IS_DIV_103,_zz__zz_decode_IS_DIV_107}};
+  assign _zz__zz_decode_IS_DIV_62 = 32'h00002010;
+  assign _zz__zz_decode_IS_DIV_64 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz__zz_decode_IS_DIV_65 = 32'h00000010;
+  assign _zz__zz_decode_IS_DIV_67 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
+  assign _zz__zz_decode_IS_DIV_68 = ((decode_INSTRUCTION & 32'h00000028) == 32'h00000000);
+  assign _zz__zz_decode_IS_DIV_75 = 32'h00000020;
+  assign _zz__zz_decode_IS_DIV_78 = (decode_INSTRUCTION & 32'h00006004);
+  assign _zz__zz_decode_IS_DIV_79 = 32'h00006000;
+  assign _zz__zz_decode_IS_DIV_81 = (decode_INSTRUCTION & 32'h00005014);
+  assign _zz__zz_decode_IS_DIV_82 = 32'h00004010;
+  assign _zz__zz_decode_IS_DIV_85 = (decode_INSTRUCTION & 32'h00006014);
+  assign _zz__zz_decode_IS_DIV_86 = 32'h00002010;
+  assign _zz__zz_decode_IS_DIV_88 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_89) == 32'h00000000);
+  assign _zz__zz_decode_IS_DIV_90 = {_zz_decode_IS_DIV_2,{_zz__zz_decode_IS_DIV_91,_zz__zz_decode_IS_DIV_92}};
+  assign _zz__zz_decode_IS_DIV_94 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_95) == 32'h00000000);
+  assign _zz__zz_decode_IS_DIV_97 = (|{_zz__zz_decode_IS_DIV_98,{_zz__zz_decode_IS_DIV_99,_zz__zz_decode_IS_DIV_101}});
+  assign _zz__zz_decode_IS_DIV_103 = (|{_zz__zz_decode_IS_DIV_104,_zz__zz_decode_IS_DIV_106});
+  assign _zz__zz_decode_IS_DIV_107 = {(|_zz__zz_decode_IS_DIV_108),(|_zz__zz_decode_IS_DIV_111)};
+  assign _zz__zz_decode_IS_DIV_89 = 32'h00000044;
+  assign _zz__zz_decode_IS_DIV_91 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
+  assign _zz__zz_decode_IS_DIV_92 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
+  assign _zz__zz_decode_IS_DIV_95 = 32'h00000058;
+  assign _zz__zz_decode_IS_DIV_98 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
+  assign _zz__zz_decode_IS_DIV_99 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_100) == 32'h00002010);
+  assign _zz__zz_decode_IS_DIV_101 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_102) == 32'h40000030);
+  assign _zz__zz_decode_IS_DIV_104 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_105) == 32'h00000004);
+  assign _zz__zz_decode_IS_DIV_106 = _zz_decode_IS_DIV_1;
+  assign _zz__zz_decode_IS_DIV_108 = {(_zz__zz_decode_IS_DIV_109 == _zz__zz_decode_IS_DIV_110),_zz_decode_IS_DIV_1};
+  assign _zz__zz_decode_IS_DIV_111 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_112) == 32'h00001008);
+  assign _zz__zz_decode_IS_DIV_100 = 32'h00002014;
+  assign _zz__zz_decode_IS_DIV_102 = 32'h40004034;
+  assign _zz__zz_decode_IS_DIV_105 = 32'h00000014;
+  assign _zz__zz_decode_IS_DIV_109 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz__zz_decode_IS_DIV_110 = 32'h00000004;
+  assign _zz__zz_decode_IS_DIV_112 = 32'h00001048;
   assign _zz_execute_BranchPlugin_branch_src2_6 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_7 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_8 = execute_INSTRUCTION[7];
@@ -1487,8 +1465,8 @@ module VexRiscv (
     .io_mem_rsp_valid                      (iBus_rsp_valid                                            ), //i
     .io_mem_rsp_payload_data               (iBus_rsp_payload_data[31:0]                               ), //i
     .io_mem_rsp_payload_error              (iBus_rsp_payload_error                                    ), //i
-    ._zz_when_Fetcher_l401                 (switch_Fetcher_l365[2:0]                                  ), //i
-    ._zz_io_cpu_fetch_data_regNextWhen     (IBusCachedPlugin_injectionPort_payload[31:0]              ), //i
+    ._zz_when_Fetcher_l411                 (IBusCachedPlugin_injector_port_state[2:0]                 ), //i
+    ._zz_io_cpu_fetch_data_regNextWhen     (DebugPlugin_injectionPort_payload[31:0]                   ), //i
     .clk                                   (clk                                                       ), //i
     .reset                                 (reset                                                     )  //i
   );
@@ -2132,7 +2110,7 @@ module VexRiscv (
   assign execute_MEMORY_ADDRESS_LOW = dBus_cmd_payload_address[1 : 0];
   assign decode_DO_EBREAK = (((! DebugPlugin_haltIt) && (decode_IS_EBREAK || ((1'b0 || (DebugPlugin_hardwareBreakpoints_0_valid && (DebugPlugin_hardwareBreakpoints_0_pc == _zz_decode_DO_EBREAK))) || (DebugPlugin_hardwareBreakpoints_1_valid && (DebugPlugin_hardwareBreakpoints_1_pc == _zz_decode_DO_EBREAK_1))))) && DebugPlugin_allowEBreak);
   assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
-  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
+  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h00)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h00))));
   assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
   assign decode_IS_DIV = _zz_decode_IS_DIV[30];
@@ -2270,7 +2248,7 @@ module VexRiscv (
     if(when_ShiftPlugins_l169) begin
       _zz_decode_RS2_1 = _zz_decode_RS2_3;
     end
-    if(when_CsrPlugin_l1189) begin
+    if(when_CsrPlugin_l1587) begin
       _zz_decode_RS2_1 = CsrPlugin_csrMapping_readDataSignal;
     end
   end
@@ -2279,7 +2257,7 @@ module VexRiscv (
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_execute_SRC2 = execute_PC;
+  assign _zz_execute_to_memory_PC = execute_PC;
   assign execute_SRC2_CTRL = _zz_execute_SRC2_CTRL;
   assign execute_SRC1_CTRL = _zz_execute_SRC1_CTRL;
   assign decode_SRC_USE_SUB_LESS = _zz_decode_IS_DIV[3];
@@ -2287,7 +2265,7 @@ module VexRiscv (
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
   assign execute_ALU_CTRL = _zz_execute_ALU_CTRL;
-  assign execute_SRC2 = _zz_execute_SRC2_5;
+  assign execute_SRC2 = _zz_execute_SRC2_4;
   assign execute_SRC1 = _zz_execute_SRC1;
   assign execute_ALU_BITWISE_CTRL = _zz_execute_ALU_BITWISE_CTRL;
   assign _zz_lastStageRegFileWrite_payload_address = writeBack_INSTRUCTION;
@@ -2307,10 +2285,10 @@ module VexRiscv (
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00001073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
+  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000107f) == 32'h00001073),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00002073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
   always @(*) begin
     _zz_decode_RS2_2 = writeBack_REGFILE_WRITE_DATA;
-    if(when_DBusSimplePlugin_l558) begin
+    if(when_DBusSimplePlugin_l566) begin
       _zz_decode_RS2_2 = writeBack_DBusSimplePlugin_rspFormated;
     end
   end
@@ -2331,28 +2309,28 @@ module VexRiscv (
   assign decode_FLUSH_ALL = _zz_decode_IS_DIV[0];
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_4 = IBusCachedPlugin_rsp_issueDetected_3;
-    if(when_IBusCachedPlugin_l256) begin
+    if(when_IBusCachedPlugin_l262) begin
       IBusCachedPlugin_rsp_issueDetected_4 = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_3 = IBusCachedPlugin_rsp_issueDetected_2;
-    if(when_IBusCachedPlugin_l250) begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_rsp_issueDetected_3 = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
-    if(when_IBusCachedPlugin_l244) begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
-    if(when_IBusCachedPlugin_l239) begin
+    if(when_IBusCachedPlugin_l245) begin
       IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
@@ -2378,7 +2356,7 @@ module VexRiscv (
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
   always @(*) begin
     decode_arbitration_haltItself = 1'b0;
-    case(switch_Fetcher_l365)
+    case(IBusCachedPlugin_injector_port_state)
       3'b010 : begin
         decode_arbitration_haltItself = 1'b1;
       end
@@ -2395,7 +2373,7 @@ module VexRiscv (
     if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(when_CsrPlugin_l1129) begin
+    if(when_CsrPlugin_l1527) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
@@ -2423,7 +2401,7 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(when_DBusSimplePlugin_l428) begin
+    if(when_DBusSimplePlugin_l436) begin
       execute_arbitration_haltItself = 1'b1;
     end
     if(when_ShiftPlugins_l169) begin
@@ -2431,7 +2409,7 @@ module VexRiscv (
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(when_CsrPlugin_l1193) begin
+    if(when_CsrPlugin_l1591) begin
       if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
@@ -2440,7 +2418,7 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if(when_DebugPlugin_l295) begin
+    if(when_DebugPlugin_l308) begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
@@ -2457,8 +2435,8 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_flushIt = 1'b0;
-    if(when_DebugPlugin_l295) begin
-      if(when_DebugPlugin_l298) begin
+    if(when_DebugPlugin_l308) begin
+      if(when_DebugPlugin_l311) begin
         execute_arbitration_flushIt = 1'b1;
       end
     end
@@ -2469,8 +2447,8 @@ module VexRiscv (
     if(CsrPlugin_selfException_valid) begin
       execute_arbitration_flushNext = 1'b1;
     end
-    if(when_DebugPlugin_l295) begin
-      if(when_DebugPlugin_l298) begin
+    if(when_DebugPlugin_l308) begin
+      if(when_DebugPlugin_l311) begin
         execute_arbitration_flushNext = 1'b1;
       end
     end
@@ -2478,7 +2456,7 @@ module VexRiscv (
 
   always @(*) begin
     memory_arbitration_haltItself = 1'b0;
-    if(when_DBusSimplePlugin_l482) begin
+    if(when_DBusSimplePlugin_l490) begin
       memory_arbitration_haltItself = 1'b1;
     end
     if(when_MulDivIterativePlugin_l96) begin
@@ -2530,10 +2508,10 @@ module VexRiscv (
   assign writeBack_arbitration_flushIt = 1'b0;
   always @(*) begin
     writeBack_arbitration_flushNext = 1'b0;
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -2544,24 +2522,24 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @(*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(when_CsrPlugin_l935) begin
+    if(when_CsrPlugin_l1272) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_DebugPlugin_l295) begin
-      if(when_DebugPlugin_l298) begin
+    if(when_DebugPlugin_l308) begin
+      if(when_DebugPlugin_l311) begin
         IBusCachedPlugin_fetcherHalt = 1'b1;
       end
     end
     if(DebugPlugin_haltIt) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_DebugPlugin_l311) begin
+    if(when_DebugPlugin_l324) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
@@ -2569,7 +2547,7 @@ module VexRiscv (
   assign IBusCachedPlugin_forceNoDecodeCond = 1'b0;
   always @(*) begin
     IBusCachedPlugin_incomingInstruction = 1'b0;
-    if(when_Fetcher_l243) begin
+    if(when_Fetcher_l242) begin
       IBusCachedPlugin_incomingInstruction = 1'b1;
     end
   end
@@ -2581,7 +2559,17 @@ module VexRiscv (
     end
   end
 
-  assign CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+  always @(*) begin
+    CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+    if(when_CsrPlugin_l1702) begin
+      CsrPlugin_csrMapping_allowCsrSignal = 1'b1;
+    end
+    if(when_CsrPlugin_l1709) begin
+      CsrPlugin_csrMapping_allowCsrSignal = 1'b1;
+    end
+  end
+
+  assign CsrPlugin_csrMapping_doForceFailCsr = 1'b0;
   assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
   assign CsrPlugin_inWfi = 1'b0;
   always @(*) begin
@@ -2593,21 +2581,21 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(when_CsrPlugin_l1077) begin
-      case(switch_CsrPlugin_l1081)
+    if(when_CsrPlugin_l1456) begin
+      case(switch_CsrPlugin_l1460)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -2626,7 +2614,7 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_allowInterrupts = 1'b1;
-    if(when_DebugPlugin_l331) begin
+    if(when_DebugPlugin_l344) begin
       CsrPlugin_allowInterrupts = 1'b0;
     end
   end
@@ -2645,6 +2633,7 @@ module VexRiscv (
     end
   end
 
+  assign CsrPlugin_xretAwayFromMachine = 1'b0;
   assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
   assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,IBusCachedPlugin_predictionJumpInterface_valid}} != 3'b000);
   assign _zz_IBusCachedPlugin_jump_pcLoad_payload = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,CsrPlugin_jumpInterface_valid}};
@@ -2671,9 +2660,8 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l134 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
-  assign IBusCachedPlugin_fetchPc_output_fire_1 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
-  assign when_Fetcher_l134_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
+  assign when_Fetcher_l133 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l133_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
   always @(*) begin
     IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_IBusCachedPlugin_fetchPc_pc);
     if(IBusCachedPlugin_fetchPc_redo_valid) begin
@@ -2696,7 +2684,7 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l161 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
+  assign when_Fetcher_l160 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
   assign IBusCachedPlugin_fetchPc_output_valid = ((! IBusCachedPlugin_fetcherHalt) && IBusCachedPlugin_fetchPc_booted);
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
   always @(*) begin
@@ -2733,7 +2721,7 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_1_output_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b0;
-    if(when_IBusCachedPlugin_l267) begin
+    if(when_IBusCachedPlugin_l273) begin
       IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b1;
     end
   end
@@ -2746,9 +2734,9 @@ module VexRiscv (
   assign IBusCachedPlugin_fetchPc_redo_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_iBusRsp_flush = ((decode_arbitration_removeIt || (decode_arbitration_flushNext && (! decode_arbitration_isStuck))) || IBusCachedPlugin_iBusRsp_redoFetch);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
-  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1 = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
   assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid)) || IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready);
   assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
@@ -2758,18 +2746,18 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
   always @(*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
-    if(when_Fetcher_l323) begin
+    if(when_Fetcher_l322) begin
       IBusCachedPlugin_iBusRsp_readyForError = 1'b0;
     end
   end
 
-  assign when_Fetcher_l243 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
-  assign when_Fetcher_l323 = (! IBusCachedPlugin_pcValids_0);
-  assign when_Fetcher_l332 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
-  assign when_Fetcher_l332_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
-  assign when_Fetcher_l332_2 = (! execute_arbitration_isStuck);
-  assign when_Fetcher_l332_3 = (! memory_arbitration_isStuck);
-  assign when_Fetcher_l332_4 = (! writeBack_arbitration_isStuck);
+  assign when_Fetcher_l242 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
+  assign when_Fetcher_l322 = (! IBusCachedPlugin_pcValids_0);
+  assign when_Fetcher_l331 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l331_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
+  assign when_Fetcher_l331_2 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l331_3 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l331_4 = (! writeBack_arbitration_isStuck);
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
@@ -2777,7 +2765,7 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
   always @(*) begin
     decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
-    case(switch_Fetcher_l365)
+    case(IBusCachedPlugin_injector_port_state)
       3'b010 : begin
         decode_arbitration_isValid = 1'b1;
       end
@@ -2934,47 +2922,47 @@ module VexRiscv (
   assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
   always @(*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(when_IBusCachedPlugin_l239) begin
+    if(when_IBusCachedPlugin_l245) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(when_IBusCachedPlugin_l250) begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_cache_io_cpu_fill_valid = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
-    if(when_IBusCachedPlugin_l250) begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_cache_io_cpu_fill_valid = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_valid = 1'b0;
-    if(when_IBusCachedPlugin_l244) begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
-    if(when_IBusCachedPlugin_l256) begin
+    if(when_IBusCachedPlugin_l262) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_payload_code = 4'bxxxx;
-    if(when_IBusCachedPlugin_l244) begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b1100;
     end
-    if(when_IBusCachedPlugin_l256) begin
+    if(when_IBusCachedPlugin_l262) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b0001;
     end
   end
 
   assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_2_input_payload[31 : 2],2'b00};
-  assign when_IBusCachedPlugin_l239 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign when_IBusCachedPlugin_l244 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
-  assign when_IBusCachedPlugin_l250 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
-  assign when_IBusCachedPlugin_l256 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
-  assign when_IBusCachedPlugin_l267 = (IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt);
+  assign when_IBusCachedPlugin_l245 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign when_IBusCachedPlugin_l250 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign when_IBusCachedPlugin_l256 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
+  assign when_IBusCachedPlugin_l262 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
+  assign when_IBusCachedPlugin_l273 = (IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt);
   assign IBusCachedPlugin_iBusRsp_output_valid = IBusCachedPlugin_iBusRsp_stages_2_output_valid;
   assign IBusCachedPlugin_iBusRsp_stages_2_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
   assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_decode_data;
@@ -3006,7 +2994,7 @@ module VexRiscv (
   end
 
   assign dBus_cmd_payload_data = _zz_dBus_cmd_payload_data;
-  assign when_DBusSimplePlugin_l428 = ((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! dBus_cmd_ready)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_dBus_cmd_valid));
+  assign when_DBusSimplePlugin_l436 = ((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! dBus_cmd_ready)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_dBus_cmd_valid));
   always @(*) begin
     case(dBus_cmd_payload_size)
       2'b00 : begin
@@ -3023,23 +3011,23 @@ module VexRiscv (
 
   assign execute_DBusSimplePlugin_formalMask = (_zz_execute_DBusSimplePlugin_formalMask <<< dBus_cmd_payload_address[1 : 0]);
   assign dBus_cmd_payload_address = execute_SRC_ADD;
-  assign when_DBusSimplePlugin_l482 = (((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (! memory_MEMORY_STORE)) && ((! dBus_rsp_ready) || 1'b0));
+  assign when_DBusSimplePlugin_l490 = (((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (! memory_MEMORY_STORE)) && ((! dBus_rsp_ready) || 1'b0));
   always @(*) begin
     DBusSimplePlugin_memoryExceptionPort_valid = 1'b0;
-    if(when_DBusSimplePlugin_l489) begin
+    if(when_DBusSimplePlugin_l497) begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b1;
     end
     if(memory_ALIGNEMENT_FAULT) begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b1;
     end
-    if(when_DBusSimplePlugin_l515) begin
+    if(when_DBusSimplePlugin_l523) begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b0;
     end
   end
 
   always @(*) begin
     DBusSimplePlugin_memoryExceptionPort_payload_code = 4'bxxxx;
-    if(when_DBusSimplePlugin_l489) begin
+    if(when_DBusSimplePlugin_l497) begin
       DBusSimplePlugin_memoryExceptionPort_payload_code = 4'b0101;
     end
     if(memory_ALIGNEMENT_FAULT) begin
@@ -3048,8 +3036,8 @@ module VexRiscv (
   end
 
   assign DBusSimplePlugin_memoryExceptionPort_payload_badAddr = memory_REGFILE_WRITE_DATA;
-  assign when_DBusSimplePlugin_l489 = ((dBus_rsp_ready && dBus_rsp_error) && (! memory_MEMORY_STORE));
-  assign when_DBusSimplePlugin_l515 = (! ((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (1'b1 || (! memory_arbitration_isStuckByOthers))));
+  assign when_DBusSimplePlugin_l497 = ((dBus_rsp_ready && dBus_rsp_error) && (! memory_MEMORY_STORE));
+  assign when_DBusSimplePlugin_l523 = (! ((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (1'b1 || (! memory_arbitration_isStuckByOthers))));
   always @(*) begin
     writeBack_DBusSimplePlugin_rspShifted = writeBack_MEMORY_READ_DATA;
     case(writeBack_MEMORY_ADDRESS_LOW)
@@ -3067,7 +3055,7 @@ module VexRiscv (
     endcase
   end
 
-  assign switch_Misc_l210 = writeBack_INSTRUCTION[13 : 12];
+  assign switch_Misc_l232 = writeBack_INSTRUCTION[13 : 12];
   assign _zz_writeBack_DBusSimplePlugin_rspFormated = (writeBack_DBusSimplePlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
   always @(*) begin
     _zz_writeBack_DBusSimplePlugin_rspFormated_1[31] = _zz_writeBack_DBusSimplePlugin_rspFormated;
@@ -3119,7 +3107,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    case(switch_Misc_l210)
+    case(switch_Misc_l232)
       2'b00 : begin
         writeBack_DBusSimplePlugin_rspFormated = _zz_writeBack_DBusSimplePlugin_rspFormated_1;
       end
@@ -3132,7 +3120,7 @@ module VexRiscv (
     endcase
   end
 
-  assign when_DBusSimplePlugin_l558 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusSimplePlugin_l566 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
   assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
@@ -3143,7 +3131,7 @@ module VexRiscv (
   assign IBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign IBusCachedPlugin_mmuBus_busy = 1'b0;
   assign _zz_decode_IS_DIV_1 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_decode_IS_DIV_2 = ((decode_INSTRUCTION & 32'h00000018) == 32'h0);
+  assign _zz_decode_IS_DIV_2 = ((decode_INSTRUCTION & 32'h00000018) == 32'h00000000);
   assign _zz_decode_IS_DIV_3 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
   assign _zz_decode_IS_DIV_4 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
   assign _zz_decode_IS_DIV_5 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
@@ -3167,29 +3155,29 @@ module VexRiscv (
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
-  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h0);
+  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h00);
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
   assign decode_RegFilePlugin_rs1Data = _zz_RegFilePlugin_regFile_port0;
   assign decode_RegFilePlugin_rs2Data = _zz_RegFilePlugin_regFile_port1;
   always @(*) begin
     lastStageRegFileWrite_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
-    if(_zz_7) begin
+    if(_zz_10) begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
   always @(*) begin
     lastStageRegFileWrite_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
-    if(_zz_7) begin
-      lastStageRegFileWrite_payload_address = 5'h0;
+    if(_zz_10) begin
+      lastStageRegFileWrite_payload_address = 5'h00;
     end
   end
 
   always @(*) begin
     lastStageRegFileWrite_payload_data = _zz_decode_RS2_2;
-    if(_zz_7) begin
-      lastStageRegFileWrite_payload_data = 32'h0;
+    if(_zz_10) begin
+      lastStageRegFileWrite_payload_data = 32'h00000000;
     end
   end
 
@@ -3230,7 +3218,7 @@ module VexRiscv (
         _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
       Src1CtrlEnum_IMU : begin
-        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h000};
       end
       default : begin
         _zz_execute_SRC1 = {27'd0, _zz__zz_execute_SRC1_1};
@@ -3238,67 +3226,67 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_execute_SRC2_1 = execute_INSTRUCTION[31];
+  assign _zz_execute_SRC2 = execute_INSTRUCTION[31];
   always @(*) begin
-    _zz_execute_SRC2_2[19] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[18] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[17] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[16] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[15] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[14] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[13] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[12] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[11] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[10] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[9] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[8] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[7] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[6] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[5] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[4] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[3] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[2] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[1] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[0] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_1[19] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[18] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[17] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[16] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[15] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[14] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[13] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[12] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[11] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[10] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[9] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[8] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[7] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[6] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[5] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[4] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[3] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[2] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[1] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[0] = _zz_execute_SRC2;
   end
 
-  assign _zz_execute_SRC2_3 = _zz__zz_execute_SRC2_3[11];
+  assign _zz_execute_SRC2_2 = _zz__zz_execute_SRC2_2[11];
   always @(*) begin
-    _zz_execute_SRC2_4[19] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[18] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[17] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[16] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[15] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[14] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[13] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[12] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[11] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[10] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[9] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[8] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[7] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[6] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[5] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[4] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[3] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[2] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[1] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[0] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_3[19] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[18] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[17] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[16] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[15] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[14] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[13] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[12] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[11] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[10] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[9] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[8] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[7] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[6] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[5] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[4] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[3] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[2] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[1] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[0] = _zz_execute_SRC2_2;
   end
 
   always @(*) begin
     case(execute_SRC2_CTRL)
       Src2CtrlEnum_RS : begin
-        _zz_execute_SRC2_5 = execute_RS2;
+        _zz_execute_SRC2_4 = execute_RS2;
       end
       Src2CtrlEnum_IMI : begin
-        _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
+        _zz_execute_SRC2_4 = {_zz_execute_SRC2_1,execute_INSTRUCTION[31 : 20]};
       end
       Src2CtrlEnum_IMS : begin
-        _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_execute_SRC2_4 = {_zz_execute_SRC2_3,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_execute_SRC2_5 = _zz_execute_SRC2;
+        _zz_execute_SRC2_4 = _zz_execute_to_memory_PC;
       end
     endcase
   end
@@ -3315,7 +3303,7 @@ module VexRiscv (
   assign execute_LightShifterPlugin_amplitude = (execute_LightShifterPlugin_isActive ? execute_LightShifterPlugin_amplitudeReg : execute_SRC2[4 : 0]);
   assign execute_LightShifterPlugin_shiftInput = (execute_LightShifterPlugin_isActive ? memory_REGFILE_WRITE_DATA : execute_SRC1);
   assign execute_LightShifterPlugin_done = (execute_LightShifterPlugin_amplitude[4 : 1] == 4'b0000);
-  assign when_ShiftPlugins_l169 = ((execute_arbitration_isValid && execute_LightShifterPlugin_isShift) && (execute_SRC2[4 : 0] != 5'h0));
+  assign when_ShiftPlugins_l169 = ((execute_arbitration_isValid && execute_LightShifterPlugin_isShift) && (execute_SRC2[4 : 0] != 5'h00));
   always @(*) begin
     case(execute_SHIFT_CTRL)
       ShiftCtrlEnum_SLL_1 : begin
@@ -3410,16 +3398,19 @@ module VexRiscv (
   assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
   assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign switch_Misc_l210_1 = execute_INSTRUCTION[14 : 12];
+  assign switch_Misc_l232_1 = execute_INSTRUCTION[14 : 12];
   always @(*) begin
-    casez(switch_Misc_l210_1)
+    case(switch_Misc_l232_1)
       3'b000 : begin
         _zz_execute_BRANCH_COND_RESULT = execute_BranchPlugin_eq;
       end
       3'b001 : begin
         _zz_execute_BRANCH_COND_RESULT = (! execute_BranchPlugin_eq);
       end
-      3'b1?1 : begin
+      3'b101 : begin
+        _zz_execute_BRANCH_COND_RESULT = (! execute_SRC_LESS);
+      end
+      3'b111 : begin
         _zz_execute_BRANCH_COND_RESULT = (! execute_SRC_LESS);
       end
       default : begin
@@ -3625,9 +3616,9 @@ module VexRiscv (
 
   assign CsrPlugin_misa_base = 2'b01;
   assign CsrPlugin_misa_extensions = 26'h0000042;
-  assign _zz_when_CsrPlugin_l965 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_when_CsrPlugin_l965_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_when_CsrPlugin_l965_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign _zz_when_CsrPlugin_l1302 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l1302_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l1302_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
   assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
@@ -3671,29 +3662,29 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l922 = (! decode_arbitration_isStuck);
-  assign when_CsrPlugin_l922_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l922_2 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l922_3 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l935 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
+  assign when_CsrPlugin_l1259 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l1272 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-  assign when_CsrPlugin_l959 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign when_CsrPlugin_l965 = ((_zz_when_CsrPlugin_l965 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l965_1 = ((_zz_when_CsrPlugin_l965_1 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l965_2 = ((_zz_when_CsrPlugin_l965_2 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1296 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l1302 = ((_zz_when_CsrPlugin_l1302 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1302_1 = ((_zz_when_CsrPlugin_l1302_1 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1302_2 = ((_zz_when_CsrPlugin_l1302_2 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_lastStageWasWfi = 1'b0;
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  assign when_CsrPlugin_l993 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l993_1 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l993_2 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l998 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  assign when_CsrPlugin_l1335 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1335_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l1335_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l1340 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
   always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(when_CsrPlugin_l1004) begin
+    if(when_CsrPlugin_l1346) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException) begin
@@ -3701,7 +3692,7 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l1004 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
+  assign when_CsrPlugin_l1346 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
   always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
@@ -3717,6 +3708,7 @@ module VexRiscv (
     end
   end
 
+  assign CsrPlugin_trapCauseEbreakDebug = 1'b0;
   always @(*) begin
     CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
@@ -3739,11 +3731,13 @@ module VexRiscv (
     endcase
   end
 
-  assign when_CsrPlugin_l1032 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign when_CsrPlugin_l1077 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
-  assign switch_CsrPlugin_l1081 = writeBack_INSTRUCTION[29 : 28];
+  assign CsrPlugin_trapEnterDebug = 1'b0;
+  assign when_CsrPlugin_l1390 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1398 = (! CsrPlugin_trapEnterDebug);
+  assign when_CsrPlugin_l1456 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign switch_CsrPlugin_l1460 = writeBack_INSTRUCTION[29 : 28];
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign when_CsrPlugin_l1129 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
+  assign when_CsrPlugin_l1527 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
   assign execute_CsrPlugin_blockedBySideEffects = ((|{writeBack_arbitration_isValid,memory_arbitration_isValid}) || 1'b0);
   always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
@@ -3785,18 +3779,18 @@ module VexRiscv (
     if(CsrPlugin_csrMapping_allowCsrSignal) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(when_CsrPlugin_l1315) begin
+    if(when_CsrPlugin_l1725) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if(when_CsrPlugin_l1149) begin
-      if(when_CsrPlugin_l1150) begin
+    if(when_CsrPlugin_l1547) begin
+      if(when_CsrPlugin_l1548) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
@@ -3804,14 +3798,14 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(when_CsrPlugin_l1157) begin
+    if(when_CsrPlugin_l1555) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(when_CsrPlugin_l1157) begin
+    if(when_CsrPlugin_l1555) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -3824,19 +3818,19 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  assign when_CsrPlugin_l1149 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
-  assign when_CsrPlugin_l1150 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
-  assign when_CsrPlugin_l1157 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
+  assign when_CsrPlugin_l1547 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign when_CsrPlugin_l1548 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1555 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
   always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -3845,9 +3839,9 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
   assign execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
-  assign switch_Misc_l210_2 = execute_INSTRUCTION[13];
+  assign switch_Misc_l232_2 = execute_INSTRUCTION[13];
   always @(*) begin
-    case(switch_Misc_l210_2)
+    case(switch_Misc_l232_2)
       1'b0 : begin
         _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
@@ -3858,8 +3852,8 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
-  assign when_CsrPlugin_l1189 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign when_CsrPlugin_l1193 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
+  assign when_CsrPlugin_l1587 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1591 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign memory_MulDivIterativePlugin_frontendOk = 1'b1;
   always @(*) begin
@@ -3882,12 +3876,12 @@ module VexRiscv (
   assign memory_MulDivIterativePlugin_mul_counter_willOverflow = (memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc && memory_MulDivIterativePlugin_mul_counter_willIncrement);
   always @(*) begin
     if(memory_MulDivIterativePlugin_mul_counter_willOverflow) begin
-      memory_MulDivIterativePlugin_mul_counter_valueNext = 6'h0;
+      memory_MulDivIterativePlugin_mul_counter_valueNext = 6'h00;
     end else begin
       memory_MulDivIterativePlugin_mul_counter_valueNext = (memory_MulDivIterativePlugin_mul_counter_value + _zz_memory_MulDivIterativePlugin_mul_counter_valueNext);
     end
     if(memory_MulDivIterativePlugin_mul_counter_willClear) begin
-      memory_MulDivIterativePlugin_mul_counter_valueNext = 6'h0;
+      memory_MulDivIterativePlugin_mul_counter_valueNext = 6'h00;
     end
   end
 
@@ -3915,12 +3909,12 @@ module VexRiscv (
   assign memory_MulDivIterativePlugin_div_counter_willOverflow = (memory_MulDivIterativePlugin_div_counter_willOverflowIfInc && memory_MulDivIterativePlugin_div_counter_willIncrement);
   always @(*) begin
     if(memory_MulDivIterativePlugin_div_counter_willOverflow) begin
-      memory_MulDivIterativePlugin_div_counter_valueNext = 6'h0;
+      memory_MulDivIterativePlugin_div_counter_valueNext = 6'h00;
     end else begin
       memory_MulDivIterativePlugin_div_counter_valueNext = (memory_MulDivIterativePlugin_div_counter_value + _zz_memory_MulDivIterativePlugin_div_counter_valueNext);
     end
     if(memory_MulDivIterativePlugin_div_counter_willClear) begin
-      memory_MulDivIterativePlugin_div_counter_valueNext = 6'h0;
+      memory_MulDivIterativePlugin_div_counter_valueNext = 6'h00;
     end
   end
 
@@ -3937,24 +3931,24 @@ module VexRiscv (
   assign when_MulDivIterativePlugin_l151 = (memory_MulDivIterativePlugin_div_counter_value == 6'h20);
   assign _zz_memory_MulDivIterativePlugin_div_result = (memory_INSTRUCTION[13] ? memory_MulDivIterativePlugin_accumulator[31 : 0] : memory_MulDivIterativePlugin_rs1[31 : 0]);
   assign when_MulDivIterativePlugin_l162 = (! memory_arbitration_isStuck);
-  assign _zz_memory_MulDivIterativePlugin_rs1 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
-  assign _zz_memory_MulDivIterativePlugin_rs1_1 = ((execute_IS_MUL && _zz_memory_MulDivIterativePlugin_rs1) || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
+  assign _zz_memory_MulDivIterativePlugin_rs2 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
+  assign _zz_memory_MulDivIterativePlugin_rs1 = ((execute_IS_MUL && _zz_memory_MulDivIterativePlugin_rs2) || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
   always @(*) begin
-    _zz_memory_MulDivIterativePlugin_rs1_2[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
-    _zz_memory_MulDivIterativePlugin_rs1_2[31 : 0] = execute_RS1;
+    _zz_memory_MulDivIterativePlugin_rs1_1[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
+    _zz_memory_MulDivIterativePlugin_rs1_1[31 : 0] = execute_RS1;
   end
 
-  assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
-  assign externalInterrupt = (|_zz_CsrPlugin_csrMapping_readDataInit_1);
-  assign when_DebugPlugin_l225 = (DebugPlugin_haltIt && (! DebugPlugin_isPipBusy));
+  assign _zz_externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
+  assign externalInterrupt = (|_zz_externalInterrupt);
+  assign when_DebugPlugin_l238 = (DebugPlugin_haltIt && (! DebugPlugin_isPipBusy));
   assign DebugPlugin_allowEBreak = (DebugPlugin_debugUsed && (! DebugPlugin_disableEbreak));
   always @(*) begin
     debug_bus_cmd_ready = 1'b1;
     if(debug_bus_cmd_valid) begin
-      case(switch_DebugPlugin_l267)
+      case(switch_DebugPlugin_l280)
         6'h01 : begin
           if(debug_bus_cmd_payload_wr) begin
-            debug_bus_cmd_ready = IBusCachedPlugin_injectionPort_ready;
+            debug_bus_cmd_ready = DebugPlugin_injectionPort_ready;
           end
         end
         default : begin
@@ -3965,7 +3959,7 @@ module VexRiscv (
 
   always @(*) begin
     debug_bus_rsp_data = DebugPlugin_busReadDataReg;
-    if(when_DebugPlugin_l244) begin
+    if(when_DebugPlugin_l257) begin
       debug_bus_rsp_data[0] = DebugPlugin_resetIt;
       debug_bus_rsp_data[1] = DebugPlugin_haltIt;
       debug_bus_rsp_data[2] = DebugPlugin_isPipBusy;
@@ -3974,14 +3968,14 @@ module VexRiscv (
     end
   end
 
-  assign when_DebugPlugin_l244 = (! _zz_when_DebugPlugin_l244);
+  assign when_DebugPlugin_l257 = (! _zz_when_DebugPlugin_l257);
   always @(*) begin
-    IBusCachedPlugin_injectionPort_valid = 1'b0;
+    DebugPlugin_injectionPort_valid = 1'b0;
     if(debug_bus_cmd_valid) begin
-      case(switch_DebugPlugin_l267)
+      case(switch_DebugPlugin_l280)
         6'h01 : begin
           if(debug_bus_cmd_payload_wr) begin
-            IBusCachedPlugin_injectionPort_valid = 1'b1;
+            DebugPlugin_injectionPort_valid = 1'b1;
           end
         end
         default : begin
@@ -3990,21 +3984,21 @@ module VexRiscv (
     end
   end
 
-  assign IBusCachedPlugin_injectionPort_payload = debug_bus_cmd_payload_data;
-  assign switch_DebugPlugin_l267 = debug_bus_cmd_payload_address[7 : 2];
-  assign when_DebugPlugin_l271 = debug_bus_cmd_payload_data[16];
-  assign when_DebugPlugin_l271_1 = debug_bus_cmd_payload_data[24];
-  assign when_DebugPlugin_l272 = debug_bus_cmd_payload_data[17];
-  assign when_DebugPlugin_l272_1 = debug_bus_cmd_payload_data[25];
-  assign when_DebugPlugin_l273 = debug_bus_cmd_payload_data[25];
-  assign when_DebugPlugin_l274 = debug_bus_cmd_payload_data[25];
-  assign when_DebugPlugin_l275 = debug_bus_cmd_payload_data[18];
-  assign when_DebugPlugin_l275_1 = debug_bus_cmd_payload_data[26];
-  assign when_DebugPlugin_l295 = (execute_arbitration_isValid && execute_DO_EBREAK);
-  assign when_DebugPlugin_l298 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
-  assign when_DebugPlugin_l311 = (DebugPlugin_stepIt && IBusCachedPlugin_incomingInstruction);
+  assign DebugPlugin_injectionPort_payload = debug_bus_cmd_payload_data;
+  assign switch_DebugPlugin_l280 = debug_bus_cmd_payload_address[7 : 2];
+  assign when_DebugPlugin_l284 = debug_bus_cmd_payload_data[16];
+  assign when_DebugPlugin_l284_1 = debug_bus_cmd_payload_data[24];
+  assign when_DebugPlugin_l285 = debug_bus_cmd_payload_data[17];
+  assign when_DebugPlugin_l285_1 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l286 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l287 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l288 = debug_bus_cmd_payload_data[18];
+  assign when_DebugPlugin_l288_1 = debug_bus_cmd_payload_data[26];
+  assign when_DebugPlugin_l308 = (execute_arbitration_isValid && execute_DO_EBREAK);
+  assign when_DebugPlugin_l311 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
+  assign when_DebugPlugin_l324 = (DebugPlugin_stepIt && IBusCachedPlugin_incomingInstruction);
   assign debug_resetOut = DebugPlugin_resetIt_regNext;
-  assign when_DebugPlugin_l331 = (DebugPlugin_haltIt || DebugPlugin_stepIt);
+  assign when_DebugPlugin_l344 = (DebugPlugin_haltIt || DebugPlugin_stepIt);
   assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
@@ -4110,93 +4104,103 @@ module VexRiscv (
   assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
   assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
   always @(*) begin
-    IBusCachedPlugin_injectionPort_ready = 1'b0;
-    case(switch_Fetcher_l365)
+    DebugPlugin_injectionPort_ready = 1'b0;
+    case(IBusCachedPlugin_injector_port_state)
       3'b100 : begin
-        IBusCachedPlugin_injectionPort_ready = 1'b1;
+        DebugPlugin_injectionPort_ready = 1'b1;
       end
       default : begin
       end
     endcase
   end
 
-  assign when_Fetcher_l381 = (! decode_arbitration_isStuck);
-  assign when_CsrPlugin_l1277 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_2 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_3 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_4 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_5 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_6 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_7 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_8 = (! execute_arbitration_isStuck);
-  assign switch_CsrPlugin_l723 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
+  assign when_Fetcher_l391 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l1669 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_8 = (! execute_arbitration_isStuck);
+  assign switch_CsrPlugin_l1031 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_1 = 32'h00000000;
     if(execute_CsrPlugin_csr_768) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_2[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_2[3 : 3] = CsrPlugin_mstatus_MIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_2[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_CsrPlugin_csrMapping_readDataInit_1[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_1[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_1[12 : 11] = CsrPlugin_mstatus_MPP;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h00000000;
     if(execute_CsrPlugin_csr_836) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_3[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_3[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_3[3 : 3] = CsrPlugin_mip_MSIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[3 : 3] = CsrPlugin_mip_MSIP;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h00000000;
     if(execute_CsrPlugin_csr_772) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_4[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_4[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_4[3 : 3] = CsrPlugin_mie_MSIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[3 : 3] = CsrPlugin_mie_MSIE;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h00000000;
     if(execute_CsrPlugin_csr_833) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_5[31 : 0] = CsrPlugin_mepc;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[31 : 0] = CsrPlugin_mepc;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h00000000;
     if(execute_CsrPlugin_csr_834) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_6[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_CsrPlugin_csrMapping_readDataInit_6[3 : 0] = CsrPlugin_mcause_exceptionCode;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h00000000;
     if(execute_CsrPlugin_csr_835) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_7[31 : 0] = CsrPlugin_mtval;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[31 : 0] = CsrPlugin_mtval;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h00000000;
     if(execute_CsrPlugin_csr_3008) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_8[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h00000000;
     if(execute_CsrPlugin_csr_4032) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_9[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_1;
+      _zz_CsrPlugin_csrMapping_readDataInit_8[31 : 0] = _zz_externalInterrupt;
     end
   end
 
-  assign CsrPlugin_csrMapping_readDataInit = (((_zz_CsrPlugin_csrMapping_readDataInit_2 | _zz_CsrPlugin_csrMapping_readDataInit_3) | (_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5)) | ((_zz_CsrPlugin_csrMapping_readDataInit_6 | _zz_CsrPlugin_csrMapping_readDataInit_7) | (_zz_CsrPlugin_csrMapping_readDataInit_8 | _zz_CsrPlugin_csrMapping_readDataInit_9)));
-  assign when_CsrPlugin_l1310 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign when_CsrPlugin_l1315 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign CsrPlugin_csrMapping_readDataInit = (((_zz_CsrPlugin_csrMapping_readDataInit_1 | _zz_CsrPlugin_csrMapping_readDataInit_2) | (_zz_CsrPlugin_csrMapping_readDataInit_3 | _zz_CsrPlugin_csrMapping_readDataInit_4)) | ((_zz_CsrPlugin_csrMapping_readDataInit_5 | _zz_CsrPlugin_csrMapping_readDataInit_6) | (_zz_CsrPlugin_csrMapping_readDataInit_7 | _zz_CsrPlugin_csrMapping_readDataInit_8)));
+  assign when_CsrPlugin_l1702 = ((execute_arbitration_isValid && execute_IS_CSR) && (({execute_CsrPlugin_csrAddress[11 : 2],2'b00} == 12'h3a0) || ({execute_CsrPlugin_csrAddress[11 : 4],4'b0000} == 12'h3b0)));
+  assign _zz_when_CsrPlugin_l1709 = (execute_CsrPlugin_csrAddress & 12'hf60);
+  assign when_CsrPlugin_l1709 = (((execute_arbitration_isValid && execute_IS_CSR) && (5'h03 <= execute_CsrPlugin_csrAddress[4 : 0])) && (((_zz_when_CsrPlugin_l1709 == 12'hb00) || (((_zz_when_CsrPlugin_l1709 == 12'hc00) && (! execute_CsrPlugin_writeInstruction)) && (CsrPlugin_privilege == 2'b11))) || ((execute_CsrPlugin_csrAddress & 12'hfe0) == 12'h320)));
+  always @(*) begin
+    when_CsrPlugin_l1719 = CsrPlugin_csrMapping_doForceFailCsr;
+    if(when_CsrPlugin_l1717) begin
+      when_CsrPlugin_l1719 = 1'b1;
+    end
+  end
+
+  assign when_CsrPlugin_l1717 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1725 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
   assign iBusWishbone_ADR = {_zz_iBusWishbone_ADR_1,_zz_iBusWishbone_ADR};
   assign iBusWishbone_CTI = ((_zz_iBusWishbone_ADR == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
@@ -4229,7 +4233,7 @@ module VexRiscv (
   assign dBus_cmd_halfPipe_payload_address = dBus_cmd_rData_address;
   assign dBus_cmd_halfPipe_payload_data = dBus_cmd_rData_data;
   assign dBus_cmd_halfPipe_payload_size = dBus_cmd_rData_size;
-  assign dBusWishbone_ADR = (dBus_cmd_halfPipe_payload_address >>> 2);
+  assign dBusWishbone_ADR = (dBus_cmd_halfPipe_payload_address >>> 2'd2);
   assign dBusWishbone_CTI = 3'b000;
   assign dBusWishbone_BTE = 2'b00;
   always @(*) begin
@@ -4248,12 +4252,12 @@ module VexRiscv (
 
   always @(*) begin
     dBusWishbone_SEL = (_zz_dBusWishbone_SEL <<< dBus_cmd_halfPipe_payload_address[1 : 0]);
-    if(when_DBusSimplePlugin_l189) begin
+    if(when_DBusSimplePlugin_l196) begin
       dBusWishbone_SEL = 4'b1111;
     end
   end
 
-  assign when_DBusSimplePlugin_l189 = (! dBus_cmd_halfPipe_payload_wr);
+  assign when_DBusSimplePlugin_l196 = (! dBus_cmd_halfPipe_payload_wr);
   assign dBusWishbone_WE = dBus_cmd_halfPipe_payload_wr;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_halfPipe_payload_data;
   assign dBus_cmd_halfPipe_ready = (dBus_cmd_halfPipe_valid && dBusWishbone_ACK);
@@ -4268,15 +4272,15 @@ module VexRiscv (
       IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
-      _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+      _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= 1'b0;
       _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= 32'h0;
-      _zz_7 <= 1'b1;
+      IBusCachedPlugin_rspCounter <= 32'h00000000;
+      _zz_10 <= 1'b1;
       execute_LightShifterPlugin_isActive <= 1'b0;
       HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
       CsrPlugin_mstatus_MIE <= 1'b0;
@@ -4285,8 +4289,8 @@ module VexRiscv (
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
-      CsrPlugin_mcycle <= 64'h0;
-      CsrPlugin_minstret <= 64'h0;
+      CsrPlugin_mcycle <= 64'h0000000000000000;
+      CsrPlugin_minstret <= 64'h0000000000000000;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= 1'b0;
@@ -4297,13 +4301,13 @@ module VexRiscv (
       CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
-      memory_MulDivIterativePlugin_mul_counter_value <= 6'h0;
-      memory_MulDivIterativePlugin_div_counter_value <= 6'h0;
-      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h0;
+      memory_MulDivIterativePlugin_mul_counter_value <= 6'h00;
+      memory_MulDivIterativePlugin_div_counter_value <= 6'h00;
+      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h00000000;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
-      switch_Fetcher_l365 <= 3'b000;
+      IBusCachedPlugin_injector_port_state <= 3'b000;
       _zz_iBusWishbone_ADR <= 3'b000;
       _zz_iBus_rsp_valid <= 1'b0;
       dBus_cmd_rValid <= 1'b0;
@@ -4315,23 +4319,23 @@ module VexRiscv (
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusCachedPlugin_fetchPc_booted <= 1'b1;
-      if(when_Fetcher_l134) begin
+      if(when_Fetcher_l133) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_output_fire_1) begin
+      if(IBusCachedPlugin_fetchPc_output_fire) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b1;
       end
-      if(when_Fetcher_l134_1) begin
+      if(when_Fetcher_l133_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(when_Fetcher_l161) begin
+      if(when_Fetcher_l160) begin
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
       if(IBusCachedPlugin_iBusRsp_flush) begin
-        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= 1'b0;
       end
       if(_zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready) begin
-        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
       if(IBusCachedPlugin_iBusRsp_flush) begin
         _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
@@ -4342,13 +4346,13 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if(when_Fetcher_l332) begin
+      if(when_Fetcher_l331) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(when_Fetcher_l332_1) begin
+      if(when_Fetcher_l331_1) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= IBusCachedPlugin_injector_nextPcCalc_valids_0;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -4357,7 +4361,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(when_Fetcher_l332_2) begin
+      if(when_Fetcher_l331_2) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= IBusCachedPlugin_injector_nextPcCalc_valids_1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -4366,7 +4370,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(when_Fetcher_l332_3) begin
+      if(when_Fetcher_l331_3) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -4375,7 +4379,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if(when_Fetcher_l332_4) begin
+      if(when_Fetcher_l331_4) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= IBusCachedPlugin_injector_nextPcCalc_valids_3;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -4384,7 +4388,7 @@ module VexRiscv (
       if(iBus_rsp_valid) begin
         IBusCachedPlugin_rspCounter <= (IBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      _zz_7 <= 1'b0;
+      _zz_10 <= 1'b0;
       if(when_ShiftPlugins_l169) begin
         if(when_ShiftPlugins_l175) begin
           execute_LightShifterPlugin_isActive <= 1'b1;
@@ -4401,50 +4405,50 @@ module VexRiscv (
       if(writeBack_arbitration_isFiring) begin
         CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
       end
-      if(when_CsrPlugin_l922) begin
+      if(when_CsrPlugin_l1259) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if(when_CsrPlugin_l922_1) begin
+      if(when_CsrPlugin_l1259_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if(when_CsrPlugin_l922_2) begin
+      if(when_CsrPlugin_l1259_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if(when_CsrPlugin_l922_3) begin
+      if(when_CsrPlugin_l1259_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(when_CsrPlugin_l959) begin
-        if(when_CsrPlugin_l965) begin
+      if(when_CsrPlugin_l1296) begin
+        if(when_CsrPlugin_l1302) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_1) begin
+        if(when_CsrPlugin_l1302_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_2) begin
+        if(when_CsrPlugin_l1302_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
       if(CsrPlugin_pipelineLiberator_active) begin
-        if(when_CsrPlugin_l993) begin
+        if(when_CsrPlugin_l1335) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if(when_CsrPlugin_l993_1) begin
+        if(when_CsrPlugin_l1335_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if(when_CsrPlugin_l993_2) begin
+        if(when_CsrPlugin_l1335_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(when_CsrPlugin_l998) begin
+      if(when_CsrPlugin_l1340) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
@@ -4453,19 +4457,21 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(when_CsrPlugin_l1032) begin
-        case(CsrPlugin_targetPrivilege)
-          2'b11 : begin
-            CsrPlugin_mstatus_MIE <= 1'b0;
-            CsrPlugin_mstatus_MPIE <= CsrPlugin_mstatus_MIE;
-            CsrPlugin_mstatus_MPP <= CsrPlugin_privilege;
-          end
-          default : begin
-          end
-        endcase
+      if(when_CsrPlugin_l1390) begin
+        if(when_CsrPlugin_l1398) begin
+          case(CsrPlugin_targetPrivilege)
+            2'b11 : begin
+              CsrPlugin_mstatus_MIE <= 1'b0;
+              CsrPlugin_mstatus_MPIE <= CsrPlugin_mstatus_MIE;
+              CsrPlugin_mstatus_MPP <= CsrPlugin_privilege;
+            end
+            default : begin
+            end
+          endcase
+        end
       end
-      if(when_CsrPlugin_l1077) begin
-        case(switch_CsrPlugin_l1081)
+      if(when_CsrPlugin_l1456) begin
+        case(switch_CsrPlugin_l1460)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -4475,7 +4481,7 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l965_2,{_zz_when_CsrPlugin_l965_1,_zz_when_CsrPlugin_l965}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l1302_2,{_zz_when_CsrPlugin_l1302_1,_zz_when_CsrPlugin_l1302}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_MulDivIterativePlugin_mul_counter_value <= memory_MulDivIterativePlugin_mul_counter_valueNext;
       memory_MulDivIterativePlugin_div_counter_value <= memory_MulDivIterativePlugin_div_counter_valueNext;
       if(when_Pipeline_l151) begin
@@ -4496,25 +4502,25 @@ module VexRiscv (
       if(when_Pipeline_l154_2) begin
         writeBack_arbitration_isValid <= memory_arbitration_isValid;
       end
-      case(switch_Fetcher_l365)
+      case(IBusCachedPlugin_injector_port_state)
         3'b000 : begin
-          if(IBusCachedPlugin_injectionPort_valid) begin
-            switch_Fetcher_l365 <= 3'b001;
+          if(DebugPlugin_injectionPort_valid) begin
+            IBusCachedPlugin_injector_port_state <= 3'b001;
           end
         end
         3'b001 : begin
-          switch_Fetcher_l365 <= 3'b010;
+          IBusCachedPlugin_injector_port_state <= 3'b010;
         end
         3'b010 : begin
-          switch_Fetcher_l365 <= 3'b011;
+          IBusCachedPlugin_injector_port_state <= 3'b011;
         end
         3'b011 : begin
-          if(when_Fetcher_l381) begin
-            switch_Fetcher_l365 <= 3'b100;
+          if(when_Fetcher_l391) begin
+            IBusCachedPlugin_injector_port_state <= 3'b100;
           end
         end
         3'b100 : begin
-          switch_Fetcher_l365 <= 3'b000;
+          IBusCachedPlugin_injector_port_state <= 3'b000;
         end
         default : begin
         end
@@ -4523,7 +4529,7 @@ module VexRiscv (
         if(execute_CsrPlugin_writeEnable) begin
           CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
           CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
-          case(switch_CsrPlugin_l723)
+          case(switch_CsrPlugin_l1031)
             2'b11 : begin
               CsrPlugin_mstatus_MPP <= 2'b11;
             end
@@ -4591,38 +4597,40 @@ module VexRiscv (
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3 ? DBusSimplePlugin_memoryExceptionPort_payload_code : BranchPlugin_branchExceptionPort_payload_code);
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3 ? DBusSimplePlugin_memoryExceptionPort_payload_badAddr : BranchPlugin_branchExceptionPort_payload_badAddr);
     end
-    if(when_CsrPlugin_l959) begin
-      if(when_CsrPlugin_l965) begin
+    if(when_CsrPlugin_l1296) begin
+      if(when_CsrPlugin_l1302) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l965_1) begin
+      if(when_CsrPlugin_l1302_1) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l965_2) begin
+      if(when_CsrPlugin_l1302_2) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(when_CsrPlugin_l1032) begin
-      case(CsrPlugin_targetPrivilege)
-        2'b11 : begin
-          CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
-          CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
-          CsrPlugin_mepc <= writeBack_PC;
-          if(CsrPlugin_hadException) begin
-            CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
+    if(when_CsrPlugin_l1390) begin
+      if(when_CsrPlugin_l1398) begin
+        case(CsrPlugin_targetPrivilege)
+          2'b11 : begin
+            CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
+            CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
+            CsrPlugin_mepc <= writeBack_PC;
+            if(CsrPlugin_hadException) begin
+              CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
+            end
           end
-        end
-        default : begin
-        end
-      endcase
+          default : begin
+          end
+        endcase
+      end
     end
     if(when_MulDivIterativePlugin_l96) begin
       if(when_MulDivIterativePlugin_l100) begin
         memory_MulDivIterativePlugin_rs2 <= (memory_MulDivIterativePlugin_rs2 >>> 1);
-        memory_MulDivIterativePlugin_accumulator <= ({_zz_memory_MulDivIterativePlugin_accumulator,memory_MulDivIterativePlugin_accumulator[31 : 0]} >>> 1);
+        memory_MulDivIterativePlugin_accumulator <= ({_zz_memory_MulDivIterativePlugin_accumulator,memory_MulDivIterativePlugin_accumulator[31 : 0]} >>> 1'd1);
       end
     end
     if(when_MulDivIterativePlugin_l126) begin
@@ -4641,17 +4649,17 @@ module VexRiscv (
       end
     end
     if(when_MulDivIterativePlugin_l162) begin
-      memory_MulDivIterativePlugin_accumulator <= 65'h0;
-      memory_MulDivIterativePlugin_rs1 <= ((_zz_memory_MulDivIterativePlugin_rs1_1 ? (~ _zz_memory_MulDivIterativePlugin_rs1_2) : _zz_memory_MulDivIterativePlugin_rs1_2) + _zz_memory_MulDivIterativePlugin_rs1_3);
-      memory_MulDivIterativePlugin_rs2 <= ((_zz_memory_MulDivIterativePlugin_rs1 ? (~ execute_RS2) : execute_RS2) + _zz_memory_MulDivIterativePlugin_rs2);
-      memory_MulDivIterativePlugin_div_needRevert <= ((_zz_memory_MulDivIterativePlugin_rs1_1 ^ (_zz_memory_MulDivIterativePlugin_rs1 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
+      memory_MulDivIterativePlugin_accumulator <= 65'h00000000000000000;
+      memory_MulDivIterativePlugin_rs1 <= ((_zz_memory_MulDivIterativePlugin_rs1 ? (~ _zz_memory_MulDivIterativePlugin_rs1_1) : _zz_memory_MulDivIterativePlugin_rs1_1) + _zz_memory_MulDivIterativePlugin_rs1_2);
+      memory_MulDivIterativePlugin_rs2 <= ((_zz_memory_MulDivIterativePlugin_rs2 ? (~ execute_RS2) : execute_RS2) + _zz_memory_MulDivIterativePlugin_rs2_1);
+      memory_MulDivIterativePlugin_div_needRevert <= ((_zz_memory_MulDivIterativePlugin_rs1 ^ (_zz_memory_MulDivIterativePlugin_rs2 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h00000000) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
     end
     externalInterruptArray_regNext <= externalInterruptArray;
     if(when_Pipeline_l124) begin
       decode_to_execute_PC <= decode_PC;
     end
     if(when_Pipeline_l124_1) begin
-      execute_to_memory_PC <= _zz_execute_SRC2;
+      execute_to_memory_PC <= _zz_execute_to_memory_PC;
     end
     if(when_Pipeline_l124_2) begin
       memory_to_writeBack_PC <= memory_PC;
@@ -4806,31 +4814,31 @@ module VexRiscv (
     if(when_Pipeline_l124_52) begin
       memory_to_writeBack_MEMORY_READ_DATA <= memory_MEMORY_READ_DATA;
     end
-    if(when_CsrPlugin_l1277) begin
+    if(when_CsrPlugin_l1669) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if(when_CsrPlugin_l1277_1) begin
+    if(when_CsrPlugin_l1669_1) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if(when_CsrPlugin_l1277_2) begin
+    if(when_CsrPlugin_l1669_2) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if(when_CsrPlugin_l1277_3) begin
+    if(when_CsrPlugin_l1669_3) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if(when_CsrPlugin_l1277_4) begin
+    if(when_CsrPlugin_l1669_4) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if(when_CsrPlugin_l1277_5) begin
+    if(when_CsrPlugin_l1669_5) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if(when_CsrPlugin_l1277_6) begin
+    if(when_CsrPlugin_l1669_6) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if(when_CsrPlugin_l1277_7) begin
+    if(when_CsrPlugin_l1669_7) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if(when_CsrPlugin_l1277_8) begin
+    if(when_CsrPlugin_l1669_8) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
     if(execute_CsrPlugin_csr_836) begin
@@ -4841,7 +4849,6 @@ module VexRiscv (
     if(execute_CsrPlugin_csr_773) begin
       if(execute_CsrPlugin_writeEnable) begin
         CsrPlugin_mtvec_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 2];
-        CsrPlugin_mtvec_mode <= CsrPlugin_csrMapping_writeDataSignal[1 : 0];
       end
     end
     if(execute_CsrPlugin_csr_833) begin
@@ -4868,9 +4875,9 @@ module VexRiscv (
     if(writeBack_arbitration_isValid) begin
       DebugPlugin_busReadDataReg <= _zz_decode_RS2_2;
     end
-    _zz_when_DebugPlugin_l244 <= debug_bus_cmd_payload_address[2];
+    _zz_when_DebugPlugin_l257 <= debug_bus_cmd_payload_address[2];
     if(debug_bus_cmd_valid) begin
-      case(switch_DebugPlugin_l267)
+      case(switch_DebugPlugin_l280)
         6'h10 : begin
           if(debug_bus_cmd_payload_wr) begin
             DebugPlugin_hardwareBreakpoints_0_pc <= debug_bus_cmd_payload_data[31 : 1];
@@ -4885,7 +4892,7 @@ module VexRiscv (
         end
       endcase
     end
-    if(when_DebugPlugin_l295) begin
+    if(when_DebugPlugin_l308) begin
       DebugPlugin_busReadDataReg <= execute_PC;
     end
     DebugPlugin_resetIt_regNext <= DebugPlugin_resetIt;
@@ -4903,39 +4910,39 @@ module VexRiscv (
       DebugPlugin_hardwareBreakpoints_0_valid <= 1'b0;
       DebugPlugin_hardwareBreakpoints_1_valid <= 1'b0;
     end else begin
-      if(when_DebugPlugin_l225) begin
+      if(when_DebugPlugin_l238) begin
         DebugPlugin_godmode <= 1'b1;
       end
       if(debug_bus_cmd_valid) begin
         DebugPlugin_debugUsed <= 1'b1;
       end
       if(debug_bus_cmd_valid) begin
-        case(switch_DebugPlugin_l267)
-          6'h0 : begin
+        case(switch_DebugPlugin_l280)
+          6'h00 : begin
             if(debug_bus_cmd_payload_wr) begin
               DebugPlugin_stepIt <= debug_bus_cmd_payload_data[4];
-              if(when_DebugPlugin_l271) begin
+              if(when_DebugPlugin_l284) begin
                 DebugPlugin_resetIt <= 1'b1;
               end
-              if(when_DebugPlugin_l271_1) begin
+              if(when_DebugPlugin_l284_1) begin
                 DebugPlugin_resetIt <= 1'b0;
               end
-              if(when_DebugPlugin_l272) begin
+              if(when_DebugPlugin_l285) begin
                 DebugPlugin_haltIt <= 1'b1;
               end
-              if(when_DebugPlugin_l272_1) begin
+              if(when_DebugPlugin_l285_1) begin
                 DebugPlugin_haltIt <= 1'b0;
               end
-              if(when_DebugPlugin_l273) begin
+              if(when_DebugPlugin_l286) begin
                 DebugPlugin_haltedByBreak <= 1'b0;
               end
-              if(when_DebugPlugin_l274) begin
+              if(when_DebugPlugin_l287) begin
                 DebugPlugin_godmode <= 1'b0;
               end
-              if(when_DebugPlugin_l275) begin
+              if(when_DebugPlugin_l288) begin
                 DebugPlugin_disableEbreak <= 1'b1;
               end
-              if(when_DebugPlugin_l275_1) begin
+              if(when_DebugPlugin_l288_1) begin
                 DebugPlugin_disableEbreak <= 1'b0;
               end
             end
@@ -4954,13 +4961,13 @@ module VexRiscv (
           end
         endcase
       end
-      if(when_DebugPlugin_l295) begin
-        if(when_DebugPlugin_l298) begin
+      if(when_DebugPlugin_l308) begin
+        if(when_DebugPlugin_l311) begin
           DebugPlugin_haltIt <= 1'b1;
           DebugPlugin_haltedByBreak <= 1'b1;
         end
       end
-      if(when_DebugPlugin_l311) begin
+      if(when_DebugPlugin_l324) begin
         if(decode_arbitration_isValid) begin
           DebugPlugin_haltIt <= 1'b1;
         end
@@ -4972,48 +4979,48 @@ module VexRiscv (
 endmodule
 
 module InstructionCache (
-  input               io_flush,
-  input               io_cpu_prefetch_isValid,
-  output reg          io_cpu_prefetch_haltIt,
-  input      [31:0]   io_cpu_prefetch_pc,
-  input               io_cpu_fetch_isValid,
-  input               io_cpu_fetch_isStuck,
-  input               io_cpu_fetch_isRemoved,
-  input      [31:0]   io_cpu_fetch_pc,
-  output     [31:0]   io_cpu_fetch_data,
-  input      [31:0]   io_cpu_fetch_mmuRsp_physicalAddress,
-  input               io_cpu_fetch_mmuRsp_isIoAccess,
-  input               io_cpu_fetch_mmuRsp_isPaging,
-  input               io_cpu_fetch_mmuRsp_allowRead,
-  input               io_cpu_fetch_mmuRsp_allowWrite,
-  input               io_cpu_fetch_mmuRsp_allowExecute,
-  input               io_cpu_fetch_mmuRsp_exception,
-  input               io_cpu_fetch_mmuRsp_refilling,
-  input               io_cpu_fetch_mmuRsp_bypassTranslation,
-  output     [31:0]   io_cpu_fetch_physicalAddress,
-  input               io_cpu_decode_isValid,
-  input               io_cpu_decode_isStuck,
-  input      [31:0]   io_cpu_decode_pc,
-  output     [31:0]   io_cpu_decode_physicalAddress,
-  output     [31:0]   io_cpu_decode_data,
-  output              io_cpu_decode_cacheMiss,
-  output              io_cpu_decode_error,
-  output              io_cpu_decode_mmuRefilling,
-  output              io_cpu_decode_mmuException,
-  input               io_cpu_decode_isUser,
-  input               io_cpu_fill_valid,
-  input      [31:0]   io_cpu_fill_payload,
-  output              io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output     [31:0]   io_mem_cmd_payload_address,
-  output     [2:0]    io_mem_cmd_payload_size,
-  input               io_mem_rsp_valid,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input      [2:0]    _zz_when_Fetcher_l401,
-  input      [31:0]   _zz_io_cpu_fetch_data_regNextWhen,
-  input               clk,
-  input               reset
+  input  wire          io_flush,
+  input  wire          io_cpu_prefetch_isValid,
+  output reg           io_cpu_prefetch_haltIt,
+  input  wire [31:0]   io_cpu_prefetch_pc,
+  input  wire          io_cpu_fetch_isValid,
+  input  wire          io_cpu_fetch_isStuck,
+  input  wire          io_cpu_fetch_isRemoved,
+  input  wire [31:0]   io_cpu_fetch_pc,
+  output wire [31:0]   io_cpu_fetch_data,
+  input  wire [31:0]   io_cpu_fetch_mmuRsp_physicalAddress,
+  input  wire          io_cpu_fetch_mmuRsp_isIoAccess,
+  input  wire          io_cpu_fetch_mmuRsp_isPaging,
+  input  wire          io_cpu_fetch_mmuRsp_allowRead,
+  input  wire          io_cpu_fetch_mmuRsp_allowWrite,
+  input  wire          io_cpu_fetch_mmuRsp_allowExecute,
+  input  wire          io_cpu_fetch_mmuRsp_exception,
+  input  wire          io_cpu_fetch_mmuRsp_refilling,
+  input  wire          io_cpu_fetch_mmuRsp_bypassTranslation,
+  output wire [31:0]   io_cpu_fetch_physicalAddress,
+  input  wire          io_cpu_decode_isValid,
+  input  wire          io_cpu_decode_isStuck,
+  input  wire [31:0]   io_cpu_decode_pc,
+  output wire [31:0]   io_cpu_decode_physicalAddress,
+  output wire [31:0]   io_cpu_decode_data,
+  output wire          io_cpu_decode_cacheMiss,
+  output wire          io_cpu_decode_error,
+  output wire          io_cpu_decode_mmuRefilling,
+  output wire          io_cpu_decode_mmuException,
+  input  wire          io_cpu_decode_isUser,
+  input  wire          io_cpu_fill_valid,
+  input  wire [31:0]   io_cpu_fill_payload,
+  output wire          io_mem_cmd_valid,
+  input  wire          io_mem_cmd_ready,
+  output wire [31:0]   io_mem_cmd_payload_address,
+  output wire [2:0]    io_mem_cmd_payload_size,
+  input  wire          io_mem_rsp_valid,
+  input  wire [31:0]   io_mem_rsp_payload_data,
+  input  wire          io_mem_rsp_payload_error,
+  input  wire [2:0]    _zz_when_Fetcher_l411,
+  input  wire [31:0]   _zz_io_cpu_fetch_data_regNextWhen,
+  input  wire          clk,
+  input  wire          reset
 );
 
   reg        [31:0]   _zz_banks_0_port1;
@@ -5033,7 +5040,7 @@ module InstructionCache (
   wire                when_InstructionCache_l351;
   reg                 lineLoader_cmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_Utils_l515;
+  wire                when_Utils_l560;
   reg                 lineLoader_wayToAllocate_willIncrement;
   wire                lineLoader_wayToAllocate_willClear;
   wire                lineLoader_wayToAllocate_willOverflowIfInc;
@@ -5079,7 +5086,7 @@ module InstructionCache (
   reg                 decodeStage_hit_valid;
   wire                when_InstructionCache_l459_2;
   reg                 decodeStage_hit_error;
-  wire                when_Fetcher_l401;
+  wire                when_Fetcher_l411;
   (* no_rw_check , ram_style = "block" *) reg [31:0] banks_0 [0:511];
   (* no_rw_check , ram_style = "block" *) reg [22:0] ways_0_tags [0:63];
 
@@ -5149,12 +5156,12 @@ module InstructionCache (
   assign when_InstructionCache_l351 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
   assign io_mem_cmd_fire = (io_mem_cmd_valid && io_mem_cmd_ready);
   assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
-  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
+  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h00};
   assign io_mem_cmd_payload_size = 3'b101;
-  assign when_Utils_l515 = (! lineLoader_valid);
+  assign when_Utils_l560 = (! lineLoader_valid);
   always @(*) begin
     lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if(when_Utils_l515) begin
+    if(when_Utils_l560) begin
       lineLoader_wayToAllocate_willIncrement = 1'b1;
     end
   end
@@ -5198,7 +5205,7 @@ module InstructionCache (
   assign io_cpu_decode_mmuRefilling = decodeStage_mmuRsp_refilling;
   assign io_cpu_decode_mmuException = (((! decodeStage_mmuRsp_refilling) && decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute)));
   assign io_cpu_decode_physicalAddress = decodeStage_mmuRsp_physicalAddress;
-  assign when_Fetcher_l401 = (_zz_when_Fetcher_l401 != 3'b000);
+  assign when_Fetcher_l411 = (_zz_when_Fetcher_l411 != 3'b000);
   always @(posedge clk) begin
     if(reset) begin
       lineLoader_valid <= 1'b0;
@@ -5246,7 +5253,7 @@ module InstructionCache (
     end
     _zz_when_InstructionCache_l342 <= lineLoader_flushCounter[6];
     if(when_InstructionCache_l351) begin
-      lineLoader_flushCounter <= 7'h0;
+      lineLoader_flushCounter <= 7'h00;
     end
     if(when_InstructionCache_l435) begin
       io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;
@@ -5268,7 +5275,7 @@ module InstructionCache (
     if(when_InstructionCache_l459_2) begin
       decodeStage_hit_error <= fetchStage_hit_error;
     end
-    if(when_Fetcher_l401) begin
+    if(when_Fetcher_l411) begin
       io_cpu_fetch_data_regNextWhen <= _zz_io_cpu_fetch_data_regNextWhen;
     end
   end

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_Min.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_Min.v
@@ -1,38 +1,38 @@
-// Generator : SpinalHDL v1.7.1    git head : 0444bb76ab1d6e19f0ec46bc03c4769776deb7d5
+// Generator : SpinalHDL v1.9.4    git head : 270018552577f3bb8e5339ee2583c9c22d324215
 // Component : VexRiscv
-// Git hash  : 581fcb065adf7ea8b626f939ff51679d4c95872f
+// Git hash  : 63430af99f84cc1d11d58b556debe1cc3f238c67
 
 `timescale 1ns/1ps
 
 module VexRiscv (
-  input      [31:0]   externalResetVector,
-  input               timerInterrupt,
-  input               softwareInterrupt,
-  input      [31:0]   externalInterruptArray,
-  output              iBusWishbone_CYC,
-  output              iBusWishbone_STB,
-  input               iBusWishbone_ACK,
-  output              iBusWishbone_WE,
-  output     [29:0]   iBusWishbone_ADR,
-  input      [31:0]   iBusWishbone_DAT_MISO,
-  output     [31:0]   iBusWishbone_DAT_MOSI,
-  output     [3:0]    iBusWishbone_SEL,
-  input               iBusWishbone_ERR,
-  output     [2:0]    iBusWishbone_CTI,
-  output     [1:0]    iBusWishbone_BTE,
-  output              dBusWishbone_CYC,
-  output              dBusWishbone_STB,
-  input               dBusWishbone_ACK,
-  output              dBusWishbone_WE,
-  output     [29:0]   dBusWishbone_ADR,
-  input      [31:0]   dBusWishbone_DAT_MISO,
-  output     [31:0]   dBusWishbone_DAT_MOSI,
-  output reg [3:0]    dBusWishbone_SEL,
-  input               dBusWishbone_ERR,
-  output     [2:0]    dBusWishbone_CTI,
-  output     [1:0]    dBusWishbone_BTE,
-  input               clk,
-  input               reset
+  input  wire [31:0]   externalResetVector,
+  input  wire          timerInterrupt,
+  input  wire          softwareInterrupt,
+  input  wire [31:0]   externalInterruptArray,
+  output wire          iBusWishbone_CYC,
+  output wire          iBusWishbone_STB,
+  input  wire          iBusWishbone_ACK,
+  output wire          iBusWishbone_WE,
+  output wire [29:0]   iBusWishbone_ADR,
+  input  wire [31:0]   iBusWishbone_DAT_MISO,
+  output wire [31:0]   iBusWishbone_DAT_MOSI,
+  output wire [3:0]    iBusWishbone_SEL,
+  input  wire          iBusWishbone_ERR,
+  output wire [2:0]    iBusWishbone_CTI,
+  output wire [1:0]    iBusWishbone_BTE,
+  output wire          dBusWishbone_CYC,
+  output wire          dBusWishbone_STB,
+  input  wire          dBusWishbone_ACK,
+  output wire          dBusWishbone_WE,
+  output wire [29:0]   dBusWishbone_ADR,
+  input  wire [31:0]   dBusWishbone_DAT_MISO,
+  output wire [31:0]   dBusWishbone_DAT_MOSI,
+  output reg  [3:0]    dBusWishbone_SEL,
+  input  wire          dBusWishbone_ERR,
+  output wire [2:0]    dBusWishbone_CTI,
+  output wire [1:0]    dBusWishbone_BTE,
+  input  wire          clk,
+  input  wire          reset
 );
   localparam EnvCtrlEnum_NONE = 2'd0;
   localparam EnvCtrlEnum_XRET = 2'd1;
@@ -61,6 +61,7 @@ module VexRiscv (
   localparam Src1CtrlEnum_URS1 = 2'd3;
 
   wire                IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_ready;
+  wire                IBusSimplePlugin_rspJoin_rspBuffer_c_io_flush;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
   wire                IBusSimplePlugin_rspJoin_rspBuffer_c_io_push_ready;
@@ -68,24 +69,24 @@ module VexRiscv (
   wire                IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_error;
   wire       [31:0]   IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_inst;
   wire       [0:0]    IBusSimplePlugin_rspJoin_rspBuffer_c_io_occupancy;
+  wire       [0:0]    IBusSimplePlugin_rspJoin_rspBuffer_c_io_availability;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_1;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_2;
   wire                _zz_decode_LEGAL_INSTRUCTION_3;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_4;
-  wire       [12:0]   _zz_decode_LEGAL_INSTRUCTION_5;
+  wire       [11:0]   _zz_decode_LEGAL_INSTRUCTION_5;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_6;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_7;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_8;
   wire                _zz_decode_LEGAL_INSTRUCTION_9;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_10;
-  wire       [6:0]    _zz_decode_LEGAL_INSTRUCTION_11;
+  wire       [5:0]    _zz_decode_LEGAL_INSTRUCTION_11;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_12;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_13;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_14;
   wire                _zz_decode_LEGAL_INSTRUCTION_15;
-  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_16;
-  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_17;
+  wire                _zz_decode_LEGAL_INSTRUCTION_16;
   wire       [1:0]    _zz_IBusSimplePlugin_jump_pcLoad_payload_1;
   wire       [1:0]    _zz_IBusSimplePlugin_jump_pcLoad_payload_2;
   wire       [31:0]   _zz_IBusSimplePlugin_fetchPc_pc;
@@ -100,98 +101,98 @@ module VexRiscv (
   wire       [2:0]    _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter_2;
   wire       [0:0]    _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter_3;
   wire       [2:0]    _zz_DBusSimplePlugin_memoryExceptionPort_payload_code;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2;
-  wire                _zz__zz_decode_ENV_CTRL_2_1;
-  wire                _zz__zz_decode_ENV_CTRL_2_2;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_3;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_4;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_5;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_6;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_7;
-  wire                _zz__zz_decode_ENV_CTRL_2_8;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_9;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_10;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_11;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_12;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_13;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_14;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_15;
-  wire       [18:0]   _zz__zz_decode_ENV_CTRL_2_16;
-  wire       [1:0]    _zz__zz_decode_ENV_CTRL_2_17;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_18;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_19;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_20;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_21;
-  wire                _zz__zz_decode_ENV_CTRL_2_22;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_23;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_24;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_25;
-  wire                _zz__zz_decode_ENV_CTRL_2_26;
-  wire       [15:0]   _zz__zz_decode_ENV_CTRL_2_27;
-  wire       [1:0]    _zz__zz_decode_ENV_CTRL_2_28;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_29;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_30;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_31;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_32;
-  wire                _zz__zz_decode_ENV_CTRL_2_33;
-  wire                _zz__zz_decode_ENV_CTRL_2_34;
-  wire                _zz__zz_decode_ENV_CTRL_2_35;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_36;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_37;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_38;
-  wire       [1:0]    _zz__zz_decode_ENV_CTRL_2_39;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_40;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_41;
-  wire       [12:0]   _zz__zz_decode_ENV_CTRL_2_42;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_43;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_44;
-  wire                _zz__zz_decode_ENV_CTRL_2_45;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_46;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_47;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_48;
-  wire       [9:0]    _zz__zz_decode_ENV_CTRL_2_49;
-  wire       [5:0]    _zz__zz_decode_ENV_CTRL_2_50;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_51;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_52;
-  wire                _zz__zz_decode_ENV_CTRL_2_53;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_54;
-  wire       [1:0]    _zz__zz_decode_ENV_CTRL_2_55;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_56;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_57;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_58;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_59;
-  wire                _zz__zz_decode_ENV_CTRL_2_60;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_61;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_62;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_63;
-  wire                _zz__zz_decode_ENV_CTRL_2_64;
-  wire       [6:0]    _zz__zz_decode_ENV_CTRL_2_65;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_66;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_67;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_68;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_69;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_70;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_71;
-  wire                _zz__zz_decode_ENV_CTRL_2_72;
-  wire                _zz__zz_decode_ENV_CTRL_2_73;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_74;
-  wire       [1:0]    _zz__zz_decode_ENV_CTRL_2_75;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_76;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_77;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_78;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_79;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_80;
-  wire                _zz__zz_decode_ENV_CTRL_2_81;
-  wire       [2:0]    _zz__zz_decode_ENV_CTRL_2_82;
-  wire       [2:0]    _zz__zz_decode_ENV_CTRL_2_83;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_84;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_85;
-  wire                _zz__zz_decode_ENV_CTRL_2_86;
-  wire                _zz__zz_decode_ENV_CTRL_2_87;
-  wire                _zz__zz_decode_ENV_CTRL_2_88;
-  wire                _zz__zz_decode_ENV_CTRL_2_89;
-  wire                _zz__zz_decode_ENV_CTRL_2_90;
-  wire                _zz__zz_decode_ENV_CTRL_2_91;
+  wire       [31:0]   _zz__zz_decode_IS_CSR;
+  wire                _zz__zz_decode_IS_CSR_1;
+  wire                _zz__zz_decode_IS_CSR_2;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_3;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_4;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_5;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_6;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_7;
+  wire                _zz__zz_decode_IS_CSR_8;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_9;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_10;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_11;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_12;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_13;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_14;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_15;
+  wire       [18:0]   _zz__zz_decode_IS_CSR_16;
+  wire       [1:0]    _zz__zz_decode_IS_CSR_17;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_18;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_19;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_20;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_21;
+  wire                _zz__zz_decode_IS_CSR_22;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_23;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_24;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_25;
+  wire                _zz__zz_decode_IS_CSR_26;
+  wire       [15:0]   _zz__zz_decode_IS_CSR_27;
+  wire       [1:0]    _zz__zz_decode_IS_CSR_28;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_29;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_30;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_31;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_32;
+  wire                _zz__zz_decode_IS_CSR_33;
+  wire                _zz__zz_decode_IS_CSR_34;
+  wire                _zz__zz_decode_IS_CSR_35;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_36;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_37;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_38;
+  wire       [1:0]    _zz__zz_decode_IS_CSR_39;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_40;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_41;
+  wire       [12:0]   _zz__zz_decode_IS_CSR_42;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_43;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_44;
+  wire                _zz__zz_decode_IS_CSR_45;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_46;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_47;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_48;
+  wire       [9:0]    _zz__zz_decode_IS_CSR_49;
+  wire       [5:0]    _zz__zz_decode_IS_CSR_50;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_51;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_52;
+  wire                _zz__zz_decode_IS_CSR_53;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_54;
+  wire       [1:0]    _zz__zz_decode_IS_CSR_55;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_56;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_57;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_58;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_59;
+  wire                _zz__zz_decode_IS_CSR_60;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_61;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_62;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_63;
+  wire                _zz__zz_decode_IS_CSR_64;
+  wire       [6:0]    _zz__zz_decode_IS_CSR_65;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_66;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_67;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_68;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_69;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_70;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_71;
+  wire                _zz__zz_decode_IS_CSR_72;
+  wire                _zz__zz_decode_IS_CSR_73;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_74;
+  wire       [1:0]    _zz__zz_decode_IS_CSR_75;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_76;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_77;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_78;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_79;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_80;
+  wire                _zz__zz_decode_IS_CSR_81;
+  wire       [2:0]    _zz__zz_decode_IS_CSR_82;
+  wire       [2:0]    _zz__zz_decode_IS_CSR_83;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_84;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_85;
+  wire                _zz__zz_decode_IS_CSR_86;
+  wire                _zz__zz_decode_IS_CSR_87;
+  wire                _zz__zz_decode_IS_CSR_88;
+  wire                _zz__zz_decode_IS_CSR_89;
+  wire                _zz__zz_decode_IS_CSR_90;
+  wire                _zz__zz_decode_IS_CSR_91;
   wire                _zz_RegFilePlugin_regFile_port;
   wire                _zz_decode_RegFilePlugin_rs1Data;
   wire                _zz_RegFilePlugin_regFile_port_1;
@@ -199,14 +200,12 @@ module VexRiscv (
   wire       [0:0]    _zz__zz_execute_REGFILE_WRITE_DATA;
   wire       [2:0]    _zz__zz_execute_SRC1;
   wire       [4:0]    _zz__zz_execute_SRC1_1;
-  wire       [11:0]   _zz__zz_execute_SRC2_3;
+  wire       [11:0]   _zz__zz_execute_SRC2_2;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_1;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_2;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_3;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_4;
-  wire       [31:0]   _zz_execute_SrcPlugin_addSub_5;
-  wire       [31:0]   _zz_execute_SrcPlugin_addSub_6;
   wire       [31:0]   _zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1;
   wire       [32:0]   _zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1_1;
   wire       [19:0]   _zz__zz_execute_BranchPlugin_branch_src2;
@@ -299,7 +298,7 @@ module VexRiscv (
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_execute_SRC2;
+  wire       [31:0]   _zz_execute_to_memory_PC;
   wire       [1:0]    execute_SRC2_CTRL;
   wire       [1:0]    _zz_execute_SRC2_CTRL;
   wire       [1:0]    execute_SRC1_CTRL;
@@ -422,8 +421,9 @@ module VexRiscv (
   wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
   wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
   wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
-  wire                CsrPlugin_csrMapping_allowCsrSignal;
+  reg                 CsrPlugin_csrMapping_allowCsrSignal;
   wire                CsrPlugin_csrMapping_hazardFree;
+  wire                CsrPlugin_csrMapping_doForceFailCsr;
   wire                CsrPlugin_inWfi /* verilator public */ ;
   wire                CsrPlugin_thirdPartyWake;
   reg                 CsrPlugin_jumpInterface_valid;
@@ -442,6 +442,7 @@ module VexRiscv (
   wire                CsrPlugin_allowInterrupts;
   wire                CsrPlugin_allowException;
   wire                CsrPlugin_allowEbreakException;
+  wire                CsrPlugin_xretAwayFromMachine;
   wire                IBusSimplePlugin_externalFlush;
   wire                IBusSimplePlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusSimplePlugin_jump_pcLoad_payload;
@@ -457,12 +458,11 @@ module VexRiscv (
   reg                 IBusSimplePlugin_fetchPc_pcRegPropagate;
   reg                 IBusSimplePlugin_fetchPc_booted;
   reg                 IBusSimplePlugin_fetchPc_inc;
-  wire                when_Fetcher_l134;
-  wire                IBusSimplePlugin_fetchPc_output_fire_1;
-  wire                when_Fetcher_l134_1;
+  wire                when_Fetcher_l133;
+  wire                when_Fetcher_l133_1;
   reg        [31:0]   IBusSimplePlugin_fetchPc_pc;
   reg                 IBusSimplePlugin_fetchPc_flushed;
-  wire                when_Fetcher_l161;
+  wire                when_Fetcher_l160;
   wire                IBusSimplePlugin_iBusRsp_redoFetch;
   wire                IBusSimplePlugin_iBusRsp_stages_0_input_valid;
   wire                IBusSimplePlugin_iBusRsp_stages_0_input_ready;
@@ -482,8 +482,8 @@ module VexRiscv (
   wire                _zz_IBusSimplePlugin_iBusRsp_stages_1_input_ready;
   wire                IBusSimplePlugin_iBusRsp_flush;
   wire                _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready;
-  wire                _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_1;
-  reg                 _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_2;
+  wire                _zz_IBusSimplePlugin_iBusRsp_stages_1_input_valid;
+  reg                 _zz_IBusSimplePlugin_iBusRsp_stages_1_input_valid_1;
   reg                 IBusSimplePlugin_iBusRsp_readyForError;
   wire                IBusSimplePlugin_iBusRsp_output_valid;
   wire                IBusSimplePlugin_iBusRsp_output_ready;
@@ -502,17 +502,17 @@ module VexRiscv (
   reg                 _zz_IBusSimplePlugin_injector_decodeInput_payload_rsp_error;
   reg        [31:0]   _zz_IBusSimplePlugin_injector_decodeInput_payload_rsp_inst;
   reg                 _zz_IBusSimplePlugin_injector_decodeInput_payload_isRvc;
-  wire                when_Fetcher_l323;
+  wire                when_Fetcher_l322;
   reg                 IBusSimplePlugin_injector_nextPcCalc_valids_0;
-  wire                when_Fetcher_l332;
+  wire                when_Fetcher_l331;
   reg                 IBusSimplePlugin_injector_nextPcCalc_valids_1;
-  wire                when_Fetcher_l332_1;
+  wire                when_Fetcher_l331_1;
   reg                 IBusSimplePlugin_injector_nextPcCalc_valids_2;
-  wire                when_Fetcher_l332_2;
+  wire                when_Fetcher_l331_2;
   reg                 IBusSimplePlugin_injector_nextPcCalc_valids_3;
-  wire                when_Fetcher_l332_3;
+  wire                when_Fetcher_l331_3;
   reg                 IBusSimplePlugin_injector_nextPcCalc_valids_4;
-  wire                when_Fetcher_l332_4;
+  wire                when_Fetcher_l331_4;
   reg        [31:0]   IBusSimplePlugin_injector_formal_rawInDecode;
   wire                IBusSimplePlugin_cmd_valid;
   wire                IBusSimplePlugin_cmd_ready;
@@ -534,7 +534,7 @@ module VexRiscv (
   wire                iBus_rsp_toStream_payload_error;
   wire       [31:0]   iBus_rsp_toStream_payload_inst;
   wire                IBusSimplePlugin_rspJoin_rspBuffer_flush;
-  wire                IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_fire;
+  wire                toplevel_IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_fire;
   wire       [31:0]   IBusSimplePlugin_rspJoin_fetchRsp_pc;
   reg                 IBusSimplePlugin_rspJoin_fetchRsp_rsp_error;
   wire       [31:0]   IBusSimplePlugin_rspJoin_fetchRsp_rsp_inst;
@@ -548,7 +548,6 @@ module VexRiscv (
   wire                IBusSimplePlugin_rspJoin_join_payload_isRvc;
   wire                IBusSimplePlugin_rspJoin_exceptionDetected;
   wire                IBusSimplePlugin_rspJoin_join_fire;
-  wire                IBusSimplePlugin_rspJoin_join_fire_1;
   wire                _zz_IBusSimplePlugin_iBusRsp_output_valid;
   wire                dBus_cmd_valid;
   wire                dBus_cmd_ready;
@@ -562,33 +561,33 @@ module VexRiscv (
   wire                _zz_dBus_cmd_valid;
   reg                 execute_DBusSimplePlugin_skipCmd;
   reg        [31:0]   _zz_dBus_cmd_payload_data;
-  wire                when_DBusSimplePlugin_l428;
+  wire                when_DBusSimplePlugin_l436;
   reg        [3:0]    _zz_execute_DBusSimplePlugin_formalMask;
   wire       [3:0]    execute_DBusSimplePlugin_formalMask;
-  wire                when_DBusSimplePlugin_l482;
-  wire                when_DBusSimplePlugin_l489;
-  wire                when_DBusSimplePlugin_l515;
+  wire                when_DBusSimplePlugin_l490;
+  wire                when_DBusSimplePlugin_l497;
+  wire                when_DBusSimplePlugin_l523;
   reg        [31:0]   writeBack_DBusSimplePlugin_rspShifted;
-  wire       [1:0]    switch_Misc_l210;
+  wire       [1:0]    switch_Misc_l232;
   wire                _zz_writeBack_DBusSimplePlugin_rspFormated;
   reg        [31:0]   _zz_writeBack_DBusSimplePlugin_rspFormated_1;
   wire                _zz_writeBack_DBusSimplePlugin_rspFormated_2;
   reg        [31:0]   _zz_writeBack_DBusSimplePlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusSimplePlugin_rspFormated;
-  wire                when_DBusSimplePlugin_l558;
-  wire       [25:0]   _zz_decode_ENV_CTRL_2;
-  wire                _zz_decode_ENV_CTRL_3;
-  wire                _zz_decode_ENV_CTRL_4;
-  wire                _zz_decode_ENV_CTRL_5;
-  wire                _zz_decode_ENV_CTRL_6;
-  wire                _zz_decode_ENV_CTRL_7;
+  wire                when_DBusSimplePlugin_l566;
+  wire       [25:0]   _zz_decode_IS_CSR;
+  wire                _zz_decode_IS_CSR_1;
+  wire                _zz_decode_IS_CSR_2;
+  wire                _zz_decode_IS_CSR_3;
+  wire                _zz_decode_IS_CSR_4;
+  wire                _zz_decode_IS_CSR_5;
   wire       [1:0]    _zz_decode_SRC1_CTRL_2;
   wire       [1:0]    _zz_decode_ALU_CTRL_2;
   wire       [1:0]    _zz_decode_SRC2_CTRL_2;
   wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL_2;
   wire       [1:0]    _zz_decode_SHIFT_CTRL_2;
   wire       [1:0]    _zz_decode_BRANCH_CTRL_2;
-  wire       [1:0]    _zz_decode_ENV_CTRL_8;
+  wire       [1:0]    _zz_decode_ENV_CTRL_2;
   wire                when_RegFilePlugin_l63;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
@@ -597,15 +596,15 @@ module VexRiscv (
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
   reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
   reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_2;
+  reg                 _zz_5;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
   reg        [31:0]   _zz_execute_REGFILE_WRITE_DATA;
   reg        [31:0]   _zz_execute_SRC1;
-  wire                _zz_execute_SRC2_1;
-  reg        [19:0]   _zz_execute_SRC2_2;
-  wire                _zz_execute_SRC2_3;
-  reg        [19:0]   _zz_execute_SRC2_4;
-  reg        [31:0]   _zz_execute_SRC2_5;
+  wire                _zz_execute_SRC2;
+  reg        [19:0]   _zz_execute_SRC2_1;
+  wire                _zz_execute_SRC2_2;
+  reg        [19:0]   _zz_execute_SRC2_3;
+  reg        [31:0]   _zz_execute_SRC2_4;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   reg                 execute_LightShifterPlugin_isActive;
@@ -644,7 +643,7 @@ module VexRiscv (
   wire                when_HazardSimplePlugin_l108;
   wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    switch_Misc_l210_1;
+  wire       [2:0]    switch_Misc_l232_1;
   reg                 _zz_execute_BRANCH_DO;
   reg                 _zz_execute_BRANCH_DO_1;
   wire       [31:0]   execute_BranchPlugin_branch_src1;
@@ -676,9 +675,9 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_mtval;
   reg        [63:0]   CsrPlugin_mcycle;
   reg        [63:0]   CsrPlugin_minstret;
-  wire                _zz_when_CsrPlugin_l965;
-  wire                _zz_when_CsrPlugin_l965_1;
-  wire                _zz_when_CsrPlugin_l965_2;
+  wire                _zz_when_CsrPlugin_l1302;
+  wire                _zz_when_CsrPlugin_l1302_1;
+  wire                _zz_when_CsrPlugin_l1302_2;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -693,60 +692,63 @@ module VexRiscv (
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
   wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code;
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
-  wire                when_CsrPlugin_l922;
-  wire                when_CsrPlugin_l922_1;
-  wire                when_CsrPlugin_l922_2;
-  wire                when_CsrPlugin_l922_3;
-  wire                when_CsrPlugin_l935;
+  wire                when_CsrPlugin_l1259;
+  wire                when_CsrPlugin_l1259_1;
+  wire                when_CsrPlugin_l1259_2;
+  wire                when_CsrPlugin_l1259_3;
+  wire                when_CsrPlugin_l1272;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
-  wire                when_CsrPlugin_l959;
-  wire                when_CsrPlugin_l965;
-  wire                when_CsrPlugin_l965_1;
-  wire                when_CsrPlugin_l965_2;
+  wire                when_CsrPlugin_l1296;
+  wire                when_CsrPlugin_l1302;
+  wire                when_CsrPlugin_l1302_1;
+  wire                when_CsrPlugin_l1302_2;
   wire                CsrPlugin_exception;
   wire                CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
-  wire                when_CsrPlugin_l993;
-  wire                when_CsrPlugin_l993_1;
-  wire                when_CsrPlugin_l993_2;
-  wire                when_CsrPlugin_l998;
+  wire                when_CsrPlugin_l1335;
+  wire                when_CsrPlugin_l1335_1;
+  wire                when_CsrPlugin_l1335_2;
+  wire                when_CsrPlugin_l1340;
   reg                 CsrPlugin_pipelineLiberator_done;
-  wire                when_CsrPlugin_l1004;
+  wire                when_CsrPlugin_l1346;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
+  wire                CsrPlugin_trapCauseEbreakDebug;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
-  wire                when_CsrPlugin_l1032;
-  wire                when_CsrPlugin_l1077;
-  wire       [1:0]    switch_CsrPlugin_l1081;
+  wire                CsrPlugin_trapEnterDebug;
+  wire                when_CsrPlugin_l1390;
+  wire                when_CsrPlugin_l1398;
+  wire                when_CsrPlugin_l1456;
+  wire       [1:0]    switch_CsrPlugin_l1460;
   reg                 execute_CsrPlugin_wfiWake;
-  wire                when_CsrPlugin_l1129;
+  wire                when_CsrPlugin_l1527;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire                when_CsrPlugin_l1149;
-  wire                when_CsrPlugin_l1150;
-  wire                when_CsrPlugin_l1157;
+  wire                when_CsrPlugin_l1547;
+  wire                when_CsrPlugin_l1548;
+  wire                when_CsrPlugin_l1555;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   wire       [31:0]   execute_CsrPlugin_readToWriteData;
-  wire                switch_Misc_l210_2;
+  wire                switch_Misc_l232_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
-  wire                when_CsrPlugin_l1189;
-  wire                when_CsrPlugin_l1193;
+  wire                when_CsrPlugin_l1587;
+  wire                when_CsrPlugin_l1591;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg        [31:0]   externalInterruptArray_regNext;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit;
-  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
+  wire       [31:0]   _zz_externalInterrupt;
   wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
   wire                when_Pipeline_l124_1;
@@ -843,25 +845,26 @@ module VexRiscv (
   wire                when_Pipeline_l154_1;
   wire                when_Pipeline_l151_2;
   wire                when_Pipeline_l154_2;
-  wire                when_CsrPlugin_l1277;
+  wire                when_CsrPlugin_l1669;
   reg                 execute_CsrPlugin_csr_768;
-  wire                when_CsrPlugin_l1277_1;
+  wire                when_CsrPlugin_l1669_1;
   reg                 execute_CsrPlugin_csr_836;
-  wire                when_CsrPlugin_l1277_2;
+  wire                when_CsrPlugin_l1669_2;
   reg                 execute_CsrPlugin_csr_772;
-  wire                when_CsrPlugin_l1277_3;
+  wire                when_CsrPlugin_l1669_3;
   reg                 execute_CsrPlugin_csr_773;
-  wire                when_CsrPlugin_l1277_4;
+  wire                when_CsrPlugin_l1669_4;
   reg                 execute_CsrPlugin_csr_833;
-  wire                when_CsrPlugin_l1277_5;
+  wire                when_CsrPlugin_l1669_5;
   reg                 execute_CsrPlugin_csr_834;
-  wire                when_CsrPlugin_l1277_6;
+  wire                when_CsrPlugin_l1669_6;
   reg                 execute_CsrPlugin_csr_835;
-  wire                when_CsrPlugin_l1277_7;
+  wire                when_CsrPlugin_l1669_7;
   reg                 execute_CsrPlugin_csr_3008;
-  wire                when_CsrPlugin_l1277_8;
+  wire                when_CsrPlugin_l1669_8;
   reg                 execute_CsrPlugin_csr_4032;
-  wire       [1:0]    switch_CsrPlugin_l723;
+  wire       [1:0]    switch_CsrPlugin_l1031;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
@@ -869,15 +872,18 @@ module VexRiscv (
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_6;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_8;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
-  wire                when_CsrPlugin_l1310;
-  wire                when_CsrPlugin_l1315;
+  wire                when_CsrPlugin_l1702;
+  wire       [11:0]   _zz_when_CsrPlugin_l1709;
+  wire                when_CsrPlugin_l1709;
+  reg                 when_CsrPlugin_l1719;
+  wire                when_CsrPlugin_l1717;
+  wire                when_CsrPlugin_l1725;
   wire                iBus_cmd_m2sPipe_valid;
   wire                iBus_cmd_m2sPipe_ready;
   wire       [31:0]   iBus_cmd_m2sPipe_payload_pc;
   reg                 iBus_cmd_rValid;
   reg        [31:0]   iBus_cmd_rData_pc;
-  wire                when_Stream_l368;
+  wire                when_Stream_l369;
   wire                dBus_cmd_halfPipe_valid;
   wire                dBus_cmd_halfPipe_ready;
   wire                dBus_cmd_halfPipe_payload_wr;
@@ -891,7 +897,7 @@ module VexRiscv (
   reg        [31:0]   dBus_cmd_rData_data;
   reg        [1:0]    dBus_cmd_rData_size;
   reg        [3:0]    _zz_dBusWishbone_SEL;
-  wire                when_DBusSimplePlugin_l189;
+  wire                when_DBusSimplePlugin_l196;
   `ifndef SYNTHESIS
   reg [39:0] _zz_memory_to_writeBack_ENV_CTRL_string;
   reg [39:0] _zz_memory_to_writeBack_ENV_CTRL_1_string;
@@ -956,7 +962,7 @@ module VexRiscv (
   reg [39:0] _zz_decode_ALU_BITWISE_CTRL_2_string;
   reg [71:0] _zz_decode_SHIFT_CTRL_2_string;
   reg [31:0] _zz_decode_BRANCH_CTRL_2_string;
-  reg [39:0] _zz_decode_ENV_CTRL_8_string;
+  reg [39:0] _zz_decode_ENV_CTRL_2_string;
   reg [95:0] decode_to_execute_SRC1_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
   reg [23:0] decode_to_execute_SRC2_CTRL_string;
@@ -988,15 +994,13 @@ module VexRiscv (
   assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
   assign _zz__zz_execute_SRC1 = 3'b100;
   assign _zz__zz_execute_SRC1_1 = execute_INSTRUCTION[19 : 15];
-  assign _zz__zz_execute_SRC2_3 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz__zz_execute_SRC2_2 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
   assign _zz_execute_SrcPlugin_addSub = ($signed(_zz_execute_SrcPlugin_addSub_1) + $signed(_zz_execute_SrcPlugin_addSub_4));
   assign _zz_execute_SrcPlugin_addSub_1 = ($signed(_zz_execute_SrcPlugin_addSub_2) + $signed(_zz_execute_SrcPlugin_addSub_3));
   assign _zz_execute_SrcPlugin_addSub_2 = execute_SRC1;
   assign _zz_execute_SrcPlugin_addSub_3 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? _zz_execute_SrcPlugin_addSub_5 : _zz_execute_SrcPlugin_addSub_6);
-  assign _zz_execute_SrcPlugin_addSub_5 = 32'h00000001;
-  assign _zz_execute_SrcPlugin_addSub_6 = 32'h0;
-  assign _zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1 = (_zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1_1 >>> 1);
+  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? 32'h00000001 : 32'h00000000);
+  assign _zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1 = (_zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1_1 >>> 1'd1);
   assign _zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1_1 = {((execute_SHIFT_CTRL == ShiftCtrlEnum_SRA_1) && execute_LightShifterPlugin_shiftInput[31]),execute_LightShifterPlugin_shiftInput};
   assign _zz__zz_execute_BranchPlugin_branch_src2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
   assign _zz__zz_execute_BranchPlugin_branch_src2_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
@@ -1004,116 +1008,115 @@ module VexRiscv (
   assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code - 2'b01);
   assign _zz_decode_RegFilePlugin_rs1Data = 1'b1;
   assign _zz_decode_RegFilePlugin_rs2Data = 1'b1;
-  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000107f;
-  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00002073;
-  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000207f;
+  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000407f);
+  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00004063;
+  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000107f) == 32'h00000013);
   assign _zz_decode_LEGAL_INSTRUCTION_5 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_6) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_7 == _zz_decode_LEGAL_INSTRUCTION_8),{_zz_decode_LEGAL_INSTRUCTION_9,{_zz_decode_LEGAL_INSTRUCTION_10,_zz_decode_LEGAL_INSTRUCTION_11}}}}}};
   assign _zz_decode_LEGAL_INSTRUCTION_6 = 32'h0000505f;
   assign _zz_decode_LEGAL_INSTRUCTION_7 = (decode_INSTRUCTION & 32'h0000707b);
   assign _zz_decode_LEGAL_INSTRUCTION_8 = 32'h00000063;
   assign _zz_decode_LEGAL_INSTRUCTION_9 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
   assign _zz_decode_LEGAL_INSTRUCTION_10 = ((decode_INSTRUCTION & 32'hfe00007f) == 32'h00000033);
-  assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & 32'hfc00307f) == 32'h00001013),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h00005033),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,{_zz_decode_LEGAL_INSTRUCTION_16,_zz_decode_LEGAL_INSTRUCTION_17}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'hbe00705f) == 32'h00005013),{((decode_INSTRUCTION & 32'hfe00305f) == 32'h00001013),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h00000033),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,_zz_decode_LEGAL_INSTRUCTION_16}}}}};
   assign _zz_decode_LEGAL_INSTRUCTION_12 = 32'hbe00707f;
-  assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'hbe00707f);
-  assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h00000033;
-  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
-  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073);
-  assign _zz_decode_LEGAL_INSTRUCTION_17 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073);
-  assign _zz__zz_decode_ENV_CTRL_2 = 32'h10403050;
-  assign _zz__zz_decode_ENV_CTRL_2_1 = ((decode_INSTRUCTION & 32'h00001050) == 32'h00001050);
-  assign _zz__zz_decode_ENV_CTRL_2_2 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002050);
-  assign _zz__zz_decode_ENV_CTRL_2_3 = _zz_decode_ENV_CTRL_7;
-  assign _zz__zz_decode_ENV_CTRL_2_4 = ((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_5) == 32'h00000004);
-  assign _zz__zz_decode_ENV_CTRL_2_6 = ((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_7) == 32'h00000040);
-  assign _zz__zz_decode_ENV_CTRL_2_8 = (|(_zz__zz_decode_ENV_CTRL_2_9 == _zz__zz_decode_ENV_CTRL_2_10));
-  assign _zz__zz_decode_ENV_CTRL_2_11 = (|{_zz__zz_decode_ENV_CTRL_2_12,_zz__zz_decode_ENV_CTRL_2_14});
-  assign _zz__zz_decode_ENV_CTRL_2_16 = {(|_zz__zz_decode_ENV_CTRL_2_17),{_zz__zz_decode_ENV_CTRL_2_22,{_zz__zz_decode_ENV_CTRL_2_25,_zz__zz_decode_ENV_CTRL_2_27}}};
-  assign _zz__zz_decode_ENV_CTRL_2_5 = 32'h0000001c;
-  assign _zz__zz_decode_ENV_CTRL_2_7 = 32'h00000058;
-  assign _zz__zz_decode_ENV_CTRL_2_9 = (decode_INSTRUCTION & 32'h00007054);
-  assign _zz__zz_decode_ENV_CTRL_2_10 = 32'h00005010;
-  assign _zz__zz_decode_ENV_CTRL_2_12 = ((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_13) == 32'h40001010);
-  assign _zz__zz_decode_ENV_CTRL_2_14 = ((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_15) == 32'h00001010);
-  assign _zz__zz_decode_ENV_CTRL_2_17 = {(_zz__zz_decode_ENV_CTRL_2_18 == _zz__zz_decode_ENV_CTRL_2_19),(_zz__zz_decode_ENV_CTRL_2_20 == _zz__zz_decode_ENV_CTRL_2_21)};
-  assign _zz__zz_decode_ENV_CTRL_2_22 = (|(_zz__zz_decode_ENV_CTRL_2_23 == _zz__zz_decode_ENV_CTRL_2_24));
-  assign _zz__zz_decode_ENV_CTRL_2_25 = (|_zz__zz_decode_ENV_CTRL_2_26);
-  assign _zz__zz_decode_ENV_CTRL_2_27 = {(|_zz__zz_decode_ENV_CTRL_2_28),{_zz__zz_decode_ENV_CTRL_2_33,{_zz__zz_decode_ENV_CTRL_2_36,_zz__zz_decode_ENV_CTRL_2_42}}};
-  assign _zz__zz_decode_ENV_CTRL_2_13 = 32'h40003054;
-  assign _zz__zz_decode_ENV_CTRL_2_15 = 32'h00007054;
-  assign _zz__zz_decode_ENV_CTRL_2_18 = (decode_INSTRUCTION & 32'h00000064);
-  assign _zz__zz_decode_ENV_CTRL_2_19 = 32'h00000024;
-  assign _zz__zz_decode_ENV_CTRL_2_20 = (decode_INSTRUCTION & 32'h00003054);
-  assign _zz__zz_decode_ENV_CTRL_2_21 = 32'h00001010;
-  assign _zz__zz_decode_ENV_CTRL_2_23 = (decode_INSTRUCTION & 32'h00001000);
-  assign _zz__zz_decode_ENV_CTRL_2_24 = 32'h00001000;
-  assign _zz__zz_decode_ENV_CTRL_2_26 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
-  assign _zz__zz_decode_ENV_CTRL_2_28 = {(_zz__zz_decode_ENV_CTRL_2_29 == _zz__zz_decode_ENV_CTRL_2_30),(_zz__zz_decode_ENV_CTRL_2_31 == _zz__zz_decode_ENV_CTRL_2_32)};
-  assign _zz__zz_decode_ENV_CTRL_2_33 = (|{_zz__zz_decode_ENV_CTRL_2_34,_zz__zz_decode_ENV_CTRL_2_35});
-  assign _zz__zz_decode_ENV_CTRL_2_36 = (|{_zz__zz_decode_ENV_CTRL_2_37,_zz__zz_decode_ENV_CTRL_2_39});
-  assign _zz__zz_decode_ENV_CTRL_2_42 = {(|_zz__zz_decode_ENV_CTRL_2_43),{_zz__zz_decode_ENV_CTRL_2_45,{_zz__zz_decode_ENV_CTRL_2_48,_zz__zz_decode_ENV_CTRL_2_49}}};
-  assign _zz__zz_decode_ENV_CTRL_2_29 = (decode_INSTRUCTION & 32'h00002010);
-  assign _zz__zz_decode_ENV_CTRL_2_30 = 32'h00002000;
-  assign _zz__zz_decode_ENV_CTRL_2_31 = (decode_INSTRUCTION & 32'h00005000);
-  assign _zz__zz_decode_ENV_CTRL_2_32 = 32'h00001000;
-  assign _zz__zz_decode_ENV_CTRL_2_34 = ((decode_INSTRUCTION & 32'h00000034) == 32'h00000020);
-  assign _zz__zz_decode_ENV_CTRL_2_35 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000020);
-  assign _zz__zz_decode_ENV_CTRL_2_37 = ((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_38) == 32'h00000040);
-  assign _zz__zz_decode_ENV_CTRL_2_39 = {_zz_decode_ENV_CTRL_4,(_zz__zz_decode_ENV_CTRL_2_40 == _zz__zz_decode_ENV_CTRL_2_41)};
-  assign _zz__zz_decode_ENV_CTRL_2_43 = ((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_44) == 32'h00000020);
-  assign _zz__zz_decode_ENV_CTRL_2_45 = (|(_zz__zz_decode_ENV_CTRL_2_46 == _zz__zz_decode_ENV_CTRL_2_47));
-  assign _zz__zz_decode_ENV_CTRL_2_48 = (|_zz_decode_ENV_CTRL_6);
-  assign _zz__zz_decode_ENV_CTRL_2_49 = {(|_zz__zz_decode_ENV_CTRL_2_50),{_zz__zz_decode_ENV_CTRL_2_60,{_zz__zz_decode_ENV_CTRL_2_63,_zz__zz_decode_ENV_CTRL_2_65}}};
-  assign _zz__zz_decode_ENV_CTRL_2_38 = 32'h00000050;
-  assign _zz__zz_decode_ENV_CTRL_2_40 = (decode_INSTRUCTION & 32'h00403040);
-  assign _zz__zz_decode_ENV_CTRL_2_41 = 32'h00000040;
-  assign _zz__zz_decode_ENV_CTRL_2_44 = 32'h00000020;
-  assign _zz__zz_decode_ENV_CTRL_2_46 = (decode_INSTRUCTION & 32'h00000010);
-  assign _zz__zz_decode_ENV_CTRL_2_47 = 32'h00000010;
-  assign _zz__zz_decode_ENV_CTRL_2_50 = {_zz_decode_ENV_CTRL_7,{(_zz__zz_decode_ENV_CTRL_2_51 == _zz__zz_decode_ENV_CTRL_2_52),{_zz__zz_decode_ENV_CTRL_2_53,{_zz__zz_decode_ENV_CTRL_2_54,_zz__zz_decode_ENV_CTRL_2_55}}}};
-  assign _zz__zz_decode_ENV_CTRL_2_60 = (|{_zz_decode_ENV_CTRL_5,(_zz__zz_decode_ENV_CTRL_2_61 == _zz__zz_decode_ENV_CTRL_2_62)});
-  assign _zz__zz_decode_ENV_CTRL_2_63 = (|{_zz_decode_ENV_CTRL_5,_zz__zz_decode_ENV_CTRL_2_64});
-  assign _zz__zz_decode_ENV_CTRL_2_65 = {(|{_zz__zz_decode_ENV_CTRL_2_66,_zz__zz_decode_ENV_CTRL_2_68}),{(|_zz__zz_decode_ENV_CTRL_2_70),{_zz__zz_decode_ENV_CTRL_2_72,{_zz__zz_decode_ENV_CTRL_2_80,_zz__zz_decode_ENV_CTRL_2_82}}}};
-  assign _zz__zz_decode_ENV_CTRL_2_51 = (decode_INSTRUCTION & 32'h00001010);
-  assign _zz__zz_decode_ENV_CTRL_2_52 = 32'h00001010;
-  assign _zz__zz_decode_ENV_CTRL_2_53 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002010);
-  assign _zz__zz_decode_ENV_CTRL_2_54 = _zz_decode_ENV_CTRL_6;
-  assign _zz__zz_decode_ENV_CTRL_2_55 = {(_zz__zz_decode_ENV_CTRL_2_56 == _zz__zz_decode_ENV_CTRL_2_57),(_zz__zz_decode_ENV_CTRL_2_58 == _zz__zz_decode_ENV_CTRL_2_59)};
-  assign _zz__zz_decode_ENV_CTRL_2_61 = (decode_INSTRUCTION & 32'h00000070);
-  assign _zz__zz_decode_ENV_CTRL_2_62 = 32'h00000020;
-  assign _zz__zz_decode_ENV_CTRL_2_64 = ((decode_INSTRUCTION & 32'h00000020) == 32'h0);
-  assign _zz__zz_decode_ENV_CTRL_2_66 = ((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_67) == 32'h00006010);
-  assign _zz__zz_decode_ENV_CTRL_2_68 = ((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_69) == 32'h00004010);
-  assign _zz__zz_decode_ENV_CTRL_2_70 = ((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_71) == 32'h00002010);
-  assign _zz__zz_decode_ENV_CTRL_2_72 = (|{_zz__zz_decode_ENV_CTRL_2_73,{_zz__zz_decode_ENV_CTRL_2_74,_zz__zz_decode_ENV_CTRL_2_75}});
-  assign _zz__zz_decode_ENV_CTRL_2_80 = (|_zz__zz_decode_ENV_CTRL_2_81);
-  assign _zz__zz_decode_ENV_CTRL_2_82 = {(|_zz__zz_decode_ENV_CTRL_2_83),{_zz__zz_decode_ENV_CTRL_2_88,_zz__zz_decode_ENV_CTRL_2_90}};
-  assign _zz__zz_decode_ENV_CTRL_2_56 = (decode_INSTRUCTION & 32'h0000000c);
-  assign _zz__zz_decode_ENV_CTRL_2_57 = 32'h00000004;
-  assign _zz__zz_decode_ENV_CTRL_2_58 = (decode_INSTRUCTION & 32'h00000028);
-  assign _zz__zz_decode_ENV_CTRL_2_59 = 32'h0;
-  assign _zz__zz_decode_ENV_CTRL_2_67 = 32'h00006014;
-  assign _zz__zz_decode_ENV_CTRL_2_69 = 32'h00005014;
-  assign _zz__zz_decode_ENV_CTRL_2_71 = 32'h00006014;
-  assign _zz__zz_decode_ENV_CTRL_2_73 = ((decode_INSTRUCTION & 32'h00000044) == 32'h0);
-  assign _zz__zz_decode_ENV_CTRL_2_74 = _zz_decode_ENV_CTRL_4;
-  assign _zz__zz_decode_ENV_CTRL_2_75 = {(_zz__zz_decode_ENV_CTRL_2_76 == _zz__zz_decode_ENV_CTRL_2_77),(_zz__zz_decode_ENV_CTRL_2_78 == _zz__zz_decode_ENV_CTRL_2_79)};
-  assign _zz__zz_decode_ENV_CTRL_2_81 = ((decode_INSTRUCTION & 32'h00000058) == 32'h0);
-  assign _zz__zz_decode_ENV_CTRL_2_83 = {(_zz__zz_decode_ENV_CTRL_2_84 == _zz__zz_decode_ENV_CTRL_2_85),{_zz__zz_decode_ENV_CTRL_2_86,_zz__zz_decode_ENV_CTRL_2_87}};
-  assign _zz__zz_decode_ENV_CTRL_2_88 = (|{_zz__zz_decode_ENV_CTRL_2_89,_zz_decode_ENV_CTRL_3});
-  assign _zz__zz_decode_ENV_CTRL_2_90 = (|{_zz__zz_decode_ENV_CTRL_2_91,_zz_decode_ENV_CTRL_3});
-  assign _zz__zz_decode_ENV_CTRL_2_76 = (decode_INSTRUCTION & 32'h00006004);
-  assign _zz__zz_decode_ENV_CTRL_2_77 = 32'h00002000;
-  assign _zz__zz_decode_ENV_CTRL_2_78 = (decode_INSTRUCTION & 32'h00005004);
-  assign _zz__zz_decode_ENV_CTRL_2_79 = 32'h00001000;
-  assign _zz__zz_decode_ENV_CTRL_2_84 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz__zz_decode_ENV_CTRL_2_85 = 32'h00000040;
-  assign _zz__zz_decode_ENV_CTRL_2_86 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00002010);
-  assign _zz__zz_decode_ENV_CTRL_2_87 = ((decode_INSTRUCTION & 32'h40004034) == 32'h40000030);
-  assign _zz__zz_decode_ENV_CTRL_2_89 = ((decode_INSTRUCTION & 32'h00000014) == 32'h00000004);
-  assign _zz__zz_decode_ENV_CTRL_2_91 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000004);
+  assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'hdfffffff);
+  assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h10200073;
+  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073);
+  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073);
+  assign _zz__zz_decode_IS_CSR = 32'h10403050;
+  assign _zz__zz_decode_IS_CSR_1 = ((decode_INSTRUCTION & 32'h00001050) == 32'h00001050);
+  assign _zz__zz_decode_IS_CSR_2 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002050);
+  assign _zz__zz_decode_IS_CSR_3 = _zz_decode_IS_CSR_5;
+  assign _zz__zz_decode_IS_CSR_4 = ((decode_INSTRUCTION & _zz__zz_decode_IS_CSR_5) == 32'h00000004);
+  assign _zz__zz_decode_IS_CSR_6 = ((decode_INSTRUCTION & _zz__zz_decode_IS_CSR_7) == 32'h00000040);
+  assign _zz__zz_decode_IS_CSR_8 = (|(_zz__zz_decode_IS_CSR_9 == _zz__zz_decode_IS_CSR_10));
+  assign _zz__zz_decode_IS_CSR_11 = (|{_zz__zz_decode_IS_CSR_12,_zz__zz_decode_IS_CSR_14});
+  assign _zz__zz_decode_IS_CSR_16 = {(|_zz__zz_decode_IS_CSR_17),{_zz__zz_decode_IS_CSR_22,{_zz__zz_decode_IS_CSR_25,_zz__zz_decode_IS_CSR_27}}};
+  assign _zz__zz_decode_IS_CSR_5 = 32'h0000001c;
+  assign _zz__zz_decode_IS_CSR_7 = 32'h00000058;
+  assign _zz__zz_decode_IS_CSR_9 = (decode_INSTRUCTION & 32'h00007054);
+  assign _zz__zz_decode_IS_CSR_10 = 32'h00005010;
+  assign _zz__zz_decode_IS_CSR_12 = ((decode_INSTRUCTION & _zz__zz_decode_IS_CSR_13) == 32'h40001010);
+  assign _zz__zz_decode_IS_CSR_14 = ((decode_INSTRUCTION & _zz__zz_decode_IS_CSR_15) == 32'h00001010);
+  assign _zz__zz_decode_IS_CSR_17 = {(_zz__zz_decode_IS_CSR_18 == _zz__zz_decode_IS_CSR_19),(_zz__zz_decode_IS_CSR_20 == _zz__zz_decode_IS_CSR_21)};
+  assign _zz__zz_decode_IS_CSR_22 = (|(_zz__zz_decode_IS_CSR_23 == _zz__zz_decode_IS_CSR_24));
+  assign _zz__zz_decode_IS_CSR_25 = (|_zz__zz_decode_IS_CSR_26);
+  assign _zz__zz_decode_IS_CSR_27 = {(|_zz__zz_decode_IS_CSR_28),{_zz__zz_decode_IS_CSR_33,{_zz__zz_decode_IS_CSR_36,_zz__zz_decode_IS_CSR_42}}};
+  assign _zz__zz_decode_IS_CSR_13 = 32'h40003054;
+  assign _zz__zz_decode_IS_CSR_15 = 32'h00007054;
+  assign _zz__zz_decode_IS_CSR_18 = (decode_INSTRUCTION & 32'h00000064);
+  assign _zz__zz_decode_IS_CSR_19 = 32'h00000024;
+  assign _zz__zz_decode_IS_CSR_20 = (decode_INSTRUCTION & 32'h00003054);
+  assign _zz__zz_decode_IS_CSR_21 = 32'h00001010;
+  assign _zz__zz_decode_IS_CSR_23 = (decode_INSTRUCTION & 32'h00001000);
+  assign _zz__zz_decode_IS_CSR_24 = 32'h00001000;
+  assign _zz__zz_decode_IS_CSR_26 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
+  assign _zz__zz_decode_IS_CSR_28 = {(_zz__zz_decode_IS_CSR_29 == _zz__zz_decode_IS_CSR_30),(_zz__zz_decode_IS_CSR_31 == _zz__zz_decode_IS_CSR_32)};
+  assign _zz__zz_decode_IS_CSR_33 = (|{_zz__zz_decode_IS_CSR_34,_zz__zz_decode_IS_CSR_35});
+  assign _zz__zz_decode_IS_CSR_36 = (|{_zz__zz_decode_IS_CSR_37,_zz__zz_decode_IS_CSR_39});
+  assign _zz__zz_decode_IS_CSR_42 = {(|_zz__zz_decode_IS_CSR_43),{_zz__zz_decode_IS_CSR_45,{_zz__zz_decode_IS_CSR_48,_zz__zz_decode_IS_CSR_49}}};
+  assign _zz__zz_decode_IS_CSR_29 = (decode_INSTRUCTION & 32'h00002010);
+  assign _zz__zz_decode_IS_CSR_30 = 32'h00002000;
+  assign _zz__zz_decode_IS_CSR_31 = (decode_INSTRUCTION & 32'h00005000);
+  assign _zz__zz_decode_IS_CSR_32 = 32'h00001000;
+  assign _zz__zz_decode_IS_CSR_34 = ((decode_INSTRUCTION & 32'h00000034) == 32'h00000020);
+  assign _zz__zz_decode_IS_CSR_35 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000020);
+  assign _zz__zz_decode_IS_CSR_37 = ((decode_INSTRUCTION & _zz__zz_decode_IS_CSR_38) == 32'h00000040);
+  assign _zz__zz_decode_IS_CSR_39 = {_zz_decode_IS_CSR_2,(_zz__zz_decode_IS_CSR_40 == _zz__zz_decode_IS_CSR_41)};
+  assign _zz__zz_decode_IS_CSR_43 = ((decode_INSTRUCTION & _zz__zz_decode_IS_CSR_44) == 32'h00000020);
+  assign _zz__zz_decode_IS_CSR_45 = (|(_zz__zz_decode_IS_CSR_46 == _zz__zz_decode_IS_CSR_47));
+  assign _zz__zz_decode_IS_CSR_48 = (|_zz_decode_IS_CSR_4);
+  assign _zz__zz_decode_IS_CSR_49 = {(|_zz__zz_decode_IS_CSR_50),{_zz__zz_decode_IS_CSR_60,{_zz__zz_decode_IS_CSR_63,_zz__zz_decode_IS_CSR_65}}};
+  assign _zz__zz_decode_IS_CSR_38 = 32'h00000050;
+  assign _zz__zz_decode_IS_CSR_40 = (decode_INSTRUCTION & 32'h00403040);
+  assign _zz__zz_decode_IS_CSR_41 = 32'h00000040;
+  assign _zz__zz_decode_IS_CSR_44 = 32'h00000020;
+  assign _zz__zz_decode_IS_CSR_46 = (decode_INSTRUCTION & 32'h00000010);
+  assign _zz__zz_decode_IS_CSR_47 = 32'h00000010;
+  assign _zz__zz_decode_IS_CSR_50 = {_zz_decode_IS_CSR_5,{(_zz__zz_decode_IS_CSR_51 == _zz__zz_decode_IS_CSR_52),{_zz__zz_decode_IS_CSR_53,{_zz__zz_decode_IS_CSR_54,_zz__zz_decode_IS_CSR_55}}}};
+  assign _zz__zz_decode_IS_CSR_60 = (|{_zz_decode_IS_CSR_3,(_zz__zz_decode_IS_CSR_61 == _zz__zz_decode_IS_CSR_62)});
+  assign _zz__zz_decode_IS_CSR_63 = (|{_zz_decode_IS_CSR_3,_zz__zz_decode_IS_CSR_64});
+  assign _zz__zz_decode_IS_CSR_65 = {(|{_zz__zz_decode_IS_CSR_66,_zz__zz_decode_IS_CSR_68}),{(|_zz__zz_decode_IS_CSR_70),{_zz__zz_decode_IS_CSR_72,{_zz__zz_decode_IS_CSR_80,_zz__zz_decode_IS_CSR_82}}}};
+  assign _zz__zz_decode_IS_CSR_51 = (decode_INSTRUCTION & 32'h00001010);
+  assign _zz__zz_decode_IS_CSR_52 = 32'h00001010;
+  assign _zz__zz_decode_IS_CSR_53 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002010);
+  assign _zz__zz_decode_IS_CSR_54 = _zz_decode_IS_CSR_4;
+  assign _zz__zz_decode_IS_CSR_55 = {(_zz__zz_decode_IS_CSR_56 == _zz__zz_decode_IS_CSR_57),(_zz__zz_decode_IS_CSR_58 == _zz__zz_decode_IS_CSR_59)};
+  assign _zz__zz_decode_IS_CSR_61 = (decode_INSTRUCTION & 32'h00000070);
+  assign _zz__zz_decode_IS_CSR_62 = 32'h00000020;
+  assign _zz__zz_decode_IS_CSR_64 = ((decode_INSTRUCTION & 32'h00000020) == 32'h00000000);
+  assign _zz__zz_decode_IS_CSR_66 = ((decode_INSTRUCTION & _zz__zz_decode_IS_CSR_67) == 32'h00006000);
+  assign _zz__zz_decode_IS_CSR_68 = ((decode_INSTRUCTION & _zz__zz_decode_IS_CSR_69) == 32'h00004010);
+  assign _zz__zz_decode_IS_CSR_70 = ((decode_INSTRUCTION & _zz__zz_decode_IS_CSR_71) == 32'h00002010);
+  assign _zz__zz_decode_IS_CSR_72 = (|{_zz__zz_decode_IS_CSR_73,{_zz__zz_decode_IS_CSR_74,_zz__zz_decode_IS_CSR_75}});
+  assign _zz__zz_decode_IS_CSR_80 = (|_zz__zz_decode_IS_CSR_81);
+  assign _zz__zz_decode_IS_CSR_82 = {(|_zz__zz_decode_IS_CSR_83),{_zz__zz_decode_IS_CSR_88,_zz__zz_decode_IS_CSR_90}};
+  assign _zz__zz_decode_IS_CSR_56 = (decode_INSTRUCTION & 32'h0000000c);
+  assign _zz__zz_decode_IS_CSR_57 = 32'h00000004;
+  assign _zz__zz_decode_IS_CSR_58 = (decode_INSTRUCTION & 32'h00000028);
+  assign _zz__zz_decode_IS_CSR_59 = 32'h00000000;
+  assign _zz__zz_decode_IS_CSR_67 = 32'h00006004;
+  assign _zz__zz_decode_IS_CSR_69 = 32'h00005014;
+  assign _zz__zz_decode_IS_CSR_71 = 32'h00006014;
+  assign _zz__zz_decode_IS_CSR_73 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000000);
+  assign _zz__zz_decode_IS_CSR_74 = _zz_decode_IS_CSR_2;
+  assign _zz__zz_decode_IS_CSR_75 = {(_zz__zz_decode_IS_CSR_76 == _zz__zz_decode_IS_CSR_77),(_zz__zz_decode_IS_CSR_78 == _zz__zz_decode_IS_CSR_79)};
+  assign _zz__zz_decode_IS_CSR_81 = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000000);
+  assign _zz__zz_decode_IS_CSR_83 = {(_zz__zz_decode_IS_CSR_84 == _zz__zz_decode_IS_CSR_85),{_zz__zz_decode_IS_CSR_86,_zz__zz_decode_IS_CSR_87}};
+  assign _zz__zz_decode_IS_CSR_88 = (|{_zz__zz_decode_IS_CSR_89,_zz_decode_IS_CSR_1});
+  assign _zz__zz_decode_IS_CSR_90 = (|{_zz__zz_decode_IS_CSR_91,_zz_decode_IS_CSR_1});
+  assign _zz__zz_decode_IS_CSR_76 = (decode_INSTRUCTION & 32'h00006004);
+  assign _zz__zz_decode_IS_CSR_77 = 32'h00002000;
+  assign _zz__zz_decode_IS_CSR_78 = (decode_INSTRUCTION & 32'h00005004);
+  assign _zz__zz_decode_IS_CSR_79 = 32'h00001000;
+  assign _zz__zz_decode_IS_CSR_84 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz__zz_decode_IS_CSR_85 = 32'h00000040;
+  assign _zz__zz_decode_IS_CSR_86 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00002010);
+  assign _zz__zz_decode_IS_CSR_87 = ((decode_INSTRUCTION & 32'h40004034) == 32'h40000030);
+  assign _zz__zz_decode_IS_CSR_89 = ((decode_INSTRUCTION & 32'h00000014) == 32'h00000004);
+  assign _zz__zz_decode_IS_CSR_91 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000004);
   always @(posedge clk) begin
     if(_zz_decode_RegFilePlugin_rs1Data) begin
       _zz_RegFilePlugin_regFile_port0 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
@@ -1141,8 +1144,9 @@ module VexRiscv (
     .io_pop_ready          (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_ready             ), //i
     .io_pop_payload_error  (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_error     ), //o
     .io_pop_payload_inst   (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_inst[31:0]), //o
-    .io_flush              (1'b0                                                          ), //i
+    .io_flush              (IBusSimplePlugin_rspJoin_rspBuffer_c_io_flush                 ), //i
     .io_occupancy          (IBusSimplePlugin_rspJoin_rspBuffer_c_io_occupancy             ), //o
+    .io_availability       (IBusSimplePlugin_rspJoin_rspBuffer_c_io_availability          ), //o
     .clk                   (clk                                                           ), //i
     .reset                 (reset                                                         )  //i
   );
@@ -1684,11 +1688,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_decode_ENV_CTRL_8)
-      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_8_string = "NONE ";
-      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_8_string = "XRET ";
-      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_8_string = "ECALL";
-      default : _zz_decode_ENV_CTRL_8_string = "?????";
+    case(_zz_decode_ENV_CTRL_2)
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1777,7 +1781,7 @@ module VexRiscv (
   assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
   assign execute_MEMORY_ADDRESS_LOW = dBus_cmd_payload_address[1 : 0];
   assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
-  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
+  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h00)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h00))));
   assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
   assign decode_RS2 = decode_RegFilePlugin_rs2Data;
   assign decode_RS1 = decode_RegFilePlugin_rs1Data;
@@ -1785,23 +1789,23 @@ module VexRiscv (
   assign _zz_execute_to_memory_ENV_CTRL = _zz_execute_to_memory_ENV_CTRL_1;
   assign decode_ENV_CTRL = _zz_decode_ENV_CTRL;
   assign _zz_decode_to_execute_ENV_CTRL = _zz_decode_to_execute_ENV_CTRL_1;
-  assign decode_IS_CSR = _zz_decode_ENV_CTRL_2[23];
+  assign decode_IS_CSR = _zz_decode_IS_CSR[23];
   assign decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL;
   assign _zz_decode_to_execute_BRANCH_CTRL = _zz_decode_to_execute_BRANCH_CTRL_1;
   assign decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL;
   assign _zz_decode_to_execute_SHIFT_CTRL = _zz_decode_to_execute_SHIFT_CTRL_1;
   assign decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL;
   assign _zz_decode_to_execute_ALU_BITWISE_CTRL = _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
-  assign decode_SRC_LESS_UNSIGNED = _zz_decode_ENV_CTRL_2[15];
-  assign decode_MEMORY_STORE = _zz_decode_ENV_CTRL_2[12];
+  assign decode_SRC_LESS_UNSIGNED = _zz_decode_IS_CSR[15];
+  assign decode_MEMORY_STORE = _zz_decode_IS_CSR[12];
   assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_decode_ENV_CTRL_2[11];
-  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_decode_ENV_CTRL_2[10];
+  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_decode_IS_CSR[11];
+  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_decode_IS_CSR[10];
   assign decode_SRC2_CTRL = _zz_decode_SRC2_CTRL;
   assign _zz_decode_to_execute_SRC2_CTRL = _zz_decode_to_execute_SRC2_CTRL_1;
   assign decode_ALU_CTRL = _zz_decode_ALU_CTRL;
   assign _zz_decode_to_execute_ALU_CTRL = _zz_decode_to_execute_ALU_CTRL_1;
-  assign decode_MEMORY_ENABLE = _zz_decode_ENV_CTRL_2[3];
+  assign decode_MEMORY_ENABLE = _zz_decode_IS_CSR[3];
   assign decode_SRC1_CTRL = _zz_decode_SRC1_CTRL;
   assign _zz_decode_to_execute_SRC1_CTRL = _zz_decode_to_execute_SRC1_CTRL_1;
   assign writeBack_FORMAL_PC_NEXT = memory_to_writeBack_FORMAL_PC_NEXT;
@@ -1820,8 +1824,8 @@ module VexRiscv (
   assign execute_PC = decode_to_execute_PC;
   assign execute_RS1 = decode_to_execute_RS1;
   assign execute_BRANCH_CTRL = _zz_execute_BRANCH_CTRL;
-  assign decode_RS2_USE = _zz_decode_ENV_CTRL_2[14];
-  assign decode_RS1_USE = _zz_decode_ENV_CTRL_2[4];
+  assign decode_RS2_USE = _zz_decode_IS_CSR[14];
+  assign decode_RS1_USE = _zz_decode_IS_CSR[4];
   assign execute_REGFILE_WRITE_VALID = decode_to_execute_REGFILE_WRITE_VALID;
   assign execute_BYPASSABLE_EXECUTE_STAGE = decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
   assign memory_REGFILE_WRITE_VALID = execute_to_memory_REGFILE_WRITE_VALID;
@@ -1833,7 +1837,7 @@ module VexRiscv (
     if(when_ShiftPlugins_l169) begin
       _zz_execute_to_memory_REGFILE_WRITE_DATA = _zz_execute_to_memory_REGFILE_WRITE_DATA_1;
     end
-    if(when_CsrPlugin_l1189) begin
+    if(when_CsrPlugin_l1587) begin
       _zz_execute_to_memory_REGFILE_WRITE_DATA = CsrPlugin_csrMapping_readDataSignal;
     end
   end
@@ -1842,15 +1846,15 @@ module VexRiscv (
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_execute_SRC2 = execute_PC;
+  assign _zz_execute_to_memory_PC = execute_PC;
   assign execute_SRC2_CTRL = _zz_execute_SRC2_CTRL;
   assign execute_SRC1_CTRL = _zz_execute_SRC1_CTRL;
-  assign decode_SRC_USE_SUB_LESS = _zz_decode_ENV_CTRL_2[2];
-  assign decode_SRC_ADD_ZERO = _zz_decode_ENV_CTRL_2[18];
+  assign decode_SRC_USE_SUB_LESS = _zz_decode_IS_CSR[2];
+  assign decode_SRC_ADD_ZERO = _zz_decode_IS_CSR[18];
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
   assign execute_ALU_CTRL = _zz_execute_ALU_CTRL;
-  assign execute_SRC2 = _zz_execute_SRC2_5;
+  assign execute_SRC2 = _zz_execute_SRC2_4;
   assign execute_SRC1 = _zz_execute_SRC1;
   assign execute_ALU_BITWISE_CTRL = _zz_execute_ALU_BITWISE_CTRL;
   assign _zz_lastStageRegFileWrite_payload_address = writeBack_INSTRUCTION;
@@ -1864,16 +1868,16 @@ module VexRiscv (
 
   assign decode_INSTRUCTION_ANTICIPATED = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusSimplePlugin_iBusRsp_output_payload_rsp_inst);
   always @(*) begin
-    decode_REGFILE_WRITE_VALID = _zz_decode_ENV_CTRL_2[9];
+    decode_REGFILE_WRITE_VALID = _zz_decode_IS_CSR[9];
     if(when_RegFilePlugin_l63) begin
       decode_REGFILE_WRITE_VALID = 1'b0;
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00001073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
+  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000107f) == 32'h00001073),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00002073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
   always @(*) begin
     _zz_lastStageRegFileWrite_payload_data = writeBack_REGFILE_WRITE_DATA;
-    if(when_DBusSimplePlugin_l558) begin
+    if(when_DBusSimplePlugin_l566) begin
       _zz_lastStageRegFileWrite_payload_data = writeBack_DBusSimplePlugin_rspFormated;
     end
   end
@@ -1911,7 +1915,7 @@ module VexRiscv (
     if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(when_CsrPlugin_l1129) begin
+    if(when_CsrPlugin_l1527) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
@@ -1936,7 +1940,7 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(when_DBusSimplePlugin_l428) begin
+    if(when_DBusSimplePlugin_l436) begin
       execute_arbitration_haltItself = 1'b1;
     end
     if(when_ShiftPlugins_l169) begin
@@ -1944,7 +1948,7 @@ module VexRiscv (
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(when_CsrPlugin_l1193) begin
+    if(when_CsrPlugin_l1591) begin
       if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
@@ -1972,7 +1976,7 @@ module VexRiscv (
 
   always @(*) begin
     memory_arbitration_haltItself = 1'b0;
-    if(when_DBusSimplePlugin_l482) begin
+    if(when_DBusSimplePlugin_l490) begin
       memory_arbitration_haltItself = 1'b1;
     end
   end
@@ -2011,10 +2015,10 @@ module VexRiscv (
   assign writeBack_arbitration_flushIt = 1'b0;
   always @(*) begin
     writeBack_arbitration_flushNext = 1'b0;
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -2025,13 +2029,13 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @(*) begin
     IBusSimplePlugin_fetcherHalt = 1'b0;
-    if(when_CsrPlugin_l935) begin
+    if(when_CsrPlugin_l1272) begin
       IBusSimplePlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       IBusSimplePlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       IBusSimplePlugin_fetcherHalt = 1'b1;
     end
   end
@@ -2048,27 +2052,37 @@ module VexRiscv (
   end
 
   assign BranchPlugin_inDebugNoFetchFlag = 1'b0;
-  assign CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+  always @(*) begin
+    CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+    if(when_CsrPlugin_l1702) begin
+      CsrPlugin_csrMapping_allowCsrSignal = 1'b1;
+    end
+    if(when_CsrPlugin_l1709) begin
+      CsrPlugin_csrMapping_allowCsrSignal = 1'b1;
+    end
+  end
+
+  assign CsrPlugin_csrMapping_doForceFailCsr = 1'b0;
   assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
   assign CsrPlugin_inWfi = 1'b0;
   assign CsrPlugin_thirdPartyWake = 1'b0;
   always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(when_CsrPlugin_l1077) begin
-      case(switch_CsrPlugin_l1081)
+    if(when_CsrPlugin_l1456) begin
+      case(switch_CsrPlugin_l1460)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -2082,6 +2096,7 @@ module VexRiscv (
   assign CsrPlugin_allowInterrupts = 1'b1;
   assign CsrPlugin_allowException = 1'b1;
   assign CsrPlugin_allowEbreakException = 1'b1;
+  assign CsrPlugin_xretAwayFromMachine = 1'b0;
   assign IBusSimplePlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
   assign IBusSimplePlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,BranchPlugin_jumpInterface_valid} != 2'b00);
   assign _zz_IBusSimplePlugin_jump_pcLoad_payload = {BranchPlugin_jumpInterface_valid,CsrPlugin_jumpInterface_valid};
@@ -2102,9 +2117,8 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l134 = (IBusSimplePlugin_fetchPc_correction || IBusSimplePlugin_fetchPc_pcRegPropagate);
-  assign IBusSimplePlugin_fetchPc_output_fire_1 = (IBusSimplePlugin_fetchPc_output_valid && IBusSimplePlugin_fetchPc_output_ready);
-  assign when_Fetcher_l134_1 = ((! IBusSimplePlugin_fetchPc_output_valid) && IBusSimplePlugin_fetchPc_output_ready);
+  assign when_Fetcher_l133 = (IBusSimplePlugin_fetchPc_correction || IBusSimplePlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l133_1 = ((! IBusSimplePlugin_fetchPc_output_valid) && IBusSimplePlugin_fetchPc_output_ready);
   always @(*) begin
     IBusSimplePlugin_fetchPc_pc = (IBusSimplePlugin_fetchPc_pcReg + _zz_IBusSimplePlugin_fetchPc_pc);
     if(IBusSimplePlugin_jump_pcLoad_valid) begin
@@ -2121,7 +2135,7 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l161 = (IBusSimplePlugin_fetchPc_booted && ((IBusSimplePlugin_fetchPc_output_ready || IBusSimplePlugin_fetchPc_correction) || IBusSimplePlugin_fetchPc_pcRegPropagate));
+  assign when_Fetcher_l160 = (IBusSimplePlugin_fetchPc_booted && ((IBusSimplePlugin_fetchPc_output_ready || IBusSimplePlugin_fetchPc_correction) || IBusSimplePlugin_fetchPc_pcRegPropagate));
   assign IBusSimplePlugin_fetchPc_output_valid = ((! IBusSimplePlugin_fetcherHalt) && IBusSimplePlugin_fetchPc_booted);
   assign IBusSimplePlugin_fetchPc_output_payload = IBusSimplePlugin_fetchPc_pc;
   assign IBusSimplePlugin_iBusRsp_redoFetch = 1'b0;
@@ -2146,16 +2160,16 @@ module VexRiscv (
   assign IBusSimplePlugin_iBusRsp_stages_1_output_payload = IBusSimplePlugin_iBusRsp_stages_1_input_payload;
   assign IBusSimplePlugin_iBusRsp_flush = (IBusSimplePlugin_externalFlush || IBusSimplePlugin_iBusRsp_redoFetch);
   assign IBusSimplePlugin_iBusRsp_stages_0_output_ready = _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready;
-  assign _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_1)) || IBusSimplePlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_1 = _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_2;
-  assign IBusSimplePlugin_iBusRsp_stages_1_input_valid = _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_1;
+  assign _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusSimplePlugin_iBusRsp_stages_1_input_valid)) || IBusSimplePlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_IBusSimplePlugin_iBusRsp_stages_1_input_valid = _zz_IBusSimplePlugin_iBusRsp_stages_1_input_valid_1;
+  assign IBusSimplePlugin_iBusRsp_stages_1_input_valid = _zz_IBusSimplePlugin_iBusRsp_stages_1_input_valid;
   assign IBusSimplePlugin_iBusRsp_stages_1_input_payload = IBusSimplePlugin_fetchPc_pcReg;
   always @(*) begin
     IBusSimplePlugin_iBusRsp_readyForError = 1'b1;
     if(IBusSimplePlugin_injector_decodeInput_valid) begin
       IBusSimplePlugin_iBusRsp_readyForError = 1'b0;
     end
-    if(when_Fetcher_l323) begin
+    if(when_Fetcher_l322) begin
       IBusSimplePlugin_iBusRsp_readyForError = 1'b0;
     end
   end
@@ -2166,12 +2180,12 @@ module VexRiscv (
   assign IBusSimplePlugin_injector_decodeInput_payload_rsp_error = _zz_IBusSimplePlugin_injector_decodeInput_payload_rsp_error;
   assign IBusSimplePlugin_injector_decodeInput_payload_rsp_inst = _zz_IBusSimplePlugin_injector_decodeInput_payload_rsp_inst;
   assign IBusSimplePlugin_injector_decodeInput_payload_isRvc = _zz_IBusSimplePlugin_injector_decodeInput_payload_isRvc;
-  assign when_Fetcher_l323 = (! IBusSimplePlugin_pcValids_0);
-  assign when_Fetcher_l332 = (! (! IBusSimplePlugin_iBusRsp_stages_1_input_ready));
-  assign when_Fetcher_l332_1 = (! (! IBusSimplePlugin_injector_decodeInput_ready));
-  assign when_Fetcher_l332_2 = (! execute_arbitration_isStuck);
-  assign when_Fetcher_l332_3 = (! memory_arbitration_isStuck);
-  assign when_Fetcher_l332_4 = (! writeBack_arbitration_isStuck);
+  assign when_Fetcher_l322 = (! IBusSimplePlugin_pcValids_0);
+  assign when_Fetcher_l331 = (! (! IBusSimplePlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l331_1 = (! (! IBusSimplePlugin_injector_decodeInput_ready));
+  assign when_Fetcher_l331_2 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l331_3 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l331_4 = (! writeBack_arbitration_isStuck);
   assign IBusSimplePlugin_pcValids_0 = IBusSimplePlugin_injector_nextPcCalc_valids_1;
   assign IBusSimplePlugin_pcValids_1 = IBusSimplePlugin_injector_nextPcCalc_valids_2;
   assign IBusSimplePlugin_pcValids_2 = IBusSimplePlugin_injector_nextPcCalc_valids_3;
@@ -2203,8 +2217,8 @@ module VexRiscv (
   assign IBusSimplePlugin_rspJoin_rspBuffer_output_payload_error = IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_error;
   assign IBusSimplePlugin_rspJoin_rspBuffer_output_payload_inst = IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_inst;
   assign IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_ready = (IBusSimplePlugin_rspJoin_rspBuffer_output_ready || IBusSimplePlugin_rspJoin_rspBuffer_flush);
-  assign IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_fire = (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid && IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_ready);
-  assign IBusSimplePlugin_pending_dec = IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_fire;
+  assign toplevel_IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_fire = (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid && IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_ready);
+  assign IBusSimplePlugin_pending_dec = toplevel_IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_fire;
   assign IBusSimplePlugin_rspJoin_fetchRsp_pc = IBusSimplePlugin_iBusRsp_stages_1_output_payload;
   always @(*) begin
     IBusSimplePlugin_rspJoin_fetchRsp_rsp_error = IBusSimplePlugin_rspJoin_rspBuffer_output_payload_error;
@@ -2223,8 +2237,7 @@ module VexRiscv (
   assign IBusSimplePlugin_rspJoin_join_payload_isRvc = IBusSimplePlugin_rspJoin_fetchRsp_isRvc;
   assign IBusSimplePlugin_rspJoin_join_fire = (IBusSimplePlugin_rspJoin_join_valid && IBusSimplePlugin_rspJoin_join_ready);
   assign IBusSimplePlugin_iBusRsp_stages_1_output_ready = (IBusSimplePlugin_iBusRsp_stages_1_output_valid ? IBusSimplePlugin_rspJoin_join_fire : IBusSimplePlugin_rspJoin_join_ready);
-  assign IBusSimplePlugin_rspJoin_join_fire_1 = (IBusSimplePlugin_rspJoin_join_valid && IBusSimplePlugin_rspJoin_join_ready);
-  assign IBusSimplePlugin_rspJoin_rspBuffer_output_ready = IBusSimplePlugin_rspJoin_join_fire_1;
+  assign IBusSimplePlugin_rspJoin_rspBuffer_output_ready = IBusSimplePlugin_rspJoin_join_fire;
   assign _zz_IBusSimplePlugin_iBusRsp_output_valid = (! IBusSimplePlugin_rspJoin_exceptionDetected);
   assign IBusSimplePlugin_rspJoin_join_ready = (IBusSimplePlugin_iBusRsp_output_ready && _zz_IBusSimplePlugin_iBusRsp_output_valid);
   assign IBusSimplePlugin_iBusRsp_output_valid = (IBusSimplePlugin_rspJoin_join_valid && _zz_IBusSimplePlugin_iBusRsp_output_valid);
@@ -2258,7 +2271,7 @@ module VexRiscv (
   end
 
   assign dBus_cmd_payload_data = _zz_dBus_cmd_payload_data;
-  assign when_DBusSimplePlugin_l428 = ((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! dBus_cmd_ready)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_dBus_cmd_valid));
+  assign when_DBusSimplePlugin_l436 = ((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! dBus_cmd_ready)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_dBus_cmd_valid));
   always @(*) begin
     case(dBus_cmd_payload_size)
       2'b00 : begin
@@ -2275,23 +2288,23 @@ module VexRiscv (
 
   assign execute_DBusSimplePlugin_formalMask = (_zz_execute_DBusSimplePlugin_formalMask <<< dBus_cmd_payload_address[1 : 0]);
   assign dBus_cmd_payload_address = execute_SRC_ADD;
-  assign when_DBusSimplePlugin_l482 = (((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (! memory_MEMORY_STORE)) && ((! dBus_rsp_ready) || 1'b0));
+  assign when_DBusSimplePlugin_l490 = (((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (! memory_MEMORY_STORE)) && ((! dBus_rsp_ready) || 1'b0));
   always @(*) begin
     DBusSimplePlugin_memoryExceptionPort_valid = 1'b0;
-    if(when_DBusSimplePlugin_l489) begin
+    if(when_DBusSimplePlugin_l497) begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b1;
     end
     if(memory_ALIGNEMENT_FAULT) begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b1;
     end
-    if(when_DBusSimplePlugin_l515) begin
+    if(when_DBusSimplePlugin_l523) begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b0;
     end
   end
 
   always @(*) begin
     DBusSimplePlugin_memoryExceptionPort_payload_code = 4'bxxxx;
-    if(when_DBusSimplePlugin_l489) begin
+    if(when_DBusSimplePlugin_l497) begin
       DBusSimplePlugin_memoryExceptionPort_payload_code = 4'b0101;
     end
     if(memory_ALIGNEMENT_FAULT) begin
@@ -2300,8 +2313,8 @@ module VexRiscv (
   end
 
   assign DBusSimplePlugin_memoryExceptionPort_payload_badAddr = memory_REGFILE_WRITE_DATA;
-  assign when_DBusSimplePlugin_l489 = ((dBus_rsp_ready && dBus_rsp_error) && (! memory_MEMORY_STORE));
-  assign when_DBusSimplePlugin_l515 = (! ((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (1'b1 || (! memory_arbitration_isStuckByOthers))));
+  assign when_DBusSimplePlugin_l497 = ((dBus_rsp_ready && dBus_rsp_error) && (! memory_MEMORY_STORE));
+  assign when_DBusSimplePlugin_l523 = (! ((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (1'b1 || (! memory_arbitration_isStuckByOthers))));
   always @(*) begin
     writeBack_DBusSimplePlugin_rspShifted = writeBack_MEMORY_READ_DATA;
     case(writeBack_MEMORY_ADDRESS_LOW)
@@ -2319,7 +2332,7 @@ module VexRiscv (
     endcase
   end
 
-  assign switch_Misc_l210 = writeBack_INSTRUCTION[13 : 12];
+  assign switch_Misc_l232 = writeBack_INSTRUCTION[13 : 12];
   assign _zz_writeBack_DBusSimplePlugin_rspFormated = (writeBack_DBusSimplePlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
   always @(*) begin
     _zz_writeBack_DBusSimplePlugin_rspFormated_1[31] = _zz_writeBack_DBusSimplePlugin_rspFormated;
@@ -2371,7 +2384,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    case(switch_Misc_l210)
+    case(switch_Misc_l232)
       2'b00 : begin
         writeBack_DBusSimplePlugin_rspFormated = _zz_writeBack_DBusSimplePlugin_rspFormated_1;
       end
@@ -2384,53 +2397,53 @@ module VexRiscv (
     endcase
   end
 
-  assign when_DBusSimplePlugin_l558 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_decode_ENV_CTRL_3 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_decode_ENV_CTRL_4 = ((decode_INSTRUCTION & 32'h00000018) == 32'h0);
-  assign _zz_decode_ENV_CTRL_5 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_decode_ENV_CTRL_6 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000010);
-  assign _zz_decode_ENV_CTRL_7 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_decode_ENV_CTRL_2 = {(|((decode_INSTRUCTION & 32'h10003050) == 32'h00000050)),{(|((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2) == 32'h10000050)),{(|{_zz__zz_decode_ENV_CTRL_2_1,_zz__zz_decode_ENV_CTRL_2_2}),{(|{_zz__zz_decode_ENV_CTRL_2_3,_zz__zz_decode_ENV_CTRL_2_4}),{(|_zz__zz_decode_ENV_CTRL_2_6),{_zz__zz_decode_ENV_CTRL_2_8,{_zz__zz_decode_ENV_CTRL_2_11,_zz__zz_decode_ENV_CTRL_2_16}}}}}}};
-  assign _zz_decode_SRC1_CTRL_2 = _zz_decode_ENV_CTRL_2[1 : 0];
+  assign when_DBusSimplePlugin_l566 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign _zz_decode_IS_CSR_1 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
+  assign _zz_decode_IS_CSR_2 = ((decode_INSTRUCTION & 32'h00000018) == 32'h00000000);
+  assign _zz_decode_IS_CSR_3 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_decode_IS_CSR_4 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000010);
+  assign _zz_decode_IS_CSR_5 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_decode_IS_CSR = {(|((decode_INSTRUCTION & 32'h10003050) == 32'h00000050)),{(|((decode_INSTRUCTION & _zz__zz_decode_IS_CSR) == 32'h10000050)),{(|{_zz__zz_decode_IS_CSR_1,_zz__zz_decode_IS_CSR_2}),{(|{_zz__zz_decode_IS_CSR_3,_zz__zz_decode_IS_CSR_4}),{(|_zz__zz_decode_IS_CSR_6),{_zz__zz_decode_IS_CSR_8,{_zz__zz_decode_IS_CSR_11,_zz__zz_decode_IS_CSR_16}}}}}}};
+  assign _zz_decode_SRC1_CTRL_2 = _zz_decode_IS_CSR[1 : 0];
   assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
-  assign _zz_decode_ALU_CTRL_2 = _zz_decode_ENV_CTRL_2[6 : 5];
+  assign _zz_decode_ALU_CTRL_2 = _zz_decode_IS_CSR[6 : 5];
   assign _zz_decode_ALU_CTRL_1 = _zz_decode_ALU_CTRL_2;
-  assign _zz_decode_SRC2_CTRL_2 = _zz_decode_ENV_CTRL_2[8 : 7];
+  assign _zz_decode_SRC2_CTRL_2 = _zz_decode_IS_CSR[8 : 7];
   assign _zz_decode_SRC2_CTRL_1 = _zz_decode_SRC2_CTRL_2;
-  assign _zz_decode_ALU_BITWISE_CTRL_2 = _zz_decode_ENV_CTRL_2[17 : 16];
+  assign _zz_decode_ALU_BITWISE_CTRL_2 = _zz_decode_IS_CSR[17 : 16];
   assign _zz_decode_ALU_BITWISE_CTRL_1 = _zz_decode_ALU_BITWISE_CTRL_2;
-  assign _zz_decode_SHIFT_CTRL_2 = _zz_decode_ENV_CTRL_2[20 : 19];
+  assign _zz_decode_SHIFT_CTRL_2 = _zz_decode_IS_CSR[20 : 19];
   assign _zz_decode_SHIFT_CTRL_1 = _zz_decode_SHIFT_CTRL_2;
-  assign _zz_decode_BRANCH_CTRL_2 = _zz_decode_ENV_CTRL_2[22 : 21];
+  assign _zz_decode_BRANCH_CTRL_2 = _zz_decode_IS_CSR[22 : 21];
   assign _zz_decode_BRANCH_CTRL_1 = _zz_decode_BRANCH_CTRL_2;
-  assign _zz_decode_ENV_CTRL_8 = _zz_decode_ENV_CTRL_2[25 : 24];
-  assign _zz_decode_ENV_CTRL_1 = _zz_decode_ENV_CTRL_8;
+  assign _zz_decode_ENV_CTRL_2 = _zz_decode_IS_CSR[25 : 24];
+  assign _zz_decode_ENV_CTRL_1 = _zz_decode_ENV_CTRL_2;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
-  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h0);
+  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h00);
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
   assign decode_RegFilePlugin_rs1Data = _zz_RegFilePlugin_regFile_port0;
   assign decode_RegFilePlugin_rs2Data = _zz_RegFilePlugin_regFile_port1;
   always @(*) begin
     lastStageRegFileWrite_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
-    if(_zz_2) begin
+    if(_zz_5) begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
   always @(*) begin
     lastStageRegFileWrite_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
-    if(_zz_2) begin
-      lastStageRegFileWrite_payload_address = 5'h0;
+    if(_zz_5) begin
+      lastStageRegFileWrite_payload_address = 5'h00;
     end
   end
 
   always @(*) begin
     lastStageRegFileWrite_payload_data = _zz_lastStageRegFileWrite_payload_data;
-    if(_zz_2) begin
-      lastStageRegFileWrite_payload_data = 32'h0;
+    if(_zz_5) begin
+      lastStageRegFileWrite_payload_data = 32'h00000000;
     end
   end
 
@@ -2471,7 +2484,7 @@ module VexRiscv (
         _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
       Src1CtrlEnum_IMU : begin
-        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h000};
       end
       default : begin
         _zz_execute_SRC1 = {27'd0, _zz__zz_execute_SRC1_1};
@@ -2479,67 +2492,67 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_execute_SRC2_1 = execute_INSTRUCTION[31];
+  assign _zz_execute_SRC2 = execute_INSTRUCTION[31];
   always @(*) begin
-    _zz_execute_SRC2_2[19] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[18] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[17] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[16] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[15] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[14] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[13] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[12] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[11] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[10] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[9] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[8] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[7] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[6] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[5] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[4] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[3] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[2] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[1] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[0] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_1[19] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[18] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[17] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[16] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[15] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[14] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[13] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[12] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[11] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[10] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[9] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[8] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[7] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[6] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[5] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[4] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[3] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[2] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[1] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[0] = _zz_execute_SRC2;
   end
 
-  assign _zz_execute_SRC2_3 = _zz__zz_execute_SRC2_3[11];
+  assign _zz_execute_SRC2_2 = _zz__zz_execute_SRC2_2[11];
   always @(*) begin
-    _zz_execute_SRC2_4[19] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[18] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[17] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[16] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[15] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[14] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[13] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[12] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[11] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[10] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[9] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[8] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[7] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[6] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[5] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[4] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[3] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[2] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[1] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[0] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_3[19] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[18] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[17] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[16] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[15] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[14] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[13] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[12] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[11] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[10] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[9] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[8] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[7] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[6] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[5] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[4] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[3] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[2] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[1] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[0] = _zz_execute_SRC2_2;
   end
 
   always @(*) begin
     case(execute_SRC2_CTRL)
       Src2CtrlEnum_RS : begin
-        _zz_execute_SRC2_5 = execute_RS2;
+        _zz_execute_SRC2_4 = execute_RS2;
       end
       Src2CtrlEnum_IMI : begin
-        _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
+        _zz_execute_SRC2_4 = {_zz_execute_SRC2_1,execute_INSTRUCTION[31 : 20]};
       end
       Src2CtrlEnum_IMS : begin
-        _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_execute_SRC2_4 = {_zz_execute_SRC2_3,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_execute_SRC2_5 = _zz_execute_SRC2;
+        _zz_execute_SRC2_4 = _zz_execute_to_memory_PC;
       end
     endcase
   end
@@ -2556,7 +2569,7 @@ module VexRiscv (
   assign execute_LightShifterPlugin_amplitude = (execute_LightShifterPlugin_isActive ? execute_LightShifterPlugin_amplitudeReg : execute_SRC2[4 : 0]);
   assign execute_LightShifterPlugin_shiftInput = (execute_LightShifterPlugin_isActive ? memory_REGFILE_WRITE_DATA : execute_SRC1);
   assign execute_LightShifterPlugin_done = (execute_LightShifterPlugin_amplitude[4 : 1] == 4'b0000);
-  assign when_ShiftPlugins_l169 = ((execute_arbitration_isValid && execute_LightShifterPlugin_isShift) && (execute_SRC2[4 : 0] != 5'h0));
+  assign when_ShiftPlugins_l169 = ((execute_arbitration_isValid && execute_LightShifterPlugin_isShift) && (execute_SRC2[4 : 0] != 5'h00));
   always @(*) begin
     case(execute_SHIFT_CTRL)
       ShiftCtrlEnum_SLL_1 : begin
@@ -2657,16 +2670,19 @@ module VexRiscv (
   assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
   assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign switch_Misc_l210_1 = execute_INSTRUCTION[14 : 12];
+  assign switch_Misc_l232_1 = execute_INSTRUCTION[14 : 12];
   always @(*) begin
-    casez(switch_Misc_l210_1)
+    case(switch_Misc_l232_1)
       3'b000 : begin
         _zz_execute_BRANCH_DO = execute_BranchPlugin_eq;
       end
       3'b001 : begin
         _zz_execute_BRANCH_DO = (! execute_BranchPlugin_eq);
       end
-      3'b1?1 : begin
+      3'b101 : begin
+        _zz_execute_BRANCH_DO = (! execute_SRC_LESS);
+      end
+      3'b111 : begin
         _zz_execute_BRANCH_DO = (! execute_SRC_LESS);
       end
       default : begin
@@ -2785,9 +2801,9 @@ module VexRiscv (
 
   assign CsrPlugin_misa_base = 2'b01;
   assign CsrPlugin_misa_extensions = 26'h0000042;
-  assign _zz_when_CsrPlugin_l965 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_when_CsrPlugin_l965_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_when_CsrPlugin_l965_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign _zz_when_CsrPlugin_l1302 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l1302_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l1302_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
   assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {BranchPlugin_branchExceptionPort_valid,DBusSimplePlugin_memoryExceptionPort_valid};
@@ -2829,29 +2845,29 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l922 = (! decode_arbitration_isStuck);
-  assign when_CsrPlugin_l922_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l922_2 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l922_3 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l935 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
+  assign when_CsrPlugin_l1259 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l1272 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-  assign when_CsrPlugin_l959 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign when_CsrPlugin_l965 = ((_zz_when_CsrPlugin_l965 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l965_1 = ((_zz_when_CsrPlugin_l965_1 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l965_2 = ((_zz_when_CsrPlugin_l965_2 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1296 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l1302 = ((_zz_when_CsrPlugin_l1302 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1302_1 = ((_zz_when_CsrPlugin_l1302_1 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1302_2 = ((_zz_when_CsrPlugin_l1302_2 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_lastStageWasWfi = 1'b0;
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  assign when_CsrPlugin_l993 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l993_1 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l993_2 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l998 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  assign when_CsrPlugin_l1335 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1335_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l1335_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l1340 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
   always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(when_CsrPlugin_l1004) begin
+    if(when_CsrPlugin_l1346) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException) begin
@@ -2859,7 +2875,7 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l1004 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
+  assign when_CsrPlugin_l1346 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
   always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
@@ -2875,6 +2891,7 @@ module VexRiscv (
     end
   end
 
+  assign CsrPlugin_trapCauseEbreakDebug = 1'b0;
   always @(*) begin
     CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
@@ -2897,11 +2914,13 @@ module VexRiscv (
     endcase
   end
 
-  assign when_CsrPlugin_l1032 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign when_CsrPlugin_l1077 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
-  assign switch_CsrPlugin_l1081 = writeBack_INSTRUCTION[29 : 28];
+  assign CsrPlugin_trapEnterDebug = 1'b0;
+  assign when_CsrPlugin_l1390 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1398 = (! CsrPlugin_trapEnterDebug);
+  assign when_CsrPlugin_l1456 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign switch_CsrPlugin_l1460 = writeBack_INSTRUCTION[29 : 28];
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign when_CsrPlugin_l1129 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
+  assign when_CsrPlugin_l1527 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
   assign execute_CsrPlugin_blockedBySideEffects = ((|{writeBack_arbitration_isValid,memory_arbitration_isValid}) || 1'b0);
   always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
@@ -2943,18 +2962,18 @@ module VexRiscv (
     if(CsrPlugin_csrMapping_allowCsrSignal) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(when_CsrPlugin_l1315) begin
+    if(when_CsrPlugin_l1725) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if(when_CsrPlugin_l1149) begin
-      if(when_CsrPlugin_l1150) begin
+    if(when_CsrPlugin_l1547) begin
+      if(when_CsrPlugin_l1548) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
@@ -2962,14 +2981,14 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(when_CsrPlugin_l1157) begin
+    if(when_CsrPlugin_l1555) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(when_CsrPlugin_l1157) begin
+    if(when_CsrPlugin_l1555) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -2982,19 +3001,19 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  assign when_CsrPlugin_l1149 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
-  assign when_CsrPlugin_l1150 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
-  assign when_CsrPlugin_l1157 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
+  assign when_CsrPlugin_l1547 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign when_CsrPlugin_l1548 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1555 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
   always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -3003,9 +3022,9 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
   assign execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
-  assign switch_Misc_l210_2 = execute_INSTRUCTION[13];
+  assign switch_Misc_l232_2 = execute_INSTRUCTION[13];
   always @(*) begin
-    case(switch_Misc_l210_2)
+    case(switch_Misc_l232_2)
       1'b0 : begin
         _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
@@ -3016,11 +3035,11 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
-  assign when_CsrPlugin_l1189 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign when_CsrPlugin_l1193 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
+  assign when_CsrPlugin_l1587 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1591 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
-  assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
-  assign externalInterrupt = (|_zz_CsrPlugin_csrMapping_readDataInit_1);
+  assign _zz_externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
+  assign externalInterrupt = (|_zz_externalInterrupt);
   assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
@@ -3117,93 +3136,103 @@ module VexRiscv (
   assign when_Pipeline_l154_1 = ((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt));
   assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
   assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
-  assign when_CsrPlugin_l1277 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_2 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_3 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_4 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_5 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_6 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_7 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_8 = (! execute_arbitration_isStuck);
-  assign switch_CsrPlugin_l723 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
+  assign when_CsrPlugin_l1669 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_8 = (! execute_arbitration_isStuck);
+  assign switch_CsrPlugin_l1031 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_1 = 32'h00000000;
     if(execute_CsrPlugin_csr_768) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_2[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_2[3 : 3] = CsrPlugin_mstatus_MIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_2[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_CsrPlugin_csrMapping_readDataInit_1[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_1[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_1[12 : 11] = CsrPlugin_mstatus_MPP;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h00000000;
     if(execute_CsrPlugin_csr_836) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_3[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_3[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_3[3 : 3] = CsrPlugin_mip_MSIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[3 : 3] = CsrPlugin_mip_MSIP;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h00000000;
     if(execute_CsrPlugin_csr_772) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_4[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_4[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_4[3 : 3] = CsrPlugin_mie_MSIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[3 : 3] = CsrPlugin_mie_MSIE;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h00000000;
     if(execute_CsrPlugin_csr_833) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_5[31 : 0] = CsrPlugin_mepc;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[31 : 0] = CsrPlugin_mepc;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h00000000;
     if(execute_CsrPlugin_csr_834) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_6[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_CsrPlugin_csrMapping_readDataInit_6[3 : 0] = CsrPlugin_mcause_exceptionCode;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h00000000;
     if(execute_CsrPlugin_csr_835) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_7[31 : 0] = CsrPlugin_mtval;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[31 : 0] = CsrPlugin_mtval;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h00000000;
     if(execute_CsrPlugin_csr_3008) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_8[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h00000000;
     if(execute_CsrPlugin_csr_4032) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_9[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_1;
+      _zz_CsrPlugin_csrMapping_readDataInit_8[31 : 0] = _zz_externalInterrupt;
     end
   end
 
-  assign CsrPlugin_csrMapping_readDataInit = (((_zz_CsrPlugin_csrMapping_readDataInit_2 | _zz_CsrPlugin_csrMapping_readDataInit_3) | (_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5)) | ((_zz_CsrPlugin_csrMapping_readDataInit_6 | _zz_CsrPlugin_csrMapping_readDataInit_7) | (_zz_CsrPlugin_csrMapping_readDataInit_8 | _zz_CsrPlugin_csrMapping_readDataInit_9)));
-  assign when_CsrPlugin_l1310 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign when_CsrPlugin_l1315 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign CsrPlugin_csrMapping_readDataInit = (((_zz_CsrPlugin_csrMapping_readDataInit_1 | _zz_CsrPlugin_csrMapping_readDataInit_2) | (_zz_CsrPlugin_csrMapping_readDataInit_3 | _zz_CsrPlugin_csrMapping_readDataInit_4)) | ((_zz_CsrPlugin_csrMapping_readDataInit_5 | _zz_CsrPlugin_csrMapping_readDataInit_6) | (_zz_CsrPlugin_csrMapping_readDataInit_7 | _zz_CsrPlugin_csrMapping_readDataInit_8)));
+  assign when_CsrPlugin_l1702 = ((execute_arbitration_isValid && execute_IS_CSR) && (({execute_CsrPlugin_csrAddress[11 : 2],2'b00} == 12'h3a0) || ({execute_CsrPlugin_csrAddress[11 : 4],4'b0000} == 12'h3b0)));
+  assign _zz_when_CsrPlugin_l1709 = (execute_CsrPlugin_csrAddress & 12'hf60);
+  assign when_CsrPlugin_l1709 = (((execute_arbitration_isValid && execute_IS_CSR) && (5'h03 <= execute_CsrPlugin_csrAddress[4 : 0])) && (((_zz_when_CsrPlugin_l1709 == 12'hb00) || (((_zz_when_CsrPlugin_l1709 == 12'hc00) && (! execute_CsrPlugin_writeInstruction)) && (CsrPlugin_privilege == 2'b11))) || ((execute_CsrPlugin_csrAddress & 12'hfe0) == 12'h320)));
+  always @(*) begin
+    when_CsrPlugin_l1719 = CsrPlugin_csrMapping_doForceFailCsr;
+    if(when_CsrPlugin_l1717) begin
+      when_CsrPlugin_l1719 = 1'b1;
+    end
+  end
+
+  assign when_CsrPlugin_l1717 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1725 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
   always @(*) begin
     iBus_cmd_ready = iBus_cmd_m2sPipe_ready;
-    if(when_Stream_l368) begin
+    if(when_Stream_l369) begin
       iBus_cmd_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l368 = (! iBus_cmd_m2sPipe_valid);
+  assign when_Stream_l369 = (! iBus_cmd_m2sPipe_valid);
   assign iBus_cmd_m2sPipe_valid = iBus_cmd_rValid;
   assign iBus_cmd_m2sPipe_payload_pc = iBus_cmd_rData_pc;
-  assign iBusWishbone_ADR = (iBus_cmd_m2sPipe_payload_pc >>> 2);
+  assign iBusWishbone_ADR = (iBus_cmd_m2sPipe_payload_pc >>> 2'd2);
   assign iBusWishbone_CTI = 3'b000;
   assign iBusWishbone_BTE = 2'b00;
   assign iBusWishbone_SEL = 4'b1111;
@@ -3222,7 +3251,7 @@ module VexRiscv (
   assign dBus_cmd_halfPipe_payload_address = dBus_cmd_rData_address;
   assign dBus_cmd_halfPipe_payload_data = dBus_cmd_rData_data;
   assign dBus_cmd_halfPipe_payload_size = dBus_cmd_rData_size;
-  assign dBusWishbone_ADR = (dBus_cmd_halfPipe_payload_address >>> 2);
+  assign dBusWishbone_ADR = (dBus_cmd_halfPipe_payload_address >>> 2'd2);
   assign dBusWishbone_CTI = 3'b000;
   assign dBusWishbone_BTE = 2'b00;
   always @(*) begin
@@ -3241,12 +3270,12 @@ module VexRiscv (
 
   always @(*) begin
     dBusWishbone_SEL = (_zz_dBusWishbone_SEL <<< dBus_cmd_halfPipe_payload_address[1 : 0]);
-    if(when_DBusSimplePlugin_l189) begin
+    if(when_DBusSimplePlugin_l196) begin
       dBusWishbone_SEL = 4'b1111;
     end
   end
 
-  assign when_DBusSimplePlugin_l189 = (! dBus_cmd_halfPipe_payload_wr);
+  assign when_DBusSimplePlugin_l196 = (! dBus_cmd_halfPipe_payload_wr);
   assign dBusWishbone_WE = dBus_cmd_halfPipe_payload_wr;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_halfPipe_payload_data;
   assign dBus_cmd_halfPipe_ready = (dBus_cmd_halfPipe_valid && dBusWishbone_ACK);
@@ -3255,13 +3284,14 @@ module VexRiscv (
   assign dBus_rsp_ready = ((dBus_cmd_halfPipe_valid && (! dBusWishbone_WE)) && dBusWishbone_ACK);
   assign dBus_rsp_data = dBusWishbone_DAT_MISO;
   assign dBus_rsp_error = 1'b0;
+  assign IBusSimplePlugin_rspJoin_rspBuffer_c_io_flush = 1'b0;
   always @(posedge clk) begin
     if(reset) begin
       IBusSimplePlugin_fetchPc_pcReg <= externalResetVector;
       IBusSimplePlugin_fetchPc_correctionReg <= 1'b0;
       IBusSimplePlugin_fetchPc_booted <= 1'b0;
       IBusSimplePlugin_fetchPc_inc <= 1'b0;
-      _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+      _zz_IBusSimplePlugin_iBusRsp_stages_1_input_valid_1 <= 1'b0;
       _zz_IBusSimplePlugin_injector_decodeInput_valid <= 1'b0;
       IBusSimplePlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusSimplePlugin_injector_nextPcCalc_valids_1 <= 1'b0;
@@ -3270,7 +3300,7 @@ module VexRiscv (
       IBusSimplePlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       IBusSimplePlugin_pending_value <= 3'b000;
       IBusSimplePlugin_rspJoin_rspBuffer_discardCounter <= 3'b000;
-      _zz_2 <= 1'b1;
+      _zz_5 <= 1'b1;
       execute_LightShifterPlugin_isActive <= 1'b0;
       HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
       CsrPlugin_mstatus_MIE <= 1'b0;
@@ -3279,8 +3309,8 @@ module VexRiscv (
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
-      CsrPlugin_mcycle <= 64'h0;
-      CsrPlugin_minstret <= 64'h0;
+      CsrPlugin_mcycle <= 64'h0000000000000000;
+      CsrPlugin_minstret <= 64'h0000000000000000;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= 1'b0;
@@ -3291,7 +3321,7 @@ module VexRiscv (
       CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
-      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h0;
+      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h00000000;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
@@ -3305,23 +3335,23 @@ module VexRiscv (
         IBusSimplePlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusSimplePlugin_fetchPc_booted <= 1'b1;
-      if(when_Fetcher_l134) begin
+      if(when_Fetcher_l133) begin
         IBusSimplePlugin_fetchPc_inc <= 1'b0;
       end
-      if(IBusSimplePlugin_fetchPc_output_fire_1) begin
+      if(IBusSimplePlugin_fetchPc_output_fire) begin
         IBusSimplePlugin_fetchPc_inc <= 1'b1;
       end
-      if(when_Fetcher_l134_1) begin
+      if(when_Fetcher_l133_1) begin
         IBusSimplePlugin_fetchPc_inc <= 1'b0;
       end
-      if(when_Fetcher_l161) begin
+      if(when_Fetcher_l160) begin
         IBusSimplePlugin_fetchPc_pcReg <= IBusSimplePlugin_fetchPc_pc;
       end
       if(IBusSimplePlugin_iBusRsp_flush) begin
-        _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+        _zz_IBusSimplePlugin_iBusRsp_stages_1_input_valid_1 <= 1'b0;
       end
       if(_zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready) begin
-        _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_2 <= (IBusSimplePlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+        _zz_IBusSimplePlugin_iBusRsp_stages_1_input_valid_1 <= (IBusSimplePlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
       if(decode_arbitration_removeIt) begin
         _zz_IBusSimplePlugin_injector_decodeInput_valid <= 1'b0;
@@ -3332,13 +3362,13 @@ module VexRiscv (
       if(IBusSimplePlugin_fetchPc_flushed) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if(when_Fetcher_l332) begin
+      if(when_Fetcher_l331) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
       if(IBusSimplePlugin_fetchPc_flushed) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(when_Fetcher_l332_1) begin
+      if(when_Fetcher_l331_1) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_1 <= IBusSimplePlugin_injector_nextPcCalc_valids_0;
       end
       if(IBusSimplePlugin_fetchPc_flushed) begin
@@ -3347,7 +3377,7 @@ module VexRiscv (
       if(IBusSimplePlugin_fetchPc_flushed) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(when_Fetcher_l332_2) begin
+      if(when_Fetcher_l331_2) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_2 <= IBusSimplePlugin_injector_nextPcCalc_valids_1;
       end
       if(IBusSimplePlugin_fetchPc_flushed) begin
@@ -3356,7 +3386,7 @@ module VexRiscv (
       if(IBusSimplePlugin_fetchPc_flushed) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(when_Fetcher_l332_3) begin
+      if(when_Fetcher_l331_3) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_3 <= IBusSimplePlugin_injector_nextPcCalc_valids_2;
       end
       if(IBusSimplePlugin_fetchPc_flushed) begin
@@ -3365,7 +3395,7 @@ module VexRiscv (
       if(IBusSimplePlugin_fetchPc_flushed) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if(when_Fetcher_l332_4) begin
+      if(when_Fetcher_l331_4) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_4 <= IBusSimplePlugin_injector_nextPcCalc_valids_3;
       end
       if(IBusSimplePlugin_fetchPc_flushed) begin
@@ -3376,7 +3406,7 @@ module VexRiscv (
       if(IBusSimplePlugin_iBusRsp_flush) begin
         IBusSimplePlugin_rspJoin_rspBuffer_discardCounter <= (IBusSimplePlugin_pending_value - _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter_2);
       end
-      _zz_2 <= 1'b0;
+      _zz_5 <= 1'b0;
       if(when_ShiftPlugins_l169) begin
         if(when_ShiftPlugins_l175) begin
           execute_LightShifterPlugin_isActive <= 1'b1;
@@ -3393,50 +3423,50 @@ module VexRiscv (
       if(writeBack_arbitration_isFiring) begin
         CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
       end
-      if(when_CsrPlugin_l922) begin
+      if(when_CsrPlugin_l1259) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if(when_CsrPlugin_l922_1) begin
+      if(when_CsrPlugin_l1259_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if(when_CsrPlugin_l922_2) begin
+      if(when_CsrPlugin_l1259_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if(when_CsrPlugin_l922_3) begin
+      if(when_CsrPlugin_l1259_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(when_CsrPlugin_l959) begin
-        if(when_CsrPlugin_l965) begin
+      if(when_CsrPlugin_l1296) begin
+        if(when_CsrPlugin_l1302) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_1) begin
+        if(when_CsrPlugin_l1302_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_2) begin
+        if(when_CsrPlugin_l1302_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
       if(CsrPlugin_pipelineLiberator_active) begin
-        if(when_CsrPlugin_l993) begin
+        if(when_CsrPlugin_l1335) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if(when_CsrPlugin_l993_1) begin
+        if(when_CsrPlugin_l1335_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if(when_CsrPlugin_l993_2) begin
+        if(when_CsrPlugin_l1335_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(when_CsrPlugin_l998) begin
+      if(when_CsrPlugin_l1340) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
@@ -3445,19 +3475,21 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(when_CsrPlugin_l1032) begin
-        case(CsrPlugin_targetPrivilege)
-          2'b11 : begin
-            CsrPlugin_mstatus_MIE <= 1'b0;
-            CsrPlugin_mstatus_MPIE <= CsrPlugin_mstatus_MIE;
-            CsrPlugin_mstatus_MPP <= CsrPlugin_privilege;
-          end
-          default : begin
-          end
-        endcase
+      if(when_CsrPlugin_l1390) begin
+        if(when_CsrPlugin_l1398) begin
+          case(CsrPlugin_targetPrivilege)
+            2'b11 : begin
+              CsrPlugin_mstatus_MIE <= 1'b0;
+              CsrPlugin_mstatus_MPIE <= CsrPlugin_mstatus_MIE;
+              CsrPlugin_mstatus_MPP <= CsrPlugin_privilege;
+            end
+            default : begin
+            end
+          endcase
+        end
       end
-      if(when_CsrPlugin_l1077) begin
-        case(switch_CsrPlugin_l1081)
+      if(when_CsrPlugin_l1456) begin
+        case(switch_CsrPlugin_l1460)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -3467,7 +3499,7 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l965_2,{_zz_when_CsrPlugin_l965_1,_zz_when_CsrPlugin_l965}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l1302_2,{_zz_when_CsrPlugin_l1302_1,_zz_when_CsrPlugin_l1302}} != 3'b000) || CsrPlugin_thirdPartyWake);
       if(when_Pipeline_l151) begin
         execute_arbitration_isValid <= 1'b0;
       end
@@ -3490,7 +3522,7 @@ module VexRiscv (
         if(execute_CsrPlugin_writeEnable) begin
           CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
           CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
-          case(switch_CsrPlugin_l723)
+          case(switch_CsrPlugin_l1031)
             2'b11 : begin
               CsrPlugin_mstatus_MPP <= 2'b11;
             end
@@ -3555,40 +3587,42 @@ module VexRiscv (
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? DBusSimplePlugin_memoryExceptionPort_payload_code : BranchPlugin_branchExceptionPort_payload_code);
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? DBusSimplePlugin_memoryExceptionPort_payload_badAddr : BranchPlugin_branchExceptionPort_payload_badAddr);
     end
-    if(when_CsrPlugin_l959) begin
-      if(when_CsrPlugin_l965) begin
+    if(when_CsrPlugin_l1296) begin
+      if(when_CsrPlugin_l1302) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l965_1) begin
+      if(when_CsrPlugin_l1302_1) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l965_2) begin
+      if(when_CsrPlugin_l1302_2) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(when_CsrPlugin_l1032) begin
-      case(CsrPlugin_targetPrivilege)
-        2'b11 : begin
-          CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
-          CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
-          CsrPlugin_mepc <= writeBack_PC;
-          if(CsrPlugin_hadException) begin
-            CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
+    if(when_CsrPlugin_l1390) begin
+      if(when_CsrPlugin_l1398) begin
+        case(CsrPlugin_targetPrivilege)
+          2'b11 : begin
+            CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
+            CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
+            CsrPlugin_mepc <= writeBack_PC;
+            if(CsrPlugin_hadException) begin
+              CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
+            end
           end
-        end
-        default : begin
-        end
-      endcase
+          default : begin
+          end
+        endcase
+      end
     end
     externalInterruptArray_regNext <= externalInterruptArray;
     if(when_Pipeline_l124) begin
       decode_to_execute_PC <= decode_PC;
     end
     if(when_Pipeline_l124_1) begin
-      execute_to_memory_PC <= _zz_execute_SRC2;
+      execute_to_memory_PC <= _zz_execute_to_memory_PC;
     end
     if(when_Pipeline_l124_2) begin
       memory_to_writeBack_PC <= memory_PC;
@@ -3719,31 +3753,31 @@ module VexRiscv (
     if(when_Pipeline_l124_44) begin
       memory_to_writeBack_MEMORY_READ_DATA <= memory_MEMORY_READ_DATA;
     end
-    if(when_CsrPlugin_l1277) begin
+    if(when_CsrPlugin_l1669) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if(when_CsrPlugin_l1277_1) begin
+    if(when_CsrPlugin_l1669_1) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if(when_CsrPlugin_l1277_2) begin
+    if(when_CsrPlugin_l1669_2) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if(when_CsrPlugin_l1277_3) begin
+    if(when_CsrPlugin_l1669_3) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if(when_CsrPlugin_l1277_4) begin
+    if(when_CsrPlugin_l1669_4) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if(when_CsrPlugin_l1277_5) begin
+    if(when_CsrPlugin_l1669_5) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if(when_CsrPlugin_l1277_6) begin
+    if(when_CsrPlugin_l1669_6) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if(when_CsrPlugin_l1277_7) begin
+    if(when_CsrPlugin_l1669_7) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if(when_CsrPlugin_l1277_8) begin
+    if(when_CsrPlugin_l1669_8) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
     if(execute_CsrPlugin_csr_836) begin
@@ -3754,7 +3788,6 @@ module VexRiscv (
     if(execute_CsrPlugin_csr_773) begin
       if(execute_CsrPlugin_writeEnable) begin
         CsrPlugin_mtvec_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 2];
-        CsrPlugin_mtvec_mode <= CsrPlugin_csrMapping_writeDataSignal[1 : 0];
       end
     end
     if(execute_CsrPlugin_csr_833) begin
@@ -3777,135 +3810,141 @@ module VexRiscv (
 endmodule
 
 module StreamFifoLowLatency (
-  input               io_push_valid,
-  output              io_push_ready,
-  input               io_push_payload_error,
-  input      [31:0]   io_push_payload_inst,
-  output reg          io_pop_valid,
-  input               io_pop_ready,
-  output reg          io_pop_payload_error,
-  output reg [31:0]   io_pop_payload_inst,
-  input               io_flush,
-  output     [0:0]    io_occupancy,
-  input               clk,
-  input               reset
+  input  wire          io_push_valid,
+  output wire          io_push_ready,
+  input  wire          io_push_payload_error,
+  input  wire [31:0]   io_push_payload_inst,
+  output wire          io_pop_valid,
+  input  wire          io_pop_ready,
+  output wire          io_pop_payload_error,
+  output wire [31:0]   io_pop_payload_inst,
+  input  wire          io_flush,
+  output wire [0:0]    io_occupancy,
+  output wire [0:0]    io_availability,
+  input  wire          clk,
+  input  wire          reset
 );
 
-  reg                 when_Phase_l649;
-  reg                 pushPtr_willIncrement;
-  reg                 pushPtr_willClear;
-  wire                pushPtr_willOverflowIfInc;
-  wire                pushPtr_willOverflow;
-  reg                 popPtr_willIncrement;
-  reg                 popPtr_willClear;
-  wire                popPtr_willOverflowIfInc;
-  wire                popPtr_willOverflow;
-  wire                ptrMatch;
-  reg                 risingOccupancy;
-  wire                empty;
-  wire                full;
-  wire                pushing;
-  wire                popping;
-  wire                readed_error;
-  wire       [31:0]   readed_inst;
-  wire       [32:0]   _zz_readed_error;
-  wire                when_Stream_l1178;
-  wire                when_Stream_l1191;
-  wire       [32:0]   _zz_readed_error_1;
-  reg        [32:0]   _zz_readed_error_2;
+  wire                fifo_io_push_ready;
+  wire                fifo_io_pop_valid;
+  wire                fifo_io_pop_payload_error;
+  wire       [31:0]   fifo_io_pop_payload_inst;
+  wire       [0:0]    fifo_io_occupancy;
+  wire       [0:0]    fifo_io_availability;
+
+  StreamFifo fifo (
+    .io_push_valid         (io_push_valid                 ), //i
+    .io_push_ready         (fifo_io_push_ready            ), //o
+    .io_push_payload_error (io_push_payload_error         ), //i
+    .io_push_payload_inst  (io_push_payload_inst[31:0]    ), //i
+    .io_pop_valid          (fifo_io_pop_valid             ), //o
+    .io_pop_ready          (io_pop_ready                  ), //i
+    .io_pop_payload_error  (fifo_io_pop_payload_error     ), //o
+    .io_pop_payload_inst   (fifo_io_pop_payload_inst[31:0]), //o
+    .io_flush              (io_flush                      ), //i
+    .io_occupancy          (fifo_io_occupancy             ), //o
+    .io_availability       (fifo_io_availability          ), //o
+    .clk                   (clk                           ), //i
+    .reset                 (reset                         )  //i
+  );
+  assign io_push_ready = fifo_io_push_ready;
+  assign io_pop_valid = fifo_io_pop_valid;
+  assign io_pop_payload_error = fifo_io_pop_payload_error;
+  assign io_pop_payload_inst = fifo_io_pop_payload_inst;
+  assign io_occupancy = fifo_io_occupancy;
+  assign io_availability = fifo_io_availability;
+
+endmodule
+
+module StreamFifo (
+  input  wire          io_push_valid,
+  output reg           io_push_ready,
+  input  wire          io_push_payload_error,
+  input  wire [31:0]   io_push_payload_inst,
+  output reg           io_pop_valid,
+  input  wire          io_pop_ready,
+  output reg           io_pop_payload_error,
+  output reg  [31:0]   io_pop_payload_inst,
+  input  wire          io_flush,
+  output wire [0:0]    io_occupancy,
+  output wire [0:0]    io_availability,
+  input  wire          clk,
+  input  wire          reset
+);
+
+  reg                 oneStage_doFlush;
+  wire                oneStage_buffer_valid;
+  wire                oneStage_buffer_ready;
+  wire                oneStage_buffer_payload_error;
+  wire       [31:0]   oneStage_buffer_payload_inst;
+  reg                 io_push_rValid;
+  reg                 io_push_rData_error;
+  reg        [31:0]   io_push_rData_inst;
+  wire                when_Stream_l369;
+  wire                when_Stream_l1187;
 
   always @(*) begin
-    when_Phase_l649 = 1'b0;
-    if(pushing) begin
-      when_Phase_l649 = 1'b1;
+    oneStage_doFlush = io_flush;
+    if(when_Stream_l1187) begin
+      if(io_pop_ready) begin
+        oneStage_doFlush = 1'b1;
+      end
     end
   end
 
   always @(*) begin
-    pushPtr_willIncrement = 1'b0;
-    if(pushing) begin
-      pushPtr_willIncrement = 1'b1;
+    io_push_ready = oneStage_buffer_ready;
+    if(when_Stream_l369) begin
+      io_push_ready = 1'b1;
     end
   end
 
+  assign when_Stream_l369 = (! oneStage_buffer_valid);
+  assign oneStage_buffer_valid = io_push_rValid;
+  assign oneStage_buffer_payload_error = io_push_rData_error;
+  assign oneStage_buffer_payload_inst = io_push_rData_inst;
   always @(*) begin
-    pushPtr_willClear = 1'b0;
-    if(io_flush) begin
-      pushPtr_willClear = 1'b1;
-    end
-  end
-
-  assign pushPtr_willOverflowIfInc = 1'b1;
-  assign pushPtr_willOverflow = (pushPtr_willOverflowIfInc && pushPtr_willIncrement);
-  always @(*) begin
-    popPtr_willIncrement = 1'b0;
-    if(popping) begin
-      popPtr_willIncrement = 1'b1;
-    end
-  end
-
-  always @(*) begin
-    popPtr_willClear = 1'b0;
-    if(io_flush) begin
-      popPtr_willClear = 1'b1;
-    end
-  end
-
-  assign popPtr_willOverflowIfInc = 1'b1;
-  assign popPtr_willOverflow = (popPtr_willOverflowIfInc && popPtr_willIncrement);
-  assign ptrMatch = 1'b1;
-  assign empty = (ptrMatch && (! risingOccupancy));
-  assign full = (ptrMatch && risingOccupancy);
-  assign pushing = (io_push_valid && io_push_ready);
-  assign popping = (io_pop_valid && io_pop_ready);
-  assign io_push_ready = (! full);
-  assign _zz_readed_error = _zz_readed_error_1;
-  assign readed_error = _zz_readed_error[0];
-  assign readed_inst = _zz_readed_error[32 : 1];
-  assign when_Stream_l1178 = (! empty);
-  always @(*) begin
-    if(when_Stream_l1178) begin
-      io_pop_valid = 1'b1;
-    end else begin
+    io_pop_valid = oneStage_buffer_valid;
+    if(when_Stream_l1187) begin
       io_pop_valid = io_push_valid;
     end
   end
 
+  assign oneStage_buffer_ready = io_pop_ready;
   always @(*) begin
-    if(when_Stream_l1178) begin
-      io_pop_payload_error = readed_error;
-    end else begin
+    io_pop_payload_error = oneStage_buffer_payload_error;
+    if(when_Stream_l1187) begin
       io_pop_payload_error = io_push_payload_error;
     end
   end
 
   always @(*) begin
-    if(when_Stream_l1178) begin
-      io_pop_payload_inst = readed_inst;
-    end else begin
+    io_pop_payload_inst = oneStage_buffer_payload_inst;
+    if(when_Stream_l1187) begin
       io_pop_payload_inst = io_push_payload_inst;
     end
   end
 
-  assign when_Stream_l1191 = (pushing != popping);
-  assign io_occupancy = (risingOccupancy && ptrMatch);
-  assign _zz_readed_error_1 = _zz_readed_error_2;
+  assign io_occupancy = oneStage_buffer_valid;
+  assign io_availability = (! oneStage_buffer_valid);
+  assign when_Stream_l1187 = (! oneStage_buffer_valid);
   always @(posedge clk) begin
     if(reset) begin
-      risingOccupancy <= 1'b0;
+      io_push_rValid <= 1'b0;
     end else begin
-      if(when_Stream_l1191) begin
-        risingOccupancy <= pushing;
+      if(io_push_ready) begin
+        io_push_rValid <= io_push_valid;
       end
-      if(io_flush) begin
-        risingOccupancy <= 1'b0;
+      if(oneStage_doFlush) begin
+        io_push_rValid <= 1'b0;
       end
     end
   end
 
   always @(posedge clk) begin
-    if(when_Phase_l649) begin
-      _zz_readed_error_2 <= {io_push_payload_inst,io_push_payload_error};
+    if(io_push_ready) begin
+      io_push_rData_error <= io_push_payload_error;
+      io_push_rData_inst <= io_push_payload_inst;
     end
   end
 

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_MinDebug.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_MinDebug.v
@@ -1,46 +1,46 @@
-// Generator : SpinalHDL v1.7.1    git head : 0444bb76ab1d6e19f0ec46bc03c4769776deb7d5
+// Generator : SpinalHDL v1.9.4    git head : 270018552577f3bb8e5339ee2583c9c22d324215
 // Component : VexRiscv
-// Git hash  : 581fcb065adf7ea8b626f939ff51679d4c95872f
+// Git hash  : 63430af99f84cc1d11d58b556debe1cc3f238c67
 
 `timescale 1ns/1ps
 
 module VexRiscv (
-  input      [31:0]   externalResetVector,
-  input               timerInterrupt,
-  input               softwareInterrupt,
-  input      [31:0]   externalInterruptArray,
-  input               debug_bus_cmd_valid,
-  output reg          debug_bus_cmd_ready,
-  input               debug_bus_cmd_payload_wr,
-  input      [7:0]    debug_bus_cmd_payload_address,
-  input      [31:0]   debug_bus_cmd_payload_data,
-  output reg [31:0]   debug_bus_rsp_data,
-  output              debug_resetOut,
-  output              iBusWishbone_CYC,
-  output              iBusWishbone_STB,
-  input               iBusWishbone_ACK,
-  output              iBusWishbone_WE,
-  output     [29:0]   iBusWishbone_ADR,
-  input      [31:0]   iBusWishbone_DAT_MISO,
-  output     [31:0]   iBusWishbone_DAT_MOSI,
-  output     [3:0]    iBusWishbone_SEL,
-  input               iBusWishbone_ERR,
-  output     [2:0]    iBusWishbone_CTI,
-  output     [1:0]    iBusWishbone_BTE,
-  output              dBusWishbone_CYC,
-  output              dBusWishbone_STB,
-  input               dBusWishbone_ACK,
-  output              dBusWishbone_WE,
-  output     [29:0]   dBusWishbone_ADR,
-  input      [31:0]   dBusWishbone_DAT_MISO,
-  output     [31:0]   dBusWishbone_DAT_MOSI,
-  output reg [3:0]    dBusWishbone_SEL,
-  input               dBusWishbone_ERR,
-  output     [2:0]    dBusWishbone_CTI,
-  output     [1:0]    dBusWishbone_BTE,
-  input               clk,
-  input               reset,
-  input               debugReset
+  input  wire [31:0]   externalResetVector,
+  input  wire          timerInterrupt,
+  input  wire          softwareInterrupt,
+  input  wire [31:0]   externalInterruptArray,
+  input  wire          debug_bus_cmd_valid,
+  output reg           debug_bus_cmd_ready,
+  input  wire          debug_bus_cmd_payload_wr,
+  input  wire [7:0]    debug_bus_cmd_payload_address,
+  input  wire [31:0]   debug_bus_cmd_payload_data,
+  output reg  [31:0]   debug_bus_rsp_data,
+  output wire          debug_resetOut,
+  output wire          iBusWishbone_CYC,
+  output wire          iBusWishbone_STB,
+  input  wire          iBusWishbone_ACK,
+  output wire          iBusWishbone_WE,
+  output wire [29:0]   iBusWishbone_ADR,
+  input  wire [31:0]   iBusWishbone_DAT_MISO,
+  output wire [31:0]   iBusWishbone_DAT_MOSI,
+  output wire [3:0]    iBusWishbone_SEL,
+  input  wire          iBusWishbone_ERR,
+  output wire [2:0]    iBusWishbone_CTI,
+  output wire [1:0]    iBusWishbone_BTE,
+  output wire          dBusWishbone_CYC,
+  output wire          dBusWishbone_STB,
+  input  wire          dBusWishbone_ACK,
+  output wire          dBusWishbone_WE,
+  output wire [29:0]   dBusWishbone_ADR,
+  input  wire [31:0]   dBusWishbone_DAT_MISO,
+  output wire [31:0]   dBusWishbone_DAT_MOSI,
+  output reg  [3:0]    dBusWishbone_SEL,
+  input  wire          dBusWishbone_ERR,
+  output wire [2:0]    dBusWishbone_CTI,
+  output wire [1:0]    dBusWishbone_BTE,
+  input  wire          clk,
+  input  wire          reset,
+  input  wire          debugReset
 );
   localparam EnvCtrlEnum_NONE = 2'd0;
   localparam EnvCtrlEnum_XRET = 2'd1;
@@ -69,6 +69,7 @@ module VexRiscv (
   localparam Src1CtrlEnum_URS1 = 2'd3;
 
   wire                IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_ready;
+  wire                IBusSimplePlugin_rspJoin_rspBuffer_c_io_flush;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
   wire                IBusSimplePlugin_rspJoin_rspBuffer_c_io_push_ready;
@@ -76,24 +77,24 @@ module VexRiscv (
   wire                IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_error;
   wire       [31:0]   IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_inst;
   wire       [0:0]    IBusSimplePlugin_rspJoin_rspBuffer_c_io_occupancy;
+  wire       [0:0]    IBusSimplePlugin_rspJoin_rspBuffer_c_io_availability;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_1;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_2;
   wire                _zz_decode_LEGAL_INSTRUCTION_3;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_4;
-  wire       [12:0]   _zz_decode_LEGAL_INSTRUCTION_5;
+  wire       [11:0]   _zz_decode_LEGAL_INSTRUCTION_5;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_6;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_7;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_8;
   wire                _zz_decode_LEGAL_INSTRUCTION_9;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_10;
-  wire       [6:0]    _zz_decode_LEGAL_INSTRUCTION_11;
+  wire       [5:0]    _zz_decode_LEGAL_INSTRUCTION_11;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_12;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_13;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_14;
   wire                _zz_decode_LEGAL_INSTRUCTION_15;
-  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_16;
-  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_17;
+  wire                _zz_decode_LEGAL_INSTRUCTION_16;
   wire       [1:0]    _zz_IBusSimplePlugin_jump_pcLoad_payload_1;
   wire       [1:0]    _zz_IBusSimplePlugin_jump_pcLoad_payload_2;
   wire       [31:0]   _zz_IBusSimplePlugin_fetchPc_pc;
@@ -108,98 +109,98 @@ module VexRiscv (
   wire       [2:0]    _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter_2;
   wire       [0:0]    _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter_3;
   wire       [2:0]    _zz_DBusSimplePlugin_memoryExceptionPort_payload_code;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_1;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_2;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_3;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_4;
-  wire       [1:0]    _zz__zz_decode_ENV_CTRL_2_5;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_6;
-  wire                _zz__zz_decode_ENV_CTRL_2_7;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_8;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_9;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_10;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_11;
-  wire       [19:0]   _zz__zz_decode_ENV_CTRL_2_12;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_13;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_14;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_15;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_16;
-  wire       [1:0]    _zz__zz_decode_ENV_CTRL_2_17;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_18;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_19;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_20;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_21;
-  wire                _zz__zz_decode_ENV_CTRL_2_22;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_23;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_24;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_25;
-  wire                _zz__zz_decode_ENV_CTRL_2_26;
-  wire       [15:0]   _zz__zz_decode_ENV_CTRL_2_27;
-  wire       [1:0]    _zz__zz_decode_ENV_CTRL_2_28;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_29;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_30;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_31;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_32;
-  wire                _zz__zz_decode_ENV_CTRL_2_33;
-  wire                _zz__zz_decode_ENV_CTRL_2_34;
-  wire                _zz__zz_decode_ENV_CTRL_2_35;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_36;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_37;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_38;
-  wire       [1:0]    _zz__zz_decode_ENV_CTRL_2_39;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_40;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_41;
-  wire       [12:0]   _zz__zz_decode_ENV_CTRL_2_42;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_43;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_44;
-  wire                _zz__zz_decode_ENV_CTRL_2_45;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_46;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_47;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_48;
-  wire       [9:0]    _zz__zz_decode_ENV_CTRL_2_49;
-  wire       [5:0]    _zz__zz_decode_ENV_CTRL_2_50;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_51;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_52;
-  wire                _zz__zz_decode_ENV_CTRL_2_53;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_54;
-  wire       [1:0]    _zz__zz_decode_ENV_CTRL_2_55;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_56;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_57;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_58;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_59;
-  wire                _zz__zz_decode_ENV_CTRL_2_60;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_61;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_62;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_63;
-  wire                _zz__zz_decode_ENV_CTRL_2_64;
-  wire       [6:0]    _zz__zz_decode_ENV_CTRL_2_65;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_66;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_67;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_68;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_69;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_70;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_71;
-  wire                _zz__zz_decode_ENV_CTRL_2_72;
-  wire                _zz__zz_decode_ENV_CTRL_2_73;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_74;
-  wire       [1:0]    _zz__zz_decode_ENV_CTRL_2_75;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_76;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_77;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_78;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_79;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_80;
-  wire                _zz__zz_decode_ENV_CTRL_2_81;
-  wire       [2:0]    _zz__zz_decode_ENV_CTRL_2_82;
-  wire       [2:0]    _zz__zz_decode_ENV_CTRL_2_83;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_84;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_85;
-  wire                _zz__zz_decode_ENV_CTRL_2_86;
-  wire                _zz__zz_decode_ENV_CTRL_2_87;
-  wire                _zz__zz_decode_ENV_CTRL_2_88;
-  wire                _zz__zz_decode_ENV_CTRL_2_89;
-  wire                _zz__zz_decode_ENV_CTRL_2_90;
-  wire                _zz__zz_decode_ENV_CTRL_2_91;
+  wire       [31:0]   _zz__zz_decode_IS_CSR;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_1;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_2;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_3;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_4;
+  wire       [1:0]    _zz__zz_decode_IS_CSR_5;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_6;
+  wire                _zz__zz_decode_IS_CSR_7;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_8;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_9;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_10;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_11;
+  wire       [19:0]   _zz__zz_decode_IS_CSR_12;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_13;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_14;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_15;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_16;
+  wire       [1:0]    _zz__zz_decode_IS_CSR_17;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_18;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_19;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_20;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_21;
+  wire                _zz__zz_decode_IS_CSR_22;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_23;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_24;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_25;
+  wire                _zz__zz_decode_IS_CSR_26;
+  wire       [15:0]   _zz__zz_decode_IS_CSR_27;
+  wire       [1:0]    _zz__zz_decode_IS_CSR_28;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_29;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_30;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_31;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_32;
+  wire                _zz__zz_decode_IS_CSR_33;
+  wire                _zz__zz_decode_IS_CSR_34;
+  wire                _zz__zz_decode_IS_CSR_35;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_36;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_37;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_38;
+  wire       [1:0]    _zz__zz_decode_IS_CSR_39;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_40;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_41;
+  wire       [12:0]   _zz__zz_decode_IS_CSR_42;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_43;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_44;
+  wire                _zz__zz_decode_IS_CSR_45;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_46;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_47;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_48;
+  wire       [9:0]    _zz__zz_decode_IS_CSR_49;
+  wire       [5:0]    _zz__zz_decode_IS_CSR_50;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_51;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_52;
+  wire                _zz__zz_decode_IS_CSR_53;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_54;
+  wire       [1:0]    _zz__zz_decode_IS_CSR_55;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_56;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_57;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_58;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_59;
+  wire                _zz__zz_decode_IS_CSR_60;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_61;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_62;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_63;
+  wire                _zz__zz_decode_IS_CSR_64;
+  wire       [6:0]    _zz__zz_decode_IS_CSR_65;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_66;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_67;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_68;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_69;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_70;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_71;
+  wire                _zz__zz_decode_IS_CSR_72;
+  wire                _zz__zz_decode_IS_CSR_73;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_74;
+  wire       [1:0]    _zz__zz_decode_IS_CSR_75;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_76;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_77;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_78;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_79;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_80;
+  wire                _zz__zz_decode_IS_CSR_81;
+  wire       [2:0]    _zz__zz_decode_IS_CSR_82;
+  wire       [2:0]    _zz__zz_decode_IS_CSR_83;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_84;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_85;
+  wire                _zz__zz_decode_IS_CSR_86;
+  wire                _zz__zz_decode_IS_CSR_87;
+  wire                _zz__zz_decode_IS_CSR_88;
+  wire                _zz__zz_decode_IS_CSR_89;
+  wire                _zz__zz_decode_IS_CSR_90;
+  wire                _zz__zz_decode_IS_CSR_91;
   wire                _zz_RegFilePlugin_regFile_port;
   wire                _zz_decode_RegFilePlugin_rs1Data;
   wire                _zz_RegFilePlugin_regFile_port_1;
@@ -207,14 +208,12 @@ module VexRiscv (
   wire       [0:0]    _zz__zz_execute_REGFILE_WRITE_DATA;
   wire       [2:0]    _zz__zz_execute_SRC1;
   wire       [4:0]    _zz__zz_execute_SRC1_1;
-  wire       [11:0]   _zz__zz_execute_SRC2_3;
+  wire       [11:0]   _zz__zz_execute_SRC2_2;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_1;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_2;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_3;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_4;
-  wire       [31:0]   _zz_execute_SrcPlugin_addSub_5;
-  wire       [31:0]   _zz_execute_SrcPlugin_addSub_6;
   wire       [31:0]   _zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1;
   wire       [32:0]   _zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1_1;
   wire       [19:0]   _zz__zz_execute_BranchPlugin_branch_src2;
@@ -310,7 +309,7 @@ module VexRiscv (
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_execute_SRC2;
+  wire       [31:0]   _zz_execute_to_memory_PC;
   wire       [1:0]    execute_SRC2_CTRL;
   wire       [1:0]    _zz_execute_SRC2_CTRL;
   wire       [1:0]    execute_SRC1_CTRL;
@@ -433,8 +432,9 @@ module VexRiscv (
   wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
   wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
   wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
-  wire                CsrPlugin_csrMapping_allowCsrSignal;
+  reg                 CsrPlugin_csrMapping_allowCsrSignal;
   wire                CsrPlugin_csrMapping_hazardFree;
+  wire                CsrPlugin_csrMapping_doForceFailCsr;
   wire                CsrPlugin_inWfi /* verilator public */ ;
   reg                 CsrPlugin_thirdPartyWake;
   reg                 CsrPlugin_jumpInterface_valid;
@@ -453,9 +453,10 @@ module VexRiscv (
   reg                 CsrPlugin_allowInterrupts;
   reg                 CsrPlugin_allowException;
   reg                 CsrPlugin_allowEbreakException;
-  reg                 IBusSimplePlugin_injectionPort_valid;
-  reg                 IBusSimplePlugin_injectionPort_ready;
-  wire       [31:0]   IBusSimplePlugin_injectionPort_payload;
+  wire                CsrPlugin_xretAwayFromMachine;
+  reg                 DebugPlugin_injectionPort_valid;
+  reg                 DebugPlugin_injectionPort_ready;
+  wire       [31:0]   DebugPlugin_injectionPort_payload;
   wire                IBusSimplePlugin_externalFlush;
   wire                IBusSimplePlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusSimplePlugin_jump_pcLoad_payload;
@@ -471,12 +472,11 @@ module VexRiscv (
   reg                 IBusSimplePlugin_fetchPc_pcRegPropagate;
   reg                 IBusSimplePlugin_fetchPc_booted;
   reg                 IBusSimplePlugin_fetchPc_inc;
-  wire                when_Fetcher_l134;
-  wire                IBusSimplePlugin_fetchPc_output_fire_1;
-  wire                when_Fetcher_l134_1;
+  wire                when_Fetcher_l133;
+  wire                when_Fetcher_l133_1;
   reg        [31:0]   IBusSimplePlugin_fetchPc_pc;
   reg                 IBusSimplePlugin_fetchPc_flushed;
-  wire                when_Fetcher_l161;
+  wire                when_Fetcher_l160;
   wire                IBusSimplePlugin_iBusRsp_redoFetch;
   wire                IBusSimplePlugin_iBusRsp_stages_0_input_valid;
   wire                IBusSimplePlugin_iBusRsp_stages_0_input_ready;
@@ -496,8 +496,8 @@ module VexRiscv (
   wire                _zz_IBusSimplePlugin_iBusRsp_stages_1_input_ready;
   wire                IBusSimplePlugin_iBusRsp_flush;
   wire                _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready;
-  wire                _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_1;
-  reg                 _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_2;
+  wire                _zz_IBusSimplePlugin_iBusRsp_stages_1_input_valid;
+  reg                 _zz_IBusSimplePlugin_iBusRsp_stages_1_input_valid_1;
   reg                 IBusSimplePlugin_iBusRsp_readyForError;
   wire                IBusSimplePlugin_iBusRsp_output_valid;
   wire                IBusSimplePlugin_iBusRsp_output_ready;
@@ -516,17 +516,17 @@ module VexRiscv (
   reg                 _zz_IBusSimplePlugin_injector_decodeInput_payload_rsp_error;
   reg        [31:0]   _zz_IBusSimplePlugin_injector_decodeInput_payload_rsp_inst;
   reg                 _zz_IBusSimplePlugin_injector_decodeInput_payload_isRvc;
-  wire                when_Fetcher_l323;
+  wire                when_Fetcher_l322;
   reg                 IBusSimplePlugin_injector_nextPcCalc_valids_0;
-  wire                when_Fetcher_l332;
+  wire                when_Fetcher_l331;
   reg                 IBusSimplePlugin_injector_nextPcCalc_valids_1;
-  wire                when_Fetcher_l332_1;
+  wire                when_Fetcher_l331_1;
   reg                 IBusSimplePlugin_injector_nextPcCalc_valids_2;
-  wire                when_Fetcher_l332_2;
+  wire                when_Fetcher_l331_2;
   reg                 IBusSimplePlugin_injector_nextPcCalc_valids_3;
-  wire                when_Fetcher_l332_3;
+  wire                when_Fetcher_l331_3;
   reg                 IBusSimplePlugin_injector_nextPcCalc_valids_4;
-  wire                when_Fetcher_l332_4;
+  wire                when_Fetcher_l331_4;
   reg        [31:0]   IBusSimplePlugin_injector_formal_rawInDecode;
   wire                IBusSimplePlugin_cmd_valid;
   wire                IBusSimplePlugin_cmd_ready;
@@ -548,7 +548,7 @@ module VexRiscv (
   wire                iBus_rsp_toStream_payload_error;
   wire       [31:0]   iBus_rsp_toStream_payload_inst;
   wire                IBusSimplePlugin_rspJoin_rspBuffer_flush;
-  wire                IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_fire;
+  wire                toplevel_IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_fire;
   wire       [31:0]   IBusSimplePlugin_rspJoin_fetchRsp_pc;
   reg                 IBusSimplePlugin_rspJoin_fetchRsp_rsp_error;
   wire       [31:0]   IBusSimplePlugin_rspJoin_fetchRsp_rsp_inst;
@@ -562,7 +562,6 @@ module VexRiscv (
   wire                IBusSimplePlugin_rspJoin_join_payload_isRvc;
   wire                IBusSimplePlugin_rspJoin_exceptionDetected;
   wire                IBusSimplePlugin_rspJoin_join_fire;
-  wire                IBusSimplePlugin_rspJoin_join_fire_1;
   wire                _zz_IBusSimplePlugin_iBusRsp_output_valid;
   wire                dBus_cmd_valid;
   wire                dBus_cmd_ready;
@@ -576,33 +575,33 @@ module VexRiscv (
   wire                _zz_dBus_cmd_valid;
   reg                 execute_DBusSimplePlugin_skipCmd;
   reg        [31:0]   _zz_dBus_cmd_payload_data;
-  wire                when_DBusSimplePlugin_l428;
+  wire                when_DBusSimplePlugin_l436;
   reg        [3:0]    _zz_execute_DBusSimplePlugin_formalMask;
   wire       [3:0]    execute_DBusSimplePlugin_formalMask;
-  wire                when_DBusSimplePlugin_l482;
-  wire                when_DBusSimplePlugin_l489;
-  wire                when_DBusSimplePlugin_l515;
+  wire                when_DBusSimplePlugin_l490;
+  wire                when_DBusSimplePlugin_l497;
+  wire                when_DBusSimplePlugin_l523;
   reg        [31:0]   writeBack_DBusSimplePlugin_rspShifted;
-  wire       [1:0]    switch_Misc_l210;
+  wire       [1:0]    switch_Misc_l232;
   wire                _zz_writeBack_DBusSimplePlugin_rspFormated;
   reg        [31:0]   _zz_writeBack_DBusSimplePlugin_rspFormated_1;
   wire                _zz_writeBack_DBusSimplePlugin_rspFormated_2;
   reg        [31:0]   _zz_writeBack_DBusSimplePlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusSimplePlugin_rspFormated;
-  wire                when_DBusSimplePlugin_l558;
-  wire       [26:0]   _zz_decode_ENV_CTRL_2;
-  wire                _zz_decode_ENV_CTRL_3;
-  wire                _zz_decode_ENV_CTRL_4;
-  wire                _zz_decode_ENV_CTRL_5;
-  wire                _zz_decode_ENV_CTRL_6;
-  wire                _zz_decode_ENV_CTRL_7;
+  wire                when_DBusSimplePlugin_l566;
+  wire       [26:0]   _zz_decode_IS_CSR;
+  wire                _zz_decode_IS_CSR_1;
+  wire                _zz_decode_IS_CSR_2;
+  wire                _zz_decode_IS_CSR_3;
+  wire                _zz_decode_IS_CSR_4;
+  wire                _zz_decode_IS_CSR_5;
   wire       [1:0]    _zz_decode_SRC1_CTRL_2;
   wire       [1:0]    _zz_decode_ALU_CTRL_2;
   wire       [1:0]    _zz_decode_SRC2_CTRL_2;
   wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL_2;
   wire       [1:0]    _zz_decode_SHIFT_CTRL_2;
   wire       [1:0]    _zz_decode_BRANCH_CTRL_2;
-  wire       [1:0]    _zz_decode_ENV_CTRL_8;
+  wire       [1:0]    _zz_decode_ENV_CTRL_2;
   wire                when_RegFilePlugin_l63;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
@@ -611,15 +610,15 @@ module VexRiscv (
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
   reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
   reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_2;
+  reg                 _zz_5;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
   reg        [31:0]   _zz_execute_REGFILE_WRITE_DATA;
   reg        [31:0]   _zz_execute_SRC1;
-  wire                _zz_execute_SRC2_1;
-  reg        [19:0]   _zz_execute_SRC2_2;
-  wire                _zz_execute_SRC2_3;
-  reg        [19:0]   _zz_execute_SRC2_4;
-  reg        [31:0]   _zz_execute_SRC2_5;
+  wire                _zz_execute_SRC2;
+  reg        [19:0]   _zz_execute_SRC2_1;
+  wire                _zz_execute_SRC2_2;
+  reg        [19:0]   _zz_execute_SRC2_3;
+  reg        [31:0]   _zz_execute_SRC2_4;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   reg                 execute_LightShifterPlugin_isActive;
@@ -658,7 +657,7 @@ module VexRiscv (
   wire                when_HazardSimplePlugin_l108;
   wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    switch_Misc_l210_1;
+  wire       [2:0]    switch_Misc_l232_1;
   reg                 _zz_execute_BRANCH_DO;
   reg                 _zz_execute_BRANCH_DO_1;
   wire       [31:0]   execute_BranchPlugin_branch_src1;
@@ -690,9 +689,9 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_mtval;
   reg        [63:0]   CsrPlugin_mcycle;
   reg        [63:0]   CsrPlugin_minstret;
-  wire                _zz_when_CsrPlugin_l965;
-  wire                _zz_when_CsrPlugin_l965_1;
-  wire                _zz_when_CsrPlugin_l965_2;
+  wire                _zz_when_CsrPlugin_l1302;
+  wire                _zz_when_CsrPlugin_l1302_1;
+  wire                _zz_when_CsrPlugin_l1302_2;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -707,60 +706,63 @@ module VexRiscv (
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
   wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code;
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
-  wire                when_CsrPlugin_l922;
-  wire                when_CsrPlugin_l922_1;
-  wire                when_CsrPlugin_l922_2;
-  wire                when_CsrPlugin_l922_3;
-  wire                when_CsrPlugin_l935;
+  wire                when_CsrPlugin_l1259;
+  wire                when_CsrPlugin_l1259_1;
+  wire                when_CsrPlugin_l1259_2;
+  wire                when_CsrPlugin_l1259_3;
+  wire                when_CsrPlugin_l1272;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
-  wire                when_CsrPlugin_l959;
-  wire                when_CsrPlugin_l965;
-  wire                when_CsrPlugin_l965_1;
-  wire                when_CsrPlugin_l965_2;
+  wire                when_CsrPlugin_l1296;
+  wire                when_CsrPlugin_l1302;
+  wire                when_CsrPlugin_l1302_1;
+  wire                when_CsrPlugin_l1302_2;
   wire                CsrPlugin_exception;
   wire                CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
-  wire                when_CsrPlugin_l993;
-  wire                when_CsrPlugin_l993_1;
-  wire                when_CsrPlugin_l993_2;
-  wire                when_CsrPlugin_l998;
+  wire                when_CsrPlugin_l1335;
+  wire                when_CsrPlugin_l1335_1;
+  wire                when_CsrPlugin_l1335_2;
+  wire                when_CsrPlugin_l1340;
   reg                 CsrPlugin_pipelineLiberator_done;
-  wire                when_CsrPlugin_l1004;
+  wire                when_CsrPlugin_l1346;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
+  wire                CsrPlugin_trapCauseEbreakDebug;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
-  wire                when_CsrPlugin_l1032;
-  wire                when_CsrPlugin_l1077;
-  wire       [1:0]    switch_CsrPlugin_l1081;
+  wire                CsrPlugin_trapEnterDebug;
+  wire                when_CsrPlugin_l1390;
+  wire                when_CsrPlugin_l1398;
+  wire                when_CsrPlugin_l1456;
+  wire       [1:0]    switch_CsrPlugin_l1460;
   reg                 execute_CsrPlugin_wfiWake;
-  wire                when_CsrPlugin_l1129;
+  wire                when_CsrPlugin_l1527;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire                when_CsrPlugin_l1149;
-  wire                when_CsrPlugin_l1150;
-  wire                when_CsrPlugin_l1157;
+  wire                when_CsrPlugin_l1547;
+  wire                when_CsrPlugin_l1548;
+  wire                when_CsrPlugin_l1555;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   wire       [31:0]   execute_CsrPlugin_readToWriteData;
-  wire                switch_Misc_l210_2;
+  wire                switch_Misc_l232_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
-  wire                when_CsrPlugin_l1189;
-  wire                when_CsrPlugin_l1193;
+  wire                when_CsrPlugin_l1587;
+  wire                when_CsrPlugin_l1591;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg        [31:0]   externalInterruptArray_regNext;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit;
-  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
+  wire       [31:0]   _zz_externalInterrupt;
   reg                 DebugPlugin_firstCycle;
   reg                 DebugPlugin_secondCycle;
   reg                 DebugPlugin_resetIt;
@@ -768,28 +770,28 @@ module VexRiscv (
   reg                 DebugPlugin_stepIt;
   reg                 DebugPlugin_isPipBusy;
   reg                 DebugPlugin_godmode;
-  wire                when_DebugPlugin_l225;
+  wire                when_DebugPlugin_l238;
   reg                 DebugPlugin_haltedByBreak;
   reg                 DebugPlugin_debugUsed /* verilator public */ ;
   reg                 DebugPlugin_disableEbreak;
   wire                DebugPlugin_allowEBreak;
   reg        [31:0]   DebugPlugin_busReadDataReg;
-  reg                 _zz_when_DebugPlugin_l244;
-  wire                when_DebugPlugin_l244;
-  wire       [5:0]    switch_DebugPlugin_l267;
-  wire                when_DebugPlugin_l271;
-  wire                when_DebugPlugin_l271_1;
-  wire                when_DebugPlugin_l272;
-  wire                when_DebugPlugin_l272_1;
-  wire                when_DebugPlugin_l273;
-  wire                when_DebugPlugin_l274;
-  wire                when_DebugPlugin_l275;
-  wire                when_DebugPlugin_l275_1;
-  wire                when_DebugPlugin_l295;
-  wire                when_DebugPlugin_l298;
+  reg                 _zz_when_DebugPlugin_l257;
+  wire                when_DebugPlugin_l257;
+  wire       [5:0]    switch_DebugPlugin_l280;
+  wire                when_DebugPlugin_l284;
+  wire                when_DebugPlugin_l284_1;
+  wire                when_DebugPlugin_l285;
+  wire                when_DebugPlugin_l285_1;
+  wire                when_DebugPlugin_l286;
+  wire                when_DebugPlugin_l287;
+  wire                when_DebugPlugin_l288;
+  wire                when_DebugPlugin_l288_1;
+  wire                when_DebugPlugin_l308;
   wire                when_DebugPlugin_l311;
+  wire                when_DebugPlugin_l324;
   reg                 DebugPlugin_resetIt_regNext;
-  wire                when_DebugPlugin_l331;
+  wire                when_DebugPlugin_l344;
   wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
   wire                when_Pipeline_l124_1;
@@ -888,28 +890,29 @@ module VexRiscv (
   wire                when_Pipeline_l154_1;
   wire                when_Pipeline_l151_2;
   wire                when_Pipeline_l154_2;
-  reg        [2:0]    switch_Fetcher_l365;
-  wire                when_Fetcher_l381;
-  wire                when_Fetcher_l401;
-  wire                when_CsrPlugin_l1277;
+  reg        [2:0]    IBusSimplePlugin_injector_port_state;
+  wire                when_Fetcher_l391;
+  wire                when_Fetcher_l411;
+  wire                when_CsrPlugin_l1669;
   reg                 execute_CsrPlugin_csr_768;
-  wire                when_CsrPlugin_l1277_1;
+  wire                when_CsrPlugin_l1669_1;
   reg                 execute_CsrPlugin_csr_836;
-  wire                when_CsrPlugin_l1277_2;
+  wire                when_CsrPlugin_l1669_2;
   reg                 execute_CsrPlugin_csr_772;
-  wire                when_CsrPlugin_l1277_3;
+  wire                when_CsrPlugin_l1669_3;
   reg                 execute_CsrPlugin_csr_773;
-  wire                when_CsrPlugin_l1277_4;
+  wire                when_CsrPlugin_l1669_4;
   reg                 execute_CsrPlugin_csr_833;
-  wire                when_CsrPlugin_l1277_5;
+  wire                when_CsrPlugin_l1669_5;
   reg                 execute_CsrPlugin_csr_834;
-  wire                when_CsrPlugin_l1277_6;
+  wire                when_CsrPlugin_l1669_6;
   reg                 execute_CsrPlugin_csr_835;
-  wire                when_CsrPlugin_l1277_7;
+  wire                when_CsrPlugin_l1669_7;
   reg                 execute_CsrPlugin_csr_3008;
-  wire                when_CsrPlugin_l1277_8;
+  wire                when_CsrPlugin_l1669_8;
   reg                 execute_CsrPlugin_csr_4032;
-  wire       [1:0]    switch_CsrPlugin_l723;
+  wire       [1:0]    switch_CsrPlugin_l1031;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
@@ -917,15 +920,18 @@ module VexRiscv (
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_6;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_8;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
-  wire                when_CsrPlugin_l1310;
-  wire                when_CsrPlugin_l1315;
+  wire                when_CsrPlugin_l1702;
+  wire       [11:0]   _zz_when_CsrPlugin_l1709;
+  wire                when_CsrPlugin_l1709;
+  reg                 when_CsrPlugin_l1719;
+  wire                when_CsrPlugin_l1717;
+  wire                when_CsrPlugin_l1725;
   wire                iBus_cmd_m2sPipe_valid;
   wire                iBus_cmd_m2sPipe_ready;
   wire       [31:0]   iBus_cmd_m2sPipe_payload_pc;
   reg                 iBus_cmd_rValid;
   reg        [31:0]   iBus_cmd_rData_pc;
-  wire                when_Stream_l368;
+  wire                when_Stream_l369;
   wire                dBus_cmd_halfPipe_valid;
   wire                dBus_cmd_halfPipe_ready;
   wire                dBus_cmd_halfPipe_payload_wr;
@@ -939,7 +945,7 @@ module VexRiscv (
   reg        [31:0]   dBus_cmd_rData_data;
   reg        [1:0]    dBus_cmd_rData_size;
   reg        [3:0]    _zz_dBusWishbone_SEL;
-  wire                when_DBusSimplePlugin_l189;
+  wire                when_DBusSimplePlugin_l196;
   `ifndef SYNTHESIS
   reg [39:0] _zz_memory_to_writeBack_ENV_CTRL_string;
   reg [39:0] _zz_memory_to_writeBack_ENV_CTRL_1_string;
@@ -1004,7 +1010,7 @@ module VexRiscv (
   reg [39:0] _zz_decode_ALU_BITWISE_CTRL_2_string;
   reg [71:0] _zz_decode_SHIFT_CTRL_2_string;
   reg [31:0] _zz_decode_BRANCH_CTRL_2_string;
-  reg [39:0] _zz_decode_ENV_CTRL_8_string;
+  reg [39:0] _zz_decode_ENV_CTRL_2_string;
   reg [95:0] decode_to_execute_SRC1_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
   reg [23:0] decode_to_execute_SRC2_CTRL_string;
@@ -1036,15 +1042,13 @@ module VexRiscv (
   assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
   assign _zz__zz_execute_SRC1 = 3'b100;
   assign _zz__zz_execute_SRC1_1 = execute_INSTRUCTION[19 : 15];
-  assign _zz__zz_execute_SRC2_3 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz__zz_execute_SRC2_2 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
   assign _zz_execute_SrcPlugin_addSub = ($signed(_zz_execute_SrcPlugin_addSub_1) + $signed(_zz_execute_SrcPlugin_addSub_4));
   assign _zz_execute_SrcPlugin_addSub_1 = ($signed(_zz_execute_SrcPlugin_addSub_2) + $signed(_zz_execute_SrcPlugin_addSub_3));
   assign _zz_execute_SrcPlugin_addSub_2 = execute_SRC1;
   assign _zz_execute_SrcPlugin_addSub_3 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? _zz_execute_SrcPlugin_addSub_5 : _zz_execute_SrcPlugin_addSub_6);
-  assign _zz_execute_SrcPlugin_addSub_5 = 32'h00000001;
-  assign _zz_execute_SrcPlugin_addSub_6 = 32'h0;
-  assign _zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1 = (_zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1_1 >>> 1);
+  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? 32'h00000001 : 32'h00000000);
+  assign _zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1 = (_zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1_1 >>> 1'd1);
   assign _zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1_1 = {((execute_SHIFT_CTRL == ShiftCtrlEnum_SRA_1) && execute_LightShifterPlugin_shiftInput[31]),execute_LightShifterPlugin_shiftInput};
   assign _zz__zz_execute_BranchPlugin_branch_src2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
   assign _zz__zz_execute_BranchPlugin_branch_src2_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
@@ -1052,116 +1056,115 @@ module VexRiscv (
   assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code - 2'b01);
   assign _zz_decode_RegFilePlugin_rs1Data = 1'b1;
   assign _zz_decode_RegFilePlugin_rs2Data = 1'b1;
-  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000107f;
-  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00002073;
-  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000207f;
+  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000407f);
+  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00004063;
+  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000107f) == 32'h00000013);
   assign _zz_decode_LEGAL_INSTRUCTION_5 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_6) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_7 == _zz_decode_LEGAL_INSTRUCTION_8),{_zz_decode_LEGAL_INSTRUCTION_9,{_zz_decode_LEGAL_INSTRUCTION_10,_zz_decode_LEGAL_INSTRUCTION_11}}}}}};
   assign _zz_decode_LEGAL_INSTRUCTION_6 = 32'h0000505f;
   assign _zz_decode_LEGAL_INSTRUCTION_7 = (decode_INSTRUCTION & 32'h0000707b);
   assign _zz_decode_LEGAL_INSTRUCTION_8 = 32'h00000063;
   assign _zz_decode_LEGAL_INSTRUCTION_9 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
   assign _zz_decode_LEGAL_INSTRUCTION_10 = ((decode_INSTRUCTION & 32'hfe00007f) == 32'h00000033);
-  assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & 32'hfc00307f) == 32'h00001013),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h00005033),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,{_zz_decode_LEGAL_INSTRUCTION_16,_zz_decode_LEGAL_INSTRUCTION_17}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'hbe00705f) == 32'h00005013),{((decode_INSTRUCTION & 32'hfe00305f) == 32'h00001013),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h00000033),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,_zz_decode_LEGAL_INSTRUCTION_16}}}}};
   assign _zz_decode_LEGAL_INSTRUCTION_12 = 32'hbe00707f;
-  assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'hbe00707f);
-  assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h00000033;
-  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
-  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hffefffff) == 32'h00000073);
-  assign _zz_decode_LEGAL_INSTRUCTION_17 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073);
-  assign _zz__zz_decode_ENV_CTRL_2 = 32'h10103050;
-  assign _zz__zz_decode_ENV_CTRL_2_1 = (decode_INSTRUCTION & 32'h10403050);
-  assign _zz__zz_decode_ENV_CTRL_2_2 = 32'h10000050;
-  assign _zz__zz_decode_ENV_CTRL_2_3 = ((decode_INSTRUCTION & 32'h00001050) == 32'h00001050);
-  assign _zz__zz_decode_ENV_CTRL_2_4 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002050);
-  assign _zz__zz_decode_ENV_CTRL_2_5 = {_zz_decode_ENV_CTRL_7,((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_6) == 32'h00000004)};
-  assign _zz__zz_decode_ENV_CTRL_2_7 = (|((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_8) == 32'h00000040));
-  assign _zz__zz_decode_ENV_CTRL_2_9 = (|(_zz__zz_decode_ENV_CTRL_2_10 == _zz__zz_decode_ENV_CTRL_2_11));
-  assign _zz__zz_decode_ENV_CTRL_2_12 = {(|{_zz__zz_decode_ENV_CTRL_2_13,_zz__zz_decode_ENV_CTRL_2_15}),{(|_zz__zz_decode_ENV_CTRL_2_17),{_zz__zz_decode_ENV_CTRL_2_22,{_zz__zz_decode_ENV_CTRL_2_25,_zz__zz_decode_ENV_CTRL_2_27}}}};
-  assign _zz__zz_decode_ENV_CTRL_2_6 = 32'h0000001c;
-  assign _zz__zz_decode_ENV_CTRL_2_8 = 32'h00000058;
-  assign _zz__zz_decode_ENV_CTRL_2_10 = (decode_INSTRUCTION & 32'h00007054);
-  assign _zz__zz_decode_ENV_CTRL_2_11 = 32'h00005010;
-  assign _zz__zz_decode_ENV_CTRL_2_13 = ((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_14) == 32'h40001010);
-  assign _zz__zz_decode_ENV_CTRL_2_15 = ((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_16) == 32'h00001010);
-  assign _zz__zz_decode_ENV_CTRL_2_17 = {(_zz__zz_decode_ENV_CTRL_2_18 == _zz__zz_decode_ENV_CTRL_2_19),(_zz__zz_decode_ENV_CTRL_2_20 == _zz__zz_decode_ENV_CTRL_2_21)};
-  assign _zz__zz_decode_ENV_CTRL_2_22 = (|(_zz__zz_decode_ENV_CTRL_2_23 == _zz__zz_decode_ENV_CTRL_2_24));
-  assign _zz__zz_decode_ENV_CTRL_2_25 = (|_zz__zz_decode_ENV_CTRL_2_26);
-  assign _zz__zz_decode_ENV_CTRL_2_27 = {(|_zz__zz_decode_ENV_CTRL_2_28),{_zz__zz_decode_ENV_CTRL_2_33,{_zz__zz_decode_ENV_CTRL_2_36,_zz__zz_decode_ENV_CTRL_2_42}}};
-  assign _zz__zz_decode_ENV_CTRL_2_14 = 32'h40003054;
-  assign _zz__zz_decode_ENV_CTRL_2_16 = 32'h00007054;
-  assign _zz__zz_decode_ENV_CTRL_2_18 = (decode_INSTRUCTION & 32'h00000064);
-  assign _zz__zz_decode_ENV_CTRL_2_19 = 32'h00000024;
-  assign _zz__zz_decode_ENV_CTRL_2_20 = (decode_INSTRUCTION & 32'h00003054);
-  assign _zz__zz_decode_ENV_CTRL_2_21 = 32'h00001010;
-  assign _zz__zz_decode_ENV_CTRL_2_23 = (decode_INSTRUCTION & 32'h00001000);
-  assign _zz__zz_decode_ENV_CTRL_2_24 = 32'h00001000;
-  assign _zz__zz_decode_ENV_CTRL_2_26 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
-  assign _zz__zz_decode_ENV_CTRL_2_28 = {(_zz__zz_decode_ENV_CTRL_2_29 == _zz__zz_decode_ENV_CTRL_2_30),(_zz__zz_decode_ENV_CTRL_2_31 == _zz__zz_decode_ENV_CTRL_2_32)};
-  assign _zz__zz_decode_ENV_CTRL_2_33 = (|{_zz__zz_decode_ENV_CTRL_2_34,_zz__zz_decode_ENV_CTRL_2_35});
-  assign _zz__zz_decode_ENV_CTRL_2_36 = (|{_zz__zz_decode_ENV_CTRL_2_37,_zz__zz_decode_ENV_CTRL_2_39});
-  assign _zz__zz_decode_ENV_CTRL_2_42 = {(|_zz__zz_decode_ENV_CTRL_2_43),{_zz__zz_decode_ENV_CTRL_2_45,{_zz__zz_decode_ENV_CTRL_2_48,_zz__zz_decode_ENV_CTRL_2_49}}};
-  assign _zz__zz_decode_ENV_CTRL_2_29 = (decode_INSTRUCTION & 32'h00002010);
-  assign _zz__zz_decode_ENV_CTRL_2_30 = 32'h00002000;
-  assign _zz__zz_decode_ENV_CTRL_2_31 = (decode_INSTRUCTION & 32'h00005000);
-  assign _zz__zz_decode_ENV_CTRL_2_32 = 32'h00001000;
-  assign _zz__zz_decode_ENV_CTRL_2_34 = ((decode_INSTRUCTION & 32'h00000034) == 32'h00000020);
-  assign _zz__zz_decode_ENV_CTRL_2_35 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000020);
-  assign _zz__zz_decode_ENV_CTRL_2_37 = ((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_38) == 32'h00000040);
-  assign _zz__zz_decode_ENV_CTRL_2_39 = {_zz_decode_ENV_CTRL_4,(_zz__zz_decode_ENV_CTRL_2_40 == _zz__zz_decode_ENV_CTRL_2_41)};
-  assign _zz__zz_decode_ENV_CTRL_2_43 = ((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_44) == 32'h00000020);
-  assign _zz__zz_decode_ENV_CTRL_2_45 = (|(_zz__zz_decode_ENV_CTRL_2_46 == _zz__zz_decode_ENV_CTRL_2_47));
-  assign _zz__zz_decode_ENV_CTRL_2_48 = (|_zz_decode_ENV_CTRL_6);
-  assign _zz__zz_decode_ENV_CTRL_2_49 = {(|_zz__zz_decode_ENV_CTRL_2_50),{_zz__zz_decode_ENV_CTRL_2_60,{_zz__zz_decode_ENV_CTRL_2_63,_zz__zz_decode_ENV_CTRL_2_65}}};
-  assign _zz__zz_decode_ENV_CTRL_2_38 = 32'h00000050;
-  assign _zz__zz_decode_ENV_CTRL_2_40 = (decode_INSTRUCTION & 32'h00103040);
-  assign _zz__zz_decode_ENV_CTRL_2_41 = 32'h00000040;
-  assign _zz__zz_decode_ENV_CTRL_2_44 = 32'h00000020;
-  assign _zz__zz_decode_ENV_CTRL_2_46 = (decode_INSTRUCTION & 32'h00000010);
-  assign _zz__zz_decode_ENV_CTRL_2_47 = 32'h00000010;
-  assign _zz__zz_decode_ENV_CTRL_2_50 = {_zz_decode_ENV_CTRL_7,{(_zz__zz_decode_ENV_CTRL_2_51 == _zz__zz_decode_ENV_CTRL_2_52),{_zz__zz_decode_ENV_CTRL_2_53,{_zz__zz_decode_ENV_CTRL_2_54,_zz__zz_decode_ENV_CTRL_2_55}}}};
-  assign _zz__zz_decode_ENV_CTRL_2_60 = (|{_zz_decode_ENV_CTRL_5,(_zz__zz_decode_ENV_CTRL_2_61 == _zz__zz_decode_ENV_CTRL_2_62)});
-  assign _zz__zz_decode_ENV_CTRL_2_63 = (|{_zz_decode_ENV_CTRL_5,_zz__zz_decode_ENV_CTRL_2_64});
-  assign _zz__zz_decode_ENV_CTRL_2_65 = {(|{_zz__zz_decode_ENV_CTRL_2_66,_zz__zz_decode_ENV_CTRL_2_68}),{(|_zz__zz_decode_ENV_CTRL_2_70),{_zz__zz_decode_ENV_CTRL_2_72,{_zz__zz_decode_ENV_CTRL_2_80,_zz__zz_decode_ENV_CTRL_2_82}}}};
-  assign _zz__zz_decode_ENV_CTRL_2_51 = (decode_INSTRUCTION & 32'h00001010);
-  assign _zz__zz_decode_ENV_CTRL_2_52 = 32'h00001010;
-  assign _zz__zz_decode_ENV_CTRL_2_53 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002010);
-  assign _zz__zz_decode_ENV_CTRL_2_54 = _zz_decode_ENV_CTRL_6;
-  assign _zz__zz_decode_ENV_CTRL_2_55 = {(_zz__zz_decode_ENV_CTRL_2_56 == _zz__zz_decode_ENV_CTRL_2_57),(_zz__zz_decode_ENV_CTRL_2_58 == _zz__zz_decode_ENV_CTRL_2_59)};
-  assign _zz__zz_decode_ENV_CTRL_2_61 = (decode_INSTRUCTION & 32'h00000070);
-  assign _zz__zz_decode_ENV_CTRL_2_62 = 32'h00000020;
-  assign _zz__zz_decode_ENV_CTRL_2_64 = ((decode_INSTRUCTION & 32'h00000020) == 32'h0);
-  assign _zz__zz_decode_ENV_CTRL_2_66 = ((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_67) == 32'h00006010);
-  assign _zz__zz_decode_ENV_CTRL_2_68 = ((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_69) == 32'h00004010);
-  assign _zz__zz_decode_ENV_CTRL_2_70 = ((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_71) == 32'h00002010);
-  assign _zz__zz_decode_ENV_CTRL_2_72 = (|{_zz__zz_decode_ENV_CTRL_2_73,{_zz__zz_decode_ENV_CTRL_2_74,_zz__zz_decode_ENV_CTRL_2_75}});
-  assign _zz__zz_decode_ENV_CTRL_2_80 = (|_zz__zz_decode_ENV_CTRL_2_81);
-  assign _zz__zz_decode_ENV_CTRL_2_82 = {(|_zz__zz_decode_ENV_CTRL_2_83),{_zz__zz_decode_ENV_CTRL_2_88,_zz__zz_decode_ENV_CTRL_2_90}};
-  assign _zz__zz_decode_ENV_CTRL_2_56 = (decode_INSTRUCTION & 32'h0000000c);
-  assign _zz__zz_decode_ENV_CTRL_2_57 = 32'h00000004;
-  assign _zz__zz_decode_ENV_CTRL_2_58 = (decode_INSTRUCTION & 32'h00000028);
-  assign _zz__zz_decode_ENV_CTRL_2_59 = 32'h0;
-  assign _zz__zz_decode_ENV_CTRL_2_67 = 32'h00006014;
-  assign _zz__zz_decode_ENV_CTRL_2_69 = 32'h00005014;
-  assign _zz__zz_decode_ENV_CTRL_2_71 = 32'h00006014;
-  assign _zz__zz_decode_ENV_CTRL_2_73 = ((decode_INSTRUCTION & 32'h00000044) == 32'h0);
-  assign _zz__zz_decode_ENV_CTRL_2_74 = _zz_decode_ENV_CTRL_4;
-  assign _zz__zz_decode_ENV_CTRL_2_75 = {(_zz__zz_decode_ENV_CTRL_2_76 == _zz__zz_decode_ENV_CTRL_2_77),(_zz__zz_decode_ENV_CTRL_2_78 == _zz__zz_decode_ENV_CTRL_2_79)};
-  assign _zz__zz_decode_ENV_CTRL_2_81 = ((decode_INSTRUCTION & 32'h00000058) == 32'h0);
-  assign _zz__zz_decode_ENV_CTRL_2_83 = {(_zz__zz_decode_ENV_CTRL_2_84 == _zz__zz_decode_ENV_CTRL_2_85),{_zz__zz_decode_ENV_CTRL_2_86,_zz__zz_decode_ENV_CTRL_2_87}};
-  assign _zz__zz_decode_ENV_CTRL_2_88 = (|{_zz__zz_decode_ENV_CTRL_2_89,_zz_decode_ENV_CTRL_3});
-  assign _zz__zz_decode_ENV_CTRL_2_90 = (|{_zz__zz_decode_ENV_CTRL_2_91,_zz_decode_ENV_CTRL_3});
-  assign _zz__zz_decode_ENV_CTRL_2_76 = (decode_INSTRUCTION & 32'h00006004);
-  assign _zz__zz_decode_ENV_CTRL_2_77 = 32'h00002000;
-  assign _zz__zz_decode_ENV_CTRL_2_78 = (decode_INSTRUCTION & 32'h00005004);
-  assign _zz__zz_decode_ENV_CTRL_2_79 = 32'h00001000;
-  assign _zz__zz_decode_ENV_CTRL_2_84 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz__zz_decode_ENV_CTRL_2_85 = 32'h00000040;
-  assign _zz__zz_decode_ENV_CTRL_2_86 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00002010);
-  assign _zz__zz_decode_ENV_CTRL_2_87 = ((decode_INSTRUCTION & 32'h40004034) == 32'h40000030);
-  assign _zz__zz_decode_ENV_CTRL_2_89 = ((decode_INSTRUCTION & 32'h00000014) == 32'h00000004);
-  assign _zz__zz_decode_ENV_CTRL_2_91 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000004);
+  assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'hdfffffff);
+  assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h10200073;
+  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hffefffff) == 32'h00000073);
+  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073);
+  assign _zz__zz_decode_IS_CSR = 32'h10103050;
+  assign _zz__zz_decode_IS_CSR_1 = (decode_INSTRUCTION & 32'h10403050);
+  assign _zz__zz_decode_IS_CSR_2 = 32'h10000050;
+  assign _zz__zz_decode_IS_CSR_3 = ((decode_INSTRUCTION & 32'h00001050) == 32'h00001050);
+  assign _zz__zz_decode_IS_CSR_4 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002050);
+  assign _zz__zz_decode_IS_CSR_5 = {_zz_decode_IS_CSR_5,((decode_INSTRUCTION & _zz__zz_decode_IS_CSR_6) == 32'h00000004)};
+  assign _zz__zz_decode_IS_CSR_7 = (|((decode_INSTRUCTION & _zz__zz_decode_IS_CSR_8) == 32'h00000040));
+  assign _zz__zz_decode_IS_CSR_9 = (|(_zz__zz_decode_IS_CSR_10 == _zz__zz_decode_IS_CSR_11));
+  assign _zz__zz_decode_IS_CSR_12 = {(|{_zz__zz_decode_IS_CSR_13,_zz__zz_decode_IS_CSR_15}),{(|_zz__zz_decode_IS_CSR_17),{_zz__zz_decode_IS_CSR_22,{_zz__zz_decode_IS_CSR_25,_zz__zz_decode_IS_CSR_27}}}};
+  assign _zz__zz_decode_IS_CSR_6 = 32'h0000001c;
+  assign _zz__zz_decode_IS_CSR_8 = 32'h00000058;
+  assign _zz__zz_decode_IS_CSR_10 = (decode_INSTRUCTION & 32'h00007054);
+  assign _zz__zz_decode_IS_CSR_11 = 32'h00005010;
+  assign _zz__zz_decode_IS_CSR_13 = ((decode_INSTRUCTION & _zz__zz_decode_IS_CSR_14) == 32'h40001010);
+  assign _zz__zz_decode_IS_CSR_15 = ((decode_INSTRUCTION & _zz__zz_decode_IS_CSR_16) == 32'h00001010);
+  assign _zz__zz_decode_IS_CSR_17 = {(_zz__zz_decode_IS_CSR_18 == _zz__zz_decode_IS_CSR_19),(_zz__zz_decode_IS_CSR_20 == _zz__zz_decode_IS_CSR_21)};
+  assign _zz__zz_decode_IS_CSR_22 = (|(_zz__zz_decode_IS_CSR_23 == _zz__zz_decode_IS_CSR_24));
+  assign _zz__zz_decode_IS_CSR_25 = (|_zz__zz_decode_IS_CSR_26);
+  assign _zz__zz_decode_IS_CSR_27 = {(|_zz__zz_decode_IS_CSR_28),{_zz__zz_decode_IS_CSR_33,{_zz__zz_decode_IS_CSR_36,_zz__zz_decode_IS_CSR_42}}};
+  assign _zz__zz_decode_IS_CSR_14 = 32'h40003054;
+  assign _zz__zz_decode_IS_CSR_16 = 32'h00007054;
+  assign _zz__zz_decode_IS_CSR_18 = (decode_INSTRUCTION & 32'h00000064);
+  assign _zz__zz_decode_IS_CSR_19 = 32'h00000024;
+  assign _zz__zz_decode_IS_CSR_20 = (decode_INSTRUCTION & 32'h00003054);
+  assign _zz__zz_decode_IS_CSR_21 = 32'h00001010;
+  assign _zz__zz_decode_IS_CSR_23 = (decode_INSTRUCTION & 32'h00001000);
+  assign _zz__zz_decode_IS_CSR_24 = 32'h00001000;
+  assign _zz__zz_decode_IS_CSR_26 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
+  assign _zz__zz_decode_IS_CSR_28 = {(_zz__zz_decode_IS_CSR_29 == _zz__zz_decode_IS_CSR_30),(_zz__zz_decode_IS_CSR_31 == _zz__zz_decode_IS_CSR_32)};
+  assign _zz__zz_decode_IS_CSR_33 = (|{_zz__zz_decode_IS_CSR_34,_zz__zz_decode_IS_CSR_35});
+  assign _zz__zz_decode_IS_CSR_36 = (|{_zz__zz_decode_IS_CSR_37,_zz__zz_decode_IS_CSR_39});
+  assign _zz__zz_decode_IS_CSR_42 = {(|_zz__zz_decode_IS_CSR_43),{_zz__zz_decode_IS_CSR_45,{_zz__zz_decode_IS_CSR_48,_zz__zz_decode_IS_CSR_49}}};
+  assign _zz__zz_decode_IS_CSR_29 = (decode_INSTRUCTION & 32'h00002010);
+  assign _zz__zz_decode_IS_CSR_30 = 32'h00002000;
+  assign _zz__zz_decode_IS_CSR_31 = (decode_INSTRUCTION & 32'h00005000);
+  assign _zz__zz_decode_IS_CSR_32 = 32'h00001000;
+  assign _zz__zz_decode_IS_CSR_34 = ((decode_INSTRUCTION & 32'h00000034) == 32'h00000020);
+  assign _zz__zz_decode_IS_CSR_35 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000020);
+  assign _zz__zz_decode_IS_CSR_37 = ((decode_INSTRUCTION & _zz__zz_decode_IS_CSR_38) == 32'h00000040);
+  assign _zz__zz_decode_IS_CSR_39 = {_zz_decode_IS_CSR_2,(_zz__zz_decode_IS_CSR_40 == _zz__zz_decode_IS_CSR_41)};
+  assign _zz__zz_decode_IS_CSR_43 = ((decode_INSTRUCTION & _zz__zz_decode_IS_CSR_44) == 32'h00000020);
+  assign _zz__zz_decode_IS_CSR_45 = (|(_zz__zz_decode_IS_CSR_46 == _zz__zz_decode_IS_CSR_47));
+  assign _zz__zz_decode_IS_CSR_48 = (|_zz_decode_IS_CSR_4);
+  assign _zz__zz_decode_IS_CSR_49 = {(|_zz__zz_decode_IS_CSR_50),{_zz__zz_decode_IS_CSR_60,{_zz__zz_decode_IS_CSR_63,_zz__zz_decode_IS_CSR_65}}};
+  assign _zz__zz_decode_IS_CSR_38 = 32'h00000050;
+  assign _zz__zz_decode_IS_CSR_40 = (decode_INSTRUCTION & 32'h00103040);
+  assign _zz__zz_decode_IS_CSR_41 = 32'h00000040;
+  assign _zz__zz_decode_IS_CSR_44 = 32'h00000020;
+  assign _zz__zz_decode_IS_CSR_46 = (decode_INSTRUCTION & 32'h00000010);
+  assign _zz__zz_decode_IS_CSR_47 = 32'h00000010;
+  assign _zz__zz_decode_IS_CSR_50 = {_zz_decode_IS_CSR_5,{(_zz__zz_decode_IS_CSR_51 == _zz__zz_decode_IS_CSR_52),{_zz__zz_decode_IS_CSR_53,{_zz__zz_decode_IS_CSR_54,_zz__zz_decode_IS_CSR_55}}}};
+  assign _zz__zz_decode_IS_CSR_60 = (|{_zz_decode_IS_CSR_3,(_zz__zz_decode_IS_CSR_61 == _zz__zz_decode_IS_CSR_62)});
+  assign _zz__zz_decode_IS_CSR_63 = (|{_zz_decode_IS_CSR_3,_zz__zz_decode_IS_CSR_64});
+  assign _zz__zz_decode_IS_CSR_65 = {(|{_zz__zz_decode_IS_CSR_66,_zz__zz_decode_IS_CSR_68}),{(|_zz__zz_decode_IS_CSR_70),{_zz__zz_decode_IS_CSR_72,{_zz__zz_decode_IS_CSR_80,_zz__zz_decode_IS_CSR_82}}}};
+  assign _zz__zz_decode_IS_CSR_51 = (decode_INSTRUCTION & 32'h00001010);
+  assign _zz__zz_decode_IS_CSR_52 = 32'h00001010;
+  assign _zz__zz_decode_IS_CSR_53 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002010);
+  assign _zz__zz_decode_IS_CSR_54 = _zz_decode_IS_CSR_4;
+  assign _zz__zz_decode_IS_CSR_55 = {(_zz__zz_decode_IS_CSR_56 == _zz__zz_decode_IS_CSR_57),(_zz__zz_decode_IS_CSR_58 == _zz__zz_decode_IS_CSR_59)};
+  assign _zz__zz_decode_IS_CSR_61 = (decode_INSTRUCTION & 32'h00000070);
+  assign _zz__zz_decode_IS_CSR_62 = 32'h00000020;
+  assign _zz__zz_decode_IS_CSR_64 = ((decode_INSTRUCTION & 32'h00000020) == 32'h00000000);
+  assign _zz__zz_decode_IS_CSR_66 = ((decode_INSTRUCTION & _zz__zz_decode_IS_CSR_67) == 32'h00006000);
+  assign _zz__zz_decode_IS_CSR_68 = ((decode_INSTRUCTION & _zz__zz_decode_IS_CSR_69) == 32'h00004010);
+  assign _zz__zz_decode_IS_CSR_70 = ((decode_INSTRUCTION & _zz__zz_decode_IS_CSR_71) == 32'h00002010);
+  assign _zz__zz_decode_IS_CSR_72 = (|{_zz__zz_decode_IS_CSR_73,{_zz__zz_decode_IS_CSR_74,_zz__zz_decode_IS_CSR_75}});
+  assign _zz__zz_decode_IS_CSR_80 = (|_zz__zz_decode_IS_CSR_81);
+  assign _zz__zz_decode_IS_CSR_82 = {(|_zz__zz_decode_IS_CSR_83),{_zz__zz_decode_IS_CSR_88,_zz__zz_decode_IS_CSR_90}};
+  assign _zz__zz_decode_IS_CSR_56 = (decode_INSTRUCTION & 32'h0000000c);
+  assign _zz__zz_decode_IS_CSR_57 = 32'h00000004;
+  assign _zz__zz_decode_IS_CSR_58 = (decode_INSTRUCTION & 32'h00000028);
+  assign _zz__zz_decode_IS_CSR_59 = 32'h00000000;
+  assign _zz__zz_decode_IS_CSR_67 = 32'h00006004;
+  assign _zz__zz_decode_IS_CSR_69 = 32'h00005014;
+  assign _zz__zz_decode_IS_CSR_71 = 32'h00006014;
+  assign _zz__zz_decode_IS_CSR_73 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000000);
+  assign _zz__zz_decode_IS_CSR_74 = _zz_decode_IS_CSR_2;
+  assign _zz__zz_decode_IS_CSR_75 = {(_zz__zz_decode_IS_CSR_76 == _zz__zz_decode_IS_CSR_77),(_zz__zz_decode_IS_CSR_78 == _zz__zz_decode_IS_CSR_79)};
+  assign _zz__zz_decode_IS_CSR_81 = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000000);
+  assign _zz__zz_decode_IS_CSR_83 = {(_zz__zz_decode_IS_CSR_84 == _zz__zz_decode_IS_CSR_85),{_zz__zz_decode_IS_CSR_86,_zz__zz_decode_IS_CSR_87}};
+  assign _zz__zz_decode_IS_CSR_88 = (|{_zz__zz_decode_IS_CSR_89,_zz_decode_IS_CSR_1});
+  assign _zz__zz_decode_IS_CSR_90 = (|{_zz__zz_decode_IS_CSR_91,_zz_decode_IS_CSR_1});
+  assign _zz__zz_decode_IS_CSR_76 = (decode_INSTRUCTION & 32'h00006004);
+  assign _zz__zz_decode_IS_CSR_77 = 32'h00002000;
+  assign _zz__zz_decode_IS_CSR_78 = (decode_INSTRUCTION & 32'h00005004);
+  assign _zz__zz_decode_IS_CSR_79 = 32'h00001000;
+  assign _zz__zz_decode_IS_CSR_84 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz__zz_decode_IS_CSR_85 = 32'h00000040;
+  assign _zz__zz_decode_IS_CSR_86 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00002010);
+  assign _zz__zz_decode_IS_CSR_87 = ((decode_INSTRUCTION & 32'h40004034) == 32'h40000030);
+  assign _zz__zz_decode_IS_CSR_89 = ((decode_INSTRUCTION & 32'h00000014) == 32'h00000004);
+  assign _zz__zz_decode_IS_CSR_91 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000004);
   always @(posedge clk) begin
     if(_zz_decode_RegFilePlugin_rs1Data) begin
       _zz_RegFilePlugin_regFile_port0 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
@@ -1189,8 +1192,9 @@ module VexRiscv (
     .io_pop_ready          (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_ready             ), //i
     .io_pop_payload_error  (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_error     ), //o
     .io_pop_payload_inst   (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_inst[31:0]), //o
-    .io_flush              (1'b0                                                          ), //i
+    .io_flush              (IBusSimplePlugin_rspJoin_rspBuffer_c_io_flush                 ), //i
     .io_occupancy          (IBusSimplePlugin_rspJoin_rspBuffer_c_io_occupancy             ), //o
+    .io_availability       (IBusSimplePlugin_rspJoin_rspBuffer_c_io_availability          ), //o
     .clk                   (clk                                                           ), //i
     .reset                 (reset                                                         )  //i
   );
@@ -1732,11 +1736,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_decode_ENV_CTRL_8)
-      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_8_string = "NONE ";
-      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_8_string = "XRET ";
-      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_8_string = "ECALL";
-      default : _zz_decode_ENV_CTRL_8_string = "?????";
+    case(_zz_decode_ENV_CTRL_2)
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1826,7 +1830,7 @@ module VexRiscv (
   assign execute_MEMORY_ADDRESS_LOW = dBus_cmd_payload_address[1 : 0];
   assign decode_DO_EBREAK = (((! DebugPlugin_haltIt) && (decode_IS_EBREAK || 1'b0)) && DebugPlugin_allowEBreak);
   assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
-  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
+  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h00)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h00))));
   assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
   assign decode_RS2 = decode_RegFilePlugin_rs2Data;
   assign decode_RS1 = decode_RegFilePlugin_rs1Data;
@@ -1834,23 +1838,23 @@ module VexRiscv (
   assign _zz_execute_to_memory_ENV_CTRL = _zz_execute_to_memory_ENV_CTRL_1;
   assign decode_ENV_CTRL = _zz_decode_ENV_CTRL;
   assign _zz_decode_to_execute_ENV_CTRL = _zz_decode_to_execute_ENV_CTRL_1;
-  assign decode_IS_CSR = _zz_decode_ENV_CTRL_2[23];
+  assign decode_IS_CSR = _zz_decode_IS_CSR[23];
   assign decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL;
   assign _zz_decode_to_execute_BRANCH_CTRL = _zz_decode_to_execute_BRANCH_CTRL_1;
   assign decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL;
   assign _zz_decode_to_execute_SHIFT_CTRL = _zz_decode_to_execute_SHIFT_CTRL_1;
   assign decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL;
   assign _zz_decode_to_execute_ALU_BITWISE_CTRL = _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
-  assign decode_SRC_LESS_UNSIGNED = _zz_decode_ENV_CTRL_2[15];
-  assign decode_MEMORY_STORE = _zz_decode_ENV_CTRL_2[12];
+  assign decode_SRC_LESS_UNSIGNED = _zz_decode_IS_CSR[15];
+  assign decode_MEMORY_STORE = _zz_decode_IS_CSR[12];
   assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_decode_ENV_CTRL_2[11];
-  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_decode_ENV_CTRL_2[10];
+  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_decode_IS_CSR[11];
+  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_decode_IS_CSR[10];
   assign decode_SRC2_CTRL = _zz_decode_SRC2_CTRL;
   assign _zz_decode_to_execute_SRC2_CTRL = _zz_decode_to_execute_SRC2_CTRL_1;
   assign decode_ALU_CTRL = _zz_decode_ALU_CTRL;
   assign _zz_decode_to_execute_ALU_CTRL = _zz_decode_to_execute_ALU_CTRL_1;
-  assign decode_MEMORY_ENABLE = _zz_decode_ENV_CTRL_2[3];
+  assign decode_MEMORY_ENABLE = _zz_decode_IS_CSR[3];
   assign decode_SRC1_CTRL = _zz_decode_SRC1_CTRL;
   assign _zz_decode_to_execute_SRC1_CTRL = _zz_decode_to_execute_SRC1_CTRL_1;
   assign writeBack_FORMAL_PC_NEXT = memory_to_writeBack_FORMAL_PC_NEXT;
@@ -1859,7 +1863,7 @@ module VexRiscv (
   assign decode_FORMAL_PC_NEXT = (decode_PC + 32'h00000004);
   assign memory_PC = execute_to_memory_PC;
   assign execute_DO_EBREAK = decode_to_execute_DO_EBREAK;
-  assign decode_IS_EBREAK = _zz_decode_ENV_CTRL_2[26];
+  assign decode_IS_EBREAK = _zz_decode_IS_CSR[26];
   assign execute_CSR_READ_OPCODE = decode_to_execute_CSR_READ_OPCODE;
   assign execute_CSR_WRITE_OPCODE = decode_to_execute_CSR_WRITE_OPCODE;
   assign execute_IS_CSR = decode_to_execute_IS_CSR;
@@ -1871,8 +1875,8 @@ module VexRiscv (
   assign execute_PC = decode_to_execute_PC;
   assign execute_RS1 = decode_to_execute_RS1;
   assign execute_BRANCH_CTRL = _zz_execute_BRANCH_CTRL;
-  assign decode_RS2_USE = _zz_decode_ENV_CTRL_2[14];
-  assign decode_RS1_USE = _zz_decode_ENV_CTRL_2[4];
+  assign decode_RS2_USE = _zz_decode_IS_CSR[14];
+  assign decode_RS1_USE = _zz_decode_IS_CSR[4];
   assign execute_REGFILE_WRITE_VALID = decode_to_execute_REGFILE_WRITE_VALID;
   assign execute_BYPASSABLE_EXECUTE_STAGE = decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
   assign memory_REGFILE_WRITE_VALID = execute_to_memory_REGFILE_WRITE_VALID;
@@ -1884,7 +1888,7 @@ module VexRiscv (
     if(when_ShiftPlugins_l169) begin
       _zz_execute_to_memory_REGFILE_WRITE_DATA = _zz_execute_to_memory_REGFILE_WRITE_DATA_1;
     end
-    if(when_CsrPlugin_l1189) begin
+    if(when_CsrPlugin_l1587) begin
       _zz_execute_to_memory_REGFILE_WRITE_DATA = CsrPlugin_csrMapping_readDataSignal;
     end
   end
@@ -1893,15 +1897,15 @@ module VexRiscv (
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_execute_SRC2 = execute_PC;
+  assign _zz_execute_to_memory_PC = execute_PC;
   assign execute_SRC2_CTRL = _zz_execute_SRC2_CTRL;
   assign execute_SRC1_CTRL = _zz_execute_SRC1_CTRL;
-  assign decode_SRC_USE_SUB_LESS = _zz_decode_ENV_CTRL_2[2];
-  assign decode_SRC_ADD_ZERO = _zz_decode_ENV_CTRL_2[18];
+  assign decode_SRC_USE_SUB_LESS = _zz_decode_IS_CSR[2];
+  assign decode_SRC_ADD_ZERO = _zz_decode_IS_CSR[18];
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
   assign execute_ALU_CTRL = _zz_execute_ALU_CTRL;
-  assign execute_SRC2 = _zz_execute_SRC2_5;
+  assign execute_SRC2 = _zz_execute_SRC2_4;
   assign execute_SRC1 = _zz_execute_SRC1;
   assign execute_ALU_BITWISE_CTRL = _zz_execute_ALU_BITWISE_CTRL;
   assign _zz_lastStageRegFileWrite_payload_address = writeBack_INSTRUCTION;
@@ -1915,16 +1919,16 @@ module VexRiscv (
 
   assign decode_INSTRUCTION_ANTICIPATED = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusSimplePlugin_iBusRsp_output_payload_rsp_inst);
   always @(*) begin
-    decode_REGFILE_WRITE_VALID = _zz_decode_ENV_CTRL_2[9];
+    decode_REGFILE_WRITE_VALID = _zz_decode_IS_CSR[9];
     if(when_RegFilePlugin_l63) begin
       decode_REGFILE_WRITE_VALID = 1'b0;
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00001073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
+  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000107f) == 32'h00001073),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00002073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
   always @(*) begin
     _zz_lastStageRegFileWrite_payload_data = writeBack_REGFILE_WRITE_DATA;
-    if(when_DBusSimplePlugin_l558) begin
+    if(when_DBusSimplePlugin_l566) begin
       _zz_lastStageRegFileWrite_payload_data = writeBack_DBusSimplePlugin_rspFormated;
     end
   end
@@ -1955,7 +1959,7 @@ module VexRiscv (
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
   always @(*) begin
     decode_arbitration_haltItself = 1'b0;
-    case(switch_Fetcher_l365)
+    case(IBusSimplePlugin_injector_port_state)
       3'b010 : begin
         decode_arbitration_haltItself = 1'b1;
       end
@@ -1972,7 +1976,7 @@ module VexRiscv (
     if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(when_CsrPlugin_l1129) begin
+    if(when_CsrPlugin_l1527) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
@@ -1997,7 +2001,7 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(when_DBusSimplePlugin_l428) begin
+    if(when_DBusSimplePlugin_l436) begin
       execute_arbitration_haltItself = 1'b1;
     end
     if(when_ShiftPlugins_l169) begin
@@ -2005,7 +2009,7 @@ module VexRiscv (
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(when_CsrPlugin_l1193) begin
+    if(when_CsrPlugin_l1591) begin
       if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
@@ -2014,7 +2018,7 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if(when_DebugPlugin_l295) begin
+    if(when_DebugPlugin_l308) begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
@@ -2031,8 +2035,8 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_flushIt = 1'b0;
-    if(when_DebugPlugin_l295) begin
-      if(when_DebugPlugin_l298) begin
+    if(when_DebugPlugin_l308) begin
+      if(when_DebugPlugin_l311) begin
         execute_arbitration_flushIt = 1'b1;
       end
     end
@@ -2043,8 +2047,8 @@ module VexRiscv (
     if(CsrPlugin_selfException_valid) begin
       execute_arbitration_flushNext = 1'b1;
     end
-    if(when_DebugPlugin_l295) begin
-      if(when_DebugPlugin_l298) begin
+    if(when_DebugPlugin_l308) begin
+      if(when_DebugPlugin_l311) begin
         execute_arbitration_flushNext = 1'b1;
       end
     end
@@ -2052,7 +2056,7 @@ module VexRiscv (
 
   always @(*) begin
     memory_arbitration_haltItself = 1'b0;
-    if(when_DBusSimplePlugin_l482) begin
+    if(when_DBusSimplePlugin_l490) begin
       memory_arbitration_haltItself = 1'b1;
     end
   end
@@ -2091,10 +2095,10 @@ module VexRiscv (
   assign writeBack_arbitration_flushIt = 1'b0;
   always @(*) begin
     writeBack_arbitration_flushNext = 1'b0;
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -2105,24 +2109,24 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @(*) begin
     IBusSimplePlugin_fetcherHalt = 1'b0;
-    if(when_CsrPlugin_l935) begin
+    if(when_CsrPlugin_l1272) begin
       IBusSimplePlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       IBusSimplePlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       IBusSimplePlugin_fetcherHalt = 1'b1;
     end
-    if(when_DebugPlugin_l295) begin
-      if(when_DebugPlugin_l298) begin
+    if(when_DebugPlugin_l308) begin
+      if(when_DebugPlugin_l311) begin
         IBusSimplePlugin_fetcherHalt = 1'b1;
       end
     end
     if(DebugPlugin_haltIt) begin
       IBusSimplePlugin_fetcherHalt = 1'b1;
     end
-    if(when_DebugPlugin_l311) begin
+    if(when_DebugPlugin_l324) begin
       IBusSimplePlugin_fetcherHalt = 1'b1;
     end
   end
@@ -2145,7 +2149,17 @@ module VexRiscv (
     end
   end
 
-  assign CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+  always @(*) begin
+    CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+    if(when_CsrPlugin_l1702) begin
+      CsrPlugin_csrMapping_allowCsrSignal = 1'b1;
+    end
+    if(when_CsrPlugin_l1709) begin
+      CsrPlugin_csrMapping_allowCsrSignal = 1'b1;
+    end
+  end
+
+  assign CsrPlugin_csrMapping_doForceFailCsr = 1'b0;
   assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
   assign CsrPlugin_inWfi = 1'b0;
   always @(*) begin
@@ -2157,21 +2171,21 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(when_CsrPlugin_l1077) begin
-      case(switch_CsrPlugin_l1081)
+    if(when_CsrPlugin_l1456) begin
+      case(switch_CsrPlugin_l1460)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -2190,7 +2204,7 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_allowInterrupts = 1'b1;
-    if(when_DebugPlugin_l331) begin
+    if(when_DebugPlugin_l344) begin
       CsrPlugin_allowInterrupts = 1'b0;
     end
   end
@@ -2209,6 +2223,7 @@ module VexRiscv (
     end
   end
 
+  assign CsrPlugin_xretAwayFromMachine = 1'b0;
   assign IBusSimplePlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
   assign IBusSimplePlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,BranchPlugin_jumpInterface_valid} != 2'b00);
   assign _zz_IBusSimplePlugin_jump_pcLoad_payload = {BranchPlugin_jumpInterface_valid,CsrPlugin_jumpInterface_valid};
@@ -2229,9 +2244,8 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l134 = (IBusSimplePlugin_fetchPc_correction || IBusSimplePlugin_fetchPc_pcRegPropagate);
-  assign IBusSimplePlugin_fetchPc_output_fire_1 = (IBusSimplePlugin_fetchPc_output_valid && IBusSimplePlugin_fetchPc_output_ready);
-  assign when_Fetcher_l134_1 = ((! IBusSimplePlugin_fetchPc_output_valid) && IBusSimplePlugin_fetchPc_output_ready);
+  assign when_Fetcher_l133 = (IBusSimplePlugin_fetchPc_correction || IBusSimplePlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l133_1 = ((! IBusSimplePlugin_fetchPc_output_valid) && IBusSimplePlugin_fetchPc_output_ready);
   always @(*) begin
     IBusSimplePlugin_fetchPc_pc = (IBusSimplePlugin_fetchPc_pcReg + _zz_IBusSimplePlugin_fetchPc_pc);
     if(IBusSimplePlugin_jump_pcLoad_valid) begin
@@ -2248,7 +2262,7 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l161 = (IBusSimplePlugin_fetchPc_booted && ((IBusSimplePlugin_fetchPc_output_ready || IBusSimplePlugin_fetchPc_correction) || IBusSimplePlugin_fetchPc_pcRegPropagate));
+  assign when_Fetcher_l160 = (IBusSimplePlugin_fetchPc_booted && ((IBusSimplePlugin_fetchPc_output_ready || IBusSimplePlugin_fetchPc_correction) || IBusSimplePlugin_fetchPc_pcRegPropagate));
   assign IBusSimplePlugin_fetchPc_output_valid = ((! IBusSimplePlugin_fetcherHalt) && IBusSimplePlugin_fetchPc_booted);
   assign IBusSimplePlugin_fetchPc_output_payload = IBusSimplePlugin_fetchPc_pc;
   assign IBusSimplePlugin_iBusRsp_redoFetch = 1'b0;
@@ -2273,16 +2287,16 @@ module VexRiscv (
   assign IBusSimplePlugin_iBusRsp_stages_1_output_payload = IBusSimplePlugin_iBusRsp_stages_1_input_payload;
   assign IBusSimplePlugin_iBusRsp_flush = (IBusSimplePlugin_externalFlush || IBusSimplePlugin_iBusRsp_redoFetch);
   assign IBusSimplePlugin_iBusRsp_stages_0_output_ready = _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready;
-  assign _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_1)) || IBusSimplePlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_1 = _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_2;
-  assign IBusSimplePlugin_iBusRsp_stages_1_input_valid = _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_1;
+  assign _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusSimplePlugin_iBusRsp_stages_1_input_valid)) || IBusSimplePlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_IBusSimplePlugin_iBusRsp_stages_1_input_valid = _zz_IBusSimplePlugin_iBusRsp_stages_1_input_valid_1;
+  assign IBusSimplePlugin_iBusRsp_stages_1_input_valid = _zz_IBusSimplePlugin_iBusRsp_stages_1_input_valid;
   assign IBusSimplePlugin_iBusRsp_stages_1_input_payload = IBusSimplePlugin_fetchPc_pcReg;
   always @(*) begin
     IBusSimplePlugin_iBusRsp_readyForError = 1'b1;
     if(IBusSimplePlugin_injector_decodeInput_valid) begin
       IBusSimplePlugin_iBusRsp_readyForError = 1'b0;
     end
-    if(when_Fetcher_l323) begin
+    if(when_Fetcher_l322) begin
       IBusSimplePlugin_iBusRsp_readyForError = 1'b0;
     end
   end
@@ -2293,12 +2307,12 @@ module VexRiscv (
   assign IBusSimplePlugin_injector_decodeInput_payload_rsp_error = _zz_IBusSimplePlugin_injector_decodeInput_payload_rsp_error;
   assign IBusSimplePlugin_injector_decodeInput_payload_rsp_inst = _zz_IBusSimplePlugin_injector_decodeInput_payload_rsp_inst;
   assign IBusSimplePlugin_injector_decodeInput_payload_isRvc = _zz_IBusSimplePlugin_injector_decodeInput_payload_isRvc;
-  assign when_Fetcher_l323 = (! IBusSimplePlugin_pcValids_0);
-  assign when_Fetcher_l332 = (! (! IBusSimplePlugin_iBusRsp_stages_1_input_ready));
-  assign when_Fetcher_l332_1 = (! (! IBusSimplePlugin_injector_decodeInput_ready));
-  assign when_Fetcher_l332_2 = (! execute_arbitration_isStuck);
-  assign when_Fetcher_l332_3 = (! memory_arbitration_isStuck);
-  assign when_Fetcher_l332_4 = (! writeBack_arbitration_isStuck);
+  assign when_Fetcher_l322 = (! IBusSimplePlugin_pcValids_0);
+  assign when_Fetcher_l331 = (! (! IBusSimplePlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l331_1 = (! (! IBusSimplePlugin_injector_decodeInput_ready));
+  assign when_Fetcher_l331_2 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l331_3 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l331_4 = (! writeBack_arbitration_isStuck);
   assign IBusSimplePlugin_pcValids_0 = IBusSimplePlugin_injector_nextPcCalc_valids_1;
   assign IBusSimplePlugin_pcValids_1 = IBusSimplePlugin_injector_nextPcCalc_valids_2;
   assign IBusSimplePlugin_pcValids_2 = IBusSimplePlugin_injector_nextPcCalc_valids_3;
@@ -2306,7 +2320,7 @@ module VexRiscv (
   assign IBusSimplePlugin_injector_decodeInput_ready = (! decode_arbitration_isStuck);
   always @(*) begin
     decode_arbitration_isValid = IBusSimplePlugin_injector_decodeInput_valid;
-    case(switch_Fetcher_l365)
+    case(IBusSimplePlugin_injector_port_state)
       3'b010 : begin
         decode_arbitration_isValid = 1'b1;
       end
@@ -2340,8 +2354,8 @@ module VexRiscv (
   assign IBusSimplePlugin_rspJoin_rspBuffer_output_payload_error = IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_error;
   assign IBusSimplePlugin_rspJoin_rspBuffer_output_payload_inst = IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_inst;
   assign IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_ready = (IBusSimplePlugin_rspJoin_rspBuffer_output_ready || IBusSimplePlugin_rspJoin_rspBuffer_flush);
-  assign IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_fire = (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid && IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_ready);
-  assign IBusSimplePlugin_pending_dec = IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_fire;
+  assign toplevel_IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_fire = (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid && IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_ready);
+  assign IBusSimplePlugin_pending_dec = toplevel_IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_fire;
   assign IBusSimplePlugin_rspJoin_fetchRsp_pc = IBusSimplePlugin_iBusRsp_stages_1_output_payload;
   always @(*) begin
     IBusSimplePlugin_rspJoin_fetchRsp_rsp_error = IBusSimplePlugin_rspJoin_rspBuffer_output_payload_error;
@@ -2360,8 +2374,7 @@ module VexRiscv (
   assign IBusSimplePlugin_rspJoin_join_payload_isRvc = IBusSimplePlugin_rspJoin_fetchRsp_isRvc;
   assign IBusSimplePlugin_rspJoin_join_fire = (IBusSimplePlugin_rspJoin_join_valid && IBusSimplePlugin_rspJoin_join_ready);
   assign IBusSimplePlugin_iBusRsp_stages_1_output_ready = (IBusSimplePlugin_iBusRsp_stages_1_output_valid ? IBusSimplePlugin_rspJoin_join_fire : IBusSimplePlugin_rspJoin_join_ready);
-  assign IBusSimplePlugin_rspJoin_join_fire_1 = (IBusSimplePlugin_rspJoin_join_valid && IBusSimplePlugin_rspJoin_join_ready);
-  assign IBusSimplePlugin_rspJoin_rspBuffer_output_ready = IBusSimplePlugin_rspJoin_join_fire_1;
+  assign IBusSimplePlugin_rspJoin_rspBuffer_output_ready = IBusSimplePlugin_rspJoin_join_fire;
   assign _zz_IBusSimplePlugin_iBusRsp_output_valid = (! IBusSimplePlugin_rspJoin_exceptionDetected);
   assign IBusSimplePlugin_rspJoin_join_ready = (IBusSimplePlugin_iBusRsp_output_ready && _zz_IBusSimplePlugin_iBusRsp_output_valid);
   assign IBusSimplePlugin_iBusRsp_output_valid = (IBusSimplePlugin_rspJoin_join_valid && _zz_IBusSimplePlugin_iBusRsp_output_valid);
@@ -2395,7 +2408,7 @@ module VexRiscv (
   end
 
   assign dBus_cmd_payload_data = _zz_dBus_cmd_payload_data;
-  assign when_DBusSimplePlugin_l428 = ((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! dBus_cmd_ready)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_dBus_cmd_valid));
+  assign when_DBusSimplePlugin_l436 = ((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! dBus_cmd_ready)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_dBus_cmd_valid));
   always @(*) begin
     case(dBus_cmd_payload_size)
       2'b00 : begin
@@ -2412,23 +2425,23 @@ module VexRiscv (
 
   assign execute_DBusSimplePlugin_formalMask = (_zz_execute_DBusSimplePlugin_formalMask <<< dBus_cmd_payload_address[1 : 0]);
   assign dBus_cmd_payload_address = execute_SRC_ADD;
-  assign when_DBusSimplePlugin_l482 = (((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (! memory_MEMORY_STORE)) && ((! dBus_rsp_ready) || 1'b0));
+  assign when_DBusSimplePlugin_l490 = (((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (! memory_MEMORY_STORE)) && ((! dBus_rsp_ready) || 1'b0));
   always @(*) begin
     DBusSimplePlugin_memoryExceptionPort_valid = 1'b0;
-    if(when_DBusSimplePlugin_l489) begin
+    if(when_DBusSimplePlugin_l497) begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b1;
     end
     if(memory_ALIGNEMENT_FAULT) begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b1;
     end
-    if(when_DBusSimplePlugin_l515) begin
+    if(when_DBusSimplePlugin_l523) begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b0;
     end
   end
 
   always @(*) begin
     DBusSimplePlugin_memoryExceptionPort_payload_code = 4'bxxxx;
-    if(when_DBusSimplePlugin_l489) begin
+    if(when_DBusSimplePlugin_l497) begin
       DBusSimplePlugin_memoryExceptionPort_payload_code = 4'b0101;
     end
     if(memory_ALIGNEMENT_FAULT) begin
@@ -2437,8 +2450,8 @@ module VexRiscv (
   end
 
   assign DBusSimplePlugin_memoryExceptionPort_payload_badAddr = memory_REGFILE_WRITE_DATA;
-  assign when_DBusSimplePlugin_l489 = ((dBus_rsp_ready && dBus_rsp_error) && (! memory_MEMORY_STORE));
-  assign when_DBusSimplePlugin_l515 = (! ((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (1'b1 || (! memory_arbitration_isStuckByOthers))));
+  assign when_DBusSimplePlugin_l497 = ((dBus_rsp_ready && dBus_rsp_error) && (! memory_MEMORY_STORE));
+  assign when_DBusSimplePlugin_l523 = (! ((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (1'b1 || (! memory_arbitration_isStuckByOthers))));
   always @(*) begin
     writeBack_DBusSimplePlugin_rspShifted = writeBack_MEMORY_READ_DATA;
     case(writeBack_MEMORY_ADDRESS_LOW)
@@ -2456,7 +2469,7 @@ module VexRiscv (
     endcase
   end
 
-  assign switch_Misc_l210 = writeBack_INSTRUCTION[13 : 12];
+  assign switch_Misc_l232 = writeBack_INSTRUCTION[13 : 12];
   assign _zz_writeBack_DBusSimplePlugin_rspFormated = (writeBack_DBusSimplePlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
   always @(*) begin
     _zz_writeBack_DBusSimplePlugin_rspFormated_1[31] = _zz_writeBack_DBusSimplePlugin_rspFormated;
@@ -2508,7 +2521,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    case(switch_Misc_l210)
+    case(switch_Misc_l232)
       2'b00 : begin
         writeBack_DBusSimplePlugin_rspFormated = _zz_writeBack_DBusSimplePlugin_rspFormated_1;
       end
@@ -2521,53 +2534,53 @@ module VexRiscv (
     endcase
   end
 
-  assign when_DBusSimplePlugin_l558 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_decode_ENV_CTRL_3 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_decode_ENV_CTRL_4 = ((decode_INSTRUCTION & 32'h00000018) == 32'h0);
-  assign _zz_decode_ENV_CTRL_5 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_decode_ENV_CTRL_6 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000010);
-  assign _zz_decode_ENV_CTRL_7 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_decode_ENV_CTRL_2 = {(|((decode_INSTRUCTION & 32'h10103050) == 32'h00100050)),{(|((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2) == 32'h00000050)),{(|(_zz__zz_decode_ENV_CTRL_2_1 == _zz__zz_decode_ENV_CTRL_2_2)),{(|{_zz__zz_decode_ENV_CTRL_2_3,_zz__zz_decode_ENV_CTRL_2_4}),{(|_zz__zz_decode_ENV_CTRL_2_5),{_zz__zz_decode_ENV_CTRL_2_7,{_zz__zz_decode_ENV_CTRL_2_9,_zz__zz_decode_ENV_CTRL_2_12}}}}}}};
-  assign _zz_decode_SRC1_CTRL_2 = _zz_decode_ENV_CTRL_2[1 : 0];
+  assign when_DBusSimplePlugin_l566 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign _zz_decode_IS_CSR_1 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
+  assign _zz_decode_IS_CSR_2 = ((decode_INSTRUCTION & 32'h00000018) == 32'h00000000);
+  assign _zz_decode_IS_CSR_3 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_decode_IS_CSR_4 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000010);
+  assign _zz_decode_IS_CSR_5 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_decode_IS_CSR = {(|((decode_INSTRUCTION & 32'h10103050) == 32'h00100050)),{(|((decode_INSTRUCTION & _zz__zz_decode_IS_CSR) == 32'h00000050)),{(|(_zz__zz_decode_IS_CSR_1 == _zz__zz_decode_IS_CSR_2)),{(|{_zz__zz_decode_IS_CSR_3,_zz__zz_decode_IS_CSR_4}),{(|_zz__zz_decode_IS_CSR_5),{_zz__zz_decode_IS_CSR_7,{_zz__zz_decode_IS_CSR_9,_zz__zz_decode_IS_CSR_12}}}}}}};
+  assign _zz_decode_SRC1_CTRL_2 = _zz_decode_IS_CSR[1 : 0];
   assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
-  assign _zz_decode_ALU_CTRL_2 = _zz_decode_ENV_CTRL_2[6 : 5];
+  assign _zz_decode_ALU_CTRL_2 = _zz_decode_IS_CSR[6 : 5];
   assign _zz_decode_ALU_CTRL_1 = _zz_decode_ALU_CTRL_2;
-  assign _zz_decode_SRC2_CTRL_2 = _zz_decode_ENV_CTRL_2[8 : 7];
+  assign _zz_decode_SRC2_CTRL_2 = _zz_decode_IS_CSR[8 : 7];
   assign _zz_decode_SRC2_CTRL_1 = _zz_decode_SRC2_CTRL_2;
-  assign _zz_decode_ALU_BITWISE_CTRL_2 = _zz_decode_ENV_CTRL_2[17 : 16];
+  assign _zz_decode_ALU_BITWISE_CTRL_2 = _zz_decode_IS_CSR[17 : 16];
   assign _zz_decode_ALU_BITWISE_CTRL_1 = _zz_decode_ALU_BITWISE_CTRL_2;
-  assign _zz_decode_SHIFT_CTRL_2 = _zz_decode_ENV_CTRL_2[20 : 19];
+  assign _zz_decode_SHIFT_CTRL_2 = _zz_decode_IS_CSR[20 : 19];
   assign _zz_decode_SHIFT_CTRL_1 = _zz_decode_SHIFT_CTRL_2;
-  assign _zz_decode_BRANCH_CTRL_2 = _zz_decode_ENV_CTRL_2[22 : 21];
+  assign _zz_decode_BRANCH_CTRL_2 = _zz_decode_IS_CSR[22 : 21];
   assign _zz_decode_BRANCH_CTRL_1 = _zz_decode_BRANCH_CTRL_2;
-  assign _zz_decode_ENV_CTRL_8 = _zz_decode_ENV_CTRL_2[25 : 24];
-  assign _zz_decode_ENV_CTRL_1 = _zz_decode_ENV_CTRL_8;
+  assign _zz_decode_ENV_CTRL_2 = _zz_decode_IS_CSR[25 : 24];
+  assign _zz_decode_ENV_CTRL_1 = _zz_decode_ENV_CTRL_2;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
-  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h0);
+  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h00);
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
   assign decode_RegFilePlugin_rs1Data = _zz_RegFilePlugin_regFile_port0;
   assign decode_RegFilePlugin_rs2Data = _zz_RegFilePlugin_regFile_port1;
   always @(*) begin
     lastStageRegFileWrite_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
-    if(_zz_2) begin
+    if(_zz_5) begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
   always @(*) begin
     lastStageRegFileWrite_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
-    if(_zz_2) begin
-      lastStageRegFileWrite_payload_address = 5'h0;
+    if(_zz_5) begin
+      lastStageRegFileWrite_payload_address = 5'h00;
     end
   end
 
   always @(*) begin
     lastStageRegFileWrite_payload_data = _zz_lastStageRegFileWrite_payload_data;
-    if(_zz_2) begin
-      lastStageRegFileWrite_payload_data = 32'h0;
+    if(_zz_5) begin
+      lastStageRegFileWrite_payload_data = 32'h00000000;
     end
   end
 
@@ -2608,7 +2621,7 @@ module VexRiscv (
         _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
       Src1CtrlEnum_IMU : begin
-        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h000};
       end
       default : begin
         _zz_execute_SRC1 = {27'd0, _zz__zz_execute_SRC1_1};
@@ -2616,67 +2629,67 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_execute_SRC2_1 = execute_INSTRUCTION[31];
+  assign _zz_execute_SRC2 = execute_INSTRUCTION[31];
   always @(*) begin
-    _zz_execute_SRC2_2[19] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[18] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[17] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[16] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[15] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[14] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[13] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[12] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[11] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[10] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[9] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[8] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[7] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[6] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[5] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[4] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[3] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[2] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[1] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[0] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_1[19] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[18] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[17] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[16] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[15] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[14] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[13] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[12] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[11] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[10] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[9] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[8] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[7] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[6] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[5] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[4] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[3] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[2] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[1] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[0] = _zz_execute_SRC2;
   end
 
-  assign _zz_execute_SRC2_3 = _zz__zz_execute_SRC2_3[11];
+  assign _zz_execute_SRC2_2 = _zz__zz_execute_SRC2_2[11];
   always @(*) begin
-    _zz_execute_SRC2_4[19] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[18] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[17] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[16] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[15] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[14] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[13] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[12] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[11] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[10] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[9] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[8] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[7] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[6] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[5] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[4] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[3] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[2] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[1] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[0] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_3[19] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[18] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[17] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[16] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[15] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[14] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[13] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[12] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[11] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[10] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[9] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[8] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[7] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[6] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[5] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[4] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[3] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[2] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[1] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[0] = _zz_execute_SRC2_2;
   end
 
   always @(*) begin
     case(execute_SRC2_CTRL)
       Src2CtrlEnum_RS : begin
-        _zz_execute_SRC2_5 = execute_RS2;
+        _zz_execute_SRC2_4 = execute_RS2;
       end
       Src2CtrlEnum_IMI : begin
-        _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
+        _zz_execute_SRC2_4 = {_zz_execute_SRC2_1,execute_INSTRUCTION[31 : 20]};
       end
       Src2CtrlEnum_IMS : begin
-        _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_execute_SRC2_4 = {_zz_execute_SRC2_3,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_execute_SRC2_5 = _zz_execute_SRC2;
+        _zz_execute_SRC2_4 = _zz_execute_to_memory_PC;
       end
     endcase
   end
@@ -2693,7 +2706,7 @@ module VexRiscv (
   assign execute_LightShifterPlugin_amplitude = (execute_LightShifterPlugin_isActive ? execute_LightShifterPlugin_amplitudeReg : execute_SRC2[4 : 0]);
   assign execute_LightShifterPlugin_shiftInput = (execute_LightShifterPlugin_isActive ? memory_REGFILE_WRITE_DATA : execute_SRC1);
   assign execute_LightShifterPlugin_done = (execute_LightShifterPlugin_amplitude[4 : 1] == 4'b0000);
-  assign when_ShiftPlugins_l169 = ((execute_arbitration_isValid && execute_LightShifterPlugin_isShift) && (execute_SRC2[4 : 0] != 5'h0));
+  assign when_ShiftPlugins_l169 = ((execute_arbitration_isValid && execute_LightShifterPlugin_isShift) && (execute_SRC2[4 : 0] != 5'h00));
   always @(*) begin
     case(execute_SHIFT_CTRL)
       ShiftCtrlEnum_SLL_1 : begin
@@ -2794,16 +2807,19 @@ module VexRiscv (
   assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
   assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign switch_Misc_l210_1 = execute_INSTRUCTION[14 : 12];
+  assign switch_Misc_l232_1 = execute_INSTRUCTION[14 : 12];
   always @(*) begin
-    casez(switch_Misc_l210_1)
+    case(switch_Misc_l232_1)
       3'b000 : begin
         _zz_execute_BRANCH_DO = execute_BranchPlugin_eq;
       end
       3'b001 : begin
         _zz_execute_BRANCH_DO = (! execute_BranchPlugin_eq);
       end
-      3'b1?1 : begin
+      3'b101 : begin
+        _zz_execute_BRANCH_DO = (! execute_SRC_LESS);
+      end
+      3'b111 : begin
         _zz_execute_BRANCH_DO = (! execute_SRC_LESS);
       end
       default : begin
@@ -2922,9 +2938,9 @@ module VexRiscv (
 
   assign CsrPlugin_misa_base = 2'b01;
   assign CsrPlugin_misa_extensions = 26'h0000042;
-  assign _zz_when_CsrPlugin_l965 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_when_CsrPlugin_l965_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_when_CsrPlugin_l965_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign _zz_when_CsrPlugin_l1302 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l1302_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l1302_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
   assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {BranchPlugin_branchExceptionPort_valid,DBusSimplePlugin_memoryExceptionPort_valid};
@@ -2966,29 +2982,29 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l922 = (! decode_arbitration_isStuck);
-  assign when_CsrPlugin_l922_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l922_2 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l922_3 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l935 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
+  assign when_CsrPlugin_l1259 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l1272 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-  assign when_CsrPlugin_l959 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign when_CsrPlugin_l965 = ((_zz_when_CsrPlugin_l965 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l965_1 = ((_zz_when_CsrPlugin_l965_1 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l965_2 = ((_zz_when_CsrPlugin_l965_2 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1296 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l1302 = ((_zz_when_CsrPlugin_l1302 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1302_1 = ((_zz_when_CsrPlugin_l1302_1 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1302_2 = ((_zz_when_CsrPlugin_l1302_2 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_lastStageWasWfi = 1'b0;
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  assign when_CsrPlugin_l993 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l993_1 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l993_2 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l998 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  assign when_CsrPlugin_l1335 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1335_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l1335_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l1340 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
   always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(when_CsrPlugin_l1004) begin
+    if(when_CsrPlugin_l1346) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException) begin
@@ -2996,7 +3012,7 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l1004 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
+  assign when_CsrPlugin_l1346 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
   always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
@@ -3012,6 +3028,7 @@ module VexRiscv (
     end
   end
 
+  assign CsrPlugin_trapCauseEbreakDebug = 1'b0;
   always @(*) begin
     CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
@@ -3034,11 +3051,13 @@ module VexRiscv (
     endcase
   end
 
-  assign when_CsrPlugin_l1032 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign when_CsrPlugin_l1077 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
-  assign switch_CsrPlugin_l1081 = writeBack_INSTRUCTION[29 : 28];
+  assign CsrPlugin_trapEnterDebug = 1'b0;
+  assign when_CsrPlugin_l1390 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1398 = (! CsrPlugin_trapEnterDebug);
+  assign when_CsrPlugin_l1456 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign switch_CsrPlugin_l1460 = writeBack_INSTRUCTION[29 : 28];
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign when_CsrPlugin_l1129 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
+  assign when_CsrPlugin_l1527 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
   assign execute_CsrPlugin_blockedBySideEffects = ((|{writeBack_arbitration_isValid,memory_arbitration_isValid}) || 1'b0);
   always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
@@ -3080,18 +3099,18 @@ module VexRiscv (
     if(CsrPlugin_csrMapping_allowCsrSignal) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(when_CsrPlugin_l1315) begin
+    if(when_CsrPlugin_l1725) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if(when_CsrPlugin_l1149) begin
-      if(when_CsrPlugin_l1150) begin
+    if(when_CsrPlugin_l1547) begin
+      if(when_CsrPlugin_l1548) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
@@ -3099,14 +3118,14 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(when_CsrPlugin_l1157) begin
+    if(when_CsrPlugin_l1555) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(when_CsrPlugin_l1157) begin
+    if(when_CsrPlugin_l1555) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -3119,19 +3138,19 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  assign when_CsrPlugin_l1149 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
-  assign when_CsrPlugin_l1150 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
-  assign when_CsrPlugin_l1157 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
+  assign when_CsrPlugin_l1547 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign when_CsrPlugin_l1548 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1555 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
   always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -3140,9 +3159,9 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
   assign execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
-  assign switch_Misc_l210_2 = execute_INSTRUCTION[13];
+  assign switch_Misc_l232_2 = execute_INSTRUCTION[13];
   always @(*) begin
-    case(switch_Misc_l210_2)
+    case(switch_Misc_l232_2)
       1'b0 : begin
         _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
@@ -3153,20 +3172,20 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
-  assign when_CsrPlugin_l1189 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign when_CsrPlugin_l1193 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
+  assign when_CsrPlugin_l1587 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1591 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
-  assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
-  assign externalInterrupt = (|_zz_CsrPlugin_csrMapping_readDataInit_1);
-  assign when_DebugPlugin_l225 = (DebugPlugin_haltIt && (! DebugPlugin_isPipBusy));
+  assign _zz_externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
+  assign externalInterrupt = (|_zz_externalInterrupt);
+  assign when_DebugPlugin_l238 = (DebugPlugin_haltIt && (! DebugPlugin_isPipBusy));
   assign DebugPlugin_allowEBreak = (DebugPlugin_debugUsed && (! DebugPlugin_disableEbreak));
   always @(*) begin
     debug_bus_cmd_ready = 1'b1;
     if(debug_bus_cmd_valid) begin
-      case(switch_DebugPlugin_l267)
+      case(switch_DebugPlugin_l280)
         6'h01 : begin
           if(debug_bus_cmd_payload_wr) begin
-            debug_bus_cmd_ready = IBusSimplePlugin_injectionPort_ready;
+            debug_bus_cmd_ready = DebugPlugin_injectionPort_ready;
           end
         end
         default : begin
@@ -3177,7 +3196,7 @@ module VexRiscv (
 
   always @(*) begin
     debug_bus_rsp_data = DebugPlugin_busReadDataReg;
-    if(when_DebugPlugin_l244) begin
+    if(when_DebugPlugin_l257) begin
       debug_bus_rsp_data[0] = DebugPlugin_resetIt;
       debug_bus_rsp_data[1] = DebugPlugin_haltIt;
       debug_bus_rsp_data[2] = DebugPlugin_isPipBusy;
@@ -3186,14 +3205,14 @@ module VexRiscv (
     end
   end
 
-  assign when_DebugPlugin_l244 = (! _zz_when_DebugPlugin_l244);
+  assign when_DebugPlugin_l257 = (! _zz_when_DebugPlugin_l257);
   always @(*) begin
-    IBusSimplePlugin_injectionPort_valid = 1'b0;
+    DebugPlugin_injectionPort_valid = 1'b0;
     if(debug_bus_cmd_valid) begin
-      case(switch_DebugPlugin_l267)
+      case(switch_DebugPlugin_l280)
         6'h01 : begin
           if(debug_bus_cmd_payload_wr) begin
-            IBusSimplePlugin_injectionPort_valid = 1'b1;
+            DebugPlugin_injectionPort_valid = 1'b1;
           end
         end
         default : begin
@@ -3202,21 +3221,21 @@ module VexRiscv (
     end
   end
 
-  assign IBusSimplePlugin_injectionPort_payload = debug_bus_cmd_payload_data;
-  assign switch_DebugPlugin_l267 = debug_bus_cmd_payload_address[7 : 2];
-  assign when_DebugPlugin_l271 = debug_bus_cmd_payload_data[16];
-  assign when_DebugPlugin_l271_1 = debug_bus_cmd_payload_data[24];
-  assign when_DebugPlugin_l272 = debug_bus_cmd_payload_data[17];
-  assign when_DebugPlugin_l272_1 = debug_bus_cmd_payload_data[25];
-  assign when_DebugPlugin_l273 = debug_bus_cmd_payload_data[25];
-  assign when_DebugPlugin_l274 = debug_bus_cmd_payload_data[25];
-  assign when_DebugPlugin_l275 = debug_bus_cmd_payload_data[18];
-  assign when_DebugPlugin_l275_1 = debug_bus_cmd_payload_data[26];
-  assign when_DebugPlugin_l295 = (execute_arbitration_isValid && execute_DO_EBREAK);
-  assign when_DebugPlugin_l298 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
-  assign when_DebugPlugin_l311 = (DebugPlugin_stepIt && IBusSimplePlugin_incomingInstruction);
+  assign DebugPlugin_injectionPort_payload = debug_bus_cmd_payload_data;
+  assign switch_DebugPlugin_l280 = debug_bus_cmd_payload_address[7 : 2];
+  assign when_DebugPlugin_l284 = debug_bus_cmd_payload_data[16];
+  assign when_DebugPlugin_l284_1 = debug_bus_cmd_payload_data[24];
+  assign when_DebugPlugin_l285 = debug_bus_cmd_payload_data[17];
+  assign when_DebugPlugin_l285_1 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l286 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l287 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l288 = debug_bus_cmd_payload_data[18];
+  assign when_DebugPlugin_l288_1 = debug_bus_cmd_payload_data[26];
+  assign when_DebugPlugin_l308 = (execute_arbitration_isValid && execute_DO_EBREAK);
+  assign when_DebugPlugin_l311 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
+  assign when_DebugPlugin_l324 = (DebugPlugin_stepIt && IBusSimplePlugin_incomingInstruction);
   assign debug_resetOut = DebugPlugin_resetIt_regNext;
-  assign when_DebugPlugin_l331 = (DebugPlugin_haltIt || DebugPlugin_stepIt);
+  assign when_DebugPlugin_l344 = (DebugPlugin_haltIt || DebugPlugin_stepIt);
   assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
@@ -3315,105 +3334,115 @@ module VexRiscv (
   assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
   assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
   always @(*) begin
-    IBusSimplePlugin_injectionPort_ready = 1'b0;
-    case(switch_Fetcher_l365)
+    DebugPlugin_injectionPort_ready = 1'b0;
+    case(IBusSimplePlugin_injector_port_state)
       3'b100 : begin
-        IBusSimplePlugin_injectionPort_ready = 1'b1;
+        DebugPlugin_injectionPort_ready = 1'b1;
       end
       default : begin
       end
     endcase
   end
 
-  assign when_Fetcher_l381 = (! decode_arbitration_isStuck);
-  assign when_Fetcher_l401 = (switch_Fetcher_l365 != 3'b000);
-  assign when_CsrPlugin_l1277 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_2 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_3 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_4 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_5 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_6 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_7 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_8 = (! execute_arbitration_isStuck);
-  assign switch_CsrPlugin_l723 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
+  assign when_Fetcher_l391 = (! decode_arbitration_isStuck);
+  assign when_Fetcher_l411 = (IBusSimplePlugin_injector_port_state != 3'b000);
+  assign when_CsrPlugin_l1669 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_8 = (! execute_arbitration_isStuck);
+  assign switch_CsrPlugin_l1031 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_1 = 32'h00000000;
     if(execute_CsrPlugin_csr_768) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_2[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_2[3 : 3] = CsrPlugin_mstatus_MIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_2[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_CsrPlugin_csrMapping_readDataInit_1[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_1[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_1[12 : 11] = CsrPlugin_mstatus_MPP;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h00000000;
     if(execute_CsrPlugin_csr_836) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_3[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_3[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_3[3 : 3] = CsrPlugin_mip_MSIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[3 : 3] = CsrPlugin_mip_MSIP;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h00000000;
     if(execute_CsrPlugin_csr_772) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_4[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_4[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_4[3 : 3] = CsrPlugin_mie_MSIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[3 : 3] = CsrPlugin_mie_MSIE;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h00000000;
     if(execute_CsrPlugin_csr_833) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_5[31 : 0] = CsrPlugin_mepc;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[31 : 0] = CsrPlugin_mepc;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h00000000;
     if(execute_CsrPlugin_csr_834) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_6[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_CsrPlugin_csrMapping_readDataInit_6[3 : 0] = CsrPlugin_mcause_exceptionCode;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h00000000;
     if(execute_CsrPlugin_csr_835) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_7[31 : 0] = CsrPlugin_mtval;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[31 : 0] = CsrPlugin_mtval;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h00000000;
     if(execute_CsrPlugin_csr_3008) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_8[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h00000000;
     if(execute_CsrPlugin_csr_4032) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_9[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_1;
+      _zz_CsrPlugin_csrMapping_readDataInit_8[31 : 0] = _zz_externalInterrupt;
     end
   end
 
-  assign CsrPlugin_csrMapping_readDataInit = (((_zz_CsrPlugin_csrMapping_readDataInit_2 | _zz_CsrPlugin_csrMapping_readDataInit_3) | (_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5)) | ((_zz_CsrPlugin_csrMapping_readDataInit_6 | _zz_CsrPlugin_csrMapping_readDataInit_7) | (_zz_CsrPlugin_csrMapping_readDataInit_8 | _zz_CsrPlugin_csrMapping_readDataInit_9)));
-  assign when_CsrPlugin_l1310 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign when_CsrPlugin_l1315 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign CsrPlugin_csrMapping_readDataInit = (((_zz_CsrPlugin_csrMapping_readDataInit_1 | _zz_CsrPlugin_csrMapping_readDataInit_2) | (_zz_CsrPlugin_csrMapping_readDataInit_3 | _zz_CsrPlugin_csrMapping_readDataInit_4)) | ((_zz_CsrPlugin_csrMapping_readDataInit_5 | _zz_CsrPlugin_csrMapping_readDataInit_6) | (_zz_CsrPlugin_csrMapping_readDataInit_7 | _zz_CsrPlugin_csrMapping_readDataInit_8)));
+  assign when_CsrPlugin_l1702 = ((execute_arbitration_isValid && execute_IS_CSR) && (({execute_CsrPlugin_csrAddress[11 : 2],2'b00} == 12'h3a0) || ({execute_CsrPlugin_csrAddress[11 : 4],4'b0000} == 12'h3b0)));
+  assign _zz_when_CsrPlugin_l1709 = (execute_CsrPlugin_csrAddress & 12'hf60);
+  assign when_CsrPlugin_l1709 = (((execute_arbitration_isValid && execute_IS_CSR) && (5'h03 <= execute_CsrPlugin_csrAddress[4 : 0])) && (((_zz_when_CsrPlugin_l1709 == 12'hb00) || (((_zz_when_CsrPlugin_l1709 == 12'hc00) && (! execute_CsrPlugin_writeInstruction)) && (CsrPlugin_privilege == 2'b11))) || ((execute_CsrPlugin_csrAddress & 12'hfe0) == 12'h320)));
+  always @(*) begin
+    when_CsrPlugin_l1719 = CsrPlugin_csrMapping_doForceFailCsr;
+    if(when_CsrPlugin_l1717) begin
+      when_CsrPlugin_l1719 = 1'b1;
+    end
+  end
+
+  assign when_CsrPlugin_l1717 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1725 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
   always @(*) begin
     iBus_cmd_ready = iBus_cmd_m2sPipe_ready;
-    if(when_Stream_l368) begin
+    if(when_Stream_l369) begin
       iBus_cmd_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l368 = (! iBus_cmd_m2sPipe_valid);
+  assign when_Stream_l369 = (! iBus_cmd_m2sPipe_valid);
   assign iBus_cmd_m2sPipe_valid = iBus_cmd_rValid;
   assign iBus_cmd_m2sPipe_payload_pc = iBus_cmd_rData_pc;
-  assign iBusWishbone_ADR = (iBus_cmd_m2sPipe_payload_pc >>> 2);
+  assign iBusWishbone_ADR = (iBus_cmd_m2sPipe_payload_pc >>> 2'd2);
   assign iBusWishbone_CTI = 3'b000;
   assign iBusWishbone_BTE = 2'b00;
   assign iBusWishbone_SEL = 4'b1111;
@@ -3432,7 +3461,7 @@ module VexRiscv (
   assign dBus_cmd_halfPipe_payload_address = dBus_cmd_rData_address;
   assign dBus_cmd_halfPipe_payload_data = dBus_cmd_rData_data;
   assign dBus_cmd_halfPipe_payload_size = dBus_cmd_rData_size;
-  assign dBusWishbone_ADR = (dBus_cmd_halfPipe_payload_address >>> 2);
+  assign dBusWishbone_ADR = (dBus_cmd_halfPipe_payload_address >>> 2'd2);
   assign dBusWishbone_CTI = 3'b000;
   assign dBusWishbone_BTE = 2'b00;
   always @(*) begin
@@ -3451,12 +3480,12 @@ module VexRiscv (
 
   always @(*) begin
     dBusWishbone_SEL = (_zz_dBusWishbone_SEL <<< dBus_cmd_halfPipe_payload_address[1 : 0]);
-    if(when_DBusSimplePlugin_l189) begin
+    if(when_DBusSimplePlugin_l196) begin
       dBusWishbone_SEL = 4'b1111;
     end
   end
 
-  assign when_DBusSimplePlugin_l189 = (! dBus_cmd_halfPipe_payload_wr);
+  assign when_DBusSimplePlugin_l196 = (! dBus_cmd_halfPipe_payload_wr);
   assign dBusWishbone_WE = dBus_cmd_halfPipe_payload_wr;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_halfPipe_payload_data;
   assign dBus_cmd_halfPipe_ready = (dBus_cmd_halfPipe_valid && dBusWishbone_ACK);
@@ -3465,13 +3494,14 @@ module VexRiscv (
   assign dBus_rsp_ready = ((dBus_cmd_halfPipe_valid && (! dBusWishbone_WE)) && dBusWishbone_ACK);
   assign dBus_rsp_data = dBusWishbone_DAT_MISO;
   assign dBus_rsp_error = 1'b0;
+  assign IBusSimplePlugin_rspJoin_rspBuffer_c_io_flush = 1'b0;
   always @(posedge clk) begin
     if(reset) begin
       IBusSimplePlugin_fetchPc_pcReg <= externalResetVector;
       IBusSimplePlugin_fetchPc_correctionReg <= 1'b0;
       IBusSimplePlugin_fetchPc_booted <= 1'b0;
       IBusSimplePlugin_fetchPc_inc <= 1'b0;
-      _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+      _zz_IBusSimplePlugin_iBusRsp_stages_1_input_valid_1 <= 1'b0;
       _zz_IBusSimplePlugin_injector_decodeInput_valid <= 1'b0;
       IBusSimplePlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusSimplePlugin_injector_nextPcCalc_valids_1 <= 1'b0;
@@ -3480,7 +3510,7 @@ module VexRiscv (
       IBusSimplePlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       IBusSimplePlugin_pending_value <= 3'b000;
       IBusSimplePlugin_rspJoin_rspBuffer_discardCounter <= 3'b000;
-      _zz_2 <= 1'b1;
+      _zz_5 <= 1'b1;
       execute_LightShifterPlugin_isActive <= 1'b0;
       HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
       CsrPlugin_mstatus_MIE <= 1'b0;
@@ -3489,8 +3519,8 @@ module VexRiscv (
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
-      CsrPlugin_mcycle <= 64'h0;
-      CsrPlugin_minstret <= 64'h0;
+      CsrPlugin_mcycle <= 64'h0000000000000000;
+      CsrPlugin_minstret <= 64'h0000000000000000;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= 1'b0;
@@ -3501,11 +3531,11 @@ module VexRiscv (
       CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
-      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h0;
+      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h00000000;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
-      switch_Fetcher_l365 <= 3'b000;
+      IBusSimplePlugin_injector_port_state <= 3'b000;
       iBus_cmd_rValid <= 1'b0;
       dBus_cmd_rValid <= 1'b0;
     end else begin
@@ -3516,23 +3546,23 @@ module VexRiscv (
         IBusSimplePlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusSimplePlugin_fetchPc_booted <= 1'b1;
-      if(when_Fetcher_l134) begin
+      if(when_Fetcher_l133) begin
         IBusSimplePlugin_fetchPc_inc <= 1'b0;
       end
-      if(IBusSimplePlugin_fetchPc_output_fire_1) begin
+      if(IBusSimplePlugin_fetchPc_output_fire) begin
         IBusSimplePlugin_fetchPc_inc <= 1'b1;
       end
-      if(when_Fetcher_l134_1) begin
+      if(when_Fetcher_l133_1) begin
         IBusSimplePlugin_fetchPc_inc <= 1'b0;
       end
-      if(when_Fetcher_l161) begin
+      if(when_Fetcher_l160) begin
         IBusSimplePlugin_fetchPc_pcReg <= IBusSimplePlugin_fetchPc_pc;
       end
       if(IBusSimplePlugin_iBusRsp_flush) begin
-        _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+        _zz_IBusSimplePlugin_iBusRsp_stages_1_input_valid_1 <= 1'b0;
       end
       if(_zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready) begin
-        _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_2 <= (IBusSimplePlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+        _zz_IBusSimplePlugin_iBusRsp_stages_1_input_valid_1 <= (IBusSimplePlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
       if(decode_arbitration_removeIt) begin
         _zz_IBusSimplePlugin_injector_decodeInput_valid <= 1'b0;
@@ -3543,13 +3573,13 @@ module VexRiscv (
       if(IBusSimplePlugin_fetchPc_flushed) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if(when_Fetcher_l332) begin
+      if(when_Fetcher_l331) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
       if(IBusSimplePlugin_fetchPc_flushed) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(when_Fetcher_l332_1) begin
+      if(when_Fetcher_l331_1) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_1 <= IBusSimplePlugin_injector_nextPcCalc_valids_0;
       end
       if(IBusSimplePlugin_fetchPc_flushed) begin
@@ -3558,7 +3588,7 @@ module VexRiscv (
       if(IBusSimplePlugin_fetchPc_flushed) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(when_Fetcher_l332_2) begin
+      if(when_Fetcher_l331_2) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_2 <= IBusSimplePlugin_injector_nextPcCalc_valids_1;
       end
       if(IBusSimplePlugin_fetchPc_flushed) begin
@@ -3567,7 +3597,7 @@ module VexRiscv (
       if(IBusSimplePlugin_fetchPc_flushed) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(when_Fetcher_l332_3) begin
+      if(when_Fetcher_l331_3) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_3 <= IBusSimplePlugin_injector_nextPcCalc_valids_2;
       end
       if(IBusSimplePlugin_fetchPc_flushed) begin
@@ -3576,7 +3606,7 @@ module VexRiscv (
       if(IBusSimplePlugin_fetchPc_flushed) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if(when_Fetcher_l332_4) begin
+      if(when_Fetcher_l331_4) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_4 <= IBusSimplePlugin_injector_nextPcCalc_valids_3;
       end
       if(IBusSimplePlugin_fetchPc_flushed) begin
@@ -3587,7 +3617,7 @@ module VexRiscv (
       if(IBusSimplePlugin_iBusRsp_flush) begin
         IBusSimplePlugin_rspJoin_rspBuffer_discardCounter <= (IBusSimplePlugin_pending_value - _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter_2);
       end
-      _zz_2 <= 1'b0;
+      _zz_5 <= 1'b0;
       if(when_ShiftPlugins_l169) begin
         if(when_ShiftPlugins_l175) begin
           execute_LightShifterPlugin_isActive <= 1'b1;
@@ -3604,50 +3634,50 @@ module VexRiscv (
       if(writeBack_arbitration_isFiring) begin
         CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
       end
-      if(when_CsrPlugin_l922) begin
+      if(when_CsrPlugin_l1259) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if(when_CsrPlugin_l922_1) begin
+      if(when_CsrPlugin_l1259_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if(when_CsrPlugin_l922_2) begin
+      if(when_CsrPlugin_l1259_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if(when_CsrPlugin_l922_3) begin
+      if(when_CsrPlugin_l1259_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(when_CsrPlugin_l959) begin
-        if(when_CsrPlugin_l965) begin
+      if(when_CsrPlugin_l1296) begin
+        if(when_CsrPlugin_l1302) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_1) begin
+        if(when_CsrPlugin_l1302_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_2) begin
+        if(when_CsrPlugin_l1302_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
       if(CsrPlugin_pipelineLiberator_active) begin
-        if(when_CsrPlugin_l993) begin
+        if(when_CsrPlugin_l1335) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if(when_CsrPlugin_l993_1) begin
+        if(when_CsrPlugin_l1335_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if(when_CsrPlugin_l993_2) begin
+        if(when_CsrPlugin_l1335_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(when_CsrPlugin_l998) begin
+      if(when_CsrPlugin_l1340) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
@@ -3656,19 +3686,21 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(when_CsrPlugin_l1032) begin
-        case(CsrPlugin_targetPrivilege)
-          2'b11 : begin
-            CsrPlugin_mstatus_MIE <= 1'b0;
-            CsrPlugin_mstatus_MPIE <= CsrPlugin_mstatus_MIE;
-            CsrPlugin_mstatus_MPP <= CsrPlugin_privilege;
-          end
-          default : begin
-          end
-        endcase
+      if(when_CsrPlugin_l1390) begin
+        if(when_CsrPlugin_l1398) begin
+          case(CsrPlugin_targetPrivilege)
+            2'b11 : begin
+              CsrPlugin_mstatus_MIE <= 1'b0;
+              CsrPlugin_mstatus_MPIE <= CsrPlugin_mstatus_MIE;
+              CsrPlugin_mstatus_MPP <= CsrPlugin_privilege;
+            end
+            default : begin
+            end
+          endcase
+        end
       end
-      if(when_CsrPlugin_l1077) begin
-        case(switch_CsrPlugin_l1081)
+      if(when_CsrPlugin_l1456) begin
+        case(switch_CsrPlugin_l1460)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -3678,7 +3710,7 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l965_2,{_zz_when_CsrPlugin_l965_1,_zz_when_CsrPlugin_l965}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l1302_2,{_zz_when_CsrPlugin_l1302_1,_zz_when_CsrPlugin_l1302}} != 3'b000) || CsrPlugin_thirdPartyWake);
       if(when_Pipeline_l151) begin
         execute_arbitration_isValid <= 1'b0;
       end
@@ -3697,25 +3729,25 @@ module VexRiscv (
       if(when_Pipeline_l154_2) begin
         writeBack_arbitration_isValid <= memory_arbitration_isValid;
       end
-      case(switch_Fetcher_l365)
+      case(IBusSimplePlugin_injector_port_state)
         3'b000 : begin
-          if(IBusSimplePlugin_injectionPort_valid) begin
-            switch_Fetcher_l365 <= 3'b001;
+          if(DebugPlugin_injectionPort_valid) begin
+            IBusSimplePlugin_injector_port_state <= 3'b001;
           end
         end
         3'b001 : begin
-          switch_Fetcher_l365 <= 3'b010;
+          IBusSimplePlugin_injector_port_state <= 3'b010;
         end
         3'b010 : begin
-          switch_Fetcher_l365 <= 3'b011;
+          IBusSimplePlugin_injector_port_state <= 3'b011;
         end
         3'b011 : begin
-          if(when_Fetcher_l381) begin
-            switch_Fetcher_l365 <= 3'b100;
+          if(when_Fetcher_l391) begin
+            IBusSimplePlugin_injector_port_state <= 3'b100;
           end
         end
         3'b100 : begin
-          switch_Fetcher_l365 <= 3'b000;
+          IBusSimplePlugin_injector_port_state <= 3'b000;
         end
         default : begin
         end
@@ -3724,7 +3756,7 @@ module VexRiscv (
         if(execute_CsrPlugin_writeEnable) begin
           CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
           CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
-          case(switch_CsrPlugin_l723)
+          case(switch_CsrPlugin_l1031)
             2'b11 : begin
               CsrPlugin_mstatus_MPP <= 2'b11;
             end
@@ -3789,40 +3821,42 @@ module VexRiscv (
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? DBusSimplePlugin_memoryExceptionPort_payload_code : BranchPlugin_branchExceptionPort_payload_code);
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? DBusSimplePlugin_memoryExceptionPort_payload_badAddr : BranchPlugin_branchExceptionPort_payload_badAddr);
     end
-    if(when_CsrPlugin_l959) begin
-      if(when_CsrPlugin_l965) begin
+    if(when_CsrPlugin_l1296) begin
+      if(when_CsrPlugin_l1302) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l965_1) begin
+      if(when_CsrPlugin_l1302_1) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l965_2) begin
+      if(when_CsrPlugin_l1302_2) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(when_CsrPlugin_l1032) begin
-      case(CsrPlugin_targetPrivilege)
-        2'b11 : begin
-          CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
-          CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
-          CsrPlugin_mepc <= writeBack_PC;
-          if(CsrPlugin_hadException) begin
-            CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
+    if(when_CsrPlugin_l1390) begin
+      if(when_CsrPlugin_l1398) begin
+        case(CsrPlugin_targetPrivilege)
+          2'b11 : begin
+            CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
+            CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
+            CsrPlugin_mepc <= writeBack_PC;
+            if(CsrPlugin_hadException) begin
+              CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
+            end
           end
-        end
-        default : begin
-        end
-      endcase
+          default : begin
+          end
+        endcase
+      end
     end
     externalInterruptArray_regNext <= externalInterruptArray;
     if(when_Pipeline_l124) begin
       decode_to_execute_PC <= decode_PC;
     end
     if(when_Pipeline_l124_1) begin
-      execute_to_memory_PC <= _zz_execute_SRC2;
+      execute_to_memory_PC <= _zz_execute_to_memory_PC;
     end
     if(when_Pipeline_l124_2) begin
       memory_to_writeBack_PC <= memory_PC;
@@ -3956,34 +3990,34 @@ module VexRiscv (
     if(when_Pipeline_l124_45) begin
       memory_to_writeBack_MEMORY_READ_DATA <= memory_MEMORY_READ_DATA;
     end
-    if(when_Fetcher_l401) begin
-      _zz_IBusSimplePlugin_injector_decodeInput_payload_rsp_inst <= IBusSimplePlugin_injectionPort_payload;
+    if(when_Fetcher_l411) begin
+      _zz_IBusSimplePlugin_injector_decodeInput_payload_rsp_inst <= DebugPlugin_injectionPort_payload;
     end
-    if(when_CsrPlugin_l1277) begin
+    if(when_CsrPlugin_l1669) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if(when_CsrPlugin_l1277_1) begin
+    if(when_CsrPlugin_l1669_1) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if(when_CsrPlugin_l1277_2) begin
+    if(when_CsrPlugin_l1669_2) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if(when_CsrPlugin_l1277_3) begin
+    if(when_CsrPlugin_l1669_3) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if(when_CsrPlugin_l1277_4) begin
+    if(when_CsrPlugin_l1669_4) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if(when_CsrPlugin_l1277_5) begin
+    if(when_CsrPlugin_l1669_5) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if(when_CsrPlugin_l1277_6) begin
+    if(when_CsrPlugin_l1669_6) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if(when_CsrPlugin_l1277_7) begin
+    if(when_CsrPlugin_l1669_7) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if(when_CsrPlugin_l1277_8) begin
+    if(when_CsrPlugin_l1669_8) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
     if(execute_CsrPlugin_csr_836) begin
@@ -3994,7 +4028,6 @@ module VexRiscv (
     if(execute_CsrPlugin_csr_773) begin
       if(execute_CsrPlugin_writeEnable) begin
         CsrPlugin_mtvec_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 2];
-        CsrPlugin_mtvec_mode <= CsrPlugin_csrMapping_writeDataSignal[1 : 0];
       end
     end
     if(execute_CsrPlugin_csr_833) begin
@@ -4023,8 +4056,8 @@ module VexRiscv (
     if(writeBack_arbitration_isValid) begin
       DebugPlugin_busReadDataReg <= _zz_lastStageRegFileWrite_payload_data;
     end
-    _zz_when_DebugPlugin_l244 <= debug_bus_cmd_payload_address[2];
-    if(when_DebugPlugin_l295) begin
+    _zz_when_DebugPlugin_l257 <= debug_bus_cmd_payload_address[2];
+    if(when_DebugPlugin_l308) begin
       DebugPlugin_busReadDataReg <= execute_PC;
     end
     DebugPlugin_resetIt_regNext <= DebugPlugin_resetIt;
@@ -4040,39 +4073,39 @@ module VexRiscv (
       DebugPlugin_debugUsed <= 1'b0;
       DebugPlugin_disableEbreak <= 1'b0;
     end else begin
-      if(when_DebugPlugin_l225) begin
+      if(when_DebugPlugin_l238) begin
         DebugPlugin_godmode <= 1'b1;
       end
       if(debug_bus_cmd_valid) begin
         DebugPlugin_debugUsed <= 1'b1;
       end
       if(debug_bus_cmd_valid) begin
-        case(switch_DebugPlugin_l267)
-          6'h0 : begin
+        case(switch_DebugPlugin_l280)
+          6'h00 : begin
             if(debug_bus_cmd_payload_wr) begin
               DebugPlugin_stepIt <= debug_bus_cmd_payload_data[4];
-              if(when_DebugPlugin_l271) begin
+              if(when_DebugPlugin_l284) begin
                 DebugPlugin_resetIt <= 1'b1;
               end
-              if(when_DebugPlugin_l271_1) begin
+              if(when_DebugPlugin_l284_1) begin
                 DebugPlugin_resetIt <= 1'b0;
               end
-              if(when_DebugPlugin_l272) begin
+              if(when_DebugPlugin_l285) begin
                 DebugPlugin_haltIt <= 1'b1;
               end
-              if(when_DebugPlugin_l272_1) begin
+              if(when_DebugPlugin_l285_1) begin
                 DebugPlugin_haltIt <= 1'b0;
               end
-              if(when_DebugPlugin_l273) begin
+              if(when_DebugPlugin_l286) begin
                 DebugPlugin_haltedByBreak <= 1'b0;
               end
-              if(when_DebugPlugin_l274) begin
+              if(when_DebugPlugin_l287) begin
                 DebugPlugin_godmode <= 1'b0;
               end
-              if(when_DebugPlugin_l275) begin
+              if(when_DebugPlugin_l288) begin
                 DebugPlugin_disableEbreak <= 1'b1;
               end
-              if(when_DebugPlugin_l275_1) begin
+              if(when_DebugPlugin_l288_1) begin
                 DebugPlugin_disableEbreak <= 1'b0;
               end
             end
@@ -4081,13 +4114,13 @@ module VexRiscv (
           end
         endcase
       end
-      if(when_DebugPlugin_l295) begin
-        if(when_DebugPlugin_l298) begin
+      if(when_DebugPlugin_l308) begin
+        if(when_DebugPlugin_l311) begin
           DebugPlugin_haltIt <= 1'b1;
           DebugPlugin_haltedByBreak <= 1'b1;
         end
       end
-      if(when_DebugPlugin_l311) begin
+      if(when_DebugPlugin_l324) begin
         if(decode_arbitration_isValid) begin
           DebugPlugin_haltIt <= 1'b1;
         end
@@ -4099,135 +4132,141 @@ module VexRiscv (
 endmodule
 
 module StreamFifoLowLatency (
-  input               io_push_valid,
-  output              io_push_ready,
-  input               io_push_payload_error,
-  input      [31:0]   io_push_payload_inst,
-  output reg          io_pop_valid,
-  input               io_pop_ready,
-  output reg          io_pop_payload_error,
-  output reg [31:0]   io_pop_payload_inst,
-  input               io_flush,
-  output     [0:0]    io_occupancy,
-  input               clk,
-  input               reset
+  input  wire          io_push_valid,
+  output wire          io_push_ready,
+  input  wire          io_push_payload_error,
+  input  wire [31:0]   io_push_payload_inst,
+  output wire          io_pop_valid,
+  input  wire          io_pop_ready,
+  output wire          io_pop_payload_error,
+  output wire [31:0]   io_pop_payload_inst,
+  input  wire          io_flush,
+  output wire [0:0]    io_occupancy,
+  output wire [0:0]    io_availability,
+  input  wire          clk,
+  input  wire          reset
 );
 
-  reg                 when_Phase_l649;
-  reg                 pushPtr_willIncrement;
-  reg                 pushPtr_willClear;
-  wire                pushPtr_willOverflowIfInc;
-  wire                pushPtr_willOverflow;
-  reg                 popPtr_willIncrement;
-  reg                 popPtr_willClear;
-  wire                popPtr_willOverflowIfInc;
-  wire                popPtr_willOverflow;
-  wire                ptrMatch;
-  reg                 risingOccupancy;
-  wire                empty;
-  wire                full;
-  wire                pushing;
-  wire                popping;
-  wire                readed_error;
-  wire       [31:0]   readed_inst;
-  wire       [32:0]   _zz_readed_error;
-  wire                when_Stream_l1178;
-  wire                when_Stream_l1191;
-  wire       [32:0]   _zz_readed_error_1;
-  reg        [32:0]   _zz_readed_error_2;
+  wire                fifo_io_push_ready;
+  wire                fifo_io_pop_valid;
+  wire                fifo_io_pop_payload_error;
+  wire       [31:0]   fifo_io_pop_payload_inst;
+  wire       [0:0]    fifo_io_occupancy;
+  wire       [0:0]    fifo_io_availability;
+
+  StreamFifo fifo (
+    .io_push_valid         (io_push_valid                 ), //i
+    .io_push_ready         (fifo_io_push_ready            ), //o
+    .io_push_payload_error (io_push_payload_error         ), //i
+    .io_push_payload_inst  (io_push_payload_inst[31:0]    ), //i
+    .io_pop_valid          (fifo_io_pop_valid             ), //o
+    .io_pop_ready          (io_pop_ready                  ), //i
+    .io_pop_payload_error  (fifo_io_pop_payload_error     ), //o
+    .io_pop_payload_inst   (fifo_io_pop_payload_inst[31:0]), //o
+    .io_flush              (io_flush                      ), //i
+    .io_occupancy          (fifo_io_occupancy             ), //o
+    .io_availability       (fifo_io_availability          ), //o
+    .clk                   (clk                           ), //i
+    .reset                 (reset                         )  //i
+  );
+  assign io_push_ready = fifo_io_push_ready;
+  assign io_pop_valid = fifo_io_pop_valid;
+  assign io_pop_payload_error = fifo_io_pop_payload_error;
+  assign io_pop_payload_inst = fifo_io_pop_payload_inst;
+  assign io_occupancy = fifo_io_occupancy;
+  assign io_availability = fifo_io_availability;
+
+endmodule
+
+module StreamFifo (
+  input  wire          io_push_valid,
+  output reg           io_push_ready,
+  input  wire          io_push_payload_error,
+  input  wire [31:0]   io_push_payload_inst,
+  output reg           io_pop_valid,
+  input  wire          io_pop_ready,
+  output reg           io_pop_payload_error,
+  output reg  [31:0]   io_pop_payload_inst,
+  input  wire          io_flush,
+  output wire [0:0]    io_occupancy,
+  output wire [0:0]    io_availability,
+  input  wire          clk,
+  input  wire          reset
+);
+
+  reg                 oneStage_doFlush;
+  wire                oneStage_buffer_valid;
+  wire                oneStage_buffer_ready;
+  wire                oneStage_buffer_payload_error;
+  wire       [31:0]   oneStage_buffer_payload_inst;
+  reg                 io_push_rValid;
+  reg                 io_push_rData_error;
+  reg        [31:0]   io_push_rData_inst;
+  wire                when_Stream_l369;
+  wire                when_Stream_l1187;
 
   always @(*) begin
-    when_Phase_l649 = 1'b0;
-    if(pushing) begin
-      when_Phase_l649 = 1'b1;
+    oneStage_doFlush = io_flush;
+    if(when_Stream_l1187) begin
+      if(io_pop_ready) begin
+        oneStage_doFlush = 1'b1;
+      end
     end
   end
 
   always @(*) begin
-    pushPtr_willIncrement = 1'b0;
-    if(pushing) begin
-      pushPtr_willIncrement = 1'b1;
+    io_push_ready = oneStage_buffer_ready;
+    if(when_Stream_l369) begin
+      io_push_ready = 1'b1;
     end
   end
 
+  assign when_Stream_l369 = (! oneStage_buffer_valid);
+  assign oneStage_buffer_valid = io_push_rValid;
+  assign oneStage_buffer_payload_error = io_push_rData_error;
+  assign oneStage_buffer_payload_inst = io_push_rData_inst;
   always @(*) begin
-    pushPtr_willClear = 1'b0;
-    if(io_flush) begin
-      pushPtr_willClear = 1'b1;
-    end
-  end
-
-  assign pushPtr_willOverflowIfInc = 1'b1;
-  assign pushPtr_willOverflow = (pushPtr_willOverflowIfInc && pushPtr_willIncrement);
-  always @(*) begin
-    popPtr_willIncrement = 1'b0;
-    if(popping) begin
-      popPtr_willIncrement = 1'b1;
-    end
-  end
-
-  always @(*) begin
-    popPtr_willClear = 1'b0;
-    if(io_flush) begin
-      popPtr_willClear = 1'b1;
-    end
-  end
-
-  assign popPtr_willOverflowIfInc = 1'b1;
-  assign popPtr_willOverflow = (popPtr_willOverflowIfInc && popPtr_willIncrement);
-  assign ptrMatch = 1'b1;
-  assign empty = (ptrMatch && (! risingOccupancy));
-  assign full = (ptrMatch && risingOccupancy);
-  assign pushing = (io_push_valid && io_push_ready);
-  assign popping = (io_pop_valid && io_pop_ready);
-  assign io_push_ready = (! full);
-  assign _zz_readed_error = _zz_readed_error_1;
-  assign readed_error = _zz_readed_error[0];
-  assign readed_inst = _zz_readed_error[32 : 1];
-  assign when_Stream_l1178 = (! empty);
-  always @(*) begin
-    if(when_Stream_l1178) begin
-      io_pop_valid = 1'b1;
-    end else begin
+    io_pop_valid = oneStage_buffer_valid;
+    if(when_Stream_l1187) begin
       io_pop_valid = io_push_valid;
     end
   end
 
+  assign oneStage_buffer_ready = io_pop_ready;
   always @(*) begin
-    if(when_Stream_l1178) begin
-      io_pop_payload_error = readed_error;
-    end else begin
+    io_pop_payload_error = oneStage_buffer_payload_error;
+    if(when_Stream_l1187) begin
       io_pop_payload_error = io_push_payload_error;
     end
   end
 
   always @(*) begin
-    if(when_Stream_l1178) begin
-      io_pop_payload_inst = readed_inst;
-    end else begin
+    io_pop_payload_inst = oneStage_buffer_payload_inst;
+    if(when_Stream_l1187) begin
       io_pop_payload_inst = io_push_payload_inst;
     end
   end
 
-  assign when_Stream_l1191 = (pushing != popping);
-  assign io_occupancy = (risingOccupancy && ptrMatch);
-  assign _zz_readed_error_1 = _zz_readed_error_2;
+  assign io_occupancy = oneStage_buffer_valid;
+  assign io_availability = (! oneStage_buffer_valid);
+  assign when_Stream_l1187 = (! oneStage_buffer_valid);
   always @(posedge clk) begin
     if(reset) begin
-      risingOccupancy <= 1'b0;
+      io_push_rValid <= 1'b0;
     end else begin
-      if(when_Stream_l1191) begin
-        risingOccupancy <= pushing;
+      if(io_push_ready) begin
+        io_push_rValid <= io_push_valid;
       end
-      if(io_flush) begin
-        risingOccupancy <= 1'b0;
+      if(oneStage_doFlush) begin
+        io_push_rValid <= 1'b0;
       end
     end
   end
 
   always @(posedge clk) begin
-    if(when_Phase_l649) begin
-      _zz_readed_error_2 <= {io_push_payload_inst,io_push_payload_error};
+    if(io_push_ready) begin
+      io_push_rData_error <= io_push_payload_error;
+      io_push_rData_inst <= io_push_payload_inst;
     end
   end
 

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_MinDebugHwBP.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_MinDebugHwBP.v
@@ -1,46 +1,46 @@
-// Generator : SpinalHDL v1.7.1    git head : 0444bb76ab1d6e19f0ec46bc03c4769776deb7d5
+// Generator : SpinalHDL v1.9.4    git head : 270018552577f3bb8e5339ee2583c9c22d324215
 // Component : VexRiscv
-// Git hash  : 581fcb065adf7ea8b626f939ff51679d4c95872f
+// Git hash  : 63430af99f84cc1d11d58b556debe1cc3f238c67
 
 `timescale 1ns/1ps
 
 module VexRiscv (
-  input      [31:0]   externalResetVector,
-  input               timerInterrupt,
-  input               softwareInterrupt,
-  input      [31:0]   externalInterruptArray,
-  input               debug_bus_cmd_valid,
-  output reg          debug_bus_cmd_ready,
-  input               debug_bus_cmd_payload_wr,
-  input      [7:0]    debug_bus_cmd_payload_address,
-  input      [31:0]   debug_bus_cmd_payload_data,
-  output reg [31:0]   debug_bus_rsp_data,
-  output              debug_resetOut,
-  output              iBusWishbone_CYC,
-  output              iBusWishbone_STB,
-  input               iBusWishbone_ACK,
-  output              iBusWishbone_WE,
-  output     [29:0]   iBusWishbone_ADR,
-  input      [31:0]   iBusWishbone_DAT_MISO,
-  output     [31:0]   iBusWishbone_DAT_MOSI,
-  output     [3:0]    iBusWishbone_SEL,
-  input               iBusWishbone_ERR,
-  output     [2:0]    iBusWishbone_CTI,
-  output     [1:0]    iBusWishbone_BTE,
-  output              dBusWishbone_CYC,
-  output              dBusWishbone_STB,
-  input               dBusWishbone_ACK,
-  output              dBusWishbone_WE,
-  output     [29:0]   dBusWishbone_ADR,
-  input      [31:0]   dBusWishbone_DAT_MISO,
-  output     [31:0]   dBusWishbone_DAT_MOSI,
-  output reg [3:0]    dBusWishbone_SEL,
-  input               dBusWishbone_ERR,
-  output     [2:0]    dBusWishbone_CTI,
-  output     [1:0]    dBusWishbone_BTE,
-  input               clk,
-  input               reset,
-  input               debugReset
+  input  wire [31:0]   externalResetVector,
+  input  wire          timerInterrupt,
+  input  wire          softwareInterrupt,
+  input  wire [31:0]   externalInterruptArray,
+  input  wire          debug_bus_cmd_valid,
+  output reg           debug_bus_cmd_ready,
+  input  wire          debug_bus_cmd_payload_wr,
+  input  wire [7:0]    debug_bus_cmd_payload_address,
+  input  wire [31:0]   debug_bus_cmd_payload_data,
+  output reg  [31:0]   debug_bus_rsp_data,
+  output wire          debug_resetOut,
+  output wire          iBusWishbone_CYC,
+  output wire          iBusWishbone_STB,
+  input  wire          iBusWishbone_ACK,
+  output wire          iBusWishbone_WE,
+  output wire [29:0]   iBusWishbone_ADR,
+  input  wire [31:0]   iBusWishbone_DAT_MISO,
+  output wire [31:0]   iBusWishbone_DAT_MOSI,
+  output wire [3:0]    iBusWishbone_SEL,
+  input  wire          iBusWishbone_ERR,
+  output wire [2:0]    iBusWishbone_CTI,
+  output wire [1:0]    iBusWishbone_BTE,
+  output wire          dBusWishbone_CYC,
+  output wire          dBusWishbone_STB,
+  input  wire          dBusWishbone_ACK,
+  output wire          dBusWishbone_WE,
+  output wire [29:0]   dBusWishbone_ADR,
+  input  wire [31:0]   dBusWishbone_DAT_MISO,
+  output wire [31:0]   dBusWishbone_DAT_MOSI,
+  output reg  [3:0]    dBusWishbone_SEL,
+  input  wire          dBusWishbone_ERR,
+  output wire [2:0]    dBusWishbone_CTI,
+  output wire [1:0]    dBusWishbone_BTE,
+  input  wire          clk,
+  input  wire          reset,
+  input  wire          debugReset
 );
   localparam EnvCtrlEnum_NONE = 2'd0;
   localparam EnvCtrlEnum_XRET = 2'd1;
@@ -69,6 +69,7 @@ module VexRiscv (
   localparam Src1CtrlEnum_URS1 = 2'd3;
 
   wire                IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_ready;
+  wire                IBusSimplePlugin_rspJoin_rspBuffer_c_io_flush;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
   wire                IBusSimplePlugin_rspJoin_rspBuffer_c_io_push_ready;
@@ -76,6 +77,7 @@ module VexRiscv (
   wire                IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_error;
   wire       [31:0]   IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_inst;
   wire       [0:0]    IBusSimplePlugin_rspJoin_rspBuffer_c_io_occupancy;
+  wire       [0:0]    IBusSimplePlugin_rspJoin_rspBuffer_c_io_availability;
   wire       [30:0]   _zz_decode_DO_EBREAK;
   wire       [30:0]   _zz_decode_DO_EBREAK_1;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION;
@@ -83,19 +85,18 @@ module VexRiscv (
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_2;
   wire                _zz_decode_LEGAL_INSTRUCTION_3;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_4;
-  wire       [12:0]   _zz_decode_LEGAL_INSTRUCTION_5;
+  wire       [11:0]   _zz_decode_LEGAL_INSTRUCTION_5;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_6;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_7;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_8;
   wire                _zz_decode_LEGAL_INSTRUCTION_9;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_10;
-  wire       [6:0]    _zz_decode_LEGAL_INSTRUCTION_11;
+  wire       [5:0]    _zz_decode_LEGAL_INSTRUCTION_11;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_12;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_13;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_14;
   wire                _zz_decode_LEGAL_INSTRUCTION_15;
-  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_16;
-  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_17;
+  wire                _zz_decode_LEGAL_INSTRUCTION_16;
   wire       [1:0]    _zz_IBusSimplePlugin_jump_pcLoad_payload_1;
   wire       [1:0]    _zz_IBusSimplePlugin_jump_pcLoad_payload_2;
   wire       [31:0]   _zz_IBusSimplePlugin_fetchPc_pc;
@@ -110,98 +111,98 @@ module VexRiscv (
   wire       [2:0]    _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter_2;
   wire       [0:0]    _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter_3;
   wire       [2:0]    _zz_DBusSimplePlugin_memoryExceptionPort_payload_code;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_1;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_2;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_3;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_4;
-  wire       [1:0]    _zz__zz_decode_ENV_CTRL_2_5;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_6;
-  wire                _zz__zz_decode_ENV_CTRL_2_7;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_8;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_9;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_10;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_11;
-  wire       [19:0]   _zz__zz_decode_ENV_CTRL_2_12;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_13;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_14;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_15;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_16;
-  wire       [1:0]    _zz__zz_decode_ENV_CTRL_2_17;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_18;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_19;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_20;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_21;
-  wire                _zz__zz_decode_ENV_CTRL_2_22;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_23;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_24;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_25;
-  wire                _zz__zz_decode_ENV_CTRL_2_26;
-  wire       [15:0]   _zz__zz_decode_ENV_CTRL_2_27;
-  wire       [1:0]    _zz__zz_decode_ENV_CTRL_2_28;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_29;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_30;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_31;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_32;
-  wire                _zz__zz_decode_ENV_CTRL_2_33;
-  wire                _zz__zz_decode_ENV_CTRL_2_34;
-  wire                _zz__zz_decode_ENV_CTRL_2_35;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_36;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_37;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_38;
-  wire       [1:0]    _zz__zz_decode_ENV_CTRL_2_39;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_40;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_41;
-  wire       [12:0]   _zz__zz_decode_ENV_CTRL_2_42;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_43;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_44;
-  wire                _zz__zz_decode_ENV_CTRL_2_45;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_46;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_47;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_48;
-  wire       [9:0]    _zz__zz_decode_ENV_CTRL_2_49;
-  wire       [5:0]    _zz__zz_decode_ENV_CTRL_2_50;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_51;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_52;
-  wire                _zz__zz_decode_ENV_CTRL_2_53;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_54;
-  wire       [1:0]    _zz__zz_decode_ENV_CTRL_2_55;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_56;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_57;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_58;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_59;
-  wire                _zz__zz_decode_ENV_CTRL_2_60;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_61;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_62;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_63;
-  wire                _zz__zz_decode_ENV_CTRL_2_64;
-  wire       [6:0]    _zz__zz_decode_ENV_CTRL_2_65;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_66;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_67;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_68;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_69;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_70;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_71;
-  wire                _zz__zz_decode_ENV_CTRL_2_72;
-  wire                _zz__zz_decode_ENV_CTRL_2_73;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_74;
-  wire       [1:0]    _zz__zz_decode_ENV_CTRL_2_75;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_76;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_77;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_78;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_79;
-  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_80;
-  wire                _zz__zz_decode_ENV_CTRL_2_81;
-  wire       [2:0]    _zz__zz_decode_ENV_CTRL_2_82;
-  wire       [2:0]    _zz__zz_decode_ENV_CTRL_2_83;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_84;
-  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_85;
-  wire                _zz__zz_decode_ENV_CTRL_2_86;
-  wire                _zz__zz_decode_ENV_CTRL_2_87;
-  wire                _zz__zz_decode_ENV_CTRL_2_88;
-  wire                _zz__zz_decode_ENV_CTRL_2_89;
-  wire                _zz__zz_decode_ENV_CTRL_2_90;
-  wire                _zz__zz_decode_ENV_CTRL_2_91;
+  wire       [31:0]   _zz__zz_decode_IS_CSR;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_1;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_2;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_3;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_4;
+  wire       [1:0]    _zz__zz_decode_IS_CSR_5;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_6;
+  wire                _zz__zz_decode_IS_CSR_7;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_8;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_9;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_10;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_11;
+  wire       [19:0]   _zz__zz_decode_IS_CSR_12;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_13;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_14;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_15;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_16;
+  wire       [1:0]    _zz__zz_decode_IS_CSR_17;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_18;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_19;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_20;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_21;
+  wire                _zz__zz_decode_IS_CSR_22;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_23;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_24;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_25;
+  wire                _zz__zz_decode_IS_CSR_26;
+  wire       [15:0]   _zz__zz_decode_IS_CSR_27;
+  wire       [1:0]    _zz__zz_decode_IS_CSR_28;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_29;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_30;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_31;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_32;
+  wire                _zz__zz_decode_IS_CSR_33;
+  wire                _zz__zz_decode_IS_CSR_34;
+  wire                _zz__zz_decode_IS_CSR_35;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_36;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_37;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_38;
+  wire       [1:0]    _zz__zz_decode_IS_CSR_39;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_40;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_41;
+  wire       [12:0]   _zz__zz_decode_IS_CSR_42;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_43;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_44;
+  wire                _zz__zz_decode_IS_CSR_45;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_46;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_47;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_48;
+  wire       [9:0]    _zz__zz_decode_IS_CSR_49;
+  wire       [5:0]    _zz__zz_decode_IS_CSR_50;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_51;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_52;
+  wire                _zz__zz_decode_IS_CSR_53;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_54;
+  wire       [1:0]    _zz__zz_decode_IS_CSR_55;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_56;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_57;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_58;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_59;
+  wire                _zz__zz_decode_IS_CSR_60;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_61;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_62;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_63;
+  wire                _zz__zz_decode_IS_CSR_64;
+  wire       [6:0]    _zz__zz_decode_IS_CSR_65;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_66;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_67;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_68;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_69;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_70;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_71;
+  wire                _zz__zz_decode_IS_CSR_72;
+  wire                _zz__zz_decode_IS_CSR_73;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_74;
+  wire       [1:0]    _zz__zz_decode_IS_CSR_75;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_76;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_77;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_78;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_79;
+  wire       [0:0]    _zz__zz_decode_IS_CSR_80;
+  wire                _zz__zz_decode_IS_CSR_81;
+  wire       [2:0]    _zz__zz_decode_IS_CSR_82;
+  wire       [2:0]    _zz__zz_decode_IS_CSR_83;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_84;
+  wire       [31:0]   _zz__zz_decode_IS_CSR_85;
+  wire                _zz__zz_decode_IS_CSR_86;
+  wire                _zz__zz_decode_IS_CSR_87;
+  wire                _zz__zz_decode_IS_CSR_88;
+  wire                _zz__zz_decode_IS_CSR_89;
+  wire                _zz__zz_decode_IS_CSR_90;
+  wire                _zz__zz_decode_IS_CSR_91;
   wire                _zz_RegFilePlugin_regFile_port;
   wire                _zz_decode_RegFilePlugin_rs1Data;
   wire                _zz_RegFilePlugin_regFile_port_1;
@@ -209,14 +210,12 @@ module VexRiscv (
   wire       [0:0]    _zz__zz_execute_REGFILE_WRITE_DATA;
   wire       [2:0]    _zz__zz_execute_SRC1;
   wire       [4:0]    _zz__zz_execute_SRC1_1;
-  wire       [11:0]   _zz__zz_execute_SRC2_3;
+  wire       [11:0]   _zz__zz_execute_SRC2_2;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_1;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_2;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_3;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_4;
-  wire       [31:0]   _zz_execute_SrcPlugin_addSub_5;
-  wire       [31:0]   _zz_execute_SrcPlugin_addSub_6;
   wire       [31:0]   _zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1;
   wire       [32:0]   _zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1_1;
   wire       [19:0]   _zz__zz_execute_BranchPlugin_branch_src2;
@@ -312,7 +311,7 @@ module VexRiscv (
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_execute_SRC2;
+  wire       [31:0]   _zz_execute_to_memory_PC;
   wire       [1:0]    execute_SRC2_CTRL;
   wire       [1:0]    _zz_execute_SRC2_CTRL;
   wire       [1:0]    execute_SRC1_CTRL;
@@ -435,8 +434,9 @@ module VexRiscv (
   wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
   wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
   wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
-  wire                CsrPlugin_csrMapping_allowCsrSignal;
+  reg                 CsrPlugin_csrMapping_allowCsrSignal;
   wire                CsrPlugin_csrMapping_hazardFree;
+  wire                CsrPlugin_csrMapping_doForceFailCsr;
   wire                CsrPlugin_inWfi /* verilator public */ ;
   reg                 CsrPlugin_thirdPartyWake;
   reg                 CsrPlugin_jumpInterface_valid;
@@ -455,9 +455,10 @@ module VexRiscv (
   reg                 CsrPlugin_allowInterrupts;
   reg                 CsrPlugin_allowException;
   reg                 CsrPlugin_allowEbreakException;
-  reg                 IBusSimplePlugin_injectionPort_valid;
-  reg                 IBusSimplePlugin_injectionPort_ready;
-  wire       [31:0]   IBusSimplePlugin_injectionPort_payload;
+  wire                CsrPlugin_xretAwayFromMachine;
+  reg                 DebugPlugin_injectionPort_valid;
+  reg                 DebugPlugin_injectionPort_ready;
+  wire       [31:0]   DebugPlugin_injectionPort_payload;
   wire                IBusSimplePlugin_externalFlush;
   wire                IBusSimplePlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusSimplePlugin_jump_pcLoad_payload;
@@ -473,12 +474,11 @@ module VexRiscv (
   reg                 IBusSimplePlugin_fetchPc_pcRegPropagate;
   reg                 IBusSimplePlugin_fetchPc_booted;
   reg                 IBusSimplePlugin_fetchPc_inc;
-  wire                when_Fetcher_l134;
-  wire                IBusSimplePlugin_fetchPc_output_fire_1;
-  wire                when_Fetcher_l134_1;
+  wire                when_Fetcher_l133;
+  wire                when_Fetcher_l133_1;
   reg        [31:0]   IBusSimplePlugin_fetchPc_pc;
   reg                 IBusSimplePlugin_fetchPc_flushed;
-  wire                when_Fetcher_l161;
+  wire                when_Fetcher_l160;
   wire                IBusSimplePlugin_iBusRsp_redoFetch;
   wire                IBusSimplePlugin_iBusRsp_stages_0_input_valid;
   wire                IBusSimplePlugin_iBusRsp_stages_0_input_ready;
@@ -498,8 +498,8 @@ module VexRiscv (
   wire                _zz_IBusSimplePlugin_iBusRsp_stages_1_input_ready;
   wire                IBusSimplePlugin_iBusRsp_flush;
   wire                _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready;
-  wire                _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_1;
-  reg                 _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_2;
+  wire                _zz_IBusSimplePlugin_iBusRsp_stages_1_input_valid;
+  reg                 _zz_IBusSimplePlugin_iBusRsp_stages_1_input_valid_1;
   reg                 IBusSimplePlugin_iBusRsp_readyForError;
   wire                IBusSimplePlugin_iBusRsp_output_valid;
   wire                IBusSimplePlugin_iBusRsp_output_ready;
@@ -518,17 +518,17 @@ module VexRiscv (
   reg                 _zz_IBusSimplePlugin_injector_decodeInput_payload_rsp_error;
   reg        [31:0]   _zz_IBusSimplePlugin_injector_decodeInput_payload_rsp_inst;
   reg                 _zz_IBusSimplePlugin_injector_decodeInput_payload_isRvc;
-  wire                when_Fetcher_l323;
+  wire                when_Fetcher_l322;
   reg                 IBusSimplePlugin_injector_nextPcCalc_valids_0;
-  wire                when_Fetcher_l332;
+  wire                when_Fetcher_l331;
   reg                 IBusSimplePlugin_injector_nextPcCalc_valids_1;
-  wire                when_Fetcher_l332_1;
+  wire                when_Fetcher_l331_1;
   reg                 IBusSimplePlugin_injector_nextPcCalc_valids_2;
-  wire                when_Fetcher_l332_2;
+  wire                when_Fetcher_l331_2;
   reg                 IBusSimplePlugin_injector_nextPcCalc_valids_3;
-  wire                when_Fetcher_l332_3;
+  wire                when_Fetcher_l331_3;
   reg                 IBusSimplePlugin_injector_nextPcCalc_valids_4;
-  wire                when_Fetcher_l332_4;
+  wire                when_Fetcher_l331_4;
   reg        [31:0]   IBusSimplePlugin_injector_formal_rawInDecode;
   wire                IBusSimplePlugin_cmd_valid;
   wire                IBusSimplePlugin_cmd_ready;
@@ -550,7 +550,7 @@ module VexRiscv (
   wire                iBus_rsp_toStream_payload_error;
   wire       [31:0]   iBus_rsp_toStream_payload_inst;
   wire                IBusSimplePlugin_rspJoin_rspBuffer_flush;
-  wire                IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_fire;
+  wire                toplevel_IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_fire;
   wire       [31:0]   IBusSimplePlugin_rspJoin_fetchRsp_pc;
   reg                 IBusSimplePlugin_rspJoin_fetchRsp_rsp_error;
   wire       [31:0]   IBusSimplePlugin_rspJoin_fetchRsp_rsp_inst;
@@ -564,7 +564,6 @@ module VexRiscv (
   wire                IBusSimplePlugin_rspJoin_join_payload_isRvc;
   wire                IBusSimplePlugin_rspJoin_exceptionDetected;
   wire                IBusSimplePlugin_rspJoin_join_fire;
-  wire                IBusSimplePlugin_rspJoin_join_fire_1;
   wire                _zz_IBusSimplePlugin_iBusRsp_output_valid;
   wire                dBus_cmd_valid;
   wire                dBus_cmd_ready;
@@ -578,33 +577,33 @@ module VexRiscv (
   wire                _zz_dBus_cmd_valid;
   reg                 execute_DBusSimplePlugin_skipCmd;
   reg        [31:0]   _zz_dBus_cmd_payload_data;
-  wire                when_DBusSimplePlugin_l428;
+  wire                when_DBusSimplePlugin_l436;
   reg        [3:0]    _zz_execute_DBusSimplePlugin_formalMask;
   wire       [3:0]    execute_DBusSimplePlugin_formalMask;
-  wire                when_DBusSimplePlugin_l482;
-  wire                when_DBusSimplePlugin_l489;
-  wire                when_DBusSimplePlugin_l515;
+  wire                when_DBusSimplePlugin_l490;
+  wire                when_DBusSimplePlugin_l497;
+  wire                when_DBusSimplePlugin_l523;
   reg        [31:0]   writeBack_DBusSimplePlugin_rspShifted;
-  wire       [1:0]    switch_Misc_l210;
+  wire       [1:0]    switch_Misc_l232;
   wire                _zz_writeBack_DBusSimplePlugin_rspFormated;
   reg        [31:0]   _zz_writeBack_DBusSimplePlugin_rspFormated_1;
   wire                _zz_writeBack_DBusSimplePlugin_rspFormated_2;
   reg        [31:0]   _zz_writeBack_DBusSimplePlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusSimplePlugin_rspFormated;
-  wire                when_DBusSimplePlugin_l558;
-  wire       [26:0]   _zz_decode_ENV_CTRL_2;
-  wire                _zz_decode_ENV_CTRL_3;
-  wire                _zz_decode_ENV_CTRL_4;
-  wire                _zz_decode_ENV_CTRL_5;
-  wire                _zz_decode_ENV_CTRL_6;
-  wire                _zz_decode_ENV_CTRL_7;
+  wire                when_DBusSimplePlugin_l566;
+  wire       [26:0]   _zz_decode_IS_CSR;
+  wire                _zz_decode_IS_CSR_1;
+  wire                _zz_decode_IS_CSR_2;
+  wire                _zz_decode_IS_CSR_3;
+  wire                _zz_decode_IS_CSR_4;
+  wire                _zz_decode_IS_CSR_5;
   wire       [1:0]    _zz_decode_SRC1_CTRL_2;
   wire       [1:0]    _zz_decode_ALU_CTRL_2;
   wire       [1:0]    _zz_decode_SRC2_CTRL_2;
   wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL_2;
   wire       [1:0]    _zz_decode_SHIFT_CTRL_2;
   wire       [1:0]    _zz_decode_BRANCH_CTRL_2;
-  wire       [1:0]    _zz_decode_ENV_CTRL_8;
+  wire       [1:0]    _zz_decode_ENV_CTRL_2;
   wire                when_RegFilePlugin_l63;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
@@ -613,15 +612,15 @@ module VexRiscv (
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
   reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
   reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_2;
+  reg                 _zz_5;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
   reg        [31:0]   _zz_execute_REGFILE_WRITE_DATA;
   reg        [31:0]   _zz_execute_SRC1;
-  wire                _zz_execute_SRC2_1;
-  reg        [19:0]   _zz_execute_SRC2_2;
-  wire                _zz_execute_SRC2_3;
-  reg        [19:0]   _zz_execute_SRC2_4;
-  reg        [31:0]   _zz_execute_SRC2_5;
+  wire                _zz_execute_SRC2;
+  reg        [19:0]   _zz_execute_SRC2_1;
+  wire                _zz_execute_SRC2_2;
+  reg        [19:0]   _zz_execute_SRC2_3;
+  reg        [31:0]   _zz_execute_SRC2_4;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   reg                 execute_LightShifterPlugin_isActive;
@@ -660,7 +659,7 @@ module VexRiscv (
   wire                when_HazardSimplePlugin_l108;
   wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    switch_Misc_l210_1;
+  wire       [2:0]    switch_Misc_l232_1;
   reg                 _zz_execute_BRANCH_DO;
   reg                 _zz_execute_BRANCH_DO_1;
   wire       [31:0]   execute_BranchPlugin_branch_src1;
@@ -692,9 +691,9 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_mtval;
   reg        [63:0]   CsrPlugin_mcycle;
   reg        [63:0]   CsrPlugin_minstret;
-  wire                _zz_when_CsrPlugin_l965;
-  wire                _zz_when_CsrPlugin_l965_1;
-  wire                _zz_when_CsrPlugin_l965_2;
+  wire                _zz_when_CsrPlugin_l1302;
+  wire                _zz_when_CsrPlugin_l1302_1;
+  wire                _zz_when_CsrPlugin_l1302_2;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -709,60 +708,63 @@ module VexRiscv (
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
   wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code;
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
-  wire                when_CsrPlugin_l922;
-  wire                when_CsrPlugin_l922_1;
-  wire                when_CsrPlugin_l922_2;
-  wire                when_CsrPlugin_l922_3;
-  wire                when_CsrPlugin_l935;
+  wire                when_CsrPlugin_l1259;
+  wire                when_CsrPlugin_l1259_1;
+  wire                when_CsrPlugin_l1259_2;
+  wire                when_CsrPlugin_l1259_3;
+  wire                when_CsrPlugin_l1272;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
-  wire                when_CsrPlugin_l959;
-  wire                when_CsrPlugin_l965;
-  wire                when_CsrPlugin_l965_1;
-  wire                when_CsrPlugin_l965_2;
+  wire                when_CsrPlugin_l1296;
+  wire                when_CsrPlugin_l1302;
+  wire                when_CsrPlugin_l1302_1;
+  wire                when_CsrPlugin_l1302_2;
   wire                CsrPlugin_exception;
   wire                CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
-  wire                when_CsrPlugin_l993;
-  wire                when_CsrPlugin_l993_1;
-  wire                when_CsrPlugin_l993_2;
-  wire                when_CsrPlugin_l998;
+  wire                when_CsrPlugin_l1335;
+  wire                when_CsrPlugin_l1335_1;
+  wire                when_CsrPlugin_l1335_2;
+  wire                when_CsrPlugin_l1340;
   reg                 CsrPlugin_pipelineLiberator_done;
-  wire                when_CsrPlugin_l1004;
+  wire                when_CsrPlugin_l1346;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
+  wire                CsrPlugin_trapCauseEbreakDebug;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
-  wire                when_CsrPlugin_l1032;
-  wire                when_CsrPlugin_l1077;
-  wire       [1:0]    switch_CsrPlugin_l1081;
+  wire                CsrPlugin_trapEnterDebug;
+  wire                when_CsrPlugin_l1390;
+  wire                when_CsrPlugin_l1398;
+  wire                when_CsrPlugin_l1456;
+  wire       [1:0]    switch_CsrPlugin_l1460;
   reg                 execute_CsrPlugin_wfiWake;
-  wire                when_CsrPlugin_l1129;
+  wire                when_CsrPlugin_l1527;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire                when_CsrPlugin_l1149;
-  wire                when_CsrPlugin_l1150;
-  wire                when_CsrPlugin_l1157;
+  wire                when_CsrPlugin_l1547;
+  wire                when_CsrPlugin_l1548;
+  wire                when_CsrPlugin_l1555;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   wire       [31:0]   execute_CsrPlugin_readToWriteData;
-  wire                switch_Misc_l210_2;
+  wire                switch_Misc_l232_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
-  wire                when_CsrPlugin_l1189;
-  wire                when_CsrPlugin_l1193;
+  wire                when_CsrPlugin_l1587;
+  wire                when_CsrPlugin_l1591;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg        [31:0]   externalInterruptArray_regNext;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit;
-  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
+  wire       [31:0]   _zz_externalInterrupt;
   reg                 DebugPlugin_firstCycle;
   reg                 DebugPlugin_secondCycle;
   reg                 DebugPlugin_resetIt;
@@ -770,7 +772,7 @@ module VexRiscv (
   reg                 DebugPlugin_stepIt;
   reg                 DebugPlugin_isPipBusy;
   reg                 DebugPlugin_godmode;
-  wire                when_DebugPlugin_l225;
+  wire                when_DebugPlugin_l238;
   reg                 DebugPlugin_haltedByBreak;
   reg                 DebugPlugin_debugUsed /* verilator public */ ;
   reg                 DebugPlugin_disableEbreak;
@@ -780,22 +782,22 @@ module VexRiscv (
   reg                 DebugPlugin_hardwareBreakpoints_1_valid;
   reg        [30:0]   DebugPlugin_hardwareBreakpoints_1_pc;
   reg        [31:0]   DebugPlugin_busReadDataReg;
-  reg                 _zz_when_DebugPlugin_l244;
-  wire                when_DebugPlugin_l244;
-  wire       [5:0]    switch_DebugPlugin_l267;
-  wire                when_DebugPlugin_l271;
-  wire                when_DebugPlugin_l271_1;
-  wire                when_DebugPlugin_l272;
-  wire                when_DebugPlugin_l272_1;
-  wire                when_DebugPlugin_l273;
-  wire                when_DebugPlugin_l274;
-  wire                when_DebugPlugin_l275;
-  wire                when_DebugPlugin_l275_1;
-  wire                when_DebugPlugin_l295;
-  wire                when_DebugPlugin_l298;
+  reg                 _zz_when_DebugPlugin_l257;
+  wire                when_DebugPlugin_l257;
+  wire       [5:0]    switch_DebugPlugin_l280;
+  wire                when_DebugPlugin_l284;
+  wire                when_DebugPlugin_l284_1;
+  wire                when_DebugPlugin_l285;
+  wire                when_DebugPlugin_l285_1;
+  wire                when_DebugPlugin_l286;
+  wire                when_DebugPlugin_l287;
+  wire                when_DebugPlugin_l288;
+  wire                when_DebugPlugin_l288_1;
+  wire                when_DebugPlugin_l308;
   wire                when_DebugPlugin_l311;
+  wire                when_DebugPlugin_l324;
   reg                 DebugPlugin_resetIt_regNext;
-  wire                when_DebugPlugin_l331;
+  wire                when_DebugPlugin_l344;
   wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
   wire                when_Pipeline_l124_1;
@@ -894,28 +896,29 @@ module VexRiscv (
   wire                when_Pipeline_l154_1;
   wire                when_Pipeline_l151_2;
   wire                when_Pipeline_l154_2;
-  reg        [2:0]    switch_Fetcher_l365;
-  wire                when_Fetcher_l381;
-  wire                when_Fetcher_l401;
-  wire                when_CsrPlugin_l1277;
+  reg        [2:0]    IBusSimplePlugin_injector_port_state;
+  wire                when_Fetcher_l391;
+  wire                when_Fetcher_l411;
+  wire                when_CsrPlugin_l1669;
   reg                 execute_CsrPlugin_csr_768;
-  wire                when_CsrPlugin_l1277_1;
+  wire                when_CsrPlugin_l1669_1;
   reg                 execute_CsrPlugin_csr_836;
-  wire                when_CsrPlugin_l1277_2;
+  wire                when_CsrPlugin_l1669_2;
   reg                 execute_CsrPlugin_csr_772;
-  wire                when_CsrPlugin_l1277_3;
+  wire                when_CsrPlugin_l1669_3;
   reg                 execute_CsrPlugin_csr_773;
-  wire                when_CsrPlugin_l1277_4;
+  wire                when_CsrPlugin_l1669_4;
   reg                 execute_CsrPlugin_csr_833;
-  wire                when_CsrPlugin_l1277_5;
+  wire                when_CsrPlugin_l1669_5;
   reg                 execute_CsrPlugin_csr_834;
-  wire                when_CsrPlugin_l1277_6;
+  wire                when_CsrPlugin_l1669_6;
   reg                 execute_CsrPlugin_csr_835;
-  wire                when_CsrPlugin_l1277_7;
+  wire                when_CsrPlugin_l1669_7;
   reg                 execute_CsrPlugin_csr_3008;
-  wire                when_CsrPlugin_l1277_8;
+  wire                when_CsrPlugin_l1669_8;
   reg                 execute_CsrPlugin_csr_4032;
-  wire       [1:0]    switch_CsrPlugin_l723;
+  wire       [1:0]    switch_CsrPlugin_l1031;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
@@ -923,15 +926,18 @@ module VexRiscv (
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_6;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_8;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
-  wire                when_CsrPlugin_l1310;
-  wire                when_CsrPlugin_l1315;
+  wire                when_CsrPlugin_l1702;
+  wire       [11:0]   _zz_when_CsrPlugin_l1709;
+  wire                when_CsrPlugin_l1709;
+  reg                 when_CsrPlugin_l1719;
+  wire                when_CsrPlugin_l1717;
+  wire                when_CsrPlugin_l1725;
   wire                iBus_cmd_m2sPipe_valid;
   wire                iBus_cmd_m2sPipe_ready;
   wire       [31:0]   iBus_cmd_m2sPipe_payload_pc;
   reg                 iBus_cmd_rValid;
   reg        [31:0]   iBus_cmd_rData_pc;
-  wire                when_Stream_l368;
+  wire                when_Stream_l369;
   wire                dBus_cmd_halfPipe_valid;
   wire                dBus_cmd_halfPipe_ready;
   wire                dBus_cmd_halfPipe_payload_wr;
@@ -945,7 +951,7 @@ module VexRiscv (
   reg        [31:0]   dBus_cmd_rData_data;
   reg        [1:0]    dBus_cmd_rData_size;
   reg        [3:0]    _zz_dBusWishbone_SEL;
-  wire                when_DBusSimplePlugin_l189;
+  wire                when_DBusSimplePlugin_l196;
   `ifndef SYNTHESIS
   reg [39:0] _zz_memory_to_writeBack_ENV_CTRL_string;
   reg [39:0] _zz_memory_to_writeBack_ENV_CTRL_1_string;
@@ -1010,7 +1016,7 @@ module VexRiscv (
   reg [39:0] _zz_decode_ALU_BITWISE_CTRL_2_string;
   reg [71:0] _zz_decode_SHIFT_CTRL_2_string;
   reg [31:0] _zz_decode_BRANCH_CTRL_2_string;
-  reg [39:0] _zz_decode_ENV_CTRL_8_string;
+  reg [39:0] _zz_decode_ENV_CTRL_2_string;
   reg [95:0] decode_to_execute_SRC1_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
   reg [23:0] decode_to_execute_SRC2_CTRL_string;
@@ -1025,8 +1031,8 @@ module VexRiscv (
   (* no_rw_check , ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
   assign _zz_when = ({BranchPlugin_branchExceptionPort_valid,DBusSimplePlugin_memoryExceptionPort_valid} != 2'b00);
-  assign _zz_decode_DO_EBREAK = (decode_PC >>> 1);
-  assign _zz_decode_DO_EBREAK_1 = (decode_PC >>> 1);
+  assign _zz_decode_DO_EBREAK = (decode_PC >>> 1'd1);
+  assign _zz_decode_DO_EBREAK_1 = (decode_PC >>> 1'd1);
   assign _zz_IBusSimplePlugin_jump_pcLoad_payload_1 = (_zz_IBusSimplePlugin_jump_pcLoad_payload & (~ _zz_IBusSimplePlugin_jump_pcLoad_payload_2));
   assign _zz_IBusSimplePlugin_jump_pcLoad_payload_2 = (_zz_IBusSimplePlugin_jump_pcLoad_payload - 2'b01);
   assign _zz_IBusSimplePlugin_fetchPc_pc_1 = {IBusSimplePlugin_fetchPc_inc,2'b00};
@@ -1044,15 +1050,13 @@ module VexRiscv (
   assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
   assign _zz__zz_execute_SRC1 = 3'b100;
   assign _zz__zz_execute_SRC1_1 = execute_INSTRUCTION[19 : 15];
-  assign _zz__zz_execute_SRC2_3 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz__zz_execute_SRC2_2 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
   assign _zz_execute_SrcPlugin_addSub = ($signed(_zz_execute_SrcPlugin_addSub_1) + $signed(_zz_execute_SrcPlugin_addSub_4));
   assign _zz_execute_SrcPlugin_addSub_1 = ($signed(_zz_execute_SrcPlugin_addSub_2) + $signed(_zz_execute_SrcPlugin_addSub_3));
   assign _zz_execute_SrcPlugin_addSub_2 = execute_SRC1;
   assign _zz_execute_SrcPlugin_addSub_3 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? _zz_execute_SrcPlugin_addSub_5 : _zz_execute_SrcPlugin_addSub_6);
-  assign _zz_execute_SrcPlugin_addSub_5 = 32'h00000001;
-  assign _zz_execute_SrcPlugin_addSub_6 = 32'h0;
-  assign _zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1 = (_zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1_1 >>> 1);
+  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? 32'h00000001 : 32'h00000000);
+  assign _zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1 = (_zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1_1 >>> 1'd1);
   assign _zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1_1 = {((execute_SHIFT_CTRL == ShiftCtrlEnum_SRA_1) && execute_LightShifterPlugin_shiftInput[31]),execute_LightShifterPlugin_shiftInput};
   assign _zz__zz_execute_BranchPlugin_branch_src2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
   assign _zz__zz_execute_BranchPlugin_branch_src2_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
@@ -1060,116 +1064,115 @@ module VexRiscv (
   assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code - 2'b01);
   assign _zz_decode_RegFilePlugin_rs1Data = 1'b1;
   assign _zz_decode_RegFilePlugin_rs2Data = 1'b1;
-  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000107f;
-  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00002073;
-  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000207f;
+  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000407f);
+  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00004063;
+  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000107f) == 32'h00000013);
   assign _zz_decode_LEGAL_INSTRUCTION_5 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_6) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_7 == _zz_decode_LEGAL_INSTRUCTION_8),{_zz_decode_LEGAL_INSTRUCTION_9,{_zz_decode_LEGAL_INSTRUCTION_10,_zz_decode_LEGAL_INSTRUCTION_11}}}}}};
   assign _zz_decode_LEGAL_INSTRUCTION_6 = 32'h0000505f;
   assign _zz_decode_LEGAL_INSTRUCTION_7 = (decode_INSTRUCTION & 32'h0000707b);
   assign _zz_decode_LEGAL_INSTRUCTION_8 = 32'h00000063;
   assign _zz_decode_LEGAL_INSTRUCTION_9 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
   assign _zz_decode_LEGAL_INSTRUCTION_10 = ((decode_INSTRUCTION & 32'hfe00007f) == 32'h00000033);
-  assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & 32'hfc00307f) == 32'h00001013),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h00005033),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,{_zz_decode_LEGAL_INSTRUCTION_16,_zz_decode_LEGAL_INSTRUCTION_17}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'hbe00705f) == 32'h00005013),{((decode_INSTRUCTION & 32'hfe00305f) == 32'h00001013),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h00000033),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,_zz_decode_LEGAL_INSTRUCTION_16}}}}};
   assign _zz_decode_LEGAL_INSTRUCTION_12 = 32'hbe00707f;
-  assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'hbe00707f);
-  assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h00000033;
-  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
-  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hffefffff) == 32'h00000073);
-  assign _zz_decode_LEGAL_INSTRUCTION_17 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073);
-  assign _zz__zz_decode_ENV_CTRL_2 = 32'h10103050;
-  assign _zz__zz_decode_ENV_CTRL_2_1 = (decode_INSTRUCTION & 32'h10403050);
-  assign _zz__zz_decode_ENV_CTRL_2_2 = 32'h10000050;
-  assign _zz__zz_decode_ENV_CTRL_2_3 = ((decode_INSTRUCTION & 32'h00001050) == 32'h00001050);
-  assign _zz__zz_decode_ENV_CTRL_2_4 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002050);
-  assign _zz__zz_decode_ENV_CTRL_2_5 = {_zz_decode_ENV_CTRL_7,((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_6) == 32'h00000004)};
-  assign _zz__zz_decode_ENV_CTRL_2_7 = (|((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_8) == 32'h00000040));
-  assign _zz__zz_decode_ENV_CTRL_2_9 = (|(_zz__zz_decode_ENV_CTRL_2_10 == _zz__zz_decode_ENV_CTRL_2_11));
-  assign _zz__zz_decode_ENV_CTRL_2_12 = {(|{_zz__zz_decode_ENV_CTRL_2_13,_zz__zz_decode_ENV_CTRL_2_15}),{(|_zz__zz_decode_ENV_CTRL_2_17),{_zz__zz_decode_ENV_CTRL_2_22,{_zz__zz_decode_ENV_CTRL_2_25,_zz__zz_decode_ENV_CTRL_2_27}}}};
-  assign _zz__zz_decode_ENV_CTRL_2_6 = 32'h0000001c;
-  assign _zz__zz_decode_ENV_CTRL_2_8 = 32'h00000058;
-  assign _zz__zz_decode_ENV_CTRL_2_10 = (decode_INSTRUCTION & 32'h00007054);
-  assign _zz__zz_decode_ENV_CTRL_2_11 = 32'h00005010;
-  assign _zz__zz_decode_ENV_CTRL_2_13 = ((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_14) == 32'h40001010);
-  assign _zz__zz_decode_ENV_CTRL_2_15 = ((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_16) == 32'h00001010);
-  assign _zz__zz_decode_ENV_CTRL_2_17 = {(_zz__zz_decode_ENV_CTRL_2_18 == _zz__zz_decode_ENV_CTRL_2_19),(_zz__zz_decode_ENV_CTRL_2_20 == _zz__zz_decode_ENV_CTRL_2_21)};
-  assign _zz__zz_decode_ENV_CTRL_2_22 = (|(_zz__zz_decode_ENV_CTRL_2_23 == _zz__zz_decode_ENV_CTRL_2_24));
-  assign _zz__zz_decode_ENV_CTRL_2_25 = (|_zz__zz_decode_ENV_CTRL_2_26);
-  assign _zz__zz_decode_ENV_CTRL_2_27 = {(|_zz__zz_decode_ENV_CTRL_2_28),{_zz__zz_decode_ENV_CTRL_2_33,{_zz__zz_decode_ENV_CTRL_2_36,_zz__zz_decode_ENV_CTRL_2_42}}};
-  assign _zz__zz_decode_ENV_CTRL_2_14 = 32'h40003054;
-  assign _zz__zz_decode_ENV_CTRL_2_16 = 32'h00007054;
-  assign _zz__zz_decode_ENV_CTRL_2_18 = (decode_INSTRUCTION & 32'h00000064);
-  assign _zz__zz_decode_ENV_CTRL_2_19 = 32'h00000024;
-  assign _zz__zz_decode_ENV_CTRL_2_20 = (decode_INSTRUCTION & 32'h00003054);
-  assign _zz__zz_decode_ENV_CTRL_2_21 = 32'h00001010;
-  assign _zz__zz_decode_ENV_CTRL_2_23 = (decode_INSTRUCTION & 32'h00001000);
-  assign _zz__zz_decode_ENV_CTRL_2_24 = 32'h00001000;
-  assign _zz__zz_decode_ENV_CTRL_2_26 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
-  assign _zz__zz_decode_ENV_CTRL_2_28 = {(_zz__zz_decode_ENV_CTRL_2_29 == _zz__zz_decode_ENV_CTRL_2_30),(_zz__zz_decode_ENV_CTRL_2_31 == _zz__zz_decode_ENV_CTRL_2_32)};
-  assign _zz__zz_decode_ENV_CTRL_2_33 = (|{_zz__zz_decode_ENV_CTRL_2_34,_zz__zz_decode_ENV_CTRL_2_35});
-  assign _zz__zz_decode_ENV_CTRL_2_36 = (|{_zz__zz_decode_ENV_CTRL_2_37,_zz__zz_decode_ENV_CTRL_2_39});
-  assign _zz__zz_decode_ENV_CTRL_2_42 = {(|_zz__zz_decode_ENV_CTRL_2_43),{_zz__zz_decode_ENV_CTRL_2_45,{_zz__zz_decode_ENV_CTRL_2_48,_zz__zz_decode_ENV_CTRL_2_49}}};
-  assign _zz__zz_decode_ENV_CTRL_2_29 = (decode_INSTRUCTION & 32'h00002010);
-  assign _zz__zz_decode_ENV_CTRL_2_30 = 32'h00002000;
-  assign _zz__zz_decode_ENV_CTRL_2_31 = (decode_INSTRUCTION & 32'h00005000);
-  assign _zz__zz_decode_ENV_CTRL_2_32 = 32'h00001000;
-  assign _zz__zz_decode_ENV_CTRL_2_34 = ((decode_INSTRUCTION & 32'h00000034) == 32'h00000020);
-  assign _zz__zz_decode_ENV_CTRL_2_35 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000020);
-  assign _zz__zz_decode_ENV_CTRL_2_37 = ((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_38) == 32'h00000040);
-  assign _zz__zz_decode_ENV_CTRL_2_39 = {_zz_decode_ENV_CTRL_4,(_zz__zz_decode_ENV_CTRL_2_40 == _zz__zz_decode_ENV_CTRL_2_41)};
-  assign _zz__zz_decode_ENV_CTRL_2_43 = ((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_44) == 32'h00000020);
-  assign _zz__zz_decode_ENV_CTRL_2_45 = (|(_zz__zz_decode_ENV_CTRL_2_46 == _zz__zz_decode_ENV_CTRL_2_47));
-  assign _zz__zz_decode_ENV_CTRL_2_48 = (|_zz_decode_ENV_CTRL_6);
-  assign _zz__zz_decode_ENV_CTRL_2_49 = {(|_zz__zz_decode_ENV_CTRL_2_50),{_zz__zz_decode_ENV_CTRL_2_60,{_zz__zz_decode_ENV_CTRL_2_63,_zz__zz_decode_ENV_CTRL_2_65}}};
-  assign _zz__zz_decode_ENV_CTRL_2_38 = 32'h00000050;
-  assign _zz__zz_decode_ENV_CTRL_2_40 = (decode_INSTRUCTION & 32'h00103040);
-  assign _zz__zz_decode_ENV_CTRL_2_41 = 32'h00000040;
-  assign _zz__zz_decode_ENV_CTRL_2_44 = 32'h00000020;
-  assign _zz__zz_decode_ENV_CTRL_2_46 = (decode_INSTRUCTION & 32'h00000010);
-  assign _zz__zz_decode_ENV_CTRL_2_47 = 32'h00000010;
-  assign _zz__zz_decode_ENV_CTRL_2_50 = {_zz_decode_ENV_CTRL_7,{(_zz__zz_decode_ENV_CTRL_2_51 == _zz__zz_decode_ENV_CTRL_2_52),{_zz__zz_decode_ENV_CTRL_2_53,{_zz__zz_decode_ENV_CTRL_2_54,_zz__zz_decode_ENV_CTRL_2_55}}}};
-  assign _zz__zz_decode_ENV_CTRL_2_60 = (|{_zz_decode_ENV_CTRL_5,(_zz__zz_decode_ENV_CTRL_2_61 == _zz__zz_decode_ENV_CTRL_2_62)});
-  assign _zz__zz_decode_ENV_CTRL_2_63 = (|{_zz_decode_ENV_CTRL_5,_zz__zz_decode_ENV_CTRL_2_64});
-  assign _zz__zz_decode_ENV_CTRL_2_65 = {(|{_zz__zz_decode_ENV_CTRL_2_66,_zz__zz_decode_ENV_CTRL_2_68}),{(|_zz__zz_decode_ENV_CTRL_2_70),{_zz__zz_decode_ENV_CTRL_2_72,{_zz__zz_decode_ENV_CTRL_2_80,_zz__zz_decode_ENV_CTRL_2_82}}}};
-  assign _zz__zz_decode_ENV_CTRL_2_51 = (decode_INSTRUCTION & 32'h00001010);
-  assign _zz__zz_decode_ENV_CTRL_2_52 = 32'h00001010;
-  assign _zz__zz_decode_ENV_CTRL_2_53 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002010);
-  assign _zz__zz_decode_ENV_CTRL_2_54 = _zz_decode_ENV_CTRL_6;
-  assign _zz__zz_decode_ENV_CTRL_2_55 = {(_zz__zz_decode_ENV_CTRL_2_56 == _zz__zz_decode_ENV_CTRL_2_57),(_zz__zz_decode_ENV_CTRL_2_58 == _zz__zz_decode_ENV_CTRL_2_59)};
-  assign _zz__zz_decode_ENV_CTRL_2_61 = (decode_INSTRUCTION & 32'h00000070);
-  assign _zz__zz_decode_ENV_CTRL_2_62 = 32'h00000020;
-  assign _zz__zz_decode_ENV_CTRL_2_64 = ((decode_INSTRUCTION & 32'h00000020) == 32'h0);
-  assign _zz__zz_decode_ENV_CTRL_2_66 = ((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_67) == 32'h00006010);
-  assign _zz__zz_decode_ENV_CTRL_2_68 = ((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_69) == 32'h00004010);
-  assign _zz__zz_decode_ENV_CTRL_2_70 = ((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_71) == 32'h00002010);
-  assign _zz__zz_decode_ENV_CTRL_2_72 = (|{_zz__zz_decode_ENV_CTRL_2_73,{_zz__zz_decode_ENV_CTRL_2_74,_zz__zz_decode_ENV_CTRL_2_75}});
-  assign _zz__zz_decode_ENV_CTRL_2_80 = (|_zz__zz_decode_ENV_CTRL_2_81);
-  assign _zz__zz_decode_ENV_CTRL_2_82 = {(|_zz__zz_decode_ENV_CTRL_2_83),{_zz__zz_decode_ENV_CTRL_2_88,_zz__zz_decode_ENV_CTRL_2_90}};
-  assign _zz__zz_decode_ENV_CTRL_2_56 = (decode_INSTRUCTION & 32'h0000000c);
-  assign _zz__zz_decode_ENV_CTRL_2_57 = 32'h00000004;
-  assign _zz__zz_decode_ENV_CTRL_2_58 = (decode_INSTRUCTION & 32'h00000028);
-  assign _zz__zz_decode_ENV_CTRL_2_59 = 32'h0;
-  assign _zz__zz_decode_ENV_CTRL_2_67 = 32'h00006014;
-  assign _zz__zz_decode_ENV_CTRL_2_69 = 32'h00005014;
-  assign _zz__zz_decode_ENV_CTRL_2_71 = 32'h00006014;
-  assign _zz__zz_decode_ENV_CTRL_2_73 = ((decode_INSTRUCTION & 32'h00000044) == 32'h0);
-  assign _zz__zz_decode_ENV_CTRL_2_74 = _zz_decode_ENV_CTRL_4;
-  assign _zz__zz_decode_ENV_CTRL_2_75 = {(_zz__zz_decode_ENV_CTRL_2_76 == _zz__zz_decode_ENV_CTRL_2_77),(_zz__zz_decode_ENV_CTRL_2_78 == _zz__zz_decode_ENV_CTRL_2_79)};
-  assign _zz__zz_decode_ENV_CTRL_2_81 = ((decode_INSTRUCTION & 32'h00000058) == 32'h0);
-  assign _zz__zz_decode_ENV_CTRL_2_83 = {(_zz__zz_decode_ENV_CTRL_2_84 == _zz__zz_decode_ENV_CTRL_2_85),{_zz__zz_decode_ENV_CTRL_2_86,_zz__zz_decode_ENV_CTRL_2_87}};
-  assign _zz__zz_decode_ENV_CTRL_2_88 = (|{_zz__zz_decode_ENV_CTRL_2_89,_zz_decode_ENV_CTRL_3});
-  assign _zz__zz_decode_ENV_CTRL_2_90 = (|{_zz__zz_decode_ENV_CTRL_2_91,_zz_decode_ENV_CTRL_3});
-  assign _zz__zz_decode_ENV_CTRL_2_76 = (decode_INSTRUCTION & 32'h00006004);
-  assign _zz__zz_decode_ENV_CTRL_2_77 = 32'h00002000;
-  assign _zz__zz_decode_ENV_CTRL_2_78 = (decode_INSTRUCTION & 32'h00005004);
-  assign _zz__zz_decode_ENV_CTRL_2_79 = 32'h00001000;
-  assign _zz__zz_decode_ENV_CTRL_2_84 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz__zz_decode_ENV_CTRL_2_85 = 32'h00000040;
-  assign _zz__zz_decode_ENV_CTRL_2_86 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00002010);
-  assign _zz__zz_decode_ENV_CTRL_2_87 = ((decode_INSTRUCTION & 32'h40004034) == 32'h40000030);
-  assign _zz__zz_decode_ENV_CTRL_2_89 = ((decode_INSTRUCTION & 32'h00000014) == 32'h00000004);
-  assign _zz__zz_decode_ENV_CTRL_2_91 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000004);
+  assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'hdfffffff);
+  assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h10200073;
+  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hffefffff) == 32'h00000073);
+  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073);
+  assign _zz__zz_decode_IS_CSR = 32'h10103050;
+  assign _zz__zz_decode_IS_CSR_1 = (decode_INSTRUCTION & 32'h10403050);
+  assign _zz__zz_decode_IS_CSR_2 = 32'h10000050;
+  assign _zz__zz_decode_IS_CSR_3 = ((decode_INSTRUCTION & 32'h00001050) == 32'h00001050);
+  assign _zz__zz_decode_IS_CSR_4 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002050);
+  assign _zz__zz_decode_IS_CSR_5 = {_zz_decode_IS_CSR_5,((decode_INSTRUCTION & _zz__zz_decode_IS_CSR_6) == 32'h00000004)};
+  assign _zz__zz_decode_IS_CSR_7 = (|((decode_INSTRUCTION & _zz__zz_decode_IS_CSR_8) == 32'h00000040));
+  assign _zz__zz_decode_IS_CSR_9 = (|(_zz__zz_decode_IS_CSR_10 == _zz__zz_decode_IS_CSR_11));
+  assign _zz__zz_decode_IS_CSR_12 = {(|{_zz__zz_decode_IS_CSR_13,_zz__zz_decode_IS_CSR_15}),{(|_zz__zz_decode_IS_CSR_17),{_zz__zz_decode_IS_CSR_22,{_zz__zz_decode_IS_CSR_25,_zz__zz_decode_IS_CSR_27}}}};
+  assign _zz__zz_decode_IS_CSR_6 = 32'h0000001c;
+  assign _zz__zz_decode_IS_CSR_8 = 32'h00000058;
+  assign _zz__zz_decode_IS_CSR_10 = (decode_INSTRUCTION & 32'h00007054);
+  assign _zz__zz_decode_IS_CSR_11 = 32'h00005010;
+  assign _zz__zz_decode_IS_CSR_13 = ((decode_INSTRUCTION & _zz__zz_decode_IS_CSR_14) == 32'h40001010);
+  assign _zz__zz_decode_IS_CSR_15 = ((decode_INSTRUCTION & _zz__zz_decode_IS_CSR_16) == 32'h00001010);
+  assign _zz__zz_decode_IS_CSR_17 = {(_zz__zz_decode_IS_CSR_18 == _zz__zz_decode_IS_CSR_19),(_zz__zz_decode_IS_CSR_20 == _zz__zz_decode_IS_CSR_21)};
+  assign _zz__zz_decode_IS_CSR_22 = (|(_zz__zz_decode_IS_CSR_23 == _zz__zz_decode_IS_CSR_24));
+  assign _zz__zz_decode_IS_CSR_25 = (|_zz__zz_decode_IS_CSR_26);
+  assign _zz__zz_decode_IS_CSR_27 = {(|_zz__zz_decode_IS_CSR_28),{_zz__zz_decode_IS_CSR_33,{_zz__zz_decode_IS_CSR_36,_zz__zz_decode_IS_CSR_42}}};
+  assign _zz__zz_decode_IS_CSR_14 = 32'h40003054;
+  assign _zz__zz_decode_IS_CSR_16 = 32'h00007054;
+  assign _zz__zz_decode_IS_CSR_18 = (decode_INSTRUCTION & 32'h00000064);
+  assign _zz__zz_decode_IS_CSR_19 = 32'h00000024;
+  assign _zz__zz_decode_IS_CSR_20 = (decode_INSTRUCTION & 32'h00003054);
+  assign _zz__zz_decode_IS_CSR_21 = 32'h00001010;
+  assign _zz__zz_decode_IS_CSR_23 = (decode_INSTRUCTION & 32'h00001000);
+  assign _zz__zz_decode_IS_CSR_24 = 32'h00001000;
+  assign _zz__zz_decode_IS_CSR_26 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
+  assign _zz__zz_decode_IS_CSR_28 = {(_zz__zz_decode_IS_CSR_29 == _zz__zz_decode_IS_CSR_30),(_zz__zz_decode_IS_CSR_31 == _zz__zz_decode_IS_CSR_32)};
+  assign _zz__zz_decode_IS_CSR_33 = (|{_zz__zz_decode_IS_CSR_34,_zz__zz_decode_IS_CSR_35});
+  assign _zz__zz_decode_IS_CSR_36 = (|{_zz__zz_decode_IS_CSR_37,_zz__zz_decode_IS_CSR_39});
+  assign _zz__zz_decode_IS_CSR_42 = {(|_zz__zz_decode_IS_CSR_43),{_zz__zz_decode_IS_CSR_45,{_zz__zz_decode_IS_CSR_48,_zz__zz_decode_IS_CSR_49}}};
+  assign _zz__zz_decode_IS_CSR_29 = (decode_INSTRUCTION & 32'h00002010);
+  assign _zz__zz_decode_IS_CSR_30 = 32'h00002000;
+  assign _zz__zz_decode_IS_CSR_31 = (decode_INSTRUCTION & 32'h00005000);
+  assign _zz__zz_decode_IS_CSR_32 = 32'h00001000;
+  assign _zz__zz_decode_IS_CSR_34 = ((decode_INSTRUCTION & 32'h00000034) == 32'h00000020);
+  assign _zz__zz_decode_IS_CSR_35 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000020);
+  assign _zz__zz_decode_IS_CSR_37 = ((decode_INSTRUCTION & _zz__zz_decode_IS_CSR_38) == 32'h00000040);
+  assign _zz__zz_decode_IS_CSR_39 = {_zz_decode_IS_CSR_2,(_zz__zz_decode_IS_CSR_40 == _zz__zz_decode_IS_CSR_41)};
+  assign _zz__zz_decode_IS_CSR_43 = ((decode_INSTRUCTION & _zz__zz_decode_IS_CSR_44) == 32'h00000020);
+  assign _zz__zz_decode_IS_CSR_45 = (|(_zz__zz_decode_IS_CSR_46 == _zz__zz_decode_IS_CSR_47));
+  assign _zz__zz_decode_IS_CSR_48 = (|_zz_decode_IS_CSR_4);
+  assign _zz__zz_decode_IS_CSR_49 = {(|_zz__zz_decode_IS_CSR_50),{_zz__zz_decode_IS_CSR_60,{_zz__zz_decode_IS_CSR_63,_zz__zz_decode_IS_CSR_65}}};
+  assign _zz__zz_decode_IS_CSR_38 = 32'h00000050;
+  assign _zz__zz_decode_IS_CSR_40 = (decode_INSTRUCTION & 32'h00103040);
+  assign _zz__zz_decode_IS_CSR_41 = 32'h00000040;
+  assign _zz__zz_decode_IS_CSR_44 = 32'h00000020;
+  assign _zz__zz_decode_IS_CSR_46 = (decode_INSTRUCTION & 32'h00000010);
+  assign _zz__zz_decode_IS_CSR_47 = 32'h00000010;
+  assign _zz__zz_decode_IS_CSR_50 = {_zz_decode_IS_CSR_5,{(_zz__zz_decode_IS_CSR_51 == _zz__zz_decode_IS_CSR_52),{_zz__zz_decode_IS_CSR_53,{_zz__zz_decode_IS_CSR_54,_zz__zz_decode_IS_CSR_55}}}};
+  assign _zz__zz_decode_IS_CSR_60 = (|{_zz_decode_IS_CSR_3,(_zz__zz_decode_IS_CSR_61 == _zz__zz_decode_IS_CSR_62)});
+  assign _zz__zz_decode_IS_CSR_63 = (|{_zz_decode_IS_CSR_3,_zz__zz_decode_IS_CSR_64});
+  assign _zz__zz_decode_IS_CSR_65 = {(|{_zz__zz_decode_IS_CSR_66,_zz__zz_decode_IS_CSR_68}),{(|_zz__zz_decode_IS_CSR_70),{_zz__zz_decode_IS_CSR_72,{_zz__zz_decode_IS_CSR_80,_zz__zz_decode_IS_CSR_82}}}};
+  assign _zz__zz_decode_IS_CSR_51 = (decode_INSTRUCTION & 32'h00001010);
+  assign _zz__zz_decode_IS_CSR_52 = 32'h00001010;
+  assign _zz__zz_decode_IS_CSR_53 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002010);
+  assign _zz__zz_decode_IS_CSR_54 = _zz_decode_IS_CSR_4;
+  assign _zz__zz_decode_IS_CSR_55 = {(_zz__zz_decode_IS_CSR_56 == _zz__zz_decode_IS_CSR_57),(_zz__zz_decode_IS_CSR_58 == _zz__zz_decode_IS_CSR_59)};
+  assign _zz__zz_decode_IS_CSR_61 = (decode_INSTRUCTION & 32'h00000070);
+  assign _zz__zz_decode_IS_CSR_62 = 32'h00000020;
+  assign _zz__zz_decode_IS_CSR_64 = ((decode_INSTRUCTION & 32'h00000020) == 32'h00000000);
+  assign _zz__zz_decode_IS_CSR_66 = ((decode_INSTRUCTION & _zz__zz_decode_IS_CSR_67) == 32'h00006000);
+  assign _zz__zz_decode_IS_CSR_68 = ((decode_INSTRUCTION & _zz__zz_decode_IS_CSR_69) == 32'h00004010);
+  assign _zz__zz_decode_IS_CSR_70 = ((decode_INSTRUCTION & _zz__zz_decode_IS_CSR_71) == 32'h00002010);
+  assign _zz__zz_decode_IS_CSR_72 = (|{_zz__zz_decode_IS_CSR_73,{_zz__zz_decode_IS_CSR_74,_zz__zz_decode_IS_CSR_75}});
+  assign _zz__zz_decode_IS_CSR_80 = (|_zz__zz_decode_IS_CSR_81);
+  assign _zz__zz_decode_IS_CSR_82 = {(|_zz__zz_decode_IS_CSR_83),{_zz__zz_decode_IS_CSR_88,_zz__zz_decode_IS_CSR_90}};
+  assign _zz__zz_decode_IS_CSR_56 = (decode_INSTRUCTION & 32'h0000000c);
+  assign _zz__zz_decode_IS_CSR_57 = 32'h00000004;
+  assign _zz__zz_decode_IS_CSR_58 = (decode_INSTRUCTION & 32'h00000028);
+  assign _zz__zz_decode_IS_CSR_59 = 32'h00000000;
+  assign _zz__zz_decode_IS_CSR_67 = 32'h00006004;
+  assign _zz__zz_decode_IS_CSR_69 = 32'h00005014;
+  assign _zz__zz_decode_IS_CSR_71 = 32'h00006014;
+  assign _zz__zz_decode_IS_CSR_73 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000000);
+  assign _zz__zz_decode_IS_CSR_74 = _zz_decode_IS_CSR_2;
+  assign _zz__zz_decode_IS_CSR_75 = {(_zz__zz_decode_IS_CSR_76 == _zz__zz_decode_IS_CSR_77),(_zz__zz_decode_IS_CSR_78 == _zz__zz_decode_IS_CSR_79)};
+  assign _zz__zz_decode_IS_CSR_81 = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000000);
+  assign _zz__zz_decode_IS_CSR_83 = {(_zz__zz_decode_IS_CSR_84 == _zz__zz_decode_IS_CSR_85),{_zz__zz_decode_IS_CSR_86,_zz__zz_decode_IS_CSR_87}};
+  assign _zz__zz_decode_IS_CSR_88 = (|{_zz__zz_decode_IS_CSR_89,_zz_decode_IS_CSR_1});
+  assign _zz__zz_decode_IS_CSR_90 = (|{_zz__zz_decode_IS_CSR_91,_zz_decode_IS_CSR_1});
+  assign _zz__zz_decode_IS_CSR_76 = (decode_INSTRUCTION & 32'h00006004);
+  assign _zz__zz_decode_IS_CSR_77 = 32'h00002000;
+  assign _zz__zz_decode_IS_CSR_78 = (decode_INSTRUCTION & 32'h00005004);
+  assign _zz__zz_decode_IS_CSR_79 = 32'h00001000;
+  assign _zz__zz_decode_IS_CSR_84 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz__zz_decode_IS_CSR_85 = 32'h00000040;
+  assign _zz__zz_decode_IS_CSR_86 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00002010);
+  assign _zz__zz_decode_IS_CSR_87 = ((decode_INSTRUCTION & 32'h40004034) == 32'h40000030);
+  assign _zz__zz_decode_IS_CSR_89 = ((decode_INSTRUCTION & 32'h00000014) == 32'h00000004);
+  assign _zz__zz_decode_IS_CSR_91 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000004);
   always @(posedge clk) begin
     if(_zz_decode_RegFilePlugin_rs1Data) begin
       _zz_RegFilePlugin_regFile_port0 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
@@ -1197,8 +1200,9 @@ module VexRiscv (
     .io_pop_ready          (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_ready             ), //i
     .io_pop_payload_error  (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_error     ), //o
     .io_pop_payload_inst   (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_inst[31:0]), //o
-    .io_flush              (1'b0                                                          ), //i
+    .io_flush              (IBusSimplePlugin_rspJoin_rspBuffer_c_io_flush                 ), //i
     .io_occupancy          (IBusSimplePlugin_rspJoin_rspBuffer_c_io_occupancy             ), //o
+    .io_availability       (IBusSimplePlugin_rspJoin_rspBuffer_c_io_availability          ), //o
     .clk                   (clk                                                           ), //i
     .reset                 (reset                                                         )  //i
   );
@@ -1740,11 +1744,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_decode_ENV_CTRL_8)
-      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_8_string = "NONE ";
-      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_8_string = "XRET ";
-      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_8_string = "ECALL";
-      default : _zz_decode_ENV_CTRL_8_string = "?????";
+    case(_zz_decode_ENV_CTRL_2)
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1834,7 +1838,7 @@ module VexRiscv (
   assign execute_MEMORY_ADDRESS_LOW = dBus_cmd_payload_address[1 : 0];
   assign decode_DO_EBREAK = (((! DebugPlugin_haltIt) && (decode_IS_EBREAK || ((1'b0 || (DebugPlugin_hardwareBreakpoints_0_valid && (DebugPlugin_hardwareBreakpoints_0_pc == _zz_decode_DO_EBREAK))) || (DebugPlugin_hardwareBreakpoints_1_valid && (DebugPlugin_hardwareBreakpoints_1_pc == _zz_decode_DO_EBREAK_1))))) && DebugPlugin_allowEBreak);
   assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
-  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
+  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h00)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h00))));
   assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
   assign decode_RS2 = decode_RegFilePlugin_rs2Data;
   assign decode_RS1 = decode_RegFilePlugin_rs1Data;
@@ -1842,23 +1846,23 @@ module VexRiscv (
   assign _zz_execute_to_memory_ENV_CTRL = _zz_execute_to_memory_ENV_CTRL_1;
   assign decode_ENV_CTRL = _zz_decode_ENV_CTRL;
   assign _zz_decode_to_execute_ENV_CTRL = _zz_decode_to_execute_ENV_CTRL_1;
-  assign decode_IS_CSR = _zz_decode_ENV_CTRL_2[23];
+  assign decode_IS_CSR = _zz_decode_IS_CSR[23];
   assign decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL;
   assign _zz_decode_to_execute_BRANCH_CTRL = _zz_decode_to_execute_BRANCH_CTRL_1;
   assign decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL;
   assign _zz_decode_to_execute_SHIFT_CTRL = _zz_decode_to_execute_SHIFT_CTRL_1;
   assign decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL;
   assign _zz_decode_to_execute_ALU_BITWISE_CTRL = _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
-  assign decode_SRC_LESS_UNSIGNED = _zz_decode_ENV_CTRL_2[15];
-  assign decode_MEMORY_STORE = _zz_decode_ENV_CTRL_2[12];
+  assign decode_SRC_LESS_UNSIGNED = _zz_decode_IS_CSR[15];
+  assign decode_MEMORY_STORE = _zz_decode_IS_CSR[12];
   assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_decode_ENV_CTRL_2[11];
-  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_decode_ENV_CTRL_2[10];
+  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_decode_IS_CSR[11];
+  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_decode_IS_CSR[10];
   assign decode_SRC2_CTRL = _zz_decode_SRC2_CTRL;
   assign _zz_decode_to_execute_SRC2_CTRL = _zz_decode_to_execute_SRC2_CTRL_1;
   assign decode_ALU_CTRL = _zz_decode_ALU_CTRL;
   assign _zz_decode_to_execute_ALU_CTRL = _zz_decode_to_execute_ALU_CTRL_1;
-  assign decode_MEMORY_ENABLE = _zz_decode_ENV_CTRL_2[3];
+  assign decode_MEMORY_ENABLE = _zz_decode_IS_CSR[3];
   assign decode_SRC1_CTRL = _zz_decode_SRC1_CTRL;
   assign _zz_decode_to_execute_SRC1_CTRL = _zz_decode_to_execute_SRC1_CTRL_1;
   assign writeBack_FORMAL_PC_NEXT = memory_to_writeBack_FORMAL_PC_NEXT;
@@ -1867,7 +1871,7 @@ module VexRiscv (
   assign decode_FORMAL_PC_NEXT = (decode_PC + 32'h00000004);
   assign memory_PC = execute_to_memory_PC;
   assign execute_DO_EBREAK = decode_to_execute_DO_EBREAK;
-  assign decode_IS_EBREAK = _zz_decode_ENV_CTRL_2[26];
+  assign decode_IS_EBREAK = _zz_decode_IS_CSR[26];
   assign execute_CSR_READ_OPCODE = decode_to_execute_CSR_READ_OPCODE;
   assign execute_CSR_WRITE_OPCODE = decode_to_execute_CSR_WRITE_OPCODE;
   assign execute_IS_CSR = decode_to_execute_IS_CSR;
@@ -1879,8 +1883,8 @@ module VexRiscv (
   assign execute_PC = decode_to_execute_PC;
   assign execute_RS1 = decode_to_execute_RS1;
   assign execute_BRANCH_CTRL = _zz_execute_BRANCH_CTRL;
-  assign decode_RS2_USE = _zz_decode_ENV_CTRL_2[14];
-  assign decode_RS1_USE = _zz_decode_ENV_CTRL_2[4];
+  assign decode_RS2_USE = _zz_decode_IS_CSR[14];
+  assign decode_RS1_USE = _zz_decode_IS_CSR[4];
   assign execute_REGFILE_WRITE_VALID = decode_to_execute_REGFILE_WRITE_VALID;
   assign execute_BYPASSABLE_EXECUTE_STAGE = decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
   assign memory_REGFILE_WRITE_VALID = execute_to_memory_REGFILE_WRITE_VALID;
@@ -1892,7 +1896,7 @@ module VexRiscv (
     if(when_ShiftPlugins_l169) begin
       _zz_execute_to_memory_REGFILE_WRITE_DATA = _zz_execute_to_memory_REGFILE_WRITE_DATA_1;
     end
-    if(when_CsrPlugin_l1189) begin
+    if(when_CsrPlugin_l1587) begin
       _zz_execute_to_memory_REGFILE_WRITE_DATA = CsrPlugin_csrMapping_readDataSignal;
     end
   end
@@ -1901,15 +1905,15 @@ module VexRiscv (
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_execute_SRC2 = execute_PC;
+  assign _zz_execute_to_memory_PC = execute_PC;
   assign execute_SRC2_CTRL = _zz_execute_SRC2_CTRL;
   assign execute_SRC1_CTRL = _zz_execute_SRC1_CTRL;
-  assign decode_SRC_USE_SUB_LESS = _zz_decode_ENV_CTRL_2[2];
-  assign decode_SRC_ADD_ZERO = _zz_decode_ENV_CTRL_2[18];
+  assign decode_SRC_USE_SUB_LESS = _zz_decode_IS_CSR[2];
+  assign decode_SRC_ADD_ZERO = _zz_decode_IS_CSR[18];
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
   assign execute_ALU_CTRL = _zz_execute_ALU_CTRL;
-  assign execute_SRC2 = _zz_execute_SRC2_5;
+  assign execute_SRC2 = _zz_execute_SRC2_4;
   assign execute_SRC1 = _zz_execute_SRC1;
   assign execute_ALU_BITWISE_CTRL = _zz_execute_ALU_BITWISE_CTRL;
   assign _zz_lastStageRegFileWrite_payload_address = writeBack_INSTRUCTION;
@@ -1923,16 +1927,16 @@ module VexRiscv (
 
   assign decode_INSTRUCTION_ANTICIPATED = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusSimplePlugin_iBusRsp_output_payload_rsp_inst);
   always @(*) begin
-    decode_REGFILE_WRITE_VALID = _zz_decode_ENV_CTRL_2[9];
+    decode_REGFILE_WRITE_VALID = _zz_decode_IS_CSR[9];
     if(when_RegFilePlugin_l63) begin
       decode_REGFILE_WRITE_VALID = 1'b0;
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00001073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
+  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000107f) == 32'h00001073),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00002073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
   always @(*) begin
     _zz_lastStageRegFileWrite_payload_data = writeBack_REGFILE_WRITE_DATA;
-    if(when_DBusSimplePlugin_l558) begin
+    if(when_DBusSimplePlugin_l566) begin
       _zz_lastStageRegFileWrite_payload_data = writeBack_DBusSimplePlugin_rspFormated;
     end
   end
@@ -1963,7 +1967,7 @@ module VexRiscv (
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
   always @(*) begin
     decode_arbitration_haltItself = 1'b0;
-    case(switch_Fetcher_l365)
+    case(IBusSimplePlugin_injector_port_state)
       3'b010 : begin
         decode_arbitration_haltItself = 1'b1;
       end
@@ -1980,7 +1984,7 @@ module VexRiscv (
     if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(when_CsrPlugin_l1129) begin
+    if(when_CsrPlugin_l1527) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
@@ -2005,7 +2009,7 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(when_DBusSimplePlugin_l428) begin
+    if(when_DBusSimplePlugin_l436) begin
       execute_arbitration_haltItself = 1'b1;
     end
     if(when_ShiftPlugins_l169) begin
@@ -2013,7 +2017,7 @@ module VexRiscv (
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(when_CsrPlugin_l1193) begin
+    if(when_CsrPlugin_l1591) begin
       if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
@@ -2022,7 +2026,7 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if(when_DebugPlugin_l295) begin
+    if(when_DebugPlugin_l308) begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
@@ -2039,8 +2043,8 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_flushIt = 1'b0;
-    if(when_DebugPlugin_l295) begin
-      if(when_DebugPlugin_l298) begin
+    if(when_DebugPlugin_l308) begin
+      if(when_DebugPlugin_l311) begin
         execute_arbitration_flushIt = 1'b1;
       end
     end
@@ -2051,8 +2055,8 @@ module VexRiscv (
     if(CsrPlugin_selfException_valid) begin
       execute_arbitration_flushNext = 1'b1;
     end
-    if(when_DebugPlugin_l295) begin
-      if(when_DebugPlugin_l298) begin
+    if(when_DebugPlugin_l308) begin
+      if(when_DebugPlugin_l311) begin
         execute_arbitration_flushNext = 1'b1;
       end
     end
@@ -2060,7 +2064,7 @@ module VexRiscv (
 
   always @(*) begin
     memory_arbitration_haltItself = 1'b0;
-    if(when_DBusSimplePlugin_l482) begin
+    if(when_DBusSimplePlugin_l490) begin
       memory_arbitration_haltItself = 1'b1;
     end
   end
@@ -2099,10 +2103,10 @@ module VexRiscv (
   assign writeBack_arbitration_flushIt = 1'b0;
   always @(*) begin
     writeBack_arbitration_flushNext = 1'b0;
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -2113,24 +2117,24 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @(*) begin
     IBusSimplePlugin_fetcherHalt = 1'b0;
-    if(when_CsrPlugin_l935) begin
+    if(when_CsrPlugin_l1272) begin
       IBusSimplePlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       IBusSimplePlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       IBusSimplePlugin_fetcherHalt = 1'b1;
     end
-    if(when_DebugPlugin_l295) begin
-      if(when_DebugPlugin_l298) begin
+    if(when_DebugPlugin_l308) begin
+      if(when_DebugPlugin_l311) begin
         IBusSimplePlugin_fetcherHalt = 1'b1;
       end
     end
     if(DebugPlugin_haltIt) begin
       IBusSimplePlugin_fetcherHalt = 1'b1;
     end
-    if(when_DebugPlugin_l311) begin
+    if(when_DebugPlugin_l324) begin
       IBusSimplePlugin_fetcherHalt = 1'b1;
     end
   end
@@ -2153,7 +2157,17 @@ module VexRiscv (
     end
   end
 
-  assign CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+  always @(*) begin
+    CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+    if(when_CsrPlugin_l1702) begin
+      CsrPlugin_csrMapping_allowCsrSignal = 1'b1;
+    end
+    if(when_CsrPlugin_l1709) begin
+      CsrPlugin_csrMapping_allowCsrSignal = 1'b1;
+    end
+  end
+
+  assign CsrPlugin_csrMapping_doForceFailCsr = 1'b0;
   assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
   assign CsrPlugin_inWfi = 1'b0;
   always @(*) begin
@@ -2165,21 +2179,21 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(when_CsrPlugin_l1077) begin
-      case(switch_CsrPlugin_l1081)
+    if(when_CsrPlugin_l1456) begin
+      case(switch_CsrPlugin_l1460)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -2198,7 +2212,7 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_allowInterrupts = 1'b1;
-    if(when_DebugPlugin_l331) begin
+    if(when_DebugPlugin_l344) begin
       CsrPlugin_allowInterrupts = 1'b0;
     end
   end
@@ -2217,6 +2231,7 @@ module VexRiscv (
     end
   end
 
+  assign CsrPlugin_xretAwayFromMachine = 1'b0;
   assign IBusSimplePlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
   assign IBusSimplePlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,BranchPlugin_jumpInterface_valid} != 2'b00);
   assign _zz_IBusSimplePlugin_jump_pcLoad_payload = {BranchPlugin_jumpInterface_valid,CsrPlugin_jumpInterface_valid};
@@ -2237,9 +2252,8 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l134 = (IBusSimplePlugin_fetchPc_correction || IBusSimplePlugin_fetchPc_pcRegPropagate);
-  assign IBusSimplePlugin_fetchPc_output_fire_1 = (IBusSimplePlugin_fetchPc_output_valid && IBusSimplePlugin_fetchPc_output_ready);
-  assign when_Fetcher_l134_1 = ((! IBusSimplePlugin_fetchPc_output_valid) && IBusSimplePlugin_fetchPc_output_ready);
+  assign when_Fetcher_l133 = (IBusSimplePlugin_fetchPc_correction || IBusSimplePlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l133_1 = ((! IBusSimplePlugin_fetchPc_output_valid) && IBusSimplePlugin_fetchPc_output_ready);
   always @(*) begin
     IBusSimplePlugin_fetchPc_pc = (IBusSimplePlugin_fetchPc_pcReg + _zz_IBusSimplePlugin_fetchPc_pc);
     if(IBusSimplePlugin_jump_pcLoad_valid) begin
@@ -2256,7 +2270,7 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l161 = (IBusSimplePlugin_fetchPc_booted && ((IBusSimplePlugin_fetchPc_output_ready || IBusSimplePlugin_fetchPc_correction) || IBusSimplePlugin_fetchPc_pcRegPropagate));
+  assign when_Fetcher_l160 = (IBusSimplePlugin_fetchPc_booted && ((IBusSimplePlugin_fetchPc_output_ready || IBusSimplePlugin_fetchPc_correction) || IBusSimplePlugin_fetchPc_pcRegPropagate));
   assign IBusSimplePlugin_fetchPc_output_valid = ((! IBusSimplePlugin_fetcherHalt) && IBusSimplePlugin_fetchPc_booted);
   assign IBusSimplePlugin_fetchPc_output_payload = IBusSimplePlugin_fetchPc_pc;
   assign IBusSimplePlugin_iBusRsp_redoFetch = 1'b0;
@@ -2281,16 +2295,16 @@ module VexRiscv (
   assign IBusSimplePlugin_iBusRsp_stages_1_output_payload = IBusSimplePlugin_iBusRsp_stages_1_input_payload;
   assign IBusSimplePlugin_iBusRsp_flush = (IBusSimplePlugin_externalFlush || IBusSimplePlugin_iBusRsp_redoFetch);
   assign IBusSimplePlugin_iBusRsp_stages_0_output_ready = _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready;
-  assign _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_1)) || IBusSimplePlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_1 = _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_2;
-  assign IBusSimplePlugin_iBusRsp_stages_1_input_valid = _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_1;
+  assign _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusSimplePlugin_iBusRsp_stages_1_input_valid)) || IBusSimplePlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_IBusSimplePlugin_iBusRsp_stages_1_input_valid = _zz_IBusSimplePlugin_iBusRsp_stages_1_input_valid_1;
+  assign IBusSimplePlugin_iBusRsp_stages_1_input_valid = _zz_IBusSimplePlugin_iBusRsp_stages_1_input_valid;
   assign IBusSimplePlugin_iBusRsp_stages_1_input_payload = IBusSimplePlugin_fetchPc_pcReg;
   always @(*) begin
     IBusSimplePlugin_iBusRsp_readyForError = 1'b1;
     if(IBusSimplePlugin_injector_decodeInput_valid) begin
       IBusSimplePlugin_iBusRsp_readyForError = 1'b0;
     end
-    if(when_Fetcher_l323) begin
+    if(when_Fetcher_l322) begin
       IBusSimplePlugin_iBusRsp_readyForError = 1'b0;
     end
   end
@@ -2301,12 +2315,12 @@ module VexRiscv (
   assign IBusSimplePlugin_injector_decodeInput_payload_rsp_error = _zz_IBusSimplePlugin_injector_decodeInput_payload_rsp_error;
   assign IBusSimplePlugin_injector_decodeInput_payload_rsp_inst = _zz_IBusSimplePlugin_injector_decodeInput_payload_rsp_inst;
   assign IBusSimplePlugin_injector_decodeInput_payload_isRvc = _zz_IBusSimplePlugin_injector_decodeInput_payload_isRvc;
-  assign when_Fetcher_l323 = (! IBusSimplePlugin_pcValids_0);
-  assign when_Fetcher_l332 = (! (! IBusSimplePlugin_iBusRsp_stages_1_input_ready));
-  assign when_Fetcher_l332_1 = (! (! IBusSimplePlugin_injector_decodeInput_ready));
-  assign when_Fetcher_l332_2 = (! execute_arbitration_isStuck);
-  assign when_Fetcher_l332_3 = (! memory_arbitration_isStuck);
-  assign when_Fetcher_l332_4 = (! writeBack_arbitration_isStuck);
+  assign when_Fetcher_l322 = (! IBusSimplePlugin_pcValids_0);
+  assign when_Fetcher_l331 = (! (! IBusSimplePlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l331_1 = (! (! IBusSimplePlugin_injector_decodeInput_ready));
+  assign when_Fetcher_l331_2 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l331_3 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l331_4 = (! writeBack_arbitration_isStuck);
   assign IBusSimplePlugin_pcValids_0 = IBusSimplePlugin_injector_nextPcCalc_valids_1;
   assign IBusSimplePlugin_pcValids_1 = IBusSimplePlugin_injector_nextPcCalc_valids_2;
   assign IBusSimplePlugin_pcValids_2 = IBusSimplePlugin_injector_nextPcCalc_valids_3;
@@ -2314,7 +2328,7 @@ module VexRiscv (
   assign IBusSimplePlugin_injector_decodeInput_ready = (! decode_arbitration_isStuck);
   always @(*) begin
     decode_arbitration_isValid = IBusSimplePlugin_injector_decodeInput_valid;
-    case(switch_Fetcher_l365)
+    case(IBusSimplePlugin_injector_port_state)
       3'b010 : begin
         decode_arbitration_isValid = 1'b1;
       end
@@ -2348,8 +2362,8 @@ module VexRiscv (
   assign IBusSimplePlugin_rspJoin_rspBuffer_output_payload_error = IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_error;
   assign IBusSimplePlugin_rspJoin_rspBuffer_output_payload_inst = IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_inst;
   assign IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_ready = (IBusSimplePlugin_rspJoin_rspBuffer_output_ready || IBusSimplePlugin_rspJoin_rspBuffer_flush);
-  assign IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_fire = (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid && IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_ready);
-  assign IBusSimplePlugin_pending_dec = IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_fire;
+  assign toplevel_IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_fire = (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid && IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_ready);
+  assign IBusSimplePlugin_pending_dec = toplevel_IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_fire;
   assign IBusSimplePlugin_rspJoin_fetchRsp_pc = IBusSimplePlugin_iBusRsp_stages_1_output_payload;
   always @(*) begin
     IBusSimplePlugin_rspJoin_fetchRsp_rsp_error = IBusSimplePlugin_rspJoin_rspBuffer_output_payload_error;
@@ -2368,8 +2382,7 @@ module VexRiscv (
   assign IBusSimplePlugin_rspJoin_join_payload_isRvc = IBusSimplePlugin_rspJoin_fetchRsp_isRvc;
   assign IBusSimplePlugin_rspJoin_join_fire = (IBusSimplePlugin_rspJoin_join_valid && IBusSimplePlugin_rspJoin_join_ready);
   assign IBusSimplePlugin_iBusRsp_stages_1_output_ready = (IBusSimplePlugin_iBusRsp_stages_1_output_valid ? IBusSimplePlugin_rspJoin_join_fire : IBusSimplePlugin_rspJoin_join_ready);
-  assign IBusSimplePlugin_rspJoin_join_fire_1 = (IBusSimplePlugin_rspJoin_join_valid && IBusSimplePlugin_rspJoin_join_ready);
-  assign IBusSimplePlugin_rspJoin_rspBuffer_output_ready = IBusSimplePlugin_rspJoin_join_fire_1;
+  assign IBusSimplePlugin_rspJoin_rspBuffer_output_ready = IBusSimplePlugin_rspJoin_join_fire;
   assign _zz_IBusSimplePlugin_iBusRsp_output_valid = (! IBusSimplePlugin_rspJoin_exceptionDetected);
   assign IBusSimplePlugin_rspJoin_join_ready = (IBusSimplePlugin_iBusRsp_output_ready && _zz_IBusSimplePlugin_iBusRsp_output_valid);
   assign IBusSimplePlugin_iBusRsp_output_valid = (IBusSimplePlugin_rspJoin_join_valid && _zz_IBusSimplePlugin_iBusRsp_output_valid);
@@ -2403,7 +2416,7 @@ module VexRiscv (
   end
 
   assign dBus_cmd_payload_data = _zz_dBus_cmd_payload_data;
-  assign when_DBusSimplePlugin_l428 = ((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! dBus_cmd_ready)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_dBus_cmd_valid));
+  assign when_DBusSimplePlugin_l436 = ((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! dBus_cmd_ready)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_dBus_cmd_valid));
   always @(*) begin
     case(dBus_cmd_payload_size)
       2'b00 : begin
@@ -2420,23 +2433,23 @@ module VexRiscv (
 
   assign execute_DBusSimplePlugin_formalMask = (_zz_execute_DBusSimplePlugin_formalMask <<< dBus_cmd_payload_address[1 : 0]);
   assign dBus_cmd_payload_address = execute_SRC_ADD;
-  assign when_DBusSimplePlugin_l482 = (((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (! memory_MEMORY_STORE)) && ((! dBus_rsp_ready) || 1'b0));
+  assign when_DBusSimplePlugin_l490 = (((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (! memory_MEMORY_STORE)) && ((! dBus_rsp_ready) || 1'b0));
   always @(*) begin
     DBusSimplePlugin_memoryExceptionPort_valid = 1'b0;
-    if(when_DBusSimplePlugin_l489) begin
+    if(when_DBusSimplePlugin_l497) begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b1;
     end
     if(memory_ALIGNEMENT_FAULT) begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b1;
     end
-    if(when_DBusSimplePlugin_l515) begin
+    if(when_DBusSimplePlugin_l523) begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b0;
     end
   end
 
   always @(*) begin
     DBusSimplePlugin_memoryExceptionPort_payload_code = 4'bxxxx;
-    if(when_DBusSimplePlugin_l489) begin
+    if(when_DBusSimplePlugin_l497) begin
       DBusSimplePlugin_memoryExceptionPort_payload_code = 4'b0101;
     end
     if(memory_ALIGNEMENT_FAULT) begin
@@ -2445,8 +2458,8 @@ module VexRiscv (
   end
 
   assign DBusSimplePlugin_memoryExceptionPort_payload_badAddr = memory_REGFILE_WRITE_DATA;
-  assign when_DBusSimplePlugin_l489 = ((dBus_rsp_ready && dBus_rsp_error) && (! memory_MEMORY_STORE));
-  assign when_DBusSimplePlugin_l515 = (! ((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (1'b1 || (! memory_arbitration_isStuckByOthers))));
+  assign when_DBusSimplePlugin_l497 = ((dBus_rsp_ready && dBus_rsp_error) && (! memory_MEMORY_STORE));
+  assign when_DBusSimplePlugin_l523 = (! ((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (1'b1 || (! memory_arbitration_isStuckByOthers))));
   always @(*) begin
     writeBack_DBusSimplePlugin_rspShifted = writeBack_MEMORY_READ_DATA;
     case(writeBack_MEMORY_ADDRESS_LOW)
@@ -2464,7 +2477,7 @@ module VexRiscv (
     endcase
   end
 
-  assign switch_Misc_l210 = writeBack_INSTRUCTION[13 : 12];
+  assign switch_Misc_l232 = writeBack_INSTRUCTION[13 : 12];
   assign _zz_writeBack_DBusSimplePlugin_rspFormated = (writeBack_DBusSimplePlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
   always @(*) begin
     _zz_writeBack_DBusSimplePlugin_rspFormated_1[31] = _zz_writeBack_DBusSimplePlugin_rspFormated;
@@ -2516,7 +2529,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    case(switch_Misc_l210)
+    case(switch_Misc_l232)
       2'b00 : begin
         writeBack_DBusSimplePlugin_rspFormated = _zz_writeBack_DBusSimplePlugin_rspFormated_1;
       end
@@ -2529,53 +2542,53 @@ module VexRiscv (
     endcase
   end
 
-  assign when_DBusSimplePlugin_l558 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_decode_ENV_CTRL_3 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_decode_ENV_CTRL_4 = ((decode_INSTRUCTION & 32'h00000018) == 32'h0);
-  assign _zz_decode_ENV_CTRL_5 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_decode_ENV_CTRL_6 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000010);
-  assign _zz_decode_ENV_CTRL_7 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_decode_ENV_CTRL_2 = {(|((decode_INSTRUCTION & 32'h10103050) == 32'h00100050)),{(|((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2) == 32'h00000050)),{(|(_zz__zz_decode_ENV_CTRL_2_1 == _zz__zz_decode_ENV_CTRL_2_2)),{(|{_zz__zz_decode_ENV_CTRL_2_3,_zz__zz_decode_ENV_CTRL_2_4}),{(|_zz__zz_decode_ENV_CTRL_2_5),{_zz__zz_decode_ENV_CTRL_2_7,{_zz__zz_decode_ENV_CTRL_2_9,_zz__zz_decode_ENV_CTRL_2_12}}}}}}};
-  assign _zz_decode_SRC1_CTRL_2 = _zz_decode_ENV_CTRL_2[1 : 0];
+  assign when_DBusSimplePlugin_l566 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign _zz_decode_IS_CSR_1 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
+  assign _zz_decode_IS_CSR_2 = ((decode_INSTRUCTION & 32'h00000018) == 32'h00000000);
+  assign _zz_decode_IS_CSR_3 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_decode_IS_CSR_4 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000010);
+  assign _zz_decode_IS_CSR_5 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_decode_IS_CSR = {(|((decode_INSTRUCTION & 32'h10103050) == 32'h00100050)),{(|((decode_INSTRUCTION & _zz__zz_decode_IS_CSR) == 32'h00000050)),{(|(_zz__zz_decode_IS_CSR_1 == _zz__zz_decode_IS_CSR_2)),{(|{_zz__zz_decode_IS_CSR_3,_zz__zz_decode_IS_CSR_4}),{(|_zz__zz_decode_IS_CSR_5),{_zz__zz_decode_IS_CSR_7,{_zz__zz_decode_IS_CSR_9,_zz__zz_decode_IS_CSR_12}}}}}}};
+  assign _zz_decode_SRC1_CTRL_2 = _zz_decode_IS_CSR[1 : 0];
   assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
-  assign _zz_decode_ALU_CTRL_2 = _zz_decode_ENV_CTRL_2[6 : 5];
+  assign _zz_decode_ALU_CTRL_2 = _zz_decode_IS_CSR[6 : 5];
   assign _zz_decode_ALU_CTRL_1 = _zz_decode_ALU_CTRL_2;
-  assign _zz_decode_SRC2_CTRL_2 = _zz_decode_ENV_CTRL_2[8 : 7];
+  assign _zz_decode_SRC2_CTRL_2 = _zz_decode_IS_CSR[8 : 7];
   assign _zz_decode_SRC2_CTRL_1 = _zz_decode_SRC2_CTRL_2;
-  assign _zz_decode_ALU_BITWISE_CTRL_2 = _zz_decode_ENV_CTRL_2[17 : 16];
+  assign _zz_decode_ALU_BITWISE_CTRL_2 = _zz_decode_IS_CSR[17 : 16];
   assign _zz_decode_ALU_BITWISE_CTRL_1 = _zz_decode_ALU_BITWISE_CTRL_2;
-  assign _zz_decode_SHIFT_CTRL_2 = _zz_decode_ENV_CTRL_2[20 : 19];
+  assign _zz_decode_SHIFT_CTRL_2 = _zz_decode_IS_CSR[20 : 19];
   assign _zz_decode_SHIFT_CTRL_1 = _zz_decode_SHIFT_CTRL_2;
-  assign _zz_decode_BRANCH_CTRL_2 = _zz_decode_ENV_CTRL_2[22 : 21];
+  assign _zz_decode_BRANCH_CTRL_2 = _zz_decode_IS_CSR[22 : 21];
   assign _zz_decode_BRANCH_CTRL_1 = _zz_decode_BRANCH_CTRL_2;
-  assign _zz_decode_ENV_CTRL_8 = _zz_decode_ENV_CTRL_2[25 : 24];
-  assign _zz_decode_ENV_CTRL_1 = _zz_decode_ENV_CTRL_8;
+  assign _zz_decode_ENV_CTRL_2 = _zz_decode_IS_CSR[25 : 24];
+  assign _zz_decode_ENV_CTRL_1 = _zz_decode_ENV_CTRL_2;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
-  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h0);
+  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h00);
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
   assign decode_RegFilePlugin_rs1Data = _zz_RegFilePlugin_regFile_port0;
   assign decode_RegFilePlugin_rs2Data = _zz_RegFilePlugin_regFile_port1;
   always @(*) begin
     lastStageRegFileWrite_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
-    if(_zz_2) begin
+    if(_zz_5) begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
   always @(*) begin
     lastStageRegFileWrite_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
-    if(_zz_2) begin
-      lastStageRegFileWrite_payload_address = 5'h0;
+    if(_zz_5) begin
+      lastStageRegFileWrite_payload_address = 5'h00;
     end
   end
 
   always @(*) begin
     lastStageRegFileWrite_payload_data = _zz_lastStageRegFileWrite_payload_data;
-    if(_zz_2) begin
-      lastStageRegFileWrite_payload_data = 32'h0;
+    if(_zz_5) begin
+      lastStageRegFileWrite_payload_data = 32'h00000000;
     end
   end
 
@@ -2616,7 +2629,7 @@ module VexRiscv (
         _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
       Src1CtrlEnum_IMU : begin
-        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h000};
       end
       default : begin
         _zz_execute_SRC1 = {27'd0, _zz__zz_execute_SRC1_1};
@@ -2624,67 +2637,67 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_execute_SRC2_1 = execute_INSTRUCTION[31];
+  assign _zz_execute_SRC2 = execute_INSTRUCTION[31];
   always @(*) begin
-    _zz_execute_SRC2_2[19] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[18] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[17] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[16] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[15] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[14] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[13] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[12] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[11] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[10] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[9] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[8] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[7] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[6] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[5] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[4] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[3] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[2] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[1] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[0] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_1[19] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[18] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[17] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[16] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[15] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[14] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[13] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[12] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[11] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[10] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[9] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[8] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[7] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[6] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[5] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[4] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[3] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[2] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[1] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[0] = _zz_execute_SRC2;
   end
 
-  assign _zz_execute_SRC2_3 = _zz__zz_execute_SRC2_3[11];
+  assign _zz_execute_SRC2_2 = _zz__zz_execute_SRC2_2[11];
   always @(*) begin
-    _zz_execute_SRC2_4[19] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[18] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[17] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[16] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[15] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[14] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[13] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[12] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[11] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[10] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[9] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[8] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[7] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[6] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[5] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[4] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[3] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[2] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[1] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[0] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_3[19] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[18] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[17] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[16] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[15] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[14] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[13] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[12] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[11] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[10] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[9] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[8] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[7] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[6] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[5] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[4] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[3] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[2] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[1] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[0] = _zz_execute_SRC2_2;
   end
 
   always @(*) begin
     case(execute_SRC2_CTRL)
       Src2CtrlEnum_RS : begin
-        _zz_execute_SRC2_5 = execute_RS2;
+        _zz_execute_SRC2_4 = execute_RS2;
       end
       Src2CtrlEnum_IMI : begin
-        _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
+        _zz_execute_SRC2_4 = {_zz_execute_SRC2_1,execute_INSTRUCTION[31 : 20]};
       end
       Src2CtrlEnum_IMS : begin
-        _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_execute_SRC2_4 = {_zz_execute_SRC2_3,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_execute_SRC2_5 = _zz_execute_SRC2;
+        _zz_execute_SRC2_4 = _zz_execute_to_memory_PC;
       end
     endcase
   end
@@ -2701,7 +2714,7 @@ module VexRiscv (
   assign execute_LightShifterPlugin_amplitude = (execute_LightShifterPlugin_isActive ? execute_LightShifterPlugin_amplitudeReg : execute_SRC2[4 : 0]);
   assign execute_LightShifterPlugin_shiftInput = (execute_LightShifterPlugin_isActive ? memory_REGFILE_WRITE_DATA : execute_SRC1);
   assign execute_LightShifterPlugin_done = (execute_LightShifterPlugin_amplitude[4 : 1] == 4'b0000);
-  assign when_ShiftPlugins_l169 = ((execute_arbitration_isValid && execute_LightShifterPlugin_isShift) && (execute_SRC2[4 : 0] != 5'h0));
+  assign when_ShiftPlugins_l169 = ((execute_arbitration_isValid && execute_LightShifterPlugin_isShift) && (execute_SRC2[4 : 0] != 5'h00));
   always @(*) begin
     case(execute_SHIFT_CTRL)
       ShiftCtrlEnum_SLL_1 : begin
@@ -2802,16 +2815,19 @@ module VexRiscv (
   assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
   assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign switch_Misc_l210_1 = execute_INSTRUCTION[14 : 12];
+  assign switch_Misc_l232_1 = execute_INSTRUCTION[14 : 12];
   always @(*) begin
-    casez(switch_Misc_l210_1)
+    case(switch_Misc_l232_1)
       3'b000 : begin
         _zz_execute_BRANCH_DO = execute_BranchPlugin_eq;
       end
       3'b001 : begin
         _zz_execute_BRANCH_DO = (! execute_BranchPlugin_eq);
       end
-      3'b1?1 : begin
+      3'b101 : begin
+        _zz_execute_BRANCH_DO = (! execute_SRC_LESS);
+      end
+      3'b111 : begin
         _zz_execute_BRANCH_DO = (! execute_SRC_LESS);
       end
       default : begin
@@ -2930,9 +2946,9 @@ module VexRiscv (
 
   assign CsrPlugin_misa_base = 2'b01;
   assign CsrPlugin_misa_extensions = 26'h0000042;
-  assign _zz_when_CsrPlugin_l965 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_when_CsrPlugin_l965_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_when_CsrPlugin_l965_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign _zz_when_CsrPlugin_l1302 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l1302_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l1302_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
   assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {BranchPlugin_branchExceptionPort_valid,DBusSimplePlugin_memoryExceptionPort_valid};
@@ -2974,29 +2990,29 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l922 = (! decode_arbitration_isStuck);
-  assign when_CsrPlugin_l922_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l922_2 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l922_3 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l935 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
+  assign when_CsrPlugin_l1259 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l1272 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-  assign when_CsrPlugin_l959 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign when_CsrPlugin_l965 = ((_zz_when_CsrPlugin_l965 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l965_1 = ((_zz_when_CsrPlugin_l965_1 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l965_2 = ((_zz_when_CsrPlugin_l965_2 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1296 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l1302 = ((_zz_when_CsrPlugin_l1302 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1302_1 = ((_zz_when_CsrPlugin_l1302_1 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1302_2 = ((_zz_when_CsrPlugin_l1302_2 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_lastStageWasWfi = 1'b0;
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  assign when_CsrPlugin_l993 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l993_1 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l993_2 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l998 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  assign when_CsrPlugin_l1335 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1335_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l1335_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l1340 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
   always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(when_CsrPlugin_l1004) begin
+    if(when_CsrPlugin_l1346) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException) begin
@@ -3004,7 +3020,7 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l1004 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
+  assign when_CsrPlugin_l1346 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
   always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
@@ -3020,6 +3036,7 @@ module VexRiscv (
     end
   end
 
+  assign CsrPlugin_trapCauseEbreakDebug = 1'b0;
   always @(*) begin
     CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
@@ -3042,11 +3059,13 @@ module VexRiscv (
     endcase
   end
 
-  assign when_CsrPlugin_l1032 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign when_CsrPlugin_l1077 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
-  assign switch_CsrPlugin_l1081 = writeBack_INSTRUCTION[29 : 28];
+  assign CsrPlugin_trapEnterDebug = 1'b0;
+  assign when_CsrPlugin_l1390 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1398 = (! CsrPlugin_trapEnterDebug);
+  assign when_CsrPlugin_l1456 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign switch_CsrPlugin_l1460 = writeBack_INSTRUCTION[29 : 28];
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign when_CsrPlugin_l1129 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
+  assign when_CsrPlugin_l1527 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
   assign execute_CsrPlugin_blockedBySideEffects = ((|{writeBack_arbitration_isValid,memory_arbitration_isValid}) || 1'b0);
   always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
@@ -3088,18 +3107,18 @@ module VexRiscv (
     if(CsrPlugin_csrMapping_allowCsrSignal) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(when_CsrPlugin_l1315) begin
+    if(when_CsrPlugin_l1725) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if(when_CsrPlugin_l1149) begin
-      if(when_CsrPlugin_l1150) begin
+    if(when_CsrPlugin_l1547) begin
+      if(when_CsrPlugin_l1548) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
@@ -3107,14 +3126,14 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(when_CsrPlugin_l1157) begin
+    if(when_CsrPlugin_l1555) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(when_CsrPlugin_l1157) begin
+    if(when_CsrPlugin_l1555) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -3127,19 +3146,19 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  assign when_CsrPlugin_l1149 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
-  assign when_CsrPlugin_l1150 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
-  assign when_CsrPlugin_l1157 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
+  assign when_CsrPlugin_l1547 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign when_CsrPlugin_l1548 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1555 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
   always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -3148,9 +3167,9 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
   assign execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
-  assign switch_Misc_l210_2 = execute_INSTRUCTION[13];
+  assign switch_Misc_l232_2 = execute_INSTRUCTION[13];
   always @(*) begin
-    case(switch_Misc_l210_2)
+    case(switch_Misc_l232_2)
       1'b0 : begin
         _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
@@ -3161,20 +3180,20 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
-  assign when_CsrPlugin_l1189 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign when_CsrPlugin_l1193 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
+  assign when_CsrPlugin_l1587 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1591 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
-  assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
-  assign externalInterrupt = (|_zz_CsrPlugin_csrMapping_readDataInit_1);
-  assign when_DebugPlugin_l225 = (DebugPlugin_haltIt && (! DebugPlugin_isPipBusy));
+  assign _zz_externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
+  assign externalInterrupt = (|_zz_externalInterrupt);
+  assign when_DebugPlugin_l238 = (DebugPlugin_haltIt && (! DebugPlugin_isPipBusy));
   assign DebugPlugin_allowEBreak = (DebugPlugin_debugUsed && (! DebugPlugin_disableEbreak));
   always @(*) begin
     debug_bus_cmd_ready = 1'b1;
     if(debug_bus_cmd_valid) begin
-      case(switch_DebugPlugin_l267)
+      case(switch_DebugPlugin_l280)
         6'h01 : begin
           if(debug_bus_cmd_payload_wr) begin
-            debug_bus_cmd_ready = IBusSimplePlugin_injectionPort_ready;
+            debug_bus_cmd_ready = DebugPlugin_injectionPort_ready;
           end
         end
         default : begin
@@ -3185,7 +3204,7 @@ module VexRiscv (
 
   always @(*) begin
     debug_bus_rsp_data = DebugPlugin_busReadDataReg;
-    if(when_DebugPlugin_l244) begin
+    if(when_DebugPlugin_l257) begin
       debug_bus_rsp_data[0] = DebugPlugin_resetIt;
       debug_bus_rsp_data[1] = DebugPlugin_haltIt;
       debug_bus_rsp_data[2] = DebugPlugin_isPipBusy;
@@ -3194,14 +3213,14 @@ module VexRiscv (
     end
   end
 
-  assign when_DebugPlugin_l244 = (! _zz_when_DebugPlugin_l244);
+  assign when_DebugPlugin_l257 = (! _zz_when_DebugPlugin_l257);
   always @(*) begin
-    IBusSimplePlugin_injectionPort_valid = 1'b0;
+    DebugPlugin_injectionPort_valid = 1'b0;
     if(debug_bus_cmd_valid) begin
-      case(switch_DebugPlugin_l267)
+      case(switch_DebugPlugin_l280)
         6'h01 : begin
           if(debug_bus_cmd_payload_wr) begin
-            IBusSimplePlugin_injectionPort_valid = 1'b1;
+            DebugPlugin_injectionPort_valid = 1'b1;
           end
         end
         default : begin
@@ -3210,21 +3229,21 @@ module VexRiscv (
     end
   end
 
-  assign IBusSimplePlugin_injectionPort_payload = debug_bus_cmd_payload_data;
-  assign switch_DebugPlugin_l267 = debug_bus_cmd_payload_address[7 : 2];
-  assign when_DebugPlugin_l271 = debug_bus_cmd_payload_data[16];
-  assign when_DebugPlugin_l271_1 = debug_bus_cmd_payload_data[24];
-  assign when_DebugPlugin_l272 = debug_bus_cmd_payload_data[17];
-  assign when_DebugPlugin_l272_1 = debug_bus_cmd_payload_data[25];
-  assign when_DebugPlugin_l273 = debug_bus_cmd_payload_data[25];
-  assign when_DebugPlugin_l274 = debug_bus_cmd_payload_data[25];
-  assign when_DebugPlugin_l275 = debug_bus_cmd_payload_data[18];
-  assign when_DebugPlugin_l275_1 = debug_bus_cmd_payload_data[26];
-  assign when_DebugPlugin_l295 = (execute_arbitration_isValid && execute_DO_EBREAK);
-  assign when_DebugPlugin_l298 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
-  assign when_DebugPlugin_l311 = (DebugPlugin_stepIt && IBusSimplePlugin_incomingInstruction);
+  assign DebugPlugin_injectionPort_payload = debug_bus_cmd_payload_data;
+  assign switch_DebugPlugin_l280 = debug_bus_cmd_payload_address[7 : 2];
+  assign when_DebugPlugin_l284 = debug_bus_cmd_payload_data[16];
+  assign when_DebugPlugin_l284_1 = debug_bus_cmd_payload_data[24];
+  assign when_DebugPlugin_l285 = debug_bus_cmd_payload_data[17];
+  assign when_DebugPlugin_l285_1 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l286 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l287 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l288 = debug_bus_cmd_payload_data[18];
+  assign when_DebugPlugin_l288_1 = debug_bus_cmd_payload_data[26];
+  assign when_DebugPlugin_l308 = (execute_arbitration_isValid && execute_DO_EBREAK);
+  assign when_DebugPlugin_l311 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
+  assign when_DebugPlugin_l324 = (DebugPlugin_stepIt && IBusSimplePlugin_incomingInstruction);
   assign debug_resetOut = DebugPlugin_resetIt_regNext;
-  assign when_DebugPlugin_l331 = (DebugPlugin_haltIt || DebugPlugin_stepIt);
+  assign when_DebugPlugin_l344 = (DebugPlugin_haltIt || DebugPlugin_stepIt);
   assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
@@ -3323,105 +3342,115 @@ module VexRiscv (
   assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
   assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
   always @(*) begin
-    IBusSimplePlugin_injectionPort_ready = 1'b0;
-    case(switch_Fetcher_l365)
+    DebugPlugin_injectionPort_ready = 1'b0;
+    case(IBusSimplePlugin_injector_port_state)
       3'b100 : begin
-        IBusSimplePlugin_injectionPort_ready = 1'b1;
+        DebugPlugin_injectionPort_ready = 1'b1;
       end
       default : begin
       end
     endcase
   end
 
-  assign when_Fetcher_l381 = (! decode_arbitration_isStuck);
-  assign when_Fetcher_l401 = (switch_Fetcher_l365 != 3'b000);
-  assign when_CsrPlugin_l1277 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_2 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_3 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_4 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_5 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_6 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_7 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_8 = (! execute_arbitration_isStuck);
-  assign switch_CsrPlugin_l723 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
+  assign when_Fetcher_l391 = (! decode_arbitration_isStuck);
+  assign when_Fetcher_l411 = (IBusSimplePlugin_injector_port_state != 3'b000);
+  assign when_CsrPlugin_l1669 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_8 = (! execute_arbitration_isStuck);
+  assign switch_CsrPlugin_l1031 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_1 = 32'h00000000;
     if(execute_CsrPlugin_csr_768) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_2[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_2[3 : 3] = CsrPlugin_mstatus_MIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_2[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_CsrPlugin_csrMapping_readDataInit_1[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_1[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_1[12 : 11] = CsrPlugin_mstatus_MPP;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h00000000;
     if(execute_CsrPlugin_csr_836) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_3[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_3[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_3[3 : 3] = CsrPlugin_mip_MSIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[3 : 3] = CsrPlugin_mip_MSIP;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h00000000;
     if(execute_CsrPlugin_csr_772) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_4[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_4[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_4[3 : 3] = CsrPlugin_mie_MSIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[3 : 3] = CsrPlugin_mie_MSIE;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h00000000;
     if(execute_CsrPlugin_csr_833) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_5[31 : 0] = CsrPlugin_mepc;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[31 : 0] = CsrPlugin_mepc;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h00000000;
     if(execute_CsrPlugin_csr_834) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_6[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_CsrPlugin_csrMapping_readDataInit_6[3 : 0] = CsrPlugin_mcause_exceptionCode;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h00000000;
     if(execute_CsrPlugin_csr_835) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_7[31 : 0] = CsrPlugin_mtval;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[31 : 0] = CsrPlugin_mtval;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h00000000;
     if(execute_CsrPlugin_csr_3008) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_8[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h00000000;
     if(execute_CsrPlugin_csr_4032) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_9[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_1;
+      _zz_CsrPlugin_csrMapping_readDataInit_8[31 : 0] = _zz_externalInterrupt;
     end
   end
 
-  assign CsrPlugin_csrMapping_readDataInit = (((_zz_CsrPlugin_csrMapping_readDataInit_2 | _zz_CsrPlugin_csrMapping_readDataInit_3) | (_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5)) | ((_zz_CsrPlugin_csrMapping_readDataInit_6 | _zz_CsrPlugin_csrMapping_readDataInit_7) | (_zz_CsrPlugin_csrMapping_readDataInit_8 | _zz_CsrPlugin_csrMapping_readDataInit_9)));
-  assign when_CsrPlugin_l1310 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign when_CsrPlugin_l1315 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign CsrPlugin_csrMapping_readDataInit = (((_zz_CsrPlugin_csrMapping_readDataInit_1 | _zz_CsrPlugin_csrMapping_readDataInit_2) | (_zz_CsrPlugin_csrMapping_readDataInit_3 | _zz_CsrPlugin_csrMapping_readDataInit_4)) | ((_zz_CsrPlugin_csrMapping_readDataInit_5 | _zz_CsrPlugin_csrMapping_readDataInit_6) | (_zz_CsrPlugin_csrMapping_readDataInit_7 | _zz_CsrPlugin_csrMapping_readDataInit_8)));
+  assign when_CsrPlugin_l1702 = ((execute_arbitration_isValid && execute_IS_CSR) && (({execute_CsrPlugin_csrAddress[11 : 2],2'b00} == 12'h3a0) || ({execute_CsrPlugin_csrAddress[11 : 4],4'b0000} == 12'h3b0)));
+  assign _zz_when_CsrPlugin_l1709 = (execute_CsrPlugin_csrAddress & 12'hf60);
+  assign when_CsrPlugin_l1709 = (((execute_arbitration_isValid && execute_IS_CSR) && (5'h03 <= execute_CsrPlugin_csrAddress[4 : 0])) && (((_zz_when_CsrPlugin_l1709 == 12'hb00) || (((_zz_when_CsrPlugin_l1709 == 12'hc00) && (! execute_CsrPlugin_writeInstruction)) && (CsrPlugin_privilege == 2'b11))) || ((execute_CsrPlugin_csrAddress & 12'hfe0) == 12'h320)));
+  always @(*) begin
+    when_CsrPlugin_l1719 = CsrPlugin_csrMapping_doForceFailCsr;
+    if(when_CsrPlugin_l1717) begin
+      when_CsrPlugin_l1719 = 1'b1;
+    end
+  end
+
+  assign when_CsrPlugin_l1717 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1725 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
   always @(*) begin
     iBus_cmd_ready = iBus_cmd_m2sPipe_ready;
-    if(when_Stream_l368) begin
+    if(when_Stream_l369) begin
       iBus_cmd_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l368 = (! iBus_cmd_m2sPipe_valid);
+  assign when_Stream_l369 = (! iBus_cmd_m2sPipe_valid);
   assign iBus_cmd_m2sPipe_valid = iBus_cmd_rValid;
   assign iBus_cmd_m2sPipe_payload_pc = iBus_cmd_rData_pc;
-  assign iBusWishbone_ADR = (iBus_cmd_m2sPipe_payload_pc >>> 2);
+  assign iBusWishbone_ADR = (iBus_cmd_m2sPipe_payload_pc >>> 2'd2);
   assign iBusWishbone_CTI = 3'b000;
   assign iBusWishbone_BTE = 2'b00;
   assign iBusWishbone_SEL = 4'b1111;
@@ -3440,7 +3469,7 @@ module VexRiscv (
   assign dBus_cmd_halfPipe_payload_address = dBus_cmd_rData_address;
   assign dBus_cmd_halfPipe_payload_data = dBus_cmd_rData_data;
   assign dBus_cmd_halfPipe_payload_size = dBus_cmd_rData_size;
-  assign dBusWishbone_ADR = (dBus_cmd_halfPipe_payload_address >>> 2);
+  assign dBusWishbone_ADR = (dBus_cmd_halfPipe_payload_address >>> 2'd2);
   assign dBusWishbone_CTI = 3'b000;
   assign dBusWishbone_BTE = 2'b00;
   always @(*) begin
@@ -3459,12 +3488,12 @@ module VexRiscv (
 
   always @(*) begin
     dBusWishbone_SEL = (_zz_dBusWishbone_SEL <<< dBus_cmd_halfPipe_payload_address[1 : 0]);
-    if(when_DBusSimplePlugin_l189) begin
+    if(when_DBusSimplePlugin_l196) begin
       dBusWishbone_SEL = 4'b1111;
     end
   end
 
-  assign when_DBusSimplePlugin_l189 = (! dBus_cmd_halfPipe_payload_wr);
+  assign when_DBusSimplePlugin_l196 = (! dBus_cmd_halfPipe_payload_wr);
   assign dBusWishbone_WE = dBus_cmd_halfPipe_payload_wr;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_halfPipe_payload_data;
   assign dBus_cmd_halfPipe_ready = (dBus_cmd_halfPipe_valid && dBusWishbone_ACK);
@@ -3473,13 +3502,14 @@ module VexRiscv (
   assign dBus_rsp_ready = ((dBus_cmd_halfPipe_valid && (! dBusWishbone_WE)) && dBusWishbone_ACK);
   assign dBus_rsp_data = dBusWishbone_DAT_MISO;
   assign dBus_rsp_error = 1'b0;
+  assign IBusSimplePlugin_rspJoin_rspBuffer_c_io_flush = 1'b0;
   always @(posedge clk) begin
     if(reset) begin
       IBusSimplePlugin_fetchPc_pcReg <= externalResetVector;
       IBusSimplePlugin_fetchPc_correctionReg <= 1'b0;
       IBusSimplePlugin_fetchPc_booted <= 1'b0;
       IBusSimplePlugin_fetchPc_inc <= 1'b0;
-      _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+      _zz_IBusSimplePlugin_iBusRsp_stages_1_input_valid_1 <= 1'b0;
       _zz_IBusSimplePlugin_injector_decodeInput_valid <= 1'b0;
       IBusSimplePlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusSimplePlugin_injector_nextPcCalc_valids_1 <= 1'b0;
@@ -3488,7 +3518,7 @@ module VexRiscv (
       IBusSimplePlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       IBusSimplePlugin_pending_value <= 3'b000;
       IBusSimplePlugin_rspJoin_rspBuffer_discardCounter <= 3'b000;
-      _zz_2 <= 1'b1;
+      _zz_5 <= 1'b1;
       execute_LightShifterPlugin_isActive <= 1'b0;
       HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
       CsrPlugin_mstatus_MIE <= 1'b0;
@@ -3497,8 +3527,8 @@ module VexRiscv (
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
-      CsrPlugin_mcycle <= 64'h0;
-      CsrPlugin_minstret <= 64'h0;
+      CsrPlugin_mcycle <= 64'h0000000000000000;
+      CsrPlugin_minstret <= 64'h0000000000000000;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= 1'b0;
@@ -3509,11 +3539,11 @@ module VexRiscv (
       CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
-      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h0;
+      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h00000000;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
-      switch_Fetcher_l365 <= 3'b000;
+      IBusSimplePlugin_injector_port_state <= 3'b000;
       iBus_cmd_rValid <= 1'b0;
       dBus_cmd_rValid <= 1'b0;
     end else begin
@@ -3524,23 +3554,23 @@ module VexRiscv (
         IBusSimplePlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusSimplePlugin_fetchPc_booted <= 1'b1;
-      if(when_Fetcher_l134) begin
+      if(when_Fetcher_l133) begin
         IBusSimplePlugin_fetchPc_inc <= 1'b0;
       end
-      if(IBusSimplePlugin_fetchPc_output_fire_1) begin
+      if(IBusSimplePlugin_fetchPc_output_fire) begin
         IBusSimplePlugin_fetchPc_inc <= 1'b1;
       end
-      if(when_Fetcher_l134_1) begin
+      if(when_Fetcher_l133_1) begin
         IBusSimplePlugin_fetchPc_inc <= 1'b0;
       end
-      if(when_Fetcher_l161) begin
+      if(when_Fetcher_l160) begin
         IBusSimplePlugin_fetchPc_pcReg <= IBusSimplePlugin_fetchPc_pc;
       end
       if(IBusSimplePlugin_iBusRsp_flush) begin
-        _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+        _zz_IBusSimplePlugin_iBusRsp_stages_1_input_valid_1 <= 1'b0;
       end
       if(_zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready) begin
-        _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_2 <= (IBusSimplePlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+        _zz_IBusSimplePlugin_iBusRsp_stages_1_input_valid_1 <= (IBusSimplePlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
       if(decode_arbitration_removeIt) begin
         _zz_IBusSimplePlugin_injector_decodeInput_valid <= 1'b0;
@@ -3551,13 +3581,13 @@ module VexRiscv (
       if(IBusSimplePlugin_fetchPc_flushed) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if(when_Fetcher_l332) begin
+      if(when_Fetcher_l331) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
       if(IBusSimplePlugin_fetchPc_flushed) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(when_Fetcher_l332_1) begin
+      if(when_Fetcher_l331_1) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_1 <= IBusSimplePlugin_injector_nextPcCalc_valids_0;
       end
       if(IBusSimplePlugin_fetchPc_flushed) begin
@@ -3566,7 +3596,7 @@ module VexRiscv (
       if(IBusSimplePlugin_fetchPc_flushed) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(when_Fetcher_l332_2) begin
+      if(when_Fetcher_l331_2) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_2 <= IBusSimplePlugin_injector_nextPcCalc_valids_1;
       end
       if(IBusSimplePlugin_fetchPc_flushed) begin
@@ -3575,7 +3605,7 @@ module VexRiscv (
       if(IBusSimplePlugin_fetchPc_flushed) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(when_Fetcher_l332_3) begin
+      if(when_Fetcher_l331_3) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_3 <= IBusSimplePlugin_injector_nextPcCalc_valids_2;
       end
       if(IBusSimplePlugin_fetchPc_flushed) begin
@@ -3584,7 +3614,7 @@ module VexRiscv (
       if(IBusSimplePlugin_fetchPc_flushed) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if(when_Fetcher_l332_4) begin
+      if(when_Fetcher_l331_4) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_4 <= IBusSimplePlugin_injector_nextPcCalc_valids_3;
       end
       if(IBusSimplePlugin_fetchPc_flushed) begin
@@ -3595,7 +3625,7 @@ module VexRiscv (
       if(IBusSimplePlugin_iBusRsp_flush) begin
         IBusSimplePlugin_rspJoin_rspBuffer_discardCounter <= (IBusSimplePlugin_pending_value - _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter_2);
       end
-      _zz_2 <= 1'b0;
+      _zz_5 <= 1'b0;
       if(when_ShiftPlugins_l169) begin
         if(when_ShiftPlugins_l175) begin
           execute_LightShifterPlugin_isActive <= 1'b1;
@@ -3612,50 +3642,50 @@ module VexRiscv (
       if(writeBack_arbitration_isFiring) begin
         CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
       end
-      if(when_CsrPlugin_l922) begin
+      if(when_CsrPlugin_l1259) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if(when_CsrPlugin_l922_1) begin
+      if(when_CsrPlugin_l1259_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if(when_CsrPlugin_l922_2) begin
+      if(when_CsrPlugin_l1259_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if(when_CsrPlugin_l922_3) begin
+      if(when_CsrPlugin_l1259_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(when_CsrPlugin_l959) begin
-        if(when_CsrPlugin_l965) begin
+      if(when_CsrPlugin_l1296) begin
+        if(when_CsrPlugin_l1302) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_1) begin
+        if(when_CsrPlugin_l1302_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_2) begin
+        if(when_CsrPlugin_l1302_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
       if(CsrPlugin_pipelineLiberator_active) begin
-        if(when_CsrPlugin_l993) begin
+        if(when_CsrPlugin_l1335) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if(when_CsrPlugin_l993_1) begin
+        if(when_CsrPlugin_l1335_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if(when_CsrPlugin_l993_2) begin
+        if(when_CsrPlugin_l1335_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(when_CsrPlugin_l998) begin
+      if(when_CsrPlugin_l1340) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
@@ -3664,19 +3694,21 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(when_CsrPlugin_l1032) begin
-        case(CsrPlugin_targetPrivilege)
-          2'b11 : begin
-            CsrPlugin_mstatus_MIE <= 1'b0;
-            CsrPlugin_mstatus_MPIE <= CsrPlugin_mstatus_MIE;
-            CsrPlugin_mstatus_MPP <= CsrPlugin_privilege;
-          end
-          default : begin
-          end
-        endcase
+      if(when_CsrPlugin_l1390) begin
+        if(when_CsrPlugin_l1398) begin
+          case(CsrPlugin_targetPrivilege)
+            2'b11 : begin
+              CsrPlugin_mstatus_MIE <= 1'b0;
+              CsrPlugin_mstatus_MPIE <= CsrPlugin_mstatus_MIE;
+              CsrPlugin_mstatus_MPP <= CsrPlugin_privilege;
+            end
+            default : begin
+            end
+          endcase
+        end
       end
-      if(when_CsrPlugin_l1077) begin
-        case(switch_CsrPlugin_l1081)
+      if(when_CsrPlugin_l1456) begin
+        case(switch_CsrPlugin_l1460)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -3686,7 +3718,7 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l965_2,{_zz_when_CsrPlugin_l965_1,_zz_when_CsrPlugin_l965}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l1302_2,{_zz_when_CsrPlugin_l1302_1,_zz_when_CsrPlugin_l1302}} != 3'b000) || CsrPlugin_thirdPartyWake);
       if(when_Pipeline_l151) begin
         execute_arbitration_isValid <= 1'b0;
       end
@@ -3705,25 +3737,25 @@ module VexRiscv (
       if(when_Pipeline_l154_2) begin
         writeBack_arbitration_isValid <= memory_arbitration_isValid;
       end
-      case(switch_Fetcher_l365)
+      case(IBusSimplePlugin_injector_port_state)
         3'b000 : begin
-          if(IBusSimplePlugin_injectionPort_valid) begin
-            switch_Fetcher_l365 <= 3'b001;
+          if(DebugPlugin_injectionPort_valid) begin
+            IBusSimplePlugin_injector_port_state <= 3'b001;
           end
         end
         3'b001 : begin
-          switch_Fetcher_l365 <= 3'b010;
+          IBusSimplePlugin_injector_port_state <= 3'b010;
         end
         3'b010 : begin
-          switch_Fetcher_l365 <= 3'b011;
+          IBusSimplePlugin_injector_port_state <= 3'b011;
         end
         3'b011 : begin
-          if(when_Fetcher_l381) begin
-            switch_Fetcher_l365 <= 3'b100;
+          if(when_Fetcher_l391) begin
+            IBusSimplePlugin_injector_port_state <= 3'b100;
           end
         end
         3'b100 : begin
-          switch_Fetcher_l365 <= 3'b000;
+          IBusSimplePlugin_injector_port_state <= 3'b000;
         end
         default : begin
         end
@@ -3732,7 +3764,7 @@ module VexRiscv (
         if(execute_CsrPlugin_writeEnable) begin
           CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
           CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
-          case(switch_CsrPlugin_l723)
+          case(switch_CsrPlugin_l1031)
             2'b11 : begin
               CsrPlugin_mstatus_MPP <= 2'b11;
             end
@@ -3797,40 +3829,42 @@ module VexRiscv (
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? DBusSimplePlugin_memoryExceptionPort_payload_code : BranchPlugin_branchExceptionPort_payload_code);
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? DBusSimplePlugin_memoryExceptionPort_payload_badAddr : BranchPlugin_branchExceptionPort_payload_badAddr);
     end
-    if(when_CsrPlugin_l959) begin
-      if(when_CsrPlugin_l965) begin
+    if(when_CsrPlugin_l1296) begin
+      if(when_CsrPlugin_l1302) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l965_1) begin
+      if(when_CsrPlugin_l1302_1) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l965_2) begin
+      if(when_CsrPlugin_l1302_2) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(when_CsrPlugin_l1032) begin
-      case(CsrPlugin_targetPrivilege)
-        2'b11 : begin
-          CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
-          CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
-          CsrPlugin_mepc <= writeBack_PC;
-          if(CsrPlugin_hadException) begin
-            CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
+    if(when_CsrPlugin_l1390) begin
+      if(when_CsrPlugin_l1398) begin
+        case(CsrPlugin_targetPrivilege)
+          2'b11 : begin
+            CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
+            CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
+            CsrPlugin_mepc <= writeBack_PC;
+            if(CsrPlugin_hadException) begin
+              CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
+            end
           end
-        end
-        default : begin
-        end
-      endcase
+          default : begin
+          end
+        endcase
+      end
     end
     externalInterruptArray_regNext <= externalInterruptArray;
     if(when_Pipeline_l124) begin
       decode_to_execute_PC <= decode_PC;
     end
     if(when_Pipeline_l124_1) begin
-      execute_to_memory_PC <= _zz_execute_SRC2;
+      execute_to_memory_PC <= _zz_execute_to_memory_PC;
     end
     if(when_Pipeline_l124_2) begin
       memory_to_writeBack_PC <= memory_PC;
@@ -3964,34 +3998,34 @@ module VexRiscv (
     if(when_Pipeline_l124_45) begin
       memory_to_writeBack_MEMORY_READ_DATA <= memory_MEMORY_READ_DATA;
     end
-    if(when_Fetcher_l401) begin
-      _zz_IBusSimplePlugin_injector_decodeInput_payload_rsp_inst <= IBusSimplePlugin_injectionPort_payload;
+    if(when_Fetcher_l411) begin
+      _zz_IBusSimplePlugin_injector_decodeInput_payload_rsp_inst <= DebugPlugin_injectionPort_payload;
     end
-    if(when_CsrPlugin_l1277) begin
+    if(when_CsrPlugin_l1669) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if(when_CsrPlugin_l1277_1) begin
+    if(when_CsrPlugin_l1669_1) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if(when_CsrPlugin_l1277_2) begin
+    if(when_CsrPlugin_l1669_2) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if(when_CsrPlugin_l1277_3) begin
+    if(when_CsrPlugin_l1669_3) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if(when_CsrPlugin_l1277_4) begin
+    if(when_CsrPlugin_l1669_4) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if(when_CsrPlugin_l1277_5) begin
+    if(when_CsrPlugin_l1669_5) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if(when_CsrPlugin_l1277_6) begin
+    if(when_CsrPlugin_l1669_6) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if(when_CsrPlugin_l1277_7) begin
+    if(when_CsrPlugin_l1669_7) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if(when_CsrPlugin_l1277_8) begin
+    if(when_CsrPlugin_l1669_8) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
     if(execute_CsrPlugin_csr_836) begin
@@ -4002,7 +4036,6 @@ module VexRiscv (
     if(execute_CsrPlugin_csr_773) begin
       if(execute_CsrPlugin_writeEnable) begin
         CsrPlugin_mtvec_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 2];
-        CsrPlugin_mtvec_mode <= CsrPlugin_csrMapping_writeDataSignal[1 : 0];
       end
     end
     if(execute_CsrPlugin_csr_833) begin
@@ -4031,9 +4064,9 @@ module VexRiscv (
     if(writeBack_arbitration_isValid) begin
       DebugPlugin_busReadDataReg <= _zz_lastStageRegFileWrite_payload_data;
     end
-    _zz_when_DebugPlugin_l244 <= debug_bus_cmd_payload_address[2];
+    _zz_when_DebugPlugin_l257 <= debug_bus_cmd_payload_address[2];
     if(debug_bus_cmd_valid) begin
-      case(switch_DebugPlugin_l267)
+      case(switch_DebugPlugin_l280)
         6'h10 : begin
           if(debug_bus_cmd_payload_wr) begin
             DebugPlugin_hardwareBreakpoints_0_pc <= debug_bus_cmd_payload_data[31 : 1];
@@ -4048,7 +4081,7 @@ module VexRiscv (
         end
       endcase
     end
-    if(when_DebugPlugin_l295) begin
+    if(when_DebugPlugin_l308) begin
       DebugPlugin_busReadDataReg <= execute_PC;
     end
     DebugPlugin_resetIt_regNext <= DebugPlugin_resetIt;
@@ -4066,39 +4099,39 @@ module VexRiscv (
       DebugPlugin_hardwareBreakpoints_0_valid <= 1'b0;
       DebugPlugin_hardwareBreakpoints_1_valid <= 1'b0;
     end else begin
-      if(when_DebugPlugin_l225) begin
+      if(when_DebugPlugin_l238) begin
         DebugPlugin_godmode <= 1'b1;
       end
       if(debug_bus_cmd_valid) begin
         DebugPlugin_debugUsed <= 1'b1;
       end
       if(debug_bus_cmd_valid) begin
-        case(switch_DebugPlugin_l267)
-          6'h0 : begin
+        case(switch_DebugPlugin_l280)
+          6'h00 : begin
             if(debug_bus_cmd_payload_wr) begin
               DebugPlugin_stepIt <= debug_bus_cmd_payload_data[4];
-              if(when_DebugPlugin_l271) begin
+              if(when_DebugPlugin_l284) begin
                 DebugPlugin_resetIt <= 1'b1;
               end
-              if(when_DebugPlugin_l271_1) begin
+              if(when_DebugPlugin_l284_1) begin
                 DebugPlugin_resetIt <= 1'b0;
               end
-              if(when_DebugPlugin_l272) begin
+              if(when_DebugPlugin_l285) begin
                 DebugPlugin_haltIt <= 1'b1;
               end
-              if(when_DebugPlugin_l272_1) begin
+              if(when_DebugPlugin_l285_1) begin
                 DebugPlugin_haltIt <= 1'b0;
               end
-              if(when_DebugPlugin_l273) begin
+              if(when_DebugPlugin_l286) begin
                 DebugPlugin_haltedByBreak <= 1'b0;
               end
-              if(when_DebugPlugin_l274) begin
+              if(when_DebugPlugin_l287) begin
                 DebugPlugin_godmode <= 1'b0;
               end
-              if(when_DebugPlugin_l275) begin
+              if(when_DebugPlugin_l288) begin
                 DebugPlugin_disableEbreak <= 1'b1;
               end
-              if(when_DebugPlugin_l275_1) begin
+              if(when_DebugPlugin_l288_1) begin
                 DebugPlugin_disableEbreak <= 1'b0;
               end
             end
@@ -4117,13 +4150,13 @@ module VexRiscv (
           end
         endcase
       end
-      if(when_DebugPlugin_l295) begin
-        if(when_DebugPlugin_l298) begin
+      if(when_DebugPlugin_l308) begin
+        if(when_DebugPlugin_l311) begin
           DebugPlugin_haltIt <= 1'b1;
           DebugPlugin_haltedByBreak <= 1'b1;
         end
       end
-      if(when_DebugPlugin_l311) begin
+      if(when_DebugPlugin_l324) begin
         if(decode_arbitration_isValid) begin
           DebugPlugin_haltIt <= 1'b1;
         end
@@ -4135,135 +4168,141 @@ module VexRiscv (
 endmodule
 
 module StreamFifoLowLatency (
-  input               io_push_valid,
-  output              io_push_ready,
-  input               io_push_payload_error,
-  input      [31:0]   io_push_payload_inst,
-  output reg          io_pop_valid,
-  input               io_pop_ready,
-  output reg          io_pop_payload_error,
-  output reg [31:0]   io_pop_payload_inst,
-  input               io_flush,
-  output     [0:0]    io_occupancy,
-  input               clk,
-  input               reset
+  input  wire          io_push_valid,
+  output wire          io_push_ready,
+  input  wire          io_push_payload_error,
+  input  wire [31:0]   io_push_payload_inst,
+  output wire          io_pop_valid,
+  input  wire          io_pop_ready,
+  output wire          io_pop_payload_error,
+  output wire [31:0]   io_pop_payload_inst,
+  input  wire          io_flush,
+  output wire [0:0]    io_occupancy,
+  output wire [0:0]    io_availability,
+  input  wire          clk,
+  input  wire          reset
 );
 
-  reg                 when_Phase_l649;
-  reg                 pushPtr_willIncrement;
-  reg                 pushPtr_willClear;
-  wire                pushPtr_willOverflowIfInc;
-  wire                pushPtr_willOverflow;
-  reg                 popPtr_willIncrement;
-  reg                 popPtr_willClear;
-  wire                popPtr_willOverflowIfInc;
-  wire                popPtr_willOverflow;
-  wire                ptrMatch;
-  reg                 risingOccupancy;
-  wire                empty;
-  wire                full;
-  wire                pushing;
-  wire                popping;
-  wire                readed_error;
-  wire       [31:0]   readed_inst;
-  wire       [32:0]   _zz_readed_error;
-  wire                when_Stream_l1178;
-  wire                when_Stream_l1191;
-  wire       [32:0]   _zz_readed_error_1;
-  reg        [32:0]   _zz_readed_error_2;
+  wire                fifo_io_push_ready;
+  wire                fifo_io_pop_valid;
+  wire                fifo_io_pop_payload_error;
+  wire       [31:0]   fifo_io_pop_payload_inst;
+  wire       [0:0]    fifo_io_occupancy;
+  wire       [0:0]    fifo_io_availability;
+
+  StreamFifo fifo (
+    .io_push_valid         (io_push_valid                 ), //i
+    .io_push_ready         (fifo_io_push_ready            ), //o
+    .io_push_payload_error (io_push_payload_error         ), //i
+    .io_push_payload_inst  (io_push_payload_inst[31:0]    ), //i
+    .io_pop_valid          (fifo_io_pop_valid             ), //o
+    .io_pop_ready          (io_pop_ready                  ), //i
+    .io_pop_payload_error  (fifo_io_pop_payload_error     ), //o
+    .io_pop_payload_inst   (fifo_io_pop_payload_inst[31:0]), //o
+    .io_flush              (io_flush                      ), //i
+    .io_occupancy          (fifo_io_occupancy             ), //o
+    .io_availability       (fifo_io_availability          ), //o
+    .clk                   (clk                           ), //i
+    .reset                 (reset                         )  //i
+  );
+  assign io_push_ready = fifo_io_push_ready;
+  assign io_pop_valid = fifo_io_pop_valid;
+  assign io_pop_payload_error = fifo_io_pop_payload_error;
+  assign io_pop_payload_inst = fifo_io_pop_payload_inst;
+  assign io_occupancy = fifo_io_occupancy;
+  assign io_availability = fifo_io_availability;
+
+endmodule
+
+module StreamFifo (
+  input  wire          io_push_valid,
+  output reg           io_push_ready,
+  input  wire          io_push_payload_error,
+  input  wire [31:0]   io_push_payload_inst,
+  output reg           io_pop_valid,
+  input  wire          io_pop_ready,
+  output reg           io_pop_payload_error,
+  output reg  [31:0]   io_pop_payload_inst,
+  input  wire          io_flush,
+  output wire [0:0]    io_occupancy,
+  output wire [0:0]    io_availability,
+  input  wire          clk,
+  input  wire          reset
+);
+
+  reg                 oneStage_doFlush;
+  wire                oneStage_buffer_valid;
+  wire                oneStage_buffer_ready;
+  wire                oneStage_buffer_payload_error;
+  wire       [31:0]   oneStage_buffer_payload_inst;
+  reg                 io_push_rValid;
+  reg                 io_push_rData_error;
+  reg        [31:0]   io_push_rData_inst;
+  wire                when_Stream_l369;
+  wire                when_Stream_l1187;
 
   always @(*) begin
-    when_Phase_l649 = 1'b0;
-    if(pushing) begin
-      when_Phase_l649 = 1'b1;
+    oneStage_doFlush = io_flush;
+    if(when_Stream_l1187) begin
+      if(io_pop_ready) begin
+        oneStage_doFlush = 1'b1;
+      end
     end
   end
 
   always @(*) begin
-    pushPtr_willIncrement = 1'b0;
-    if(pushing) begin
-      pushPtr_willIncrement = 1'b1;
+    io_push_ready = oneStage_buffer_ready;
+    if(when_Stream_l369) begin
+      io_push_ready = 1'b1;
     end
   end
 
+  assign when_Stream_l369 = (! oneStage_buffer_valid);
+  assign oneStage_buffer_valid = io_push_rValid;
+  assign oneStage_buffer_payload_error = io_push_rData_error;
+  assign oneStage_buffer_payload_inst = io_push_rData_inst;
   always @(*) begin
-    pushPtr_willClear = 1'b0;
-    if(io_flush) begin
-      pushPtr_willClear = 1'b1;
-    end
-  end
-
-  assign pushPtr_willOverflowIfInc = 1'b1;
-  assign pushPtr_willOverflow = (pushPtr_willOverflowIfInc && pushPtr_willIncrement);
-  always @(*) begin
-    popPtr_willIncrement = 1'b0;
-    if(popping) begin
-      popPtr_willIncrement = 1'b1;
-    end
-  end
-
-  always @(*) begin
-    popPtr_willClear = 1'b0;
-    if(io_flush) begin
-      popPtr_willClear = 1'b1;
-    end
-  end
-
-  assign popPtr_willOverflowIfInc = 1'b1;
-  assign popPtr_willOverflow = (popPtr_willOverflowIfInc && popPtr_willIncrement);
-  assign ptrMatch = 1'b1;
-  assign empty = (ptrMatch && (! risingOccupancy));
-  assign full = (ptrMatch && risingOccupancy);
-  assign pushing = (io_push_valid && io_push_ready);
-  assign popping = (io_pop_valid && io_pop_ready);
-  assign io_push_ready = (! full);
-  assign _zz_readed_error = _zz_readed_error_1;
-  assign readed_error = _zz_readed_error[0];
-  assign readed_inst = _zz_readed_error[32 : 1];
-  assign when_Stream_l1178 = (! empty);
-  always @(*) begin
-    if(when_Stream_l1178) begin
-      io_pop_valid = 1'b1;
-    end else begin
+    io_pop_valid = oneStage_buffer_valid;
+    if(when_Stream_l1187) begin
       io_pop_valid = io_push_valid;
     end
   end
 
+  assign oneStage_buffer_ready = io_pop_ready;
   always @(*) begin
-    if(when_Stream_l1178) begin
-      io_pop_payload_error = readed_error;
-    end else begin
+    io_pop_payload_error = oneStage_buffer_payload_error;
+    if(when_Stream_l1187) begin
       io_pop_payload_error = io_push_payload_error;
     end
   end
 
   always @(*) begin
-    if(when_Stream_l1178) begin
-      io_pop_payload_inst = readed_inst;
-    end else begin
+    io_pop_payload_inst = oneStage_buffer_payload_inst;
+    if(when_Stream_l1187) begin
       io_pop_payload_inst = io_push_payload_inst;
     end
   end
 
-  assign when_Stream_l1191 = (pushing != popping);
-  assign io_occupancy = (risingOccupancy && ptrMatch);
-  assign _zz_readed_error_1 = _zz_readed_error_2;
+  assign io_occupancy = oneStage_buffer_valid;
+  assign io_availability = (! oneStage_buffer_valid);
+  assign when_Stream_l1187 = (! oneStage_buffer_valid);
   always @(posedge clk) begin
     if(reset) begin
-      risingOccupancy <= 1'b0;
+      io_push_rValid <= 1'b0;
     end else begin
-      if(when_Stream_l1191) begin
-        risingOccupancy <= pushing;
+      if(io_push_ready) begin
+        io_push_rValid <= io_push_valid;
       end
-      if(io_flush) begin
-        risingOccupancy <= 1'b0;
+      if(oneStage_doFlush) begin
+        io_push_rValid <= 1'b0;
       end
     end
   end
 
   always @(posedge clk) begin
-    if(when_Phase_l649) begin
-      _zz_readed_error_2 <= {io_push_payload_inst,io_push_payload_error};
+    if(io_push_ready) begin
+      io_push_rData_error <= io_push_payload_error;
+      io_push_rData_inst <= io_push_payload_inst;
     end
   end
 

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_Secure.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_Secure.v
@@ -1,38 +1,38 @@
-// Generator : SpinalHDL v1.7.1    git head : 0444bb76ab1d6e19f0ec46bc03c4769776deb7d5
+// Generator : SpinalHDL v1.9.4    git head : 270018552577f3bb8e5339ee2583c9c22d324215
 // Component : VexRiscv
-// Git hash  : 581fcb065adf7ea8b626f939ff51679d4c95872f
+// Git hash  : 63430af99f84cc1d11d58b556debe1cc3f238c67
 
 `timescale 1ns/1ps
 
 module VexRiscv (
-  input      [31:0]   externalResetVector,
-  input               timerInterrupt,
-  input               softwareInterrupt,
-  input      [31:0]   externalInterruptArray,
-  output reg          iBusWishbone_CYC,
-  output reg          iBusWishbone_STB,
-  input               iBusWishbone_ACK,
-  output              iBusWishbone_WE,
-  output     [29:0]   iBusWishbone_ADR,
-  input      [31:0]   iBusWishbone_DAT_MISO,
-  output     [31:0]   iBusWishbone_DAT_MOSI,
-  output     [3:0]    iBusWishbone_SEL,
-  input               iBusWishbone_ERR,
-  output     [2:0]    iBusWishbone_CTI,
-  output     [1:0]    iBusWishbone_BTE,
-  output              dBusWishbone_CYC,
-  output              dBusWishbone_STB,
-  input               dBusWishbone_ACK,
-  output              dBusWishbone_WE,
-  output     [29:0]   dBusWishbone_ADR,
-  input      [31:0]   dBusWishbone_DAT_MISO,
-  output     [31:0]   dBusWishbone_DAT_MOSI,
-  output     [3:0]    dBusWishbone_SEL,
-  input               dBusWishbone_ERR,
-  output     [2:0]    dBusWishbone_CTI,
-  output     [1:0]    dBusWishbone_BTE,
-  input               clk,
-  input               reset
+  input  wire [31:0]   externalResetVector,
+  input  wire          timerInterrupt,
+  input  wire          softwareInterrupt,
+  input  wire [31:0]   externalInterruptArray,
+  output reg           iBusWishbone_CYC,
+  output reg           iBusWishbone_STB,
+  input  wire          iBusWishbone_ACK,
+  output wire          iBusWishbone_WE,
+  output wire [29:0]   iBusWishbone_ADR,
+  input  wire [31:0]   iBusWishbone_DAT_MISO,
+  output wire [31:0]   iBusWishbone_DAT_MOSI,
+  output wire [3:0]    iBusWishbone_SEL,
+  input  wire          iBusWishbone_ERR,
+  output wire [2:0]    iBusWishbone_CTI,
+  output wire [1:0]    iBusWishbone_BTE,
+  output wire          dBusWishbone_CYC,
+  output wire          dBusWishbone_STB,
+  input  wire          dBusWishbone_ACK,
+  output wire          dBusWishbone_WE,
+  output wire [29:0]   dBusWishbone_ADR,
+  input  wire [31:0]   dBusWishbone_DAT_MISO,
+  output wire [31:0]   dBusWishbone_DAT_MOSI,
+  output wire [3:0]    dBusWishbone_SEL,
+  input  wire          dBusWishbone_ERR,
+  output wire [2:0]    dBusWishbone_CTI,
+  output wire [1:0]    dBusWishbone_BTE,
+  input  wire          clk,
+  input  wire          reset
 );
   localparam ShiftCtrlEnum_DISABLE_1 = 2'd0;
   localparam ShiftCtrlEnum_SLL_1 = 2'd1;
@@ -60,13 +60,7 @@ module VexRiscv (
   localparam Src1CtrlEnum_IMU = 2'd1;
   localparam Src1CtrlEnum_PC_INCREMENT = 2'd2;
   localparam Src1CtrlEnum_URS1 = 2'd3;
-  localparam execute_PmpPlugin_fsm_enumDef_BOOT = 3'd0;
-  localparam execute_PmpPlugin_fsm_enumDef_stateIdle = 3'd1;
-  localparam execute_PmpPlugin_fsm_enumDef_stateWrite = 3'd2;
-  localparam execute_PmpPlugin_fsm_enumDef_stateCfg = 3'd3;
-  localparam execute_PmpPlugin_fsm_enumDef_stateAddr = 3'd4;
 
-  reg        [31:0]   PmpPlugin_setter_io_addr;
   wire                IBusCachedPlugin_cache_io_flush;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_isValid;
   wire                IBusCachedPlugin_cache_io_cpu_fetch_isValid;
@@ -97,13 +91,8 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_flush_valid;
   wire                dataCache_1_io_cpu_flush_payload_singleLine;
   wire       [6:0]    dataCache_1_io_cpu_flush_payload_lineId;
-  wire                dataCache_1_io_mem_cmd_ready;
-  wire       [31:0]   _zz_PmpPlugin_pmpaddr_port0;
-  wire       [31:0]   _zz_PmpPlugin_pmpaddr_port2;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
-  wire       [24:0]   PmpPlugin_setter_io_base;
-  wire       [24:0]   PmpPlugin_setter_io_mask;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_data;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress;
@@ -129,6 +118,7 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_writeBack_exclusiveOk;
   wire                dataCache_1_io_cpu_flush_ready;
   wire                dataCache_1_io_cpu_redo;
+  wire                dataCache_1_io_cpu_writesPending;
   wire                dataCache_1_io_mem_cmd_valid;
   wire                dataCache_1_io_mem_cmd_payload_wr;
   wire                dataCache_1_io_mem_cmd_payload_uncached;
@@ -140,12 +130,11 @@ module VexRiscv (
   wire       [51:0]   _zz_memory_MUL_LOW;
   wire       [51:0]   _zz_memory_MUL_LOW_1;
   wire       [51:0]   _zz_memory_MUL_LOW_2;
-  wire       [51:0]   _zz_memory_MUL_LOW_3;
-  wire       [32:0]   _zz_memory_MUL_LOW_4;
-  wire       [51:0]   _zz_memory_MUL_LOW_5;
-  wire       [49:0]   _zz_memory_MUL_LOW_6;
-  wire       [51:0]   _zz_memory_MUL_LOW_7;
-  wire       [49:0]   _zz_memory_MUL_LOW_8;
+  wire       [32:0]   _zz_memory_MUL_LOW_3;
+  wire       [51:0]   _zz_memory_MUL_LOW_4;
+  wire       [49:0]   _zz_memory_MUL_LOW_5;
+  wire       [51:0]   _zz_memory_MUL_LOW_6;
+  wire       [49:0]   _zz_memory_MUL_LOW_7;
   wire       [31:0]   _zz_execute_SHIFT_RIGHT;
   wire       [32:0]   _zz_execute_SHIFT_RIGHT_1;
   wire       [32:0]   _zz_execute_SHIFT_RIGHT_2;
@@ -154,19 +143,19 @@ module VexRiscv (
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_2;
   wire                _zz_decode_LEGAL_INSTRUCTION_3;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_4;
-  wire       [13:0]   _zz_decode_LEGAL_INSTRUCTION_5;
+  wire       [12:0]   _zz_decode_LEGAL_INSTRUCTION_5;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_6;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_7;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_8;
   wire                _zz_decode_LEGAL_INSTRUCTION_9;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_10;
-  wire       [7:0]    _zz_decode_LEGAL_INSTRUCTION_11;
+  wire       [6:0]    _zz_decode_LEGAL_INSTRUCTION_11;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_12;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_13;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_14;
   wire                _zz_decode_LEGAL_INSTRUCTION_15;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_16;
-  wire       [1:0]    _zz_decode_LEGAL_INSTRUCTION_17;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_17;
   wire       [3:0]    _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1;
   reg        [31:0]   _zz_IBusCachedPlugin_jump_pcLoad_payload_5;
   wire       [1:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_6;
@@ -174,10 +163,10 @@ module VexRiscv (
   wire       [2:0]    _zz_IBusCachedPlugin_fetchPc_pc_1;
   wire       [11:0]   _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   wire       [31:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2;
-  wire       [19:0]   _zz__zz_3;
-  wire       [11:0]   _zz__zz_5;
-  wire       [31:0]   _zz__zz_7;
-  wire       [31:0]   _zz__zz_7_1;
+  wire       [19:0]   _zz__zz_2;
+  wire       [11:0]   _zz__zz_4;
+  wire       [31:0]   _zz__zz_6;
+  wire       [31:0]   _zz__zz_6_1;
   wire       [19:0]   _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload;
   wire       [11:0]   _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
   wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_4;
@@ -191,73 +180,169 @@ module VexRiscv (
   wire       [1:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_1;
   reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_2;
   wire       [0:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_3;
-  reg        [7:0]    _zz_when_PmpPlugin_l246;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_0_1;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_0_2;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_0_3;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_0_4;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_1;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_1_1;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_1_2;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_1_3;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_2;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_2_1;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_2_2;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_2_3;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_3;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_3_1;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_3_2;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_3_3;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_4;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_4_1;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_4_2;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_4_3;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_5;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_5_1;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_5_2;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_5_3;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_6;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_6_1;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_6_2;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_6_3;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_7;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_7_1;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_7_2;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_7_3;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_8;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_8_1;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_8_2;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_8_3;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_9;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_9_1;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_9_2;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_9_3;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_10;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_10_1;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_10_2;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_10_3;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_11;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_11_1;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_11_2;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_11_3;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_12;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_12_1;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_12_2;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_12_3;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_13;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_13_1;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_13_2;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_13_3;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_14;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_14_1;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_14_2;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_14_3;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_15;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_15_1;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_15_2;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_15_3;
-  wire       [0:0]    _zz_when_PmpPlugin_l277;
-  wire       [5:0]    _zz_when_PmpPlugin_l277_1;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_0_6;
+  wire       [35:0]   _zz__zz_PmpPlugin_ports_0_hits_0_3;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_0_3_1;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_1_6;
+  wire       [35:0]   _zz__zz_PmpPlugin_ports_0_hits_1_3;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_1_3_1;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_2_6;
+  wire       [35:0]   _zz__zz_PmpPlugin_ports_0_hits_2_3;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_2_3_1;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_3_6;
+  wire       [35:0]   _zz__zz_PmpPlugin_ports_0_hits_3_3;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_3_3_1;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_4_6;
+  wire       [35:0]   _zz__zz_PmpPlugin_ports_0_hits_4_3;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_4_3_1;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_5_6;
+  wire       [35:0]   _zz__zz_PmpPlugin_ports_0_hits_5_3;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_5_3_1;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_6_6;
+  wire       [35:0]   _zz__zz_PmpPlugin_ports_0_hits_6_3;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_6_3_1;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_7_6;
+  wire       [35:0]   _zz__zz_PmpPlugin_ports_0_hits_7_3;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_7_3_1;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_8_6;
+  wire       [35:0]   _zz__zz_PmpPlugin_ports_0_hits_8_3;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_8_3_1;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_9_6;
+  wire       [35:0]   _zz__zz_PmpPlugin_ports_0_hits_9_3;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_9_3_1;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_10_6;
+  wire       [35:0]   _zz__zz_PmpPlugin_ports_0_hits_10_3;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_10_3_1;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_11_6;
+  wire       [35:0]   _zz__zz_PmpPlugin_ports_0_hits_11_3;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_11_3_1;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_12_6;
+  wire       [35:0]   _zz__zz_PmpPlugin_ports_0_hits_12_3;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_12_3_1;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_13_6;
+  wire       [35:0]   _zz__zz_PmpPlugin_ports_0_hits_13_3;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_13_3_1;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_14_6;
+  wire       [35:0]   _zz__zz_PmpPlugin_ports_0_hits_14_3;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_14_3_1;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_15_6;
+  wire       [35:0]   _zz__zz_PmpPlugin_ports_0_hits_15_3;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_15_3_1;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_0_8;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_0_9;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_1_8;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_1_9;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_2_8;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_2_9;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_3_8;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_3_9;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_4_8;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_4_9;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_5_8;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_5_9;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_6_8;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_6_9;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_7_8;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_7_9;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_8_8;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_8_9;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_9_8;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_9_9;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_10_8;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_10_9;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_11_8;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_11_9;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_12_8;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_12_9;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_13_8;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_13_9;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_14_8;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_14_9;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_15_8;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_15_9;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_16;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_17;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_18;
+  reg        [4:0]    _zz_when_PmpPlugin_l250_19;
+  wire       [2:0]    _zz_when_PmpPlugin_l250_20;
+  reg        [4:0]    _zz_when_PmpPlugin_l250_21;
+  wire       [2:0]    _zz_when_PmpPlugin_l250_22;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_23;
+  reg        [4:0]    _zz_when_PmpPlugin_l250_24;
+  wire       [2:0]    _zz_when_PmpPlugin_l250_25;
+  reg        [4:0]    _zz_when_PmpPlugin_l250_26;
+  wire       [2:0]    _zz_when_PmpPlugin_l250_27;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_28;
+  reg        [4:0]    _zz_when_PmpPlugin_l250_29;
+  wire       [2:0]    _zz_when_PmpPlugin_l250_30;
+  reg        [4:0]    _zz_when_PmpPlugin_l250_31;
+  wire       [2:0]    _zz_when_PmpPlugin_l250_32;
+  wire       [0:0]    _zz_when_PmpPlugin_l250_33;
+  wire       [0:0]    _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowRead_32;
+  wire       [4:0]    _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowRead_32_1;
+  wire       [15:0]   _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowRead_33;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_49;
+  wire       [3:0]    _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_50;
+  wire       [0:0]    _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_32;
+  wire       [4:0]    _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_32_1;
+  wire       [15:0]   _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_33;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_49;
+  wire       [3:0]    _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_50;
+  wire       [0:0]    _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_32;
+  wire       [4:0]    _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_32_1;
+  wire       [15:0]   _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_33;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_49;
+  wire       [3:0]    _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_50;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_0;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_0_1;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_1;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_1_1;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_2;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_2_1;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_3;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_3_1;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_4;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_4_1;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_5;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_5_1;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_6;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_6_1;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_7;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_7_1;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_8;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_8_1;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_9;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_9_1;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_10;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_10_1;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_11;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_11_1;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_12;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_12_1;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_13;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_13_1;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_14;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_14_1;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_15;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_15_1;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_1_1;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_1_2;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_1_3;
+  reg        [4:0]    _zz_when_PmpPlugin_l250_1_4;
+  wire       [2:0]    _zz_when_PmpPlugin_l250_1_5;
+  reg        [4:0]    _zz_when_PmpPlugin_l250_1_6;
+  wire       [2:0]    _zz_when_PmpPlugin_l250_1_7;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_1_8;
+  reg        [4:0]    _zz_when_PmpPlugin_l250_1_9;
+  wire       [2:0]    _zz_when_PmpPlugin_l250_1_10;
+  reg        [4:0]    _zz_when_PmpPlugin_l250_1_11;
+  wire       [2:0]    _zz_when_PmpPlugin_l250_1_12;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_1_13;
+  reg        [4:0]    _zz_when_PmpPlugin_l250_1_14;
+  wire       [2:0]    _zz_when_PmpPlugin_l250_1_15;
+  reg        [4:0]    _zz_when_PmpPlugin_l250_1_16;
+  wire       [2:0]    _zz_when_PmpPlugin_l250_1_17;
+  wire       [0:0]    _zz_when_PmpPlugin_l250_1_18;
   wire       [0:0]    _zz__zz_DBusCachedPlugin_mmuBus_rsp_allowRead;
   wire       [4:0]    _zz__zz_DBusCachedPlugin_mmuBus_rsp_allowRead_1;
   wire       [15:0]   _zz__zz_DBusCachedPlugin_mmuBus_rsp_allowRead_1_1;
@@ -268,77 +353,11 @@ module VexRiscv (
   wire       [15:0]   _zz__zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_1_1;
   reg                 _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17;
   wire       [3:0]    _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_18;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_0_1;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_0_2;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_0_3;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_0_4;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_1;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_1_1;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_1_2;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_1_3;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_2;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_2_1;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_2_2;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_2_3;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_3;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_3_1;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_3_2;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_3_3;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_4;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_4_1;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_4_2;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_4_3;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_5;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_5_1;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_5_2;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_5_3;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_6;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_6_1;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_6_2;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_6_3;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_7;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_7_1;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_7_2;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_7_3;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_8;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_8_1;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_8_2;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_8_3;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_9;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_9_1;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_9_2;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_9_3;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_10;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_10_1;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_10_2;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_10_3;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_11;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_11_1;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_11_2;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_11_3;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_12;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_12_1;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_12_2;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_12_3;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_13;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_13_1;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_13_2;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_13_3;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_14;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_14_1;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_14_2;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_14_3;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_15;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_15_1;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_15_2;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_15_3;
-  wire       [0:0]    _zz_when_PmpPlugin_l299;
-  wire       [5:0]    _zz_when_PmpPlugin_l299_1;
-  wire       [0:0]    _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowExecute;
-  wire       [4:0]    _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1;
-  wire       [15:0]   _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1_1;
-  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_17;
-  wire       [3:0]    _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_18;
+  wire       [0:0]    _zz__zz_DBusCachedPlugin_mmuBus_rsp_allowExecute;
+  wire       [4:0]    _zz__zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_1;
+  wire       [15:0]   _zz__zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_1_1;
+  reg                 _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_17;
+  wire       [3:0]    _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_18;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_1;
   wire                _zz__zz_decode_IS_RS2_SIGNED_2;
@@ -355,134 +374,124 @@ module VexRiscv (
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_13;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_14;
   wire                _zz__zz_decode_IS_RS2_SIGNED_15;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_16;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_17;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_16;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_17;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_18;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_19;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_20;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_21;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_22;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_23;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_20;
+  wire       [20:0]   _zz__zz_decode_IS_RS2_SIGNED_21;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_22;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_23;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_24;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_25;
-  wire       [20:0]   _zz__zz_decode_IS_RS2_SIGNED_26;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_27;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_28;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_29;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_30;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_31;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_32;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_33;
-  wire       [17:0]   _zz__zz_decode_IS_RS2_SIGNED_34;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_35;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_25;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_26;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_27;
+  wire       [17:0]   _zz__zz_decode_IS_RS2_SIGNED_28;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_29;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_30;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_31;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_32;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_33;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_34;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_35;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_36;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_37;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_37;
   wire                _zz__zz_decode_IS_RS2_SIGNED_38;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_39;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_40;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_41;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_42;
-  wire       [14:0]   _zz__zz_decode_IS_RS2_SIGNED_43;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_44;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_39;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_40;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_41;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_42;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_43;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_44;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_45;
-  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_46;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_47;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_48;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_49;
+  wire       [13:0]   _zz__zz_decode_IS_RS2_SIGNED_46;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_47;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_48;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_49;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_50;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_51;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_52;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_53;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_54;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_55;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_54;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_55;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_56;
   wire                _zz__zz_decode_IS_RS2_SIGNED_57;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_58;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_59;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_58;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_59;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_60;
-  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_61;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_62;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_63;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_64;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_61;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_62;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_63;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_64;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_65;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_66;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_67;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_66;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_67;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_68;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_69;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_70;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_71;
-  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_72;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_73;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_74;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_75;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_69;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_70;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_71;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_72;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_73;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_74;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_75;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_76;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_77;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_78;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_79;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_80;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_77;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_78;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_79;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_80;
   wire                _zz__zz_decode_IS_RS2_SIGNED_81;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_82;
-  wire       [10:0]   _zz__zz_decode_IS_RS2_SIGNED_83;
-  wire       [5:0]    _zz__zz_decode_IS_RS2_SIGNED_84;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_85;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_86;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_87;
-  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_88;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_89;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_90;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_82;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_83;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_84;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_85;
+  wire       [9:0]    _zz__zz_decode_IS_RS2_SIGNED_86;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_87;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_88;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_89;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_90;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_91;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_92;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_92;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_93;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_94;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_95;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_96;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_97;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_98;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_99;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_100;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_101;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_94;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_95;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_96;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_97;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_98;
+  wire       [6:0]    _zz__zz_decode_IS_RS2_SIGNED_99;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_100;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_101;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_102;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_103;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_104;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_103;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_104;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_105;
-  wire       [7:0]    _zz__zz_decode_IS_RS2_SIGNED_106;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_107;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_108;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_106;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_107;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_108;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_109;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_110;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_111;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_110;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_111;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_112;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_113;
-  wire       [5:0]    _zz__zz_decode_IS_RS2_SIGNED_114;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_115;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_116;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_117;
-  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_118;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_119;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_120;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_113;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_114;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_115;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_116;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_117;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_118;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_119;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_120;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_121;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_122;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_122;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_123;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_124;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_125;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_126;
-  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_127;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_128;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_124;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_125;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_126;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_127;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_128;
   wire                _zz__zz_decode_IS_RS2_SIGNED_129;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_130;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_131;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_132;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_130;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_131;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_132;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_133;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_134;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_135;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_136;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_137;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_138;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_139;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_140;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_141;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_142;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_143;
   wire                _zz_RegFilePlugin_regFile_port;
   wire                _zz_decode_RegFilePlugin_rs1Data;
   wire                _zz_RegFilePlugin_regFile_port_1;
@@ -490,14 +499,12 @@ module VexRiscv (
   wire       [0:0]    _zz__zz_execute_REGFILE_WRITE_DATA;
   wire       [2:0]    _zz__zz_execute_SRC1;
   wire       [4:0]    _zz__zz_execute_SRC1_1;
-  wire       [11:0]   _zz__zz_execute_SRC2_3;
+  wire       [11:0]   _zz__zz_execute_SRC2_2;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_1;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_2;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_3;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_4;
-  wire       [31:0]   _zz_execute_SrcPlugin_addSub_5;
-  wire       [31:0]   _zz_execute_SrcPlugin_addSub_6;
   wire       [19:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_2;
   wire       [11:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_4;
   wire       [31:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_6;
@@ -531,27 +538,24 @@ module VexRiscv (
   wire       [0:0]    _zz_memory_DivPlugin_rs1_3;
   wire       [31:0]   _zz_memory_DivPlugin_rs2_1;
   wire       [0:0]    _zz_memory_DivPlugin_rs2_2;
-  wire       [31:0]   _zz_PmpPlugin_pmpaddr_port;
-  reg        [7:0]    _zz_when_PmpPlugin_l209;
-  wire       [3:0]    _zz_when_PmpPlugin_l209_1;
-  reg        [7:0]    _zz_when_PmpPlugin_l209_1_1;
-  wire       [3:0]    _zz_when_PmpPlugin_l209_1_2;
-  reg        [7:0]    _zz_when_PmpPlugin_l209_2;
-  wire       [3:0]    _zz_when_PmpPlugin_l209_2_1;
-  reg        [7:0]    _zz_when_PmpPlugin_l209_3;
-  wire       [3:0]    _zz_when_PmpPlugin_l209_3_1;
-  reg        [7:0]    _zz_when_PmpPlugin_l216;
-  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_25;
-  reg        [7:0]    _zz_CsrPlugin_csrMapping_readDataSignal;
-  wire       [3:0]    _zz_CsrPlugin_csrMapping_readDataSignal_1;
-  reg        [7:0]    _zz_CsrPlugin_csrMapping_readDataSignal_2;
-  wire       [3:0]    _zz_CsrPlugin_csrMapping_readDataSignal_3;
-  reg        [7:0]    _zz_CsrPlugin_csrMapping_readDataSignal_4;
-  wire       [3:0]    _zz_CsrPlugin_csrMapping_readDataSignal_5;
-  reg        [7:0]    _zz_CsrPlugin_csrMapping_readDataSignal_6;
-  wire       [3:0]    _zz_CsrPlugin_csrMapping_readDataSignal_7;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_109;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_110;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_111;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_112;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_113;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_114;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_115;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_116;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_117;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_118;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_119;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_120;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_121;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_122;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_123;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_124;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_125;
   wire       [26:0]   _zz_iBusWishbone_ADR_1;
-  reg                 _zz_1;
   wire       [51:0]   memory_MUL_LOW;
   wire       [33:0]   memory_MUL_HH;
   wire       [33:0]   execute_MUL_HH;
@@ -666,7 +670,7 @@ module VexRiscv (
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_execute_SRC2;
+  wire       [31:0]   _zz_execute_to_memory_PC;
   wire       [1:0]    execute_SRC2_CTRL;
   wire       [1:0]    _zz_execute_SRC2_CTRL;
   wire       [1:0]    execute_SRC1_CTRL;
@@ -683,7 +687,7 @@ module VexRiscv (
   wire       [1:0]    _zz_execute_ALU_BITWISE_CTRL;
   wire       [31:0]   _zz_lastStageRegFileWrite_payload_address;
   wire                _zz_lastStageRegFileWrite_valid;
-  reg                 _zz_2;
+  reg                 _zz_1;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
@@ -792,8 +796,8 @@ module VexRiscv (
   wire       [31:0]   IBusCachedPlugin_mmuBus_rsp_physicalAddress;
   wire                IBusCachedPlugin_mmuBus_rsp_isIoAccess;
   wire                IBusCachedPlugin_mmuBus_rsp_isPaging;
-  wire                IBusCachedPlugin_mmuBus_rsp_allowRead;
-  wire                IBusCachedPlugin_mmuBus_rsp_allowWrite;
+  reg                 IBusCachedPlugin_mmuBus_rsp_allowRead;
+  reg                 IBusCachedPlugin_mmuBus_rsp_allowWrite;
   reg                 IBusCachedPlugin_mmuBus_rsp_allowExecute;
   wire                IBusCachedPlugin_mmuBus_rsp_exception;
   wire                IBusCachedPlugin_mmuBus_rsp_refilling;
@@ -822,7 +826,7 @@ module VexRiscv (
   wire                DBusCachedPlugin_mmuBus_rsp_isPaging;
   reg                 DBusCachedPlugin_mmuBus_rsp_allowRead;
   reg                 DBusCachedPlugin_mmuBus_rsp_allowWrite;
-  wire                DBusCachedPlugin_mmuBus_rsp_allowExecute;
+  reg                 DBusCachedPlugin_mmuBus_rsp_allowExecute;
   wire                DBusCachedPlugin_mmuBus_rsp_exception;
   wire                DBusCachedPlugin_mmuBus_rsp_refilling;
   wire                DBusCachedPlugin_mmuBus_rsp_bypassTranslation;
@@ -842,11 +846,12 @@ module VexRiscv (
   wire       [3:0]    BranchPlugin_branchExceptionPort_payload_code;
   wire       [31:0]   BranchPlugin_branchExceptionPort_payload_badAddr;
   wire                BranchPlugin_inDebugNoFetchFlag;
-  reg        [31:0]   CsrPlugin_csrMapping_readDataSignal;
+  wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
   wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
   wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
   reg                 CsrPlugin_csrMapping_allowCsrSignal;
   wire                CsrPlugin_csrMapping_hazardFree;
+  reg                 CsrPlugin_csrMapping_doForceFailCsr;
   reg                 CsrPlugin_inWfi /* verilator public */ ;
   wire                CsrPlugin_thirdPartyWake;
   reg                 CsrPlugin_jumpInterface_valid;
@@ -865,6 +870,7 @@ module VexRiscv (
   wire                CsrPlugin_allowInterrupts;
   wire                CsrPlugin_allowException;
   wire                CsrPlugin_allowEbreakException;
+  reg                 CsrPlugin_xretAwayFromMachine;
   wire                IBusCachedPlugin_externalFlush;
   wire                IBusCachedPlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
@@ -884,14 +890,13 @@ module VexRiscv (
   reg                 IBusCachedPlugin_fetchPc_pcRegPropagate;
   reg                 IBusCachedPlugin_fetchPc_booted;
   reg                 IBusCachedPlugin_fetchPc_inc;
-  wire                when_Fetcher_l134;
-  wire                IBusCachedPlugin_fetchPc_output_fire_1;
-  wire                when_Fetcher_l134_1;
+  wire                when_Fetcher_l133;
+  wire                when_Fetcher_l133_1;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pc;
   wire                IBusCachedPlugin_fetchPc_redo_valid;
   wire       [31:0]   IBusCachedPlugin_fetchPc_redo_payload;
   reg                 IBusCachedPlugin_fetchPc_flushed;
-  wire                when_Fetcher_l161;
+  wire                when_Fetcher_l160;
   reg                 IBusCachedPlugin_iBusRsp_redoFetch;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_ready;
@@ -919,8 +924,8 @@ module VexRiscv (
   wire                _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready;
   wire                IBusCachedPlugin_iBusRsp_flush;
   wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
-  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
-  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid;
+  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1;
   wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
@@ -933,25 +938,25 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_output_payload_rsp_error;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   wire                IBusCachedPlugin_iBusRsp_output_payload_isRvc;
-  wire                when_Fetcher_l243;
-  wire                when_Fetcher_l323;
+  wire                when_Fetcher_l242;
+  wire                when_Fetcher_l322;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
-  wire                when_Fetcher_l332;
+  wire                when_Fetcher_l331;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
-  wire                when_Fetcher_l332_1;
+  wire                when_Fetcher_l331_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
-  wire                when_Fetcher_l332_2;
+  wire                when_Fetcher_l331_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
-  wire                when_Fetcher_l332_3;
+  wire                when_Fetcher_l331_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                when_Fetcher_l332_4;
+  wire                when_Fetcher_l331_4;
   wire                _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   reg        [18:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1;
-  wire                _zz_3;
-  reg        [10:0]   _zz_4;
-  wire                _zz_5;
-  reg        [18:0]   _zz_6;
-  reg                 _zz_7;
+  wire                _zz_2;
+  reg        [10:0]   _zz_3;
+  wire                _zz_4;
+  reg        [18:0]   _zz_5;
+  reg                 _zz_6;
   wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload;
   reg        [10:0]   _zz_IBusCachedPlugin_predictionJumpInterface_payload_1;
   wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
@@ -970,156 +975,507 @@ module VexRiscv (
   wire                IBusCachedPlugin_rsp_iBusRspOutputHalt;
   wire                IBusCachedPlugin_rsp_issueDetected;
   reg                 IBusCachedPlugin_rsp_redoFetch;
-  wire                when_IBusCachedPlugin_l239;
-  wire                when_IBusCachedPlugin_l244;
+  wire                when_IBusCachedPlugin_l245;
   wire                when_IBusCachedPlugin_l250;
   wire                when_IBusCachedPlugin_l256;
-  wire                when_IBusCachedPlugin_l267;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_valid;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_ready;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_address;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_data;
-  wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_size;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_last;
-  reg                 dataCache_1_io_mem_cmd_rValid;
-  reg                 dataCache_1_io_mem_cmd_rData_wr;
-  reg                 dataCache_1_io_mem_cmd_rData_uncached;
-  reg        [31:0]   dataCache_1_io_mem_cmd_rData_address;
-  reg        [31:0]   dataCache_1_io_mem_cmd_rData_data;
-  reg        [3:0]    dataCache_1_io_mem_cmd_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_rData_size;
-  reg                 dataCache_1_io_mem_cmd_rData_last;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
-  wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data;
-  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
-  wire                when_Stream_l368;
+  wire                when_IBusCachedPlugin_l262;
+  wire                when_IBusCachedPlugin_l273;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_valid;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+  wire       [3:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+  wire       [2:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_size;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rValidN;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rData_wr;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rData_uncached;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_rData_address;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_rData_data;
+  reg        [3:0]    toplevel_dataCache_1_io_mem_cmd_rData_mask;
+  reg        [2:0]    toplevel_dataCache_1_io_mem_cmd_rData_size;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rData_last;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
+  wire       [3:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
+  wire       [2:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_address;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_data;
+  reg        [3:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
+  reg        [2:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_size;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  wire                when_Stream_l369;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
-  wire                when_DBusCachedPlugin_l308;
+  wire                when_DBusCachedPlugin_l352;
   wire       [1:0]    execute_DBusCachedPlugin_size;
   reg        [31:0]   _zz_execute_MEMORY_STORE_DATA_RF;
-  wire                dataCache_1_io_cpu_flush_isStall;
-  wire                when_DBusCachedPlugin_l350;
-  wire                when_DBusCachedPlugin_l366;
-  wire                when_DBusCachedPlugin_l393;
-  wire                when_DBusCachedPlugin_l446;
-  wire                when_DBusCachedPlugin_l466;
+  wire                toplevel_dataCache_1_io_cpu_flush_isStall;
+  wire                when_DBusCachedPlugin_l394;
+  wire                when_DBusCachedPlugin_l410;
+  wire                when_DBusCachedPlugin_l472;
+  wire                when_DBusCachedPlugin_l533;
+  wire                when_DBusCachedPlugin_l553;
+  wire       [31:0]   writeBack_DBusCachedPlugin_rspData;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_0;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_1;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_2;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
   wire       [31:0]   writeBack_DBusCachedPlugin_rspRf;
-  wire       [1:0]    switch_Misc_l210;
+  wire       [1:0]    switch_Misc_l232;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_1;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated_2;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
-  wire                when_DBusCachedPlugin_l492;
-  reg        [7:0]    PmpPlugin_pmpcfg_0;
-  reg        [7:0]    PmpPlugin_pmpcfg_1;
-  reg        [7:0]    PmpPlugin_pmpcfg_2;
-  reg        [7:0]    PmpPlugin_pmpcfg_3;
-  reg        [7:0]    PmpPlugin_pmpcfg_4;
-  reg        [7:0]    PmpPlugin_pmpcfg_5;
-  reg        [7:0]    PmpPlugin_pmpcfg_6;
-  reg        [7:0]    PmpPlugin_pmpcfg_7;
-  reg        [7:0]    PmpPlugin_pmpcfg_8;
-  reg        [7:0]    PmpPlugin_pmpcfg_9;
-  reg        [7:0]    PmpPlugin_pmpcfg_10;
-  reg        [7:0]    PmpPlugin_pmpcfg_11;
-  reg        [7:0]    PmpPlugin_pmpcfg_12;
-  reg        [7:0]    PmpPlugin_pmpcfg_13;
-  reg        [7:0]    PmpPlugin_pmpcfg_14;
-  reg        [7:0]    PmpPlugin_pmpcfg_15;
-  reg        [24:0]   PmpPlugin_base_0;
-  reg        [24:0]   PmpPlugin_base_1;
-  reg        [24:0]   PmpPlugin_base_2;
-  reg        [24:0]   PmpPlugin_base_3;
-  reg        [24:0]   PmpPlugin_base_4;
-  reg        [24:0]   PmpPlugin_base_5;
-  reg        [24:0]   PmpPlugin_base_6;
-  reg        [24:0]   PmpPlugin_base_7;
-  reg        [24:0]   PmpPlugin_base_8;
-  reg        [24:0]   PmpPlugin_base_9;
-  reg        [24:0]   PmpPlugin_base_10;
-  reg        [24:0]   PmpPlugin_base_11;
-  reg        [24:0]   PmpPlugin_base_12;
-  reg        [24:0]   PmpPlugin_base_13;
-  reg        [24:0]   PmpPlugin_base_14;
-  reg        [24:0]   PmpPlugin_base_15;
-  reg        [24:0]   PmpPlugin_mask_0;
-  reg        [24:0]   PmpPlugin_mask_1;
-  reg        [24:0]   PmpPlugin_mask_2;
-  reg        [24:0]   PmpPlugin_mask_3;
-  reg        [24:0]   PmpPlugin_mask_4;
-  reg        [24:0]   PmpPlugin_mask_5;
-  reg        [24:0]   PmpPlugin_mask_6;
-  reg        [24:0]   PmpPlugin_mask_7;
-  reg        [24:0]   PmpPlugin_mask_8;
-  reg        [24:0]   PmpPlugin_mask_9;
-  reg        [24:0]   PmpPlugin_mask_10;
-  reg        [24:0]   PmpPlugin_mask_11;
-  reg        [24:0]   PmpPlugin_mask_12;
-  reg        [24:0]   PmpPlugin_mask_13;
-  reg        [24:0]   PmpPlugin_mask_14;
-  reg        [24:0]   PmpPlugin_mask_15;
-  reg                 execute_PmpPlugin_fsmPending;
-  wire                when_PmpPlugin_l138;
-  reg                 execute_PmpPlugin_fsmComplete;
-  wire       [11:0]   execute_PmpPlugin_csrAddress;
-  wire       [3:0]    execute_PmpPlugin_pmpNcfg;
-  wire       [1:0]    execute_PmpPlugin_pmpcfgN;
-  wire                execute_PmpPlugin_pmpcfgCsr;
-  wire                execute_PmpPlugin_pmpaddrCsr;
-  reg        [3:0]    execute_PmpPlugin_pmpNcfg_;
-  reg        [1:0]    execute_PmpPlugin_pmpcfgN_;
-  reg                 execute_PmpPlugin_pmpcfgCsr_;
-  reg                 execute_PmpPlugin_pmpaddrCsr_;
-  reg        [31:0]   execute_PmpPlugin_writeData_;
-  wire                execute_PmpPlugin_fsm_wantExit;
-  reg                 execute_PmpPlugin_fsm_wantStart;
-  wire                execute_PmpPlugin_fsm_wantKill;
-  reg                 execute_PmpPlugin_fsm_fsmEnable;
-  reg        [3:0]    execute_PmpPlugin_fsm_fsmCounter;
-  wire                when_PmpPlugin_l246;
-  wire       [15:0]   _zz_8;
-  wire       [15:0]   _zz_9;
-  wire       [24:0]   _zz_PmpPlugin_dGuard_hits_0;
-  wire                PmpPlugin_dGuard_hits_0;
-  wire                PmpPlugin_dGuard_hits_1;
-  wire                PmpPlugin_dGuard_hits_2;
-  wire                PmpPlugin_dGuard_hits_3;
-  wire                PmpPlugin_dGuard_hits_4;
-  wire                PmpPlugin_dGuard_hits_5;
-  wire                PmpPlugin_dGuard_hits_6;
-  wire                PmpPlugin_dGuard_hits_7;
-  wire                PmpPlugin_dGuard_hits_8;
-  wire                PmpPlugin_dGuard_hits_9;
-  wire                PmpPlugin_dGuard_hits_10;
-  wire                PmpPlugin_dGuard_hits_11;
-  wire                PmpPlugin_dGuard_hits_12;
-  wire                PmpPlugin_dGuard_hits_13;
-  wire                PmpPlugin_dGuard_hits_14;
-  wire                PmpPlugin_dGuard_hits_15;
-  wire                when_PmpPlugin_l277;
+  wire                when_DBusCachedPlugin_l580;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute;
+  reg                 _zz_when_PmpPlugin_l126;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_1;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_1;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1;
+  reg                 _zz_when_PmpPlugin_l126_1;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_2;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
+  reg                 _zz_PmpPlugin_ports_0_hits_0;
+  wire                _zz_PmpPlugin_ports_0_hits_0_1;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_0_2;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_0_3;
+  wire                when_PmpPlugin_l126;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_0_4;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_0_5;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_0_6;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_0_7;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_2;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_2;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_2;
+  reg                 _zz_when_PmpPlugin_l126_2;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_4;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_5;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_3;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_3;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_3;
+  reg                 _zz_when_PmpPlugin_l126_3;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_6;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
+  reg                 _zz_PmpPlugin_ports_0_hits_1;
+  wire                _zz_PmpPlugin_ports_0_hits_1_1;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_1_2;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_1_3;
+  wire                when_PmpPlugin_l126_1;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_1_4;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_1_5;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_1_6;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_1_7;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_4;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_4;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_4;
+  reg                 _zz_when_PmpPlugin_l126_4;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_8;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_5;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_5;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_5;
+  reg                 _zz_when_PmpPlugin_l126_5;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_10;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_11;
+  reg                 _zz_PmpPlugin_ports_0_hits_2;
+  wire                _zz_PmpPlugin_ports_0_hits_2_1;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_2_2;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_2_3;
+  wire                when_PmpPlugin_l126_2;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_2_4;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_2_5;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_2_6;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_2_7;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_6;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_6;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_6;
+  reg                 _zz_when_PmpPlugin_l126_6;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_12;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_13;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_7;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_7;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_7;
+  reg                 _zz_when_PmpPlugin_l126_7;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_14;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_15;
+  reg                 _zz_PmpPlugin_ports_0_hits_3;
+  wire                _zz_PmpPlugin_ports_0_hits_3_1;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_3_2;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_3_3;
+  wire                when_PmpPlugin_l126_3;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_3_4;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_3_5;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_3_6;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_3_7;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_8;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_8;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_8;
+  reg                 _zz_when_PmpPlugin_l126_8;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_16;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_17;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_9;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_9;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_9;
+  reg                 _zz_when_PmpPlugin_l126_9;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_18;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_19;
+  reg                 _zz_PmpPlugin_ports_0_hits_4;
+  wire                _zz_PmpPlugin_ports_0_hits_4_1;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_4_2;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_4_3;
+  wire                when_PmpPlugin_l126_4;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_4_4;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_4_5;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_4_6;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_4_7;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_10;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_10;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_10;
+  reg                 _zz_when_PmpPlugin_l126_10;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_20;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_21;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_11;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_11;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_11;
+  reg                 _zz_when_PmpPlugin_l126_11;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_22;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_23;
+  reg                 _zz_PmpPlugin_ports_0_hits_5;
+  wire                _zz_PmpPlugin_ports_0_hits_5_1;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_5_2;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_5_3;
+  wire                when_PmpPlugin_l126_5;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_5_4;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_5_5;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_5_6;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_5_7;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_12;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_12;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_12;
+  reg                 _zz_when_PmpPlugin_l126_12;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_24;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_25;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_13;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_13;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_13;
+  reg                 _zz_when_PmpPlugin_l126_13;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_26;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_27;
+  reg                 _zz_PmpPlugin_ports_0_hits_6;
+  wire                _zz_PmpPlugin_ports_0_hits_6_1;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_6_2;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_6_3;
+  wire                when_PmpPlugin_l126_6;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_6_4;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_6_5;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_6_6;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_6_7;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_14;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_14;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_14;
+  reg                 _zz_when_PmpPlugin_l126_14;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_28;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_29;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_15;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_15;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_15;
+  reg                 _zz_when_PmpPlugin_l126_15;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_30;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_31;
+  reg                 _zz_PmpPlugin_ports_0_hits_7;
+  wire                _zz_PmpPlugin_ports_0_hits_7_1;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_7_2;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_7_3;
+  wire                when_PmpPlugin_l126_7;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_7_4;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_7_5;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_7_6;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_7_7;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_16;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_16;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_16;
+  reg                 _zz_when_PmpPlugin_l126_16;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_32;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_33;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_17;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_17;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_17;
+  reg                 _zz_when_PmpPlugin_l126_17;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_34;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_35;
+  reg                 _zz_PmpPlugin_ports_0_hits_8;
+  wire                _zz_PmpPlugin_ports_0_hits_8_1;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_8_2;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_8_3;
+  wire                when_PmpPlugin_l126_8;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_8_4;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_8_5;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_8_6;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_8_7;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_18;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_18;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_18;
+  reg                 _zz_when_PmpPlugin_l126_18;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_36;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_37;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_19;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_19;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_19;
+  reg                 _zz_when_PmpPlugin_l126_19;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_38;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_39;
+  reg                 _zz_PmpPlugin_ports_0_hits_9;
+  wire                _zz_PmpPlugin_ports_0_hits_9_1;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_9_2;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_9_3;
+  wire                when_PmpPlugin_l126_9;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_9_4;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_9_5;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_9_6;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_9_7;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_20;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_20;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_20;
+  reg                 _zz_when_PmpPlugin_l126_20;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_40;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_41;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_21;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_21;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_21;
+  reg                 _zz_when_PmpPlugin_l126_21;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_42;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_43;
+  reg                 _zz_PmpPlugin_ports_0_hits_10;
+  wire                _zz_PmpPlugin_ports_0_hits_10_1;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_10_2;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_10_3;
+  wire                when_PmpPlugin_l126_10;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_10_4;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_10_5;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_10_6;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_10_7;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_22;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_22;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_22;
+  reg                 _zz_when_PmpPlugin_l126_22;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_44;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_45;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_23;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_23;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_23;
+  reg                 _zz_when_PmpPlugin_l126_23;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_46;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_47;
+  reg                 _zz_PmpPlugin_ports_0_hits_11;
+  wire                _zz_PmpPlugin_ports_0_hits_11_1;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_11_2;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_11_3;
+  wire                when_PmpPlugin_l126_11;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_11_4;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_11_5;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_11_6;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_11_7;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_24;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_24;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_24;
+  reg                 _zz_when_PmpPlugin_l126_24;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_48;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_49;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_25;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_25;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_25;
+  reg                 _zz_when_PmpPlugin_l126_25;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_50;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_51;
+  reg                 _zz_PmpPlugin_ports_0_hits_12;
+  wire                _zz_PmpPlugin_ports_0_hits_12_1;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_12_2;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_12_3;
+  wire                when_PmpPlugin_l126_12;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_12_4;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_12_5;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_12_6;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_12_7;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_26;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_26;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_26;
+  reg                 _zz_when_PmpPlugin_l126_26;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_52;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_53;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_27;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_27;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_27;
+  reg                 _zz_when_PmpPlugin_l126_27;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_54;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_55;
+  reg                 _zz_PmpPlugin_ports_0_hits_13;
+  wire                _zz_PmpPlugin_ports_0_hits_13_1;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_13_2;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_13_3;
+  wire                when_PmpPlugin_l126_13;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_13_4;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_13_5;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_13_6;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_13_7;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_28;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_28;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_28;
+  reg                 _zz_when_PmpPlugin_l126_28;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_56;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_57;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_29;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_29;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_29;
+  reg                 _zz_when_PmpPlugin_l126_29;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_58;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_59;
+  reg                 _zz_PmpPlugin_ports_0_hits_14;
+  wire                _zz_PmpPlugin_ports_0_hits_14_1;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_14_2;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_14_3;
+  wire                when_PmpPlugin_l126_14;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_14_4;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_14_5;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_14_6;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_14_7;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_30;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_30;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_30;
+  reg                 _zz_when_PmpPlugin_l126_30;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_60;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_61;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_31;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_31;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_31;
+  reg                 _zz_when_PmpPlugin_l126_31;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_62;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_63;
+  reg                 _zz_PmpPlugin_ports_0_hits_15;
+  wire                _zz_PmpPlugin_ports_0_hits_15_1;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_15_2;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_15_3;
+  wire                when_PmpPlugin_l126_15;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_15_4;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_15_5;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_15_6;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_15_7;
+  wire                PmpPlugin_ports_0_hits_0;
+  wire                PmpPlugin_ports_0_hits_1;
+  wire                PmpPlugin_ports_0_hits_2;
+  wire                PmpPlugin_ports_0_hits_3;
+  wire                PmpPlugin_ports_0_hits_4;
+  wire                PmpPlugin_ports_0_hits_5;
+  wire                PmpPlugin_ports_0_hits_6;
+  wire                PmpPlugin_ports_0_hits_7;
+  wire                PmpPlugin_ports_0_hits_8;
+  wire                PmpPlugin_ports_0_hits_9;
+  wire                PmpPlugin_ports_0_hits_10;
+  wire                PmpPlugin_ports_0_hits_11;
+  wire                PmpPlugin_ports_0_hits_12;
+  wire                PmpPlugin_ports_0_hits_13;
+  wire                PmpPlugin_ports_0_hits_14;
+  wire                PmpPlugin_ports_0_hits_15;
+  wire       [4:0]    _zz_when_PmpPlugin_l250;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_1;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_2;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_3;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_4;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_5;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_6;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_7;
+  wire                when_PmpPlugin_l250;
+  wire       [15:0]   _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_32;
+  wire       [15:0]   _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_33;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_34;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_35;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_36;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_37;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_38;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_39;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_40;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_41;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_42;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_43;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_44;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_45;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_46;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_47;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_48;
+  wire       [15:0]   _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_32;
+  wire       [15:0]   _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_33;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_34;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_35;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_36;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_37;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_38;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_39;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_40;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_41;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_42;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_43;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_44;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_45;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_46;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_47;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_48;
+  wire       [15:0]   _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_32;
+  wire       [15:0]   _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_33;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_34;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_35;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_36;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_37;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_38;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_39;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_40;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_41;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_42;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_43;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_44;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_45;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_46;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_47;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_48;
+  wire                PmpPlugin_ports_1_hits_0;
+  wire                PmpPlugin_ports_1_hits_1;
+  wire                PmpPlugin_ports_1_hits_2;
+  wire                PmpPlugin_ports_1_hits_3;
+  wire                PmpPlugin_ports_1_hits_4;
+  wire                PmpPlugin_ports_1_hits_5;
+  wire                PmpPlugin_ports_1_hits_6;
+  wire                PmpPlugin_ports_1_hits_7;
+  wire                PmpPlugin_ports_1_hits_8;
+  wire                PmpPlugin_ports_1_hits_9;
+  wire                PmpPlugin_ports_1_hits_10;
+  wire                PmpPlugin_ports_1_hits_11;
+  wire                PmpPlugin_ports_1_hits_12;
+  wire                PmpPlugin_ports_1_hits_13;
+  wire                PmpPlugin_ports_1_hits_14;
+  wire                PmpPlugin_ports_1_hits_15;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_8;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_9;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_10;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_11;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_12;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_13;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_14;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_15;
+  wire                when_PmpPlugin_l250_1;
   wire       [15:0]   _zz_DBusCachedPlugin_mmuBus_rsp_allowRead;
   wire       [15:0]   _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_1;
   wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_2;
@@ -1154,41 +1510,23 @@ module VexRiscv (
   wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_14;
   wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_15;
   wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_16;
-  wire       [24:0]   _zz_PmpPlugin_iGuard_hits_0;
-  wire                PmpPlugin_iGuard_hits_0;
-  wire                PmpPlugin_iGuard_hits_1;
-  wire                PmpPlugin_iGuard_hits_2;
-  wire                PmpPlugin_iGuard_hits_3;
-  wire                PmpPlugin_iGuard_hits_4;
-  wire                PmpPlugin_iGuard_hits_5;
-  wire                PmpPlugin_iGuard_hits_6;
-  wire                PmpPlugin_iGuard_hits_7;
-  wire                PmpPlugin_iGuard_hits_8;
-  wire                PmpPlugin_iGuard_hits_9;
-  wire                PmpPlugin_iGuard_hits_10;
-  wire                PmpPlugin_iGuard_hits_11;
-  wire                PmpPlugin_iGuard_hits_12;
-  wire                PmpPlugin_iGuard_hits_13;
-  wire                PmpPlugin_iGuard_hits_14;
-  wire                PmpPlugin_iGuard_hits_15;
-  wire                when_PmpPlugin_l299;
-  wire       [15:0]   _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute;
-  wire       [15:0]   _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1;
-  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_2;
-  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_3;
-  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_4;
-  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_5;
-  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_6;
-  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_7;
-  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_8;
-  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_9;
-  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_10;
-  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_11;
-  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_12;
-  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_13;
-  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_14;
-  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_15;
-  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_16;
+  wire       [15:0]   _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute;
+  wire       [15:0]   _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_1;
+  wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_2;
+  wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_3;
+  wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_4;
+  wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_5;
+  wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_6;
+  wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_7;
+  wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_8;
+  wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_9;
+  wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_10;
+  wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_11;
+  wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_12;
+  wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_13;
+  wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_14;
+  wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_15;
+  wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_16;
   wire       [31:0]   _zz_decode_IS_RS2_SIGNED;
   wire                _zz_decode_IS_RS2_SIGNED_1;
   wire                _zz_decode_IS_RS2_SIGNED_2;
@@ -1214,11 +1552,11 @@ module VexRiscv (
   reg        [31:0]   execute_IntAluPlugin_bitwise;
   reg        [31:0]   _zz_execute_REGFILE_WRITE_DATA;
   reg        [31:0]   _zz_execute_SRC1;
-  wire                _zz_execute_SRC2_1;
-  reg        [19:0]   _zz_execute_SRC2_2;
-  wire                _zz_execute_SRC2_3;
-  reg        [19:0]   _zz_execute_SRC2_4;
-  reg        [31:0]   _zz_execute_SRC2_5;
+  wire                _zz_execute_SRC2;
+  reg        [19:0]   _zz_execute_SRC2_1;
+  wire                _zz_execute_SRC2_2;
+  reg        [19:0]   _zz_execute_SRC2_3;
+  reg        [31:0]   _zz_execute_SRC2_4;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   wire       [4:0]    execute_FullBarrelShifterPlugin_amplitude;
@@ -1255,7 +1593,7 @@ module VexRiscv (
   wire                when_HazardSimplePlugin_l108;
   wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    switch_Misc_l210_1;
+  wire       [2:0]    switch_Misc_l232_1;
   reg                 _zz_execute_BRANCH_COND_RESULT;
   reg                 _zz_execute_BRANCH_COND_RESULT_1;
   wire                _zz_execute_BranchPlugin_missAlignedTarget;
@@ -1276,8 +1614,8 @@ module VexRiscv (
   reg        [18:0]   _zz_execute_BranchPlugin_branch_src2_5;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
   reg        [1:0]    _zz_CsrPlugin_privilege;
-  reg        [1:0]    CsrPlugin_misa_base;
-  reg        [25:0]   CsrPlugin_misa_extensions;
+  wire       [1:0]    CsrPlugin_misa_base;
+  wire       [25:0]   CsrPlugin_misa_extensions;
   reg        [1:0]    CsrPlugin_mtvec_mode;
   reg        [29:0]   CsrPlugin_mtvec_base;
   reg        [31:0]   CsrPlugin_mepc;
@@ -1296,9 +1634,12 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_mtval;
   reg        [63:0]   CsrPlugin_mcycle;
   reg        [63:0]   CsrPlugin_minstret;
-  wire                _zz_when_CsrPlugin_l965;
-  wire                _zz_when_CsrPlugin_l965_1;
-  wire                _zz_when_CsrPlugin_l965_2;
+  reg                 CsrPlugin_mcounteren_IR;
+  wire                CsrPlugin_mcounteren_TM;
+  reg                 CsrPlugin_mcounteren_CY;
+  wire                _zz_when_CsrPlugin_l1302;
+  wire                _zz_when_CsrPlugin_l1302_1;
+  wire                _zz_when_CsrPlugin_l1302_2;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -1313,59 +1654,63 @@ module VexRiscv (
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
   wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code;
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
-  wire                when_CsrPlugin_l922;
-  wire                when_CsrPlugin_l922_1;
-  wire                when_CsrPlugin_l922_2;
-  wire                when_CsrPlugin_l922_3;
-  wire                when_CsrPlugin_l935;
+  wire                when_CsrPlugin_l1259;
+  wire                when_CsrPlugin_l1259_1;
+  wire                when_CsrPlugin_l1259_2;
+  wire                when_CsrPlugin_l1259_3;
+  wire                when_CsrPlugin_l1272;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
-  wire                when_CsrPlugin_l959;
-  wire                when_CsrPlugin_l965;
-  wire                when_CsrPlugin_l965_1;
-  wire                when_CsrPlugin_l965_2;
+  wire                when_CsrPlugin_l1296;
+  wire                when_CsrPlugin_l1302;
+  wire                when_CsrPlugin_l1302_1;
+  wire                when_CsrPlugin_l1302_2;
   wire                CsrPlugin_exception;
   reg                 CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
-  wire                when_CsrPlugin_l993;
-  wire                when_CsrPlugin_l993_1;
-  wire                when_CsrPlugin_l993_2;
-  wire                when_CsrPlugin_l998;
+  wire                when_CsrPlugin_l1335;
+  wire                when_CsrPlugin_l1335_1;
+  wire                when_CsrPlugin_l1335_2;
+  wire                when_CsrPlugin_l1340;
   reg                 CsrPlugin_pipelineLiberator_done;
-  wire                when_CsrPlugin_l1004;
+  wire                when_CsrPlugin_l1346;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
+  wire                CsrPlugin_trapCauseEbreakDebug;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
-  wire                when_CsrPlugin_l1032;
-  wire                when_CsrPlugin_l1077;
-  wire       [1:0]    switch_CsrPlugin_l1081;
+  wire                CsrPlugin_trapEnterDebug;
+  wire                when_CsrPlugin_l1390;
+  wire                when_CsrPlugin_l1398;
+  wire                when_CsrPlugin_l1456;
+  wire       [1:0]    switch_CsrPlugin_l1460;
+  wire                when_CsrPlugin_l1468;
   reg                 execute_CsrPlugin_wfiWake;
-  wire                when_CsrPlugin_l1121;
-  wire                when_CsrPlugin_l1123;
-  wire                when_CsrPlugin_l1129;
+  wire                when_CsrPlugin_l1519;
+  wire                when_CsrPlugin_l1521;
+  wire                when_CsrPlugin_l1527;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire                when_CsrPlugin_l1142;
-  wire                when_CsrPlugin_l1149;
-  wire                when_CsrPlugin_l1150;
-  wire                when_CsrPlugin_l1157;
+  wire                when_CsrPlugin_l1540;
+  wire                when_CsrPlugin_l1547;
+  wire                when_CsrPlugin_l1548;
+  wire                when_CsrPlugin_l1555;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   wire       [31:0]   execute_CsrPlugin_readToWriteData;
-  wire                switch_Misc_l210_2;
+  wire                switch_Misc_l232_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
-  wire                when_CsrPlugin_l1189;
-  wire                when_CsrPlugin_l1193;
+  wire                when_CsrPlugin_l1587;
+  wire                when_CsrPlugin_l1591;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg                 execute_MulPlugin_aSigned;
   reg                 execute_MulPlugin_bSigned;
@@ -1411,8 +1756,8 @@ module VexRiscv (
   wire                _zz_memory_DivPlugin_rs1;
   reg        [32:0]   _zz_memory_DivPlugin_rs1_1;
   reg        [31:0]   externalInterruptArray_regNext;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit;
-  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_64;
+  wire       [31:0]   _zz_externalInterrupt;
   wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
   wire                when_Pipeline_l124_1;
@@ -1543,113 +1888,160 @@ module VexRiscv (
   wire                when_Pipeline_l154_1;
   wire                when_Pipeline_l151_2;
   wire                when_Pipeline_l154_2;
-  reg        [2:0]    execute_PmpPlugin_fsm_stateReg;
-  reg        [2:0]    execute_PmpPlugin_fsm_stateNext;
-  wire       [7:0]    _zz_PmpPlugin_pmpcfg_0;
-  wire       [7:0]    _zz_PmpPlugin_pmpcfg_0_1;
-  wire       [7:0]    _zz_PmpPlugin_pmpcfg_0_2;
-  wire       [7:0]    _zz_PmpPlugin_pmpcfg_0_3;
-  wire                when_PmpPlugin_l209;
-  wire       [15:0]   _zz_11;
-  wire                when_PmpPlugin_l209_1;
-  wire       [15:0]   _zz_12;
-  wire                when_PmpPlugin_l209_2;
-  wire       [15:0]   _zz_13;
-  wire                when_PmpPlugin_l209_3;
-  wire       [15:0]   _zz_14;
-  wire                when_PmpPlugin_l216;
-  wire                when_PmpPlugin_l229;
-  wire                when_StateMachine_l233;
-  wire                when_StateMachine_l249;
-  wire                when_StateMachine_l249_1;
-  wire                when_StateMachine_l249_2;
-  wire                when_CsrPlugin_l1277;
+  wire                when_CsrPlugin_l1669;
   reg                 execute_CsrPlugin_csr_3264;
-  wire                when_CsrPlugin_l1277_1;
+  wire                when_CsrPlugin_l1669_1;
+  reg                 execute_CsrPlugin_csr_944;
+  wire                when_CsrPlugin_l1669_2;
+  reg                 execute_CsrPlugin_csr_945;
+  wire                when_CsrPlugin_l1669_3;
+  reg                 execute_CsrPlugin_csr_946;
+  wire                when_CsrPlugin_l1669_4;
+  reg                 execute_CsrPlugin_csr_947;
+  wire                when_CsrPlugin_l1669_5;
+  reg                 execute_CsrPlugin_csr_948;
+  wire                when_CsrPlugin_l1669_6;
+  reg                 execute_CsrPlugin_csr_949;
+  wire                when_CsrPlugin_l1669_7;
+  reg                 execute_CsrPlugin_csr_950;
+  wire                when_CsrPlugin_l1669_8;
+  reg                 execute_CsrPlugin_csr_951;
+  wire                when_CsrPlugin_l1669_9;
+  reg                 execute_CsrPlugin_csr_952;
+  wire                when_CsrPlugin_l1669_10;
+  reg                 execute_CsrPlugin_csr_953;
+  wire                when_CsrPlugin_l1669_11;
+  reg                 execute_CsrPlugin_csr_954;
+  wire                when_CsrPlugin_l1669_12;
+  reg                 execute_CsrPlugin_csr_955;
+  wire                when_CsrPlugin_l1669_13;
+  reg                 execute_CsrPlugin_csr_956;
+  wire                when_CsrPlugin_l1669_14;
+  reg                 execute_CsrPlugin_csr_957;
+  wire                when_CsrPlugin_l1669_15;
+  reg                 execute_CsrPlugin_csr_958;
+  wire                when_CsrPlugin_l1669_16;
+  reg                 execute_CsrPlugin_csr_959;
+  wire                when_CsrPlugin_l1669_17;
+  reg                 execute_CsrPlugin_csr_928;
+  wire                when_CsrPlugin_l1669_18;
+  reg                 execute_CsrPlugin_csr_929;
+  wire                when_CsrPlugin_l1669_19;
+  reg                 execute_CsrPlugin_csr_930;
+  wire                when_CsrPlugin_l1669_20;
+  reg                 execute_CsrPlugin_csr_931;
+  wire                when_CsrPlugin_l1669_21;
   reg                 execute_CsrPlugin_csr_3857;
-  wire                when_CsrPlugin_l1277_2;
+  wire                when_CsrPlugin_l1669_22;
   reg                 execute_CsrPlugin_csr_3858;
-  wire                when_CsrPlugin_l1277_3;
+  wire                when_CsrPlugin_l1669_23;
   reg                 execute_CsrPlugin_csr_3859;
-  wire                when_CsrPlugin_l1277_4;
+  wire                when_CsrPlugin_l1669_24;
   reg                 execute_CsrPlugin_csr_3860;
-  wire                when_CsrPlugin_l1277_5;
+  wire                when_CsrPlugin_l1669_25;
   reg                 execute_CsrPlugin_csr_769;
-  wire                when_CsrPlugin_l1277_6;
+  wire                when_CsrPlugin_l1669_26;
   reg                 execute_CsrPlugin_csr_768;
-  wire                when_CsrPlugin_l1277_7;
+  wire                when_CsrPlugin_l1669_27;
   reg                 execute_CsrPlugin_csr_836;
-  wire                when_CsrPlugin_l1277_8;
+  wire                when_CsrPlugin_l1669_28;
   reg                 execute_CsrPlugin_csr_772;
-  wire                when_CsrPlugin_l1277_9;
+  wire                when_CsrPlugin_l1669_29;
   reg                 execute_CsrPlugin_csr_773;
-  wire                when_CsrPlugin_l1277_10;
+  wire                when_CsrPlugin_l1669_30;
   reg                 execute_CsrPlugin_csr_833;
-  wire                when_CsrPlugin_l1277_11;
+  wire                when_CsrPlugin_l1669_31;
   reg                 execute_CsrPlugin_csr_832;
-  wire                when_CsrPlugin_l1277_12;
+  wire                when_CsrPlugin_l1669_32;
   reg                 execute_CsrPlugin_csr_834;
-  wire                when_CsrPlugin_l1277_13;
+  wire                when_CsrPlugin_l1669_33;
   reg                 execute_CsrPlugin_csr_835;
-  wire                when_CsrPlugin_l1277_14;
+  wire                when_CsrPlugin_l1669_34;
   reg                 execute_CsrPlugin_csr_2816;
-  wire                when_CsrPlugin_l1277_15;
+  wire                when_CsrPlugin_l1669_35;
   reg                 execute_CsrPlugin_csr_2944;
-  wire                when_CsrPlugin_l1277_16;
+  wire                when_CsrPlugin_l1669_36;
   reg                 execute_CsrPlugin_csr_2818;
-  wire                when_CsrPlugin_l1277_17;
+  wire                when_CsrPlugin_l1669_37;
   reg                 execute_CsrPlugin_csr_2946;
-  wire                when_CsrPlugin_l1277_18;
+  wire                when_CsrPlugin_l1669_38;
   reg                 execute_CsrPlugin_csr_3072;
-  wire                when_CsrPlugin_l1277_19;
+  wire                when_CsrPlugin_l1669_39;
   reg                 execute_CsrPlugin_csr_3200;
-  wire                when_CsrPlugin_l1277_20;
+  wire                when_CsrPlugin_l1669_40;
   reg                 execute_CsrPlugin_csr_3074;
-  wire                when_CsrPlugin_l1277_21;
+  wire                when_CsrPlugin_l1669_41;
   reg                 execute_CsrPlugin_csr_3202;
-  wire                when_CsrPlugin_l1277_22;
+  wire                when_CsrPlugin_l1669_42;
+  reg                 execute_CsrPlugin_csr_774;
+  wire                when_CsrPlugin_l1669_43;
   reg                 execute_CsrPlugin_csr_3008;
-  wire                when_CsrPlugin_l1277_23;
+  wire                when_CsrPlugin_l1669_44;
   reg                 execute_CsrPlugin_csr_4032;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_5;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_6;
-  wire       [1:0]    switch_CsrPlugin_l723;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_8;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_10;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_11;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_12;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_13;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_14;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_15;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_16;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_17;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_18;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_19;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_20;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_21;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_22;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_23;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_24;
-  wire                when_PmpPlugin_l155;
-  wire                when_PmpPlugin_l172;
-  wire                when_PmpPlugin_l175;
-  wire                when_CsrPlugin_l1310;
-  wire                when_CsrPlugin_l1315;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_65;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_66;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_67;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_68;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_69;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_70;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_71;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_72;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_73;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_74;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_75;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_76;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_77;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_78;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_79;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_80;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_81;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_82;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_83;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_84;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_85;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_86;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_87;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_88;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_89;
+  wire       [1:0]    switch_CsrPlugin_l1031;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_90;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_91;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_92;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_93;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_94;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_95;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_96;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_97;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_98;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_99;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_100;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_101;
+  wire                when_CsrPlugin_l1076;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_102;
+  wire                when_CsrPlugin_l1076_1;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_103;
+  wire                when_CsrPlugin_l1076_2;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_104;
+  wire                when_CsrPlugin_l1076_3;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_105;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_106;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_107;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_108;
+  wire       [11:0]   _zz_when_CsrPlugin_l1709;
+  wire                when_CsrPlugin_l1709;
+  reg                 when_CsrPlugin_l1719;
+  wire                when_CsrPlugin_l1717;
+  wire                when_CsrPlugin_l1725;
   reg        [2:0]    _zz_iBusWishbone_ADR;
   wire                when_InstructionCache_l239;
   reg                 _zz_iBus_rsp_valid;
   reg        [31:0]   iBusWishbone_DAT_MISO_regNext;
-  reg        [2:0]    _zz_dBus_cmd_ready;
+  reg        [2:0]    _zz_dBusWishbone_ADR;
+  wire                _zz_dBusWishbone_CYC;
+  wire                _zz_dBus_cmd_ready;
   wire                _zz_dBus_cmd_ready_1;
   wire                _zz_dBus_cmd_ready_2;
-  wire                _zz_dBus_cmd_ready_3;
-  wire                _zz_dBus_cmd_ready_4;
-  wire                _zz_dBus_cmd_ready_5;
+  wire                _zz_dBusWishbone_ADR_1;
   reg                 _zz_dBus_rsp_valid;
   reg        [31:0]   dBusWishbone_DAT_MISO_regNext;
   `ifndef SYNTHESIS
@@ -1731,23 +2123,19 @@ module VexRiscv (
   reg [39:0] decode_to_execute_ENV_CTRL_string;
   reg [39:0] execute_to_memory_ENV_CTRL_string;
   reg [39:0] memory_to_writeBack_ENV_CTRL_string;
-  reg [79:0] execute_PmpPlugin_fsm_stateReg_string;
-  reg [79:0] execute_PmpPlugin_fsm_stateNext_string;
   `endif
 
-  (* ram_style = "distributed" *) reg [31:0] PmpPlugin_pmpaddr [0:15];
   (* no_rw_check , ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
   assign _zz_when = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
-  assign _zz_memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW_1) + $signed(_zz_memory_MUL_LOW_5));
-  assign _zz_memory_MUL_LOW_1 = ($signed(_zz_memory_MUL_LOW_2) + $signed(_zz_memory_MUL_LOW_3));
-  assign _zz_memory_MUL_LOW_2 = 52'h0;
-  assign _zz_memory_MUL_LOW_4 = {1'b0,memory_MUL_LL};
-  assign _zz_memory_MUL_LOW_3 = {{19{_zz_memory_MUL_LOW_4[32]}}, _zz_memory_MUL_LOW_4};
-  assign _zz_memory_MUL_LOW_6 = ({16'd0,memory_MUL_LH} <<< 16);
-  assign _zz_memory_MUL_LOW_5 = {{2{_zz_memory_MUL_LOW_6[49]}}, _zz_memory_MUL_LOW_6};
-  assign _zz_memory_MUL_LOW_8 = ({16'd0,memory_MUL_HL} <<< 16);
-  assign _zz_memory_MUL_LOW_7 = {{2{_zz_memory_MUL_LOW_8[49]}}, _zz_memory_MUL_LOW_8};
+  assign _zz_memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW_1) + $signed(_zz_memory_MUL_LOW_4));
+  assign _zz_memory_MUL_LOW_1 = ($signed(52'h0000000000000) + $signed(_zz_memory_MUL_LOW_2));
+  assign _zz_memory_MUL_LOW_3 = {1'b0,memory_MUL_LL};
+  assign _zz_memory_MUL_LOW_2 = {{19{_zz_memory_MUL_LOW_3[32]}}, _zz_memory_MUL_LOW_3};
+  assign _zz_memory_MUL_LOW_5 = ({16'd0,memory_MUL_LH} <<< 5'd16);
+  assign _zz_memory_MUL_LOW_4 = {{2{_zz_memory_MUL_LOW_5[49]}}, _zz_memory_MUL_LOW_5};
+  assign _zz_memory_MUL_LOW_7 = ({16'd0,memory_MUL_HL} <<< 5'd16);
+  assign _zz_memory_MUL_LOW_6 = {{2{_zz_memory_MUL_LOW_7[49]}}, _zz_memory_MUL_LOW_7};
   assign _zz_execute_SHIFT_RIGHT_1 = ($signed(_zz_execute_SHIFT_RIGHT_2) >>> execute_FullBarrelShifterPlugin_amplitude);
   assign _zz_execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT_1[31 : 0];
   assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == ShiftCtrlEnum_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
@@ -1756,30 +2144,157 @@ module VexRiscv (
   assign _zz_IBusCachedPlugin_fetchPc_pc = {29'd0, _zz_IBusCachedPlugin_fetchPc_pc_1};
   assign _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
   assign _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2 = {{_zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz__zz_3 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz__zz_5 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz__zz_7 = {{_zz_4,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz__zz_7_1 = {{_zz_6,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz__zz_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz__zz_4 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz__zz_6 = {{_zz_3,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
+  assign _zz__zz_6_1 = {{_zz_5,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
   assign _zz_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId_1;
-  assign _zz_io_cpu_flush_payload_lineId_1 = (execute_RS1 >>> 5);
+  assign _zz_io_cpu_flush_payload_lineId_1 = (execute_RS1 >>> 3'd5);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code_1 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
+  assign _zz__zz_PmpPlugin_ports_0_hits_0_6 = (_zz_PmpPlugin_ports_0_hits_0_4 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_0_3 = ({2'd0,_zz__zz_PmpPlugin_ports_0_hits_0_3_1} <<< 2'd2);
+  assign _zz__zz_PmpPlugin_ports_0_hits_0_3_1 = (_zz_PmpPlugin_ports_0_hits_0_6 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_1_6 = (_zz_PmpPlugin_ports_0_hits_1_4 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_1_3 = ({2'd0,_zz__zz_PmpPlugin_ports_0_hits_1_3_1} <<< 2'd2);
+  assign _zz__zz_PmpPlugin_ports_0_hits_1_3_1 = (_zz_PmpPlugin_ports_0_hits_1_6 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_2_6 = (_zz_PmpPlugin_ports_0_hits_2_4 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_2_3 = ({2'd0,_zz__zz_PmpPlugin_ports_0_hits_2_3_1} <<< 2'd2);
+  assign _zz__zz_PmpPlugin_ports_0_hits_2_3_1 = (_zz_PmpPlugin_ports_0_hits_2_6 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_3_6 = (_zz_PmpPlugin_ports_0_hits_3_4 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_3_3 = ({2'd0,_zz__zz_PmpPlugin_ports_0_hits_3_3_1} <<< 2'd2);
+  assign _zz__zz_PmpPlugin_ports_0_hits_3_3_1 = (_zz_PmpPlugin_ports_0_hits_3_6 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_4_6 = (_zz_PmpPlugin_ports_0_hits_4_4 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_4_3 = ({2'd0,_zz__zz_PmpPlugin_ports_0_hits_4_3_1} <<< 2'd2);
+  assign _zz__zz_PmpPlugin_ports_0_hits_4_3_1 = (_zz_PmpPlugin_ports_0_hits_4_6 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_5_6 = (_zz_PmpPlugin_ports_0_hits_5_4 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_5_3 = ({2'd0,_zz__zz_PmpPlugin_ports_0_hits_5_3_1} <<< 2'd2);
+  assign _zz__zz_PmpPlugin_ports_0_hits_5_3_1 = (_zz_PmpPlugin_ports_0_hits_5_6 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_6_6 = (_zz_PmpPlugin_ports_0_hits_6_4 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_6_3 = ({2'd0,_zz__zz_PmpPlugin_ports_0_hits_6_3_1} <<< 2'd2);
+  assign _zz__zz_PmpPlugin_ports_0_hits_6_3_1 = (_zz_PmpPlugin_ports_0_hits_6_6 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_7_6 = (_zz_PmpPlugin_ports_0_hits_7_4 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_7_3 = ({2'd0,_zz__zz_PmpPlugin_ports_0_hits_7_3_1} <<< 2'd2);
+  assign _zz__zz_PmpPlugin_ports_0_hits_7_3_1 = (_zz_PmpPlugin_ports_0_hits_7_6 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_8_6 = (_zz_PmpPlugin_ports_0_hits_8_4 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_8_3 = ({2'd0,_zz__zz_PmpPlugin_ports_0_hits_8_3_1} <<< 2'd2);
+  assign _zz__zz_PmpPlugin_ports_0_hits_8_3_1 = (_zz_PmpPlugin_ports_0_hits_8_6 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_9_6 = (_zz_PmpPlugin_ports_0_hits_9_4 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_9_3 = ({2'd0,_zz__zz_PmpPlugin_ports_0_hits_9_3_1} <<< 2'd2);
+  assign _zz__zz_PmpPlugin_ports_0_hits_9_3_1 = (_zz_PmpPlugin_ports_0_hits_9_6 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_10_6 = (_zz_PmpPlugin_ports_0_hits_10_4 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_10_3 = ({2'd0,_zz__zz_PmpPlugin_ports_0_hits_10_3_1} <<< 2'd2);
+  assign _zz__zz_PmpPlugin_ports_0_hits_10_3_1 = (_zz_PmpPlugin_ports_0_hits_10_6 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_11_6 = (_zz_PmpPlugin_ports_0_hits_11_4 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_11_3 = ({2'd0,_zz__zz_PmpPlugin_ports_0_hits_11_3_1} <<< 2'd2);
+  assign _zz__zz_PmpPlugin_ports_0_hits_11_3_1 = (_zz_PmpPlugin_ports_0_hits_11_6 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_12_6 = (_zz_PmpPlugin_ports_0_hits_12_4 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_12_3 = ({2'd0,_zz__zz_PmpPlugin_ports_0_hits_12_3_1} <<< 2'd2);
+  assign _zz__zz_PmpPlugin_ports_0_hits_12_3_1 = (_zz_PmpPlugin_ports_0_hits_12_6 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_13_6 = (_zz_PmpPlugin_ports_0_hits_13_4 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_13_3 = ({2'd0,_zz__zz_PmpPlugin_ports_0_hits_13_3_1} <<< 2'd2);
+  assign _zz__zz_PmpPlugin_ports_0_hits_13_3_1 = (_zz_PmpPlugin_ports_0_hits_13_6 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_14_6 = (_zz_PmpPlugin_ports_0_hits_14_4 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_14_3 = ({2'd0,_zz__zz_PmpPlugin_ports_0_hits_14_3_1} <<< 2'd2);
+  assign _zz__zz_PmpPlugin_ports_0_hits_14_3_1 = (_zz_PmpPlugin_ports_0_hits_14_6 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_15_6 = (_zz_PmpPlugin_ports_0_hits_15_4 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_15_3 = ({2'd0,_zz__zz_PmpPlugin_ports_0_hits_15_3_1} <<< 2'd2);
+  assign _zz__zz_PmpPlugin_ports_0_hits_15_3_1 = (_zz_PmpPlugin_ports_0_hits_15_6 + 34'h000000001);
+  assign _zz_PmpPlugin_ports_0_hits_0_8 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_0_9 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_1_8 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_1_9 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_2_8 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_2_9 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_3_8 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_3_9 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_4_8 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_4_9 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_5_8 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_5_9 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_6_8 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_6_9 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_7_8 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_7_9 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_8_8 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_8_9 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_9_8 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_9_9 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_10_8 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_10_9 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_11_8 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_11_9 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_12_8 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_12_9 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_13_8 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_13_9 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_14_8 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_14_9 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_15_8 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_15_9 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_when_PmpPlugin_l250_16 = (_zz_when_PmpPlugin_l250_17 + _zz_when_PmpPlugin_l250_28);
+  assign _zz_when_PmpPlugin_l250_17 = (_zz_when_PmpPlugin_l250_18 + _zz_when_PmpPlugin_l250_23);
+  assign _zz_when_PmpPlugin_l250_18 = (_zz_when_PmpPlugin_l250_19 + _zz_when_PmpPlugin_l250_21);
+  assign _zz_when_PmpPlugin_l250_23 = (_zz_when_PmpPlugin_l250_24 + _zz_when_PmpPlugin_l250_26);
+  assign _zz_when_PmpPlugin_l250_28 = (_zz_when_PmpPlugin_l250_29 + _zz_when_PmpPlugin_l250_31);
+  assign _zz_when_PmpPlugin_l250_33 = PmpPlugin_ports_0_hits_15;
+  assign _zz_when_PmpPlugin_l250_32 = {2'd0, _zz_when_PmpPlugin_l250_33};
+  assign _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowRead_33 = (_zz_IBusCachedPlugin_mmuBus_rsp_allowRead_32 - 16'h0001);
+  assign _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_33 = (_zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_32 - 16'h0001);
+  assign _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_33 = (_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_32 - 16'h0001);
+  assign _zz_PmpPlugin_ports_1_hits_0 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_0_1 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_1 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_1_1 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_2 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_2_1 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_3 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_3_1 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_4 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_4_1 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_5 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_5_1 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_6 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_6_1 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_7 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_7_1 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_8 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_8_1 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_9 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_9_1 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_10 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_10_1 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_11 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_11_1 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_12 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_12_1 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_13 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_13_1 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_14 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_14_1 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_15 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_15_1 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_when_PmpPlugin_l250_1_1 = (_zz_when_PmpPlugin_l250_1_2 + _zz_when_PmpPlugin_l250_1_13);
+  assign _zz_when_PmpPlugin_l250_1_2 = (_zz_when_PmpPlugin_l250_1_3 + _zz_when_PmpPlugin_l250_1_8);
+  assign _zz_when_PmpPlugin_l250_1_3 = (_zz_when_PmpPlugin_l250_1_4 + _zz_when_PmpPlugin_l250_1_6);
+  assign _zz_when_PmpPlugin_l250_1_8 = (_zz_when_PmpPlugin_l250_1_9 + _zz_when_PmpPlugin_l250_1_11);
+  assign _zz_when_PmpPlugin_l250_1_13 = (_zz_when_PmpPlugin_l250_1_14 + _zz_when_PmpPlugin_l250_1_16);
+  assign _zz_when_PmpPlugin_l250_1_18 = PmpPlugin_ports_1_hits_15;
+  assign _zz_when_PmpPlugin_l250_1_17 = {2'd0, _zz_when_PmpPlugin_l250_1_18};
   assign _zz__zz_DBusCachedPlugin_mmuBus_rsp_allowRead_1_1 = (_zz_DBusCachedPlugin_mmuBus_rsp_allowRead - 16'h0001);
   assign _zz__zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_1_1 = (_zz_DBusCachedPlugin_mmuBus_rsp_allowWrite - 16'h0001);
-  assign _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1_1 = (_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute - 16'h0001);
+  assign _zz__zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_1_1 = (_zz_DBusCachedPlugin_mmuBus_rsp_allowExecute - 16'h0001);
   assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
   assign _zz__zz_execute_SRC1 = 3'b100;
   assign _zz__zz_execute_SRC1_1 = execute_INSTRUCTION[19 : 15];
-  assign _zz__zz_execute_SRC2_3 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz__zz_execute_SRC2_2 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
   assign _zz_execute_SrcPlugin_addSub = ($signed(_zz_execute_SrcPlugin_addSub_1) + $signed(_zz_execute_SrcPlugin_addSub_4));
   assign _zz_execute_SrcPlugin_addSub_1 = ($signed(_zz_execute_SrcPlugin_addSub_2) + $signed(_zz_execute_SrcPlugin_addSub_3));
   assign _zz_execute_SrcPlugin_addSub_2 = execute_SRC1;
   assign _zz_execute_SrcPlugin_addSub_3 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? _zz_execute_SrcPlugin_addSub_5 : _zz_execute_SrcPlugin_addSub_6);
-  assign _zz_execute_SrcPlugin_addSub_5 = 32'h00000001;
-  assign _zz_execute_SrcPlugin_addSub_6 = 32'h0;
+  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? 32'h00000001 : 32'h00000000);
   assign _zz__zz_execute_BranchPlugin_missAlignedTarget_2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
   assign _zz__zz_execute_BranchPlugin_missAlignedTarget_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
   assign _zz__zz_execute_BranchPlugin_missAlignedTarget_6 = {_zz_execute_BranchPlugin_missAlignedTarget_1,execute_INSTRUCTION[31 : 20]};
@@ -1791,7 +2306,7 @@ module VexRiscv (
   assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code & (~ _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1));
   assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code - 2'b01);
   assign _zz_writeBack_MulPlugin_result = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
-  assign _zz_writeBack_MulPlugin_result_1 = ({32'd0,writeBack_MUL_HH} <<< 32);
+  assign _zz_writeBack_MulPlugin_result_1 = ({32'd0,writeBack_MUL_HH} <<< 6'd32);
   assign _zz__zz_decode_RS2_2 = writeBack_MUL_LOW[31 : 0];
   assign _zz__zz_decode_RS2_2_1 = writeBack_MulPlugin_result[63 : 32];
   assign _zz_memory_DivPlugin_div_counter_valueNext_1 = memory_DivPlugin_div_counter_willIncrement;
@@ -1809,275 +2324,215 @@ module VexRiscv (
   assign _zz_memory_DivPlugin_rs1_2 = {32'd0, _zz_memory_DivPlugin_rs1_3};
   assign _zz_memory_DivPlugin_rs2_2 = _zz_memory_DivPlugin_rs2;
   assign _zz_memory_DivPlugin_rs2_1 = {31'd0, _zz_memory_DivPlugin_rs2_2};
-  assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 5);
-  assign _zz_PmpPlugin_pmpaddr_port = execute_PmpPlugin_writeData_;
+  assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 3'd5);
   assign _zz_decode_RegFilePlugin_rs1Data = 1'b1;
   assign _zz_decode_RegFilePlugin_rs2Data = 1'b1;
   assign _zz_IBusCachedPlugin_jump_pcLoad_payload_6 = {_zz_IBusCachedPlugin_jump_pcLoad_payload_4,_zz_IBusCachedPlugin_jump_pcLoad_payload_3};
   assign _zz_writeBack_DBusCachedPlugin_rspShifted_1 = dataCache_1_io_cpu_writeBack_address[1 : 0];
   assign _zz_writeBack_DBusCachedPlugin_rspShifted_3 = dataCache_1_io_cpu_writeBack_address[1 : 1];
-  assign _zz_PmpPlugin_dGuard_hits_0_2 = 4'b0000;
-  assign _zz_PmpPlugin_dGuard_hits_0_4 = 4'b0000;
-  assign _zz_PmpPlugin_dGuard_hits_1_1 = 4'b0001;
-  assign _zz_PmpPlugin_dGuard_hits_1_3 = 4'b0001;
-  assign _zz_PmpPlugin_dGuard_hits_2_1 = 4'b0010;
-  assign _zz_PmpPlugin_dGuard_hits_2_3 = 4'b0010;
-  assign _zz_PmpPlugin_dGuard_hits_3_1 = 4'b0011;
-  assign _zz_PmpPlugin_dGuard_hits_3_3 = 4'b0011;
-  assign _zz_PmpPlugin_dGuard_hits_4_1 = 4'b0100;
-  assign _zz_PmpPlugin_dGuard_hits_4_3 = 4'b0100;
-  assign _zz_PmpPlugin_dGuard_hits_5_1 = 4'b0101;
-  assign _zz_PmpPlugin_dGuard_hits_5_3 = 4'b0101;
-  assign _zz_PmpPlugin_dGuard_hits_6_1 = 4'b0110;
-  assign _zz_PmpPlugin_dGuard_hits_6_3 = 4'b0110;
-  assign _zz_PmpPlugin_dGuard_hits_7_1 = 4'b0111;
-  assign _zz_PmpPlugin_dGuard_hits_7_3 = 4'b0111;
-  assign _zz_PmpPlugin_dGuard_hits_8_1 = 4'b1000;
-  assign _zz_PmpPlugin_dGuard_hits_8_3 = 4'b1000;
-  assign _zz_PmpPlugin_dGuard_hits_9_1 = 4'b1001;
-  assign _zz_PmpPlugin_dGuard_hits_9_3 = 4'b1001;
-  assign _zz_PmpPlugin_dGuard_hits_10_1 = 4'b1010;
-  assign _zz_PmpPlugin_dGuard_hits_10_3 = 4'b1010;
-  assign _zz_PmpPlugin_dGuard_hits_11_1 = 4'b1011;
-  assign _zz_PmpPlugin_dGuard_hits_11_3 = 4'b1011;
-  assign _zz_PmpPlugin_dGuard_hits_12_1 = 4'b1100;
-  assign _zz_PmpPlugin_dGuard_hits_12_3 = 4'b1100;
-  assign _zz_PmpPlugin_dGuard_hits_13_1 = 4'b1101;
-  assign _zz_PmpPlugin_dGuard_hits_13_3 = 4'b1101;
-  assign _zz_PmpPlugin_dGuard_hits_14_1 = 4'b1110;
-  assign _zz_PmpPlugin_dGuard_hits_14_3 = 4'b1110;
-  assign _zz_PmpPlugin_dGuard_hits_15_1 = 4'b1111;
-  assign _zz_PmpPlugin_dGuard_hits_15_3 = 4'b1111;
+  assign _zz_when_PmpPlugin_l250_20 = {PmpPlugin_ports_0_hits_2,{PmpPlugin_ports_0_hits_1,PmpPlugin_ports_0_hits_0}};
+  assign _zz_when_PmpPlugin_l250_22 = {PmpPlugin_ports_0_hits_5,{PmpPlugin_ports_0_hits_4,PmpPlugin_ports_0_hits_3}};
+  assign _zz_when_PmpPlugin_l250_25 = {PmpPlugin_ports_0_hits_8,{PmpPlugin_ports_0_hits_7,PmpPlugin_ports_0_hits_6}};
+  assign _zz_when_PmpPlugin_l250_27 = {PmpPlugin_ports_0_hits_11,{PmpPlugin_ports_0_hits_10,PmpPlugin_ports_0_hits_9}};
+  assign _zz_when_PmpPlugin_l250_30 = {PmpPlugin_ports_0_hits_14,{PmpPlugin_ports_0_hits_13,PmpPlugin_ports_0_hits_12}};
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_50 = {_zz_IBusCachedPlugin_mmuBus_rsp_allowRead_48,{_zz_IBusCachedPlugin_mmuBus_rsp_allowRead_47,{_zz_IBusCachedPlugin_mmuBus_rsp_allowRead_46,_zz_IBusCachedPlugin_mmuBus_rsp_allowRead_45}}};
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_50 = {_zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_48,{_zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_47,{_zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_46,_zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_45}}};
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_50 = {_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_48,{_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_47,{_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_46,_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_45}}};
+  assign _zz_when_PmpPlugin_l250_1_5 = {PmpPlugin_ports_1_hits_2,{PmpPlugin_ports_1_hits_1,PmpPlugin_ports_1_hits_0}};
+  assign _zz_when_PmpPlugin_l250_1_7 = {PmpPlugin_ports_1_hits_5,{PmpPlugin_ports_1_hits_4,PmpPlugin_ports_1_hits_3}};
+  assign _zz_when_PmpPlugin_l250_1_10 = {PmpPlugin_ports_1_hits_8,{PmpPlugin_ports_1_hits_7,PmpPlugin_ports_1_hits_6}};
+  assign _zz_when_PmpPlugin_l250_1_12 = {PmpPlugin_ports_1_hits_11,{PmpPlugin_ports_1_hits_10,PmpPlugin_ports_1_hits_9}};
+  assign _zz_when_PmpPlugin_l250_1_15 = {PmpPlugin_ports_1_hits_14,{PmpPlugin_ports_1_hits_13,PmpPlugin_ports_1_hits_12}};
   assign _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_18 = {_zz_DBusCachedPlugin_mmuBus_rsp_allowRead_16,{_zz_DBusCachedPlugin_mmuBus_rsp_allowRead_15,{_zz_DBusCachedPlugin_mmuBus_rsp_allowRead_14,_zz_DBusCachedPlugin_mmuBus_rsp_allowRead_13}}};
   assign _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_18 = {_zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_16,{_zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_15,{_zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_14,_zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_13}}};
-  assign _zz_PmpPlugin_iGuard_hits_0_2 = 4'b0000;
-  assign _zz_PmpPlugin_iGuard_hits_0_4 = 4'b0000;
-  assign _zz_PmpPlugin_iGuard_hits_1_1 = 4'b0001;
-  assign _zz_PmpPlugin_iGuard_hits_1_3 = 4'b0001;
-  assign _zz_PmpPlugin_iGuard_hits_2_1 = 4'b0010;
-  assign _zz_PmpPlugin_iGuard_hits_2_3 = 4'b0010;
-  assign _zz_PmpPlugin_iGuard_hits_3_1 = 4'b0011;
-  assign _zz_PmpPlugin_iGuard_hits_3_3 = 4'b0011;
-  assign _zz_PmpPlugin_iGuard_hits_4_1 = 4'b0100;
-  assign _zz_PmpPlugin_iGuard_hits_4_3 = 4'b0100;
-  assign _zz_PmpPlugin_iGuard_hits_5_1 = 4'b0101;
-  assign _zz_PmpPlugin_iGuard_hits_5_3 = 4'b0101;
-  assign _zz_PmpPlugin_iGuard_hits_6_1 = 4'b0110;
-  assign _zz_PmpPlugin_iGuard_hits_6_3 = 4'b0110;
-  assign _zz_PmpPlugin_iGuard_hits_7_1 = 4'b0111;
-  assign _zz_PmpPlugin_iGuard_hits_7_3 = 4'b0111;
-  assign _zz_PmpPlugin_iGuard_hits_8_1 = 4'b1000;
-  assign _zz_PmpPlugin_iGuard_hits_8_3 = 4'b1000;
-  assign _zz_PmpPlugin_iGuard_hits_9_1 = 4'b1001;
-  assign _zz_PmpPlugin_iGuard_hits_9_3 = 4'b1001;
-  assign _zz_PmpPlugin_iGuard_hits_10_1 = 4'b1010;
-  assign _zz_PmpPlugin_iGuard_hits_10_3 = 4'b1010;
-  assign _zz_PmpPlugin_iGuard_hits_11_1 = 4'b1011;
-  assign _zz_PmpPlugin_iGuard_hits_11_3 = 4'b1011;
-  assign _zz_PmpPlugin_iGuard_hits_12_1 = 4'b1100;
-  assign _zz_PmpPlugin_iGuard_hits_12_3 = 4'b1100;
-  assign _zz_PmpPlugin_iGuard_hits_13_1 = 4'b1101;
-  assign _zz_PmpPlugin_iGuard_hits_13_3 = 4'b1101;
-  assign _zz_PmpPlugin_iGuard_hits_14_1 = 4'b1110;
-  assign _zz_PmpPlugin_iGuard_hits_14_3 = 4'b1110;
-  assign _zz_PmpPlugin_iGuard_hits_15_1 = 4'b1111;
-  assign _zz_PmpPlugin_iGuard_hits_15_3 = 4'b1111;
-  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_18 = {_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_16,{_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_15,{_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_14,_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_13}}};
-  assign _zz_when_PmpPlugin_l209_1 = {execute_PmpPlugin_pmpcfgN_,2'b00};
-  assign _zz_when_PmpPlugin_l209_1_2 = {execute_PmpPlugin_pmpcfgN_,2'b01};
-  assign _zz_when_PmpPlugin_l209_2_1 = {execute_PmpPlugin_pmpcfgN_,2'b10};
-  assign _zz_when_PmpPlugin_l209_3_1 = {execute_PmpPlugin_pmpcfgN_,2'b11};
-  assign _zz_CsrPlugin_csrMapping_readDataSignal_1 = {execute_PmpPlugin_pmpcfgN,2'b11};
-  assign _zz_CsrPlugin_csrMapping_readDataSignal_3 = {execute_PmpPlugin_pmpcfgN,2'b10};
-  assign _zz_CsrPlugin_csrMapping_readDataSignal_5 = {execute_PmpPlugin_pmpcfgN,2'b01};
-  assign _zz_CsrPlugin_csrMapping_readDataSignal_7 = {execute_PmpPlugin_pmpcfgN,2'b00};
-  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000107f;
-  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00002073;
-  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_18 = {_zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_16,{_zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_15,{_zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_14,_zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_13}}};
+  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000207f;
+  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000407f);
+  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00004063;
+  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000107f) == 32'h00000013);
   assign _zz_decode_LEGAL_INSTRUCTION_5 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_6) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_7 == _zz_decode_LEGAL_INSTRUCTION_8),{_zz_decode_LEGAL_INSTRUCTION_9,{_zz_decode_LEGAL_INSTRUCTION_10,_zz_decode_LEGAL_INSTRUCTION_11}}}}}};
   assign _zz_decode_LEGAL_INSTRUCTION_6 = 32'h0000505f;
   assign _zz_decode_LEGAL_INSTRUCTION_7 = (decode_INSTRUCTION & 32'h0000707b);
   assign _zz_decode_LEGAL_INSTRUCTION_8 = 32'h00000063;
   assign _zz_decode_LEGAL_INSTRUCTION_9 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
   assign _zz_decode_LEGAL_INSTRUCTION_10 = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
-  assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h00001013),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,{_zz_decode_LEGAL_INSTRUCTION_16,_zz_decode_LEGAL_INSTRUCTION_17}}}}}};
-  assign _zz_decode_LEGAL_INSTRUCTION_12 = 32'hfc00307f;
+  assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & 32'hbe00705f) == 32'h00005013),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h00001013),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,{_zz_decode_LEGAL_INSTRUCTION_16,_zz_decode_LEGAL_INSTRUCTION_17}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_12 = 32'hfe00305f;
   assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'hbe00707f);
-  assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h00005033;
-  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
-  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
-  assign _zz_decode_LEGAL_INSTRUCTION_17 = {((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073),((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073)};
+  assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h00000033;
+  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
+  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073);
+  assign _zz_decode_LEGAL_INSTRUCTION_17 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073);
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_4 = decode_INSTRUCTION[31];
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_5 = decode_INSTRUCTION[31];
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_6 = decode_INSTRUCTION[7];
-  assign _zz_when_PmpPlugin_l277 = PmpPlugin_dGuard_hits_6;
-  assign _zz_when_PmpPlugin_l277_1 = {PmpPlugin_dGuard_hits_5,{PmpPlugin_dGuard_hits_4,{PmpPlugin_dGuard_hits_3,{PmpPlugin_dGuard_hits_2,{PmpPlugin_dGuard_hits_1,PmpPlugin_dGuard_hits_0}}}}};
-  assign _zz__zz_DBusCachedPlugin_mmuBus_rsp_allowRead = PmpPlugin_dGuard_hits_5;
-  assign _zz__zz_DBusCachedPlugin_mmuBus_rsp_allowRead_1 = {PmpPlugin_dGuard_hits_4,{PmpPlugin_dGuard_hits_3,{PmpPlugin_dGuard_hits_2,{PmpPlugin_dGuard_hits_1,PmpPlugin_dGuard_hits_0}}}};
-  assign _zz__zz_DBusCachedPlugin_mmuBus_rsp_allowWrite = PmpPlugin_dGuard_hits_5;
-  assign _zz__zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_1 = {PmpPlugin_dGuard_hits_4,{PmpPlugin_dGuard_hits_3,{PmpPlugin_dGuard_hits_2,{PmpPlugin_dGuard_hits_1,PmpPlugin_dGuard_hits_0}}}};
-  assign _zz_when_PmpPlugin_l299 = PmpPlugin_iGuard_hits_6;
-  assign _zz_when_PmpPlugin_l299_1 = {PmpPlugin_iGuard_hits_5,{PmpPlugin_iGuard_hits_4,{PmpPlugin_iGuard_hits_3,{PmpPlugin_iGuard_hits_2,{PmpPlugin_iGuard_hits_1,PmpPlugin_iGuard_hits_0}}}}};
-  assign _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowExecute = PmpPlugin_iGuard_hits_5;
-  assign _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1 = {PmpPlugin_iGuard_hits_4,{PmpPlugin_iGuard_hits_3,{PmpPlugin_iGuard_hits_2,{PmpPlugin_iGuard_hits_1,PmpPlugin_iGuard_hits_0}}}};
+  assign _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowRead_32 = PmpPlugin_ports_0_hits_5;
+  assign _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowRead_32_1 = {PmpPlugin_ports_0_hits_4,{PmpPlugin_ports_0_hits_3,{PmpPlugin_ports_0_hits_2,{PmpPlugin_ports_0_hits_1,PmpPlugin_ports_0_hits_0}}}};
+  assign _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_32 = PmpPlugin_ports_0_hits_5;
+  assign _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_32_1 = {PmpPlugin_ports_0_hits_4,{PmpPlugin_ports_0_hits_3,{PmpPlugin_ports_0_hits_2,{PmpPlugin_ports_0_hits_1,PmpPlugin_ports_0_hits_0}}}};
+  assign _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_32 = PmpPlugin_ports_0_hits_5;
+  assign _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_32_1 = {PmpPlugin_ports_0_hits_4,{PmpPlugin_ports_0_hits_3,{PmpPlugin_ports_0_hits_2,{PmpPlugin_ports_0_hits_1,PmpPlugin_ports_0_hits_0}}}};
+  assign _zz__zz_DBusCachedPlugin_mmuBus_rsp_allowRead = PmpPlugin_ports_1_hits_5;
+  assign _zz__zz_DBusCachedPlugin_mmuBus_rsp_allowRead_1 = {PmpPlugin_ports_1_hits_4,{PmpPlugin_ports_1_hits_3,{PmpPlugin_ports_1_hits_2,{PmpPlugin_ports_1_hits_1,PmpPlugin_ports_1_hits_0}}}};
+  assign _zz__zz_DBusCachedPlugin_mmuBus_rsp_allowWrite = PmpPlugin_ports_1_hits_5;
+  assign _zz__zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_1 = {PmpPlugin_ports_1_hits_4,{PmpPlugin_ports_1_hits_3,{PmpPlugin_ports_1_hits_2,{PmpPlugin_ports_1_hits_1,PmpPlugin_ports_1_hits_0}}}};
+  assign _zz__zz_DBusCachedPlugin_mmuBus_rsp_allowExecute = PmpPlugin_ports_1_hits_5;
+  assign _zz__zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_1 = {PmpPlugin_ports_1_hits_4,{PmpPlugin_ports_1_hits_3,{PmpPlugin_ports_1_hits_2,{PmpPlugin_ports_1_hits_1,PmpPlugin_ports_1_hits_0}}}};
   assign _zz__zz_decode_IS_RS2_SIGNED = (decode_INSTRUCTION & 32'h02004064);
   assign _zz__zz_decode_IS_RS2_SIGNED_1 = 32'h02004020;
   assign _zz__zz_decode_IS_RS2_SIGNED_2 = ((decode_INSTRUCTION & 32'h02004074) == 32'h02000030);
   assign _zz__zz_decode_IS_RS2_SIGNED_3 = ((decode_INSTRUCTION & 32'h00203050) == 32'h00000050);
   assign _zz__zz_decode_IS_RS2_SIGNED_4 = (|((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_5) == 32'h00000050));
   assign _zz__zz_decode_IS_RS2_SIGNED_6 = (|{_zz__zz_decode_IS_RS2_SIGNED_7,_zz__zz_decode_IS_RS2_SIGNED_8});
-  assign _zz__zz_decode_IS_RS2_SIGNED_9 = {(|{_zz__zz_decode_IS_RS2_SIGNED_10,_zz__zz_decode_IS_RS2_SIGNED_11}),{(|_zz__zz_decode_IS_RS2_SIGNED_13),{_zz__zz_decode_IS_RS2_SIGNED_15,{_zz__zz_decode_IS_RS2_SIGNED_18,_zz__zz_decode_IS_RS2_SIGNED_26}}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_9 = {(|{_zz__zz_decode_IS_RS2_SIGNED_10,_zz__zz_decode_IS_RS2_SIGNED_11}),{(|_zz__zz_decode_IS_RS2_SIGNED_13),{_zz__zz_decode_IS_RS2_SIGNED_15,{_zz__zz_decode_IS_RS2_SIGNED_18,_zz__zz_decode_IS_RS2_SIGNED_21}}}};
   assign _zz__zz_decode_IS_RS2_SIGNED_5 = 32'h00403050;
   assign _zz__zz_decode_IS_RS2_SIGNED_7 = ((decode_INSTRUCTION & 32'h00001050) == 32'h00001050);
   assign _zz__zz_decode_IS_RS2_SIGNED_8 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002050);
   assign _zz__zz_decode_IS_RS2_SIGNED_10 = _zz_decode_IS_RS2_SIGNED_4;
   assign _zz__zz_decode_IS_RS2_SIGNED_11 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_12) == 32'h00000004);
   assign _zz__zz_decode_IS_RS2_SIGNED_13 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_14) == 32'h00000040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_15 = (|{_zz__zz_decode_IS_RS2_SIGNED_16,_zz__zz_decode_IS_RS2_SIGNED_17});
-  assign _zz__zz_decode_IS_RS2_SIGNED_18 = (|{_zz__zz_decode_IS_RS2_SIGNED_19,_zz__zz_decode_IS_RS2_SIGNED_21});
-  assign _zz__zz_decode_IS_RS2_SIGNED_26 = {(|_zz__zz_decode_IS_RS2_SIGNED_27),{_zz__zz_decode_IS_RS2_SIGNED_29,{_zz__zz_decode_IS_RS2_SIGNED_32,_zz__zz_decode_IS_RS2_SIGNED_34}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_15 = (|(_zz__zz_decode_IS_RS2_SIGNED_16 == _zz__zz_decode_IS_RS2_SIGNED_17));
+  assign _zz__zz_decode_IS_RS2_SIGNED_18 = (|{_zz__zz_decode_IS_RS2_SIGNED_19,_zz__zz_decode_IS_RS2_SIGNED_20});
+  assign _zz__zz_decode_IS_RS2_SIGNED_21 = {(|_zz__zz_decode_IS_RS2_SIGNED_22),{_zz__zz_decode_IS_RS2_SIGNED_23,{_zz__zz_decode_IS_RS2_SIGNED_25,_zz__zz_decode_IS_RS2_SIGNED_28}}};
   assign _zz__zz_decode_IS_RS2_SIGNED_12 = 32'h0000001c;
   assign _zz__zz_decode_IS_RS2_SIGNED_14 = 32'h00000058;
-  assign _zz__zz_decode_IS_RS2_SIGNED_16 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00005010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_17 = ((decode_INSTRUCTION & 32'h02007064) == 32'h00005020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_19 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_20) == 32'h40001010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_21 = {(_zz__zz_decode_IS_RS2_SIGNED_22 == _zz__zz_decode_IS_RS2_SIGNED_23),(_zz__zz_decode_IS_RS2_SIGNED_24 == _zz__zz_decode_IS_RS2_SIGNED_25)};
-  assign _zz__zz_decode_IS_RS2_SIGNED_27 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_28) == 32'h00000024);
-  assign _zz__zz_decode_IS_RS2_SIGNED_29 = (|(_zz__zz_decode_IS_RS2_SIGNED_30 == _zz__zz_decode_IS_RS2_SIGNED_31));
-  assign _zz__zz_decode_IS_RS2_SIGNED_32 = (|_zz__zz_decode_IS_RS2_SIGNED_33);
-  assign _zz__zz_decode_IS_RS2_SIGNED_34 = {(|_zz__zz_decode_IS_RS2_SIGNED_35),{_zz__zz_decode_IS_RS2_SIGNED_38,{_zz__zz_decode_IS_RS2_SIGNED_40,_zz__zz_decode_IS_RS2_SIGNED_43}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_20 = 32'h40003054;
-  assign _zz__zz_decode_IS_RS2_SIGNED_22 = (decode_INSTRUCTION & 32'h00007034);
-  assign _zz__zz_decode_IS_RS2_SIGNED_23 = 32'h00001010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_24 = (decode_INSTRUCTION & 32'h02007054);
-  assign _zz__zz_decode_IS_RS2_SIGNED_25 = 32'h00001010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_28 = 32'h00000064;
-  assign _zz__zz_decode_IS_RS2_SIGNED_30 = (decode_INSTRUCTION & 32'h00001000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_31 = 32'h00001000;
-  assign _zz__zz_decode_IS_RS2_SIGNED_33 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_35 = {((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_36) == 32'h00002000),((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_37) == 32'h00001000)};
-  assign _zz__zz_decode_IS_RS2_SIGNED_38 = (|((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_39) == 32'h00004008));
-  assign _zz__zz_decode_IS_RS2_SIGNED_40 = (|{_zz__zz_decode_IS_RS2_SIGNED_41,_zz__zz_decode_IS_RS2_SIGNED_42});
-  assign _zz__zz_decode_IS_RS2_SIGNED_43 = {(|{_zz__zz_decode_IS_RS2_SIGNED_44,_zz__zz_decode_IS_RS2_SIGNED_46}),{(|_zz__zz_decode_IS_RS2_SIGNED_55),{_zz__zz_decode_IS_RS2_SIGNED_57,{_zz__zz_decode_IS_RS2_SIGNED_70,_zz__zz_decode_IS_RS2_SIGNED_83}}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_36 = 32'h00002010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_37 = 32'h00005000;
-  assign _zz__zz_decode_IS_RS2_SIGNED_39 = 32'h00004048;
-  assign _zz__zz_decode_IS_RS2_SIGNED_41 = ((decode_INSTRUCTION & 32'h00000034) == 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_42 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_44 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_45) == 32'h00002040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_46 = {(_zz__zz_decode_IS_RS2_SIGNED_47 == _zz__zz_decode_IS_RS2_SIGNED_48),{_zz__zz_decode_IS_RS2_SIGNED_49,{_zz__zz_decode_IS_RS2_SIGNED_51,_zz__zz_decode_IS_RS2_SIGNED_54}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_55 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_56) == 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_57 = (|{_zz__zz_decode_IS_RS2_SIGNED_58,{_zz__zz_decode_IS_RS2_SIGNED_60,_zz__zz_decode_IS_RS2_SIGNED_61}});
-  assign _zz__zz_decode_IS_RS2_SIGNED_70 = (|{_zz__zz_decode_IS_RS2_SIGNED_71,_zz__zz_decode_IS_RS2_SIGNED_72});
-  assign _zz__zz_decode_IS_RS2_SIGNED_83 = {(|_zz__zz_decode_IS_RS2_SIGNED_84),{_zz__zz_decode_IS_RS2_SIGNED_97,{_zz__zz_decode_IS_RS2_SIGNED_102,_zz__zz_decode_IS_RS2_SIGNED_106}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_45 = 32'h00002040;
-  assign _zz__zz_decode_IS_RS2_SIGNED_47 = (decode_INSTRUCTION & 32'h00001040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_48 = 32'h00001040;
-  assign _zz__zz_decode_IS_RS2_SIGNED_49 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_50) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_16 = (decode_INSTRUCTION & 32'h02007054);
+  assign _zz__zz_decode_IS_RS2_SIGNED_17 = 32'h00005010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_19 = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_20 = ((decode_INSTRUCTION & 32'h02007054) == 32'h00001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_22 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
+  assign _zz__zz_decode_IS_RS2_SIGNED_23 = (|((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_24) == 32'h00001000));
+  assign _zz__zz_decode_IS_RS2_SIGNED_25 = (|(_zz__zz_decode_IS_RS2_SIGNED_26 == _zz__zz_decode_IS_RS2_SIGNED_27));
+  assign _zz__zz_decode_IS_RS2_SIGNED_28 = {(|{_zz__zz_decode_IS_RS2_SIGNED_29,_zz__zz_decode_IS_RS2_SIGNED_30}),{(|_zz__zz_decode_IS_RS2_SIGNED_31),{_zz__zz_decode_IS_RS2_SIGNED_32,{_zz__zz_decode_IS_RS2_SIGNED_37,_zz__zz_decode_IS_RS2_SIGNED_46}}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_24 = 32'h00001000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_26 = (decode_INSTRUCTION & 32'h00003000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_27 = 32'h00002000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_29 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_30 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00001000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_31 = ((decode_INSTRUCTION & 32'h00004048) == 32'h00004008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_32 = (|{(_zz__zz_decode_IS_RS2_SIGNED_33 == _zz__zz_decode_IS_RS2_SIGNED_34),(_zz__zz_decode_IS_RS2_SIGNED_35 == _zz__zz_decode_IS_RS2_SIGNED_36)});
+  assign _zz__zz_decode_IS_RS2_SIGNED_37 = (|{_zz__zz_decode_IS_RS2_SIGNED_38,{_zz__zz_decode_IS_RS2_SIGNED_39,_zz__zz_decode_IS_RS2_SIGNED_41}});
+  assign _zz__zz_decode_IS_RS2_SIGNED_46 = {(|_zz__zz_decode_IS_RS2_SIGNED_47),{(|_zz__zz_decode_IS_RS2_SIGNED_48),{_zz__zz_decode_IS_RS2_SIGNED_59,{_zz__zz_decode_IS_RS2_SIGNED_72,_zz__zz_decode_IS_RS2_SIGNED_86}}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_33 = (decode_INSTRUCTION & 32'h00000034);
+  assign _zz__zz_decode_IS_RS2_SIGNED_34 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_35 = (decode_INSTRUCTION & 32'h00000064);
+  assign _zz__zz_decode_IS_RS2_SIGNED_36 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_38 = ((decode_INSTRUCTION & 32'h00002040) == 32'h00002040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_39 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_40) == 32'h00001040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_41 = {(_zz__zz_decode_IS_RS2_SIGNED_42 == _zz__zz_decode_IS_RS2_SIGNED_43),{_zz__zz_decode_IS_RS2_SIGNED_44,_zz_decode_IS_RS2_SIGNED_2}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_47 = ((decode_INSTRUCTION & 32'h00000020) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_48 = {(_zz__zz_decode_IS_RS2_SIGNED_49 == _zz__zz_decode_IS_RS2_SIGNED_50),{_zz_decode_IS_RS2_SIGNED_3,{_zz__zz_decode_IS_RS2_SIGNED_51,_zz__zz_decode_IS_RS2_SIGNED_54}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_59 = (|{_zz_decode_IS_RS2_SIGNED_3,{_zz__zz_decode_IS_RS2_SIGNED_60,_zz__zz_decode_IS_RS2_SIGNED_63}});
+  assign _zz__zz_decode_IS_RS2_SIGNED_72 = (|{_zz__zz_decode_IS_RS2_SIGNED_73,_zz__zz_decode_IS_RS2_SIGNED_74});
+  assign _zz__zz_decode_IS_RS2_SIGNED_86 = {(|_zz__zz_decode_IS_RS2_SIGNED_87),{_zz__zz_decode_IS_RS2_SIGNED_90,{_zz__zz_decode_IS_RS2_SIGNED_95,_zz__zz_decode_IS_RS2_SIGNED_99}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_40 = 32'h00001040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_42 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_43 = 32'h00000040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_44 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_45) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_49 = (decode_INSTRUCTION & 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_50 = 32'h00000040;
   assign _zz__zz_decode_IS_RS2_SIGNED_51 = (_zz__zz_decode_IS_RS2_SIGNED_52 == _zz__zz_decode_IS_RS2_SIGNED_53);
-  assign _zz__zz_decode_IS_RS2_SIGNED_54 = _zz_decode_IS_RS2_SIGNED_2;
-  assign _zz__zz_decode_IS_RS2_SIGNED_56 = 32'h00000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_58 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_59) == 32'h00000040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_60 = _zz_decode_IS_RS2_SIGNED_3;
-  assign _zz__zz_decode_IS_RS2_SIGNED_61 = {_zz__zz_decode_IS_RS2_SIGNED_62,{_zz__zz_decode_IS_RS2_SIGNED_64,_zz__zz_decode_IS_RS2_SIGNED_67}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_71 = _zz_decode_IS_RS2_SIGNED_3;
-  assign _zz__zz_decode_IS_RS2_SIGNED_72 = {_zz__zz_decode_IS_RS2_SIGNED_73,{_zz__zz_decode_IS_RS2_SIGNED_75,_zz__zz_decode_IS_RS2_SIGNED_78}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_84 = {_zz_decode_IS_RS2_SIGNED_4,{_zz__zz_decode_IS_RS2_SIGNED_85,_zz__zz_decode_IS_RS2_SIGNED_88}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_97 = (|{_zz__zz_decode_IS_RS2_SIGNED_98,_zz__zz_decode_IS_RS2_SIGNED_99});
+  assign _zz__zz_decode_IS_RS2_SIGNED_54 = {_zz__zz_decode_IS_RS2_SIGNED_55,_zz__zz_decode_IS_RS2_SIGNED_57};
+  assign _zz__zz_decode_IS_RS2_SIGNED_60 = (_zz__zz_decode_IS_RS2_SIGNED_61 == _zz__zz_decode_IS_RS2_SIGNED_62);
+  assign _zz__zz_decode_IS_RS2_SIGNED_63 = {_zz__zz_decode_IS_RS2_SIGNED_64,{_zz__zz_decode_IS_RS2_SIGNED_66,_zz__zz_decode_IS_RS2_SIGNED_69}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_73 = _zz_decode_IS_RS2_SIGNED_4;
+  assign _zz__zz_decode_IS_RS2_SIGNED_74 = {_zz__zz_decode_IS_RS2_SIGNED_75,{_zz__zz_decode_IS_RS2_SIGNED_77,_zz__zz_decode_IS_RS2_SIGNED_80}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_87 = {_zz_decode_IS_RS2_SIGNED_3,_zz__zz_decode_IS_RS2_SIGNED_88};
+  assign _zz__zz_decode_IS_RS2_SIGNED_90 = (|{_zz__zz_decode_IS_RS2_SIGNED_91,_zz__zz_decode_IS_RS2_SIGNED_92});
+  assign _zz__zz_decode_IS_RS2_SIGNED_95 = (|_zz__zz_decode_IS_RS2_SIGNED_96);
+  assign _zz__zz_decode_IS_RS2_SIGNED_99 = {_zz__zz_decode_IS_RS2_SIGNED_100,{_zz__zz_decode_IS_RS2_SIGNED_102,_zz__zz_decode_IS_RS2_SIGNED_113}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_45 = 32'h00400040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_52 = (decode_INSTRUCTION & 32'h00004020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_53 = 32'h00004020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_55 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_56) == 32'h00000010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_57 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_58) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_61 = (decode_INSTRUCTION & 32'h00002030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_62 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_64 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_65) == 32'h00000010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_66 = (_zz__zz_decode_IS_RS2_SIGNED_67 == _zz__zz_decode_IS_RS2_SIGNED_68);
+  assign _zz__zz_decode_IS_RS2_SIGNED_69 = (_zz__zz_decode_IS_RS2_SIGNED_70 == _zz__zz_decode_IS_RS2_SIGNED_71);
+  assign _zz__zz_decode_IS_RS2_SIGNED_75 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_76) == 32'h00001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_77 = (_zz__zz_decode_IS_RS2_SIGNED_78 == _zz__zz_decode_IS_RS2_SIGNED_79);
+  assign _zz__zz_decode_IS_RS2_SIGNED_80 = {_zz__zz_decode_IS_RS2_SIGNED_81,{_zz__zz_decode_IS_RS2_SIGNED_82,_zz__zz_decode_IS_RS2_SIGNED_84}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_88 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_89) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_91 = _zz_decode_IS_RS2_SIGNED_3;
+  assign _zz__zz_decode_IS_RS2_SIGNED_92 = (_zz__zz_decode_IS_RS2_SIGNED_93 == _zz__zz_decode_IS_RS2_SIGNED_94);
+  assign _zz__zz_decode_IS_RS2_SIGNED_96 = (_zz__zz_decode_IS_RS2_SIGNED_97 == _zz__zz_decode_IS_RS2_SIGNED_98);
+  assign _zz__zz_decode_IS_RS2_SIGNED_100 = (|_zz__zz_decode_IS_RS2_SIGNED_101);
   assign _zz__zz_decode_IS_RS2_SIGNED_102 = (|_zz__zz_decode_IS_RS2_SIGNED_103);
-  assign _zz__zz_decode_IS_RS2_SIGNED_106 = {_zz__zz_decode_IS_RS2_SIGNED_107,{_zz__zz_decode_IS_RS2_SIGNED_110,_zz__zz_decode_IS_RS2_SIGNED_114}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_50 = 32'h00000050;
-  assign _zz__zz_decode_IS_RS2_SIGNED_52 = (decode_INSTRUCTION & 32'h00400040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_53 = 32'h00000040;
-  assign _zz__zz_decode_IS_RS2_SIGNED_59 = 32'h00000040;
-  assign _zz__zz_decode_IS_RS2_SIGNED_62 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_63) == 32'h00004020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_64 = (_zz__zz_decode_IS_RS2_SIGNED_65 == _zz__zz_decode_IS_RS2_SIGNED_66);
-  assign _zz__zz_decode_IS_RS2_SIGNED_67 = (_zz__zz_decode_IS_RS2_SIGNED_68 == _zz__zz_decode_IS_RS2_SIGNED_69);
-  assign _zz__zz_decode_IS_RS2_SIGNED_73 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_74) == 32'h00002010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_75 = (_zz__zz_decode_IS_RS2_SIGNED_76 == _zz__zz_decode_IS_RS2_SIGNED_77);
-  assign _zz__zz_decode_IS_RS2_SIGNED_78 = {_zz__zz_decode_IS_RS2_SIGNED_79,_zz__zz_decode_IS_RS2_SIGNED_81};
-  assign _zz__zz_decode_IS_RS2_SIGNED_85 = (_zz__zz_decode_IS_RS2_SIGNED_86 == _zz__zz_decode_IS_RS2_SIGNED_87);
-  assign _zz__zz_decode_IS_RS2_SIGNED_88 = {_zz__zz_decode_IS_RS2_SIGNED_89,{_zz__zz_decode_IS_RS2_SIGNED_91,_zz__zz_decode_IS_RS2_SIGNED_94}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_98 = _zz_decode_IS_RS2_SIGNED_3;
-  assign _zz__zz_decode_IS_RS2_SIGNED_99 = (_zz__zz_decode_IS_RS2_SIGNED_100 == _zz__zz_decode_IS_RS2_SIGNED_101);
-  assign _zz__zz_decode_IS_RS2_SIGNED_103 = {_zz_decode_IS_RS2_SIGNED_3,_zz__zz_decode_IS_RS2_SIGNED_104};
-  assign _zz__zz_decode_IS_RS2_SIGNED_107 = (|_zz__zz_decode_IS_RS2_SIGNED_108);
-  assign _zz__zz_decode_IS_RS2_SIGNED_110 = (|_zz__zz_decode_IS_RS2_SIGNED_111);
-  assign _zz__zz_decode_IS_RS2_SIGNED_114 = {_zz__zz_decode_IS_RS2_SIGNED_115,{_zz__zz_decode_IS_RS2_SIGNED_124,_zz__zz_decode_IS_RS2_SIGNED_127}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_63 = 32'h00004020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_65 = (decode_INSTRUCTION & 32'h00000030);
-  assign _zz__zz_decode_IS_RS2_SIGNED_66 = 32'h00000010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_68 = (decode_INSTRUCTION & 32'h02000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_69 = 32'h00000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_74 = 32'h00002030;
-  assign _zz__zz_decode_IS_RS2_SIGNED_76 = (decode_INSTRUCTION & 32'h00001030);
-  assign _zz__zz_decode_IS_RS2_SIGNED_77 = 32'h00000010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_79 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_80) == 32'h00002020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_81 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_82) == 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_86 = (decode_INSTRUCTION & 32'h00001010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_87 = 32'h00001010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_89 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_90) == 32'h00002010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_91 = (_zz__zz_decode_IS_RS2_SIGNED_92 == _zz__zz_decode_IS_RS2_SIGNED_93);
-  assign _zz__zz_decode_IS_RS2_SIGNED_94 = {_zz__zz_decode_IS_RS2_SIGNED_95,_zz__zz_decode_IS_RS2_SIGNED_96};
-  assign _zz__zz_decode_IS_RS2_SIGNED_100 = (decode_INSTRUCTION & 32'h00000070);
-  assign _zz__zz_decode_IS_RS2_SIGNED_101 = 32'h00000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_104 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_105) == 32'h0);
-  assign _zz__zz_decode_IS_RS2_SIGNED_108 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_109) == 32'h00004010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_111 = (_zz__zz_decode_IS_RS2_SIGNED_112 == _zz__zz_decode_IS_RS2_SIGNED_113);
-  assign _zz__zz_decode_IS_RS2_SIGNED_115 = (|{_zz__zz_decode_IS_RS2_SIGNED_116,_zz__zz_decode_IS_RS2_SIGNED_118});
-  assign _zz__zz_decode_IS_RS2_SIGNED_124 = (|_zz__zz_decode_IS_RS2_SIGNED_125);
-  assign _zz__zz_decode_IS_RS2_SIGNED_127 = {_zz__zz_decode_IS_RS2_SIGNED_128,{_zz__zz_decode_IS_RS2_SIGNED_134,_zz__zz_decode_IS_RS2_SIGNED_138}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_80 = 32'h02002060;
-  assign _zz__zz_decode_IS_RS2_SIGNED_82 = 32'h02003020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_90 = 32'h00002010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_92 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz__zz_decode_IS_RS2_SIGNED_93 = 32'h00000010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_95 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
-  assign _zz__zz_decode_IS_RS2_SIGNED_96 = ((decode_INSTRUCTION & 32'h00000028) == 32'h0);
-  assign _zz__zz_decode_IS_RS2_SIGNED_105 = 32'h00000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_109 = 32'h00004014;
-  assign _zz__zz_decode_IS_RS2_SIGNED_112 = (decode_INSTRUCTION & 32'h00006014);
-  assign _zz__zz_decode_IS_RS2_SIGNED_113 = 32'h00002010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_116 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_117) == 32'h0);
-  assign _zz__zz_decode_IS_RS2_SIGNED_118 = {_zz_decode_IS_RS2_SIGNED_2,{_zz__zz_decode_IS_RS2_SIGNED_119,{_zz__zz_decode_IS_RS2_SIGNED_120,_zz__zz_decode_IS_RS2_SIGNED_122}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_125 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_126) == 32'h0);
-  assign _zz__zz_decode_IS_RS2_SIGNED_128 = (|{_zz__zz_decode_IS_RS2_SIGNED_129,{_zz__zz_decode_IS_RS2_SIGNED_130,_zz__zz_decode_IS_RS2_SIGNED_132}});
-  assign _zz__zz_decode_IS_RS2_SIGNED_134 = (|{_zz__zz_decode_IS_RS2_SIGNED_135,_zz__zz_decode_IS_RS2_SIGNED_137});
-  assign _zz__zz_decode_IS_RS2_SIGNED_138 = {(|_zz__zz_decode_IS_RS2_SIGNED_139),(|_zz__zz_decode_IS_RS2_SIGNED_142)};
-  assign _zz__zz_decode_IS_RS2_SIGNED_117 = 32'h00000044;
-  assign _zz__zz_decode_IS_RS2_SIGNED_119 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_120 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_121) == 32'h00001000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_122 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_123) == 32'h00004000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_126 = 32'h00000058;
-  assign _zz__zz_decode_IS_RS2_SIGNED_129 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_130 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_131) == 32'h00002010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_132 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_133) == 32'h40000030);
-  assign _zz__zz_decode_IS_RS2_SIGNED_135 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_136) == 32'h00000004);
-  assign _zz__zz_decode_IS_RS2_SIGNED_137 = _zz_decode_IS_RS2_SIGNED_1;
-  assign _zz__zz_decode_IS_RS2_SIGNED_139 = {(_zz__zz_decode_IS_RS2_SIGNED_140 == _zz__zz_decode_IS_RS2_SIGNED_141),_zz_decode_IS_RS2_SIGNED_1};
-  assign _zz__zz_decode_IS_RS2_SIGNED_142 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_143) == 32'h00001008);
-  assign _zz__zz_decode_IS_RS2_SIGNED_121 = 32'h00005004;
-  assign _zz__zz_decode_IS_RS2_SIGNED_123 = 32'h00004050;
-  assign _zz__zz_decode_IS_RS2_SIGNED_131 = 32'h00002014;
-  assign _zz__zz_decode_IS_RS2_SIGNED_133 = 32'h40000034;
-  assign _zz__zz_decode_IS_RS2_SIGNED_136 = 32'h00000014;
-  assign _zz__zz_decode_IS_RS2_SIGNED_140 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz__zz_decode_IS_RS2_SIGNED_141 = 32'h00000004;
-  assign _zz__zz_decode_IS_RS2_SIGNED_143 = 32'h00005048;
+  assign _zz__zz_decode_IS_RS2_SIGNED_113 = {_zz__zz_decode_IS_RS2_SIGNED_114,{_zz__zz_decode_IS_RS2_SIGNED_117,_zz__zz_decode_IS_RS2_SIGNED_125}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_56 = 32'h00000030;
+  assign _zz__zz_decode_IS_RS2_SIGNED_58 = 32'h02000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_65 = 32'h00001030;
+  assign _zz__zz_decode_IS_RS2_SIGNED_67 = (decode_INSTRUCTION & 32'h02002060);
+  assign _zz__zz_decode_IS_RS2_SIGNED_68 = 32'h00002020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_70 = (decode_INSTRUCTION & 32'h02003020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_71 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_76 = 32'h00001010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_78 = (decode_INSTRUCTION & 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_79 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_81 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_82 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_83) == 32'h00000004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_84 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_85) == 32'h00000000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_89 = 32'h00000070;
+  assign _zz__zz_decode_IS_RS2_SIGNED_93 = (decode_INSTRUCTION & 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_94 = 32'h00000000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_97 = (decode_INSTRUCTION & 32'h00004014);
+  assign _zz__zz_decode_IS_RS2_SIGNED_98 = 32'h00004010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_101 = ((decode_INSTRUCTION & 32'h00006014) == 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_103 = {(_zz__zz_decode_IS_RS2_SIGNED_104 == _zz__zz_decode_IS_RS2_SIGNED_105),{_zz_decode_IS_RS2_SIGNED_2,{_zz__zz_decode_IS_RS2_SIGNED_106,_zz__zz_decode_IS_RS2_SIGNED_108}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_114 = (|(_zz__zz_decode_IS_RS2_SIGNED_115 == _zz__zz_decode_IS_RS2_SIGNED_116));
+  assign _zz__zz_decode_IS_RS2_SIGNED_117 = (|{_zz__zz_decode_IS_RS2_SIGNED_118,_zz__zz_decode_IS_RS2_SIGNED_120});
+  assign _zz__zz_decode_IS_RS2_SIGNED_125 = {(|_zz__zz_decode_IS_RS2_SIGNED_126),{_zz__zz_decode_IS_RS2_SIGNED_129,_zz__zz_decode_IS_RS2_SIGNED_131}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_83 = 32'h0000000c;
+  assign _zz__zz_decode_IS_RS2_SIGNED_85 = 32'h00000028;
+  assign _zz__zz_decode_IS_RS2_SIGNED_104 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz__zz_decode_IS_RS2_SIGNED_105 = 32'h00000000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_106 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_107) == 32'h00002000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_108 = {(_zz__zz_decode_IS_RS2_SIGNED_109 == _zz__zz_decode_IS_RS2_SIGNED_110),(_zz__zz_decode_IS_RS2_SIGNED_111 == _zz__zz_decode_IS_RS2_SIGNED_112)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_115 = (decode_INSTRUCTION & 32'h00000058);
+  assign _zz__zz_decode_IS_RS2_SIGNED_116 = 32'h00000000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_118 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_119) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_120 = {(_zz__zz_decode_IS_RS2_SIGNED_121 == _zz__zz_decode_IS_RS2_SIGNED_122),(_zz__zz_decode_IS_RS2_SIGNED_123 == _zz__zz_decode_IS_RS2_SIGNED_124)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_126 = {(_zz__zz_decode_IS_RS2_SIGNED_127 == _zz__zz_decode_IS_RS2_SIGNED_128),_zz_decode_IS_RS2_SIGNED_1};
+  assign _zz__zz_decode_IS_RS2_SIGNED_129 = (|{_zz__zz_decode_IS_RS2_SIGNED_130,_zz_decode_IS_RS2_SIGNED_1});
+  assign _zz__zz_decode_IS_RS2_SIGNED_131 = (|(_zz__zz_decode_IS_RS2_SIGNED_132 == _zz__zz_decode_IS_RS2_SIGNED_133));
+  assign _zz__zz_decode_IS_RS2_SIGNED_107 = 32'h00006004;
+  assign _zz__zz_decode_IS_RS2_SIGNED_109 = (decode_INSTRUCTION & 32'h00005004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_110 = 32'h00001000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_111 = (decode_INSTRUCTION & 32'h00004050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_112 = 32'h00004000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_119 = 32'h00000044;
+  assign _zz__zz_decode_IS_RS2_SIGNED_121 = (decode_INSTRUCTION & 32'h00002014);
+  assign _zz__zz_decode_IS_RS2_SIGNED_122 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_123 = (decode_INSTRUCTION & 32'h40000034);
+  assign _zz__zz_decode_IS_RS2_SIGNED_124 = 32'h40000030;
+  assign _zz__zz_decode_IS_RS2_SIGNED_127 = (decode_INSTRUCTION & 32'h00000014);
+  assign _zz__zz_decode_IS_RS2_SIGNED_128 = 32'h00000004;
+  assign _zz__zz_decode_IS_RS2_SIGNED_130 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_132 = (decode_INSTRUCTION & 32'h00005048);
+  assign _zz__zz_decode_IS_RS2_SIGNED_133 = 32'h00001008;
   assign _zz_execute_BranchPlugin_branch_src2_6 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_7 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_8 = execute_INSTRUCTION[7];
-  assign _zz_CsrPlugin_csrMapping_readDataInit_25 = 32'h0;
-  assign _zz_PmpPlugin_pmpaddr_port0 = PmpPlugin_pmpaddr[execute_PmpPlugin_fsm_fsmCounter];
-  always @(posedge clk) begin
-    if(_zz_1) begin
-      PmpPlugin_pmpaddr[execute_PmpPlugin_pmpNcfg_] <= _zz_PmpPlugin_pmpaddr_port;
-    end
-  end
-
-  assign _zz_PmpPlugin_pmpaddr_port2 = PmpPlugin_pmpaddr[execute_PmpPlugin_pmpNcfg];
+  assign _zz_CsrPlugin_csrMapping_readDataInit_109 = (_zz_CsrPlugin_csrMapping_readDataInit_65 | _zz_CsrPlugin_csrMapping_readDataInit_66);
+  assign _zz_CsrPlugin_csrMapping_readDataInit_110 = (_zz_CsrPlugin_csrMapping_readDataInit_67 | _zz_CsrPlugin_csrMapping_readDataInit_68);
+  assign _zz_CsrPlugin_csrMapping_readDataInit_111 = (_zz_CsrPlugin_csrMapping_readDataInit_69 | _zz_CsrPlugin_csrMapping_readDataInit_70);
+  assign _zz_CsrPlugin_csrMapping_readDataInit_112 = (_zz_CsrPlugin_csrMapping_readDataInit_71 | _zz_CsrPlugin_csrMapping_readDataInit_72);
+  assign _zz_CsrPlugin_csrMapping_readDataInit_113 = (_zz_CsrPlugin_csrMapping_readDataInit_73 | _zz_CsrPlugin_csrMapping_readDataInit_74);
+  assign _zz_CsrPlugin_csrMapping_readDataInit_114 = (_zz_CsrPlugin_csrMapping_readDataInit_75 | _zz_CsrPlugin_csrMapping_readDataInit_76);
+  assign _zz_CsrPlugin_csrMapping_readDataInit_115 = (_zz_CsrPlugin_csrMapping_readDataInit_77 | _zz_CsrPlugin_csrMapping_readDataInit_78);
+  assign _zz_CsrPlugin_csrMapping_readDataInit_116 = (_zz_CsrPlugin_csrMapping_readDataInit_79 | _zz_CsrPlugin_csrMapping_readDataInit_80);
+  assign _zz_CsrPlugin_csrMapping_readDataInit_117 = (_zz_CsrPlugin_csrMapping_readDataInit_81 | _zz_CsrPlugin_csrMapping_readDataInit_82);
+  assign _zz_CsrPlugin_csrMapping_readDataInit_118 = (_zz_CsrPlugin_csrMapping_readDataInit_83 | _zz_CsrPlugin_csrMapping_readDataInit_84);
+  assign _zz_CsrPlugin_csrMapping_readDataInit_119 = (_zz_CsrPlugin_csrMapping_readDataInit_85 | _zz_CsrPlugin_csrMapping_readDataInit_86);
+  assign _zz_CsrPlugin_csrMapping_readDataInit_120 = (_zz_CsrPlugin_csrMapping_readDataInit_87 | _zz_CsrPlugin_csrMapping_readDataInit_88);
+  assign _zz_CsrPlugin_csrMapping_readDataInit_121 = (_zz_CsrPlugin_csrMapping_readDataInit_122 | _zz_CsrPlugin_csrMapping_readDataInit_89);
+  assign _zz_CsrPlugin_csrMapping_readDataInit_123 = (_zz_CsrPlugin_csrMapping_readDataInit_90 | _zz_CsrPlugin_csrMapping_readDataInit_91);
+  assign _zz_CsrPlugin_csrMapping_readDataInit_124 = (_zz_CsrPlugin_csrMapping_readDataInit_92 | _zz_CsrPlugin_csrMapping_readDataInit_93);
+  assign _zz_CsrPlugin_csrMapping_readDataInit_125 = (_zz_CsrPlugin_csrMapping_readDataInit_94 | _zz_CsrPlugin_csrMapping_readDataInit_95);
+  assign _zz_CsrPlugin_csrMapping_readDataInit_122 = 32'h00000000;
   always @(posedge clk) begin
     if(_zz_decode_RegFilePlugin_rs1Data) begin
       _zz_RegFilePlugin_regFile_port0 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
@@ -2091,16 +2546,11 @@ module VexRiscv (
   end
 
   always @(posedge clk) begin
-    if(_zz_2) begin
+    if(_zz_1) begin
       RegFilePlugin_regFile[lastStageRegFileWrite_payload_address] <= lastStageRegFileWrite_payload_data;
     end
   end
 
-  PmpSetter PmpPlugin_setter (
-    .io_addr (PmpPlugin_setter_io_addr[31:0]), //i
-    .io_base (PmpPlugin_setter_io_base[24:0]), //o
-    .io_mask (PmpPlugin_setter_io_mask[24:0])  //o
-  );
   InstructionCache IBusCachedPlugin_cache (
     .io_flush                              (IBusCachedPlugin_cache_io_flush                           ), //i
     .io_cpu_prefetch_isValid               (IBusCachedPlugin_cache_io_cpu_prefetch_isValid            ), //i
@@ -2192,8 +2642,9 @@ module VexRiscv (
     .io_cpu_flush_ready                     (dataCache_1_io_cpu_flush_ready                   ), //o
     .io_cpu_flush_payload_singleLine        (dataCache_1_io_cpu_flush_payload_singleLine      ), //i
     .io_cpu_flush_payload_lineId            (dataCache_1_io_cpu_flush_payload_lineId[6:0]     ), //i
+    .io_cpu_writesPending                   (dataCache_1_io_cpu_writesPending                 ), //o
     .io_mem_cmd_valid                       (dataCache_1_io_mem_cmd_valid                     ), //o
-    .io_mem_cmd_ready                       (dataCache_1_io_mem_cmd_ready                     ), //i
+    .io_mem_cmd_ready                       (toplevel_dataCache_1_io_mem_cmd_rValidN          ), //i
     .io_mem_cmd_payload_wr                  (dataCache_1_io_mem_cmd_payload_wr                ), //o
     .io_mem_cmd_payload_uncached            (dataCache_1_io_mem_cmd_payload_uncached          ), //o
     .io_mem_cmd_payload_address             (dataCache_1_io_mem_cmd_payload_address[31:0]     ), //o
@@ -2234,1619 +2685,284 @@ module VexRiscv (
   end
 
   always @(*) begin
-    case(execute_PmpPlugin_fsm_fsmCounter)
-      4'b0000 : _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_0;
-      4'b0001 : _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_1;
-      4'b0010 : _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_2;
-      4'b0011 : _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_3;
-      4'b0100 : _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_4;
-      4'b0101 : _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_5;
-      4'b0110 : _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_6;
-      4'b0111 : _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_7;
-      4'b1000 : _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_8;
-      4'b1001 : _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_9;
-      4'b1010 : _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_10;
-      4'b1011 : _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_11;
-      4'b1100 : _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_12;
-      4'b1101 : _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_13;
-      4'b1110 : _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_14;
-      default : _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_15;
+    case(_zz_when_PmpPlugin_l250_20)
+      3'b000 : _zz_when_PmpPlugin_l250_19 = _zz_when_PmpPlugin_l250;
+      3'b001 : _zz_when_PmpPlugin_l250_19 = _zz_when_PmpPlugin_l250_1;
+      3'b010 : _zz_when_PmpPlugin_l250_19 = _zz_when_PmpPlugin_l250_2;
+      3'b011 : _zz_when_PmpPlugin_l250_19 = _zz_when_PmpPlugin_l250_3;
+      3'b100 : _zz_when_PmpPlugin_l250_19 = _zz_when_PmpPlugin_l250_4;
+      3'b101 : _zz_when_PmpPlugin_l250_19 = _zz_when_PmpPlugin_l250_5;
+      3'b110 : _zz_when_PmpPlugin_l250_19 = _zz_when_PmpPlugin_l250_6;
+      default : _zz_when_PmpPlugin_l250_19 = _zz_when_PmpPlugin_l250_7;
     endcase
   end
 
   always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_0_2)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_15;
+    case(_zz_when_PmpPlugin_l250_22)
+      3'b000 : _zz_when_PmpPlugin_l250_21 = _zz_when_PmpPlugin_l250;
+      3'b001 : _zz_when_PmpPlugin_l250_21 = _zz_when_PmpPlugin_l250_1;
+      3'b010 : _zz_when_PmpPlugin_l250_21 = _zz_when_PmpPlugin_l250_2;
+      3'b011 : _zz_when_PmpPlugin_l250_21 = _zz_when_PmpPlugin_l250_3;
+      3'b100 : _zz_when_PmpPlugin_l250_21 = _zz_when_PmpPlugin_l250_4;
+      3'b101 : _zz_when_PmpPlugin_l250_21 = _zz_when_PmpPlugin_l250_5;
+      3'b110 : _zz_when_PmpPlugin_l250_21 = _zz_when_PmpPlugin_l250_6;
+      default : _zz_when_PmpPlugin_l250_21 = _zz_when_PmpPlugin_l250_7;
     endcase
   end
 
   always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_0_4)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_15;
+    case(_zz_when_PmpPlugin_l250_25)
+      3'b000 : _zz_when_PmpPlugin_l250_24 = _zz_when_PmpPlugin_l250;
+      3'b001 : _zz_when_PmpPlugin_l250_24 = _zz_when_PmpPlugin_l250_1;
+      3'b010 : _zz_when_PmpPlugin_l250_24 = _zz_when_PmpPlugin_l250_2;
+      3'b011 : _zz_when_PmpPlugin_l250_24 = _zz_when_PmpPlugin_l250_3;
+      3'b100 : _zz_when_PmpPlugin_l250_24 = _zz_when_PmpPlugin_l250_4;
+      3'b101 : _zz_when_PmpPlugin_l250_24 = _zz_when_PmpPlugin_l250_5;
+      3'b110 : _zz_when_PmpPlugin_l250_24 = _zz_when_PmpPlugin_l250_6;
+      default : _zz_when_PmpPlugin_l250_24 = _zz_when_PmpPlugin_l250_7;
     endcase
   end
 
   always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_1_1)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_15;
+    case(_zz_when_PmpPlugin_l250_27)
+      3'b000 : _zz_when_PmpPlugin_l250_26 = _zz_when_PmpPlugin_l250;
+      3'b001 : _zz_when_PmpPlugin_l250_26 = _zz_when_PmpPlugin_l250_1;
+      3'b010 : _zz_when_PmpPlugin_l250_26 = _zz_when_PmpPlugin_l250_2;
+      3'b011 : _zz_when_PmpPlugin_l250_26 = _zz_when_PmpPlugin_l250_3;
+      3'b100 : _zz_when_PmpPlugin_l250_26 = _zz_when_PmpPlugin_l250_4;
+      3'b101 : _zz_when_PmpPlugin_l250_26 = _zz_when_PmpPlugin_l250_5;
+      3'b110 : _zz_when_PmpPlugin_l250_26 = _zz_when_PmpPlugin_l250_6;
+      default : _zz_when_PmpPlugin_l250_26 = _zz_when_PmpPlugin_l250_7;
     endcase
   end
 
   always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_1_3)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_15;
+    case(_zz_when_PmpPlugin_l250_30)
+      3'b000 : _zz_when_PmpPlugin_l250_29 = _zz_when_PmpPlugin_l250;
+      3'b001 : _zz_when_PmpPlugin_l250_29 = _zz_when_PmpPlugin_l250_1;
+      3'b010 : _zz_when_PmpPlugin_l250_29 = _zz_when_PmpPlugin_l250_2;
+      3'b011 : _zz_when_PmpPlugin_l250_29 = _zz_when_PmpPlugin_l250_3;
+      3'b100 : _zz_when_PmpPlugin_l250_29 = _zz_when_PmpPlugin_l250_4;
+      3'b101 : _zz_when_PmpPlugin_l250_29 = _zz_when_PmpPlugin_l250_5;
+      3'b110 : _zz_when_PmpPlugin_l250_29 = _zz_when_PmpPlugin_l250_6;
+      default : _zz_when_PmpPlugin_l250_29 = _zz_when_PmpPlugin_l250_7;
     endcase
   end
 
   always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_2_1)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_15;
+    case(_zz_when_PmpPlugin_l250_32)
+      3'b000 : _zz_when_PmpPlugin_l250_31 = _zz_when_PmpPlugin_l250;
+      3'b001 : _zz_when_PmpPlugin_l250_31 = _zz_when_PmpPlugin_l250_1;
+      3'b010 : _zz_when_PmpPlugin_l250_31 = _zz_when_PmpPlugin_l250_2;
+      3'b011 : _zz_when_PmpPlugin_l250_31 = _zz_when_PmpPlugin_l250_3;
+      3'b100 : _zz_when_PmpPlugin_l250_31 = _zz_when_PmpPlugin_l250_4;
+      3'b101 : _zz_when_PmpPlugin_l250_31 = _zz_when_PmpPlugin_l250_5;
+      3'b110 : _zz_when_PmpPlugin_l250_31 = _zz_when_PmpPlugin_l250_6;
+      default : _zz_when_PmpPlugin_l250_31 = _zz_when_PmpPlugin_l250_7;
     endcase
   end
 
   always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_2_3)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_15;
+    case(_zz_IBusCachedPlugin_mmuBus_rsp_allowRead_50)
+      4'b0000 : _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead;
+      4'b0001 : _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_2;
+      4'b0010 : _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_4;
+      4'b0011 : _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_6;
+      4'b0100 : _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_8;
+      4'b0101 : _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_10;
+      4'b0110 : _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_12;
+      4'b0111 : _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_14;
+      4'b1000 : _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_16;
+      4'b1001 : _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_18;
+      4'b1010 : _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_20;
+      4'b1011 : _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_22;
+      4'b1100 : _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_24;
+      4'b1101 : _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_26;
+      4'b1110 : _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_28;
+      default : _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_30;
     endcase
   end
 
   always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_3_1)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_15;
+    case(_zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_50)
+      4'b0000 : _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite;
+      4'b0001 : _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_2;
+      4'b0010 : _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_4;
+      4'b0011 : _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_6;
+      4'b0100 : _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_8;
+      4'b0101 : _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_10;
+      4'b0110 : _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_12;
+      4'b0111 : _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_14;
+      4'b1000 : _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_16;
+      4'b1001 : _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_18;
+      4'b1010 : _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_20;
+      4'b1011 : _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_22;
+      4'b1100 : _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_24;
+      4'b1101 : _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_26;
+      4'b1110 : _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_28;
+      default : _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_30;
     endcase
   end
 
   always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_3_3)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_15;
+    case(_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_50)
+      4'b0000 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute;
+      4'b0001 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_2;
+      4'b0010 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_4;
+      4'b0011 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_6;
+      4'b0100 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_8;
+      4'b0101 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_10;
+      4'b0110 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_12;
+      4'b0111 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_14;
+      4'b1000 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_16;
+      4'b1001 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_18;
+      4'b1010 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_20;
+      4'b1011 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_22;
+      4'b1100 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_24;
+      4'b1101 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_26;
+      4'b1110 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_28;
+      default : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_30;
     endcase
   end
 
   always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_4_1)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_15;
+    case(_zz_when_PmpPlugin_l250_1_5)
+      3'b000 : _zz_when_PmpPlugin_l250_1_4 = _zz_when_PmpPlugin_l250_8;
+      3'b001 : _zz_when_PmpPlugin_l250_1_4 = _zz_when_PmpPlugin_l250_9;
+      3'b010 : _zz_when_PmpPlugin_l250_1_4 = _zz_when_PmpPlugin_l250_10;
+      3'b011 : _zz_when_PmpPlugin_l250_1_4 = _zz_when_PmpPlugin_l250_11;
+      3'b100 : _zz_when_PmpPlugin_l250_1_4 = _zz_when_PmpPlugin_l250_12;
+      3'b101 : _zz_when_PmpPlugin_l250_1_4 = _zz_when_PmpPlugin_l250_13;
+      3'b110 : _zz_when_PmpPlugin_l250_1_4 = _zz_when_PmpPlugin_l250_14;
+      default : _zz_when_PmpPlugin_l250_1_4 = _zz_when_PmpPlugin_l250_15;
     endcase
   end
 
   always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_4_3)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_15;
+    case(_zz_when_PmpPlugin_l250_1_7)
+      3'b000 : _zz_when_PmpPlugin_l250_1_6 = _zz_when_PmpPlugin_l250_8;
+      3'b001 : _zz_when_PmpPlugin_l250_1_6 = _zz_when_PmpPlugin_l250_9;
+      3'b010 : _zz_when_PmpPlugin_l250_1_6 = _zz_when_PmpPlugin_l250_10;
+      3'b011 : _zz_when_PmpPlugin_l250_1_6 = _zz_when_PmpPlugin_l250_11;
+      3'b100 : _zz_when_PmpPlugin_l250_1_6 = _zz_when_PmpPlugin_l250_12;
+      3'b101 : _zz_when_PmpPlugin_l250_1_6 = _zz_when_PmpPlugin_l250_13;
+      3'b110 : _zz_when_PmpPlugin_l250_1_6 = _zz_when_PmpPlugin_l250_14;
+      default : _zz_when_PmpPlugin_l250_1_6 = _zz_when_PmpPlugin_l250_15;
     endcase
   end
 
   always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_5_1)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_15;
+    case(_zz_when_PmpPlugin_l250_1_10)
+      3'b000 : _zz_when_PmpPlugin_l250_1_9 = _zz_when_PmpPlugin_l250_8;
+      3'b001 : _zz_when_PmpPlugin_l250_1_9 = _zz_when_PmpPlugin_l250_9;
+      3'b010 : _zz_when_PmpPlugin_l250_1_9 = _zz_when_PmpPlugin_l250_10;
+      3'b011 : _zz_when_PmpPlugin_l250_1_9 = _zz_when_PmpPlugin_l250_11;
+      3'b100 : _zz_when_PmpPlugin_l250_1_9 = _zz_when_PmpPlugin_l250_12;
+      3'b101 : _zz_when_PmpPlugin_l250_1_9 = _zz_when_PmpPlugin_l250_13;
+      3'b110 : _zz_when_PmpPlugin_l250_1_9 = _zz_when_PmpPlugin_l250_14;
+      default : _zz_when_PmpPlugin_l250_1_9 = _zz_when_PmpPlugin_l250_15;
     endcase
   end
 
   always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_5_3)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_15;
+    case(_zz_when_PmpPlugin_l250_1_12)
+      3'b000 : _zz_when_PmpPlugin_l250_1_11 = _zz_when_PmpPlugin_l250_8;
+      3'b001 : _zz_when_PmpPlugin_l250_1_11 = _zz_when_PmpPlugin_l250_9;
+      3'b010 : _zz_when_PmpPlugin_l250_1_11 = _zz_when_PmpPlugin_l250_10;
+      3'b011 : _zz_when_PmpPlugin_l250_1_11 = _zz_when_PmpPlugin_l250_11;
+      3'b100 : _zz_when_PmpPlugin_l250_1_11 = _zz_when_PmpPlugin_l250_12;
+      3'b101 : _zz_when_PmpPlugin_l250_1_11 = _zz_when_PmpPlugin_l250_13;
+      3'b110 : _zz_when_PmpPlugin_l250_1_11 = _zz_when_PmpPlugin_l250_14;
+      default : _zz_when_PmpPlugin_l250_1_11 = _zz_when_PmpPlugin_l250_15;
     endcase
   end
 
   always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_6_1)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_15;
+    case(_zz_when_PmpPlugin_l250_1_15)
+      3'b000 : _zz_when_PmpPlugin_l250_1_14 = _zz_when_PmpPlugin_l250_8;
+      3'b001 : _zz_when_PmpPlugin_l250_1_14 = _zz_when_PmpPlugin_l250_9;
+      3'b010 : _zz_when_PmpPlugin_l250_1_14 = _zz_when_PmpPlugin_l250_10;
+      3'b011 : _zz_when_PmpPlugin_l250_1_14 = _zz_when_PmpPlugin_l250_11;
+      3'b100 : _zz_when_PmpPlugin_l250_1_14 = _zz_when_PmpPlugin_l250_12;
+      3'b101 : _zz_when_PmpPlugin_l250_1_14 = _zz_when_PmpPlugin_l250_13;
+      3'b110 : _zz_when_PmpPlugin_l250_1_14 = _zz_when_PmpPlugin_l250_14;
+      default : _zz_when_PmpPlugin_l250_1_14 = _zz_when_PmpPlugin_l250_15;
     endcase
   end
 
   always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_6_3)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_7_1)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_7_3)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_8_1)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_8_3)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_9_1)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_9_3)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_10_1)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_10_3)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_11_1)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_11_3)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_12_1)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_12_3)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_13_1)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_13_3)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_14_1)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_14_3)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_15_1)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_15_3)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_15;
+    case(_zz_when_PmpPlugin_l250_1_17)
+      3'b000 : _zz_when_PmpPlugin_l250_1_16 = _zz_when_PmpPlugin_l250_8;
+      3'b001 : _zz_when_PmpPlugin_l250_1_16 = _zz_when_PmpPlugin_l250_9;
+      3'b010 : _zz_when_PmpPlugin_l250_1_16 = _zz_when_PmpPlugin_l250_10;
+      3'b011 : _zz_when_PmpPlugin_l250_1_16 = _zz_when_PmpPlugin_l250_11;
+      3'b100 : _zz_when_PmpPlugin_l250_1_16 = _zz_when_PmpPlugin_l250_12;
+      3'b101 : _zz_when_PmpPlugin_l250_1_16 = _zz_when_PmpPlugin_l250_13;
+      3'b110 : _zz_when_PmpPlugin_l250_1_16 = _zz_when_PmpPlugin_l250_14;
+      default : _zz_when_PmpPlugin_l250_1_16 = _zz_when_PmpPlugin_l250_15;
     endcase
   end
 
   always @(*) begin
     case(_zz_DBusCachedPlugin_mmuBus_rsp_allowRead_18)
-      4'b0000 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = PmpPlugin_pmpcfg_0[0];
-      4'b0001 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = PmpPlugin_pmpcfg_1[0];
-      4'b0010 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = PmpPlugin_pmpcfg_2[0];
-      4'b0011 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = PmpPlugin_pmpcfg_3[0];
-      4'b0100 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = PmpPlugin_pmpcfg_4[0];
-      4'b0101 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = PmpPlugin_pmpcfg_5[0];
-      4'b0110 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = PmpPlugin_pmpcfg_6[0];
-      4'b0111 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = PmpPlugin_pmpcfg_7[0];
-      4'b1000 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = PmpPlugin_pmpcfg_8[0];
-      4'b1001 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = PmpPlugin_pmpcfg_9[0];
-      4'b1010 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = PmpPlugin_pmpcfg_10[0];
-      4'b1011 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = PmpPlugin_pmpcfg_11[0];
-      4'b1100 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = PmpPlugin_pmpcfg_12[0];
-      4'b1101 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = PmpPlugin_pmpcfg_13[0];
-      4'b1110 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = PmpPlugin_pmpcfg_14[0];
-      default : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = PmpPlugin_pmpcfg_15[0];
+      4'b0000 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead;
+      4'b0001 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_2;
+      4'b0010 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_4;
+      4'b0011 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_6;
+      4'b0100 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_8;
+      4'b0101 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_10;
+      4'b0110 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_12;
+      4'b0111 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_14;
+      4'b1000 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_16;
+      4'b1001 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_18;
+      4'b1010 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_20;
+      4'b1011 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_22;
+      4'b1100 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_24;
+      4'b1101 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_26;
+      4'b1110 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_28;
+      default : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_30;
     endcase
   end
 
   always @(*) begin
     case(_zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_18)
-      4'b0000 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = PmpPlugin_pmpcfg_0[1];
-      4'b0001 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = PmpPlugin_pmpcfg_1[1];
-      4'b0010 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = PmpPlugin_pmpcfg_2[1];
-      4'b0011 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = PmpPlugin_pmpcfg_3[1];
-      4'b0100 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = PmpPlugin_pmpcfg_4[1];
-      4'b0101 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = PmpPlugin_pmpcfg_5[1];
-      4'b0110 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = PmpPlugin_pmpcfg_6[1];
-      4'b0111 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = PmpPlugin_pmpcfg_7[1];
-      4'b1000 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = PmpPlugin_pmpcfg_8[1];
-      4'b1001 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = PmpPlugin_pmpcfg_9[1];
-      4'b1010 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = PmpPlugin_pmpcfg_10[1];
-      4'b1011 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = PmpPlugin_pmpcfg_11[1];
-      4'b1100 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = PmpPlugin_pmpcfg_12[1];
-      4'b1101 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = PmpPlugin_pmpcfg_13[1];
-      4'b1110 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = PmpPlugin_pmpcfg_14[1];
-      default : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = PmpPlugin_pmpcfg_15[1];
+      4'b0000 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite;
+      4'b0001 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_2;
+      4'b0010 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_4;
+      4'b0011 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_6;
+      4'b0100 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_8;
+      4'b0101 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_10;
+      4'b0110 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_12;
+      4'b0111 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_14;
+      4'b1000 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_16;
+      4'b1001 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_18;
+      4'b1010 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_20;
+      4'b1011 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_22;
+      4'b1100 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_24;
+      4'b1101 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_26;
+      4'b1110 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_28;
+      default : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_30;
     endcase
   end
 
   always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_0_2)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_0_4)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_1_1)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_1_3)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_2_1)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_2_3)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_3_1)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_3_3)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_4_1)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_4_3)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_5_1)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_5_3)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_6_1)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_6_3)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_7_1)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_7_3)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_8_1)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_8_3)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_9_1)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_9_3)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_10_1)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_10_3)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_11_1)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_11_3)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_12_1)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_12_3)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_13_1)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_13_3)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_14_1)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_14_3)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_15_1)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_15_3)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_18)
-      4'b0000 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_17 = PmpPlugin_pmpcfg_0[2];
-      4'b0001 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_17 = PmpPlugin_pmpcfg_1[2];
-      4'b0010 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_17 = PmpPlugin_pmpcfg_2[2];
-      4'b0011 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_17 = PmpPlugin_pmpcfg_3[2];
-      4'b0100 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_17 = PmpPlugin_pmpcfg_4[2];
-      4'b0101 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_17 = PmpPlugin_pmpcfg_5[2];
-      4'b0110 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_17 = PmpPlugin_pmpcfg_6[2];
-      4'b0111 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_17 = PmpPlugin_pmpcfg_7[2];
-      4'b1000 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_17 = PmpPlugin_pmpcfg_8[2];
-      4'b1001 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_17 = PmpPlugin_pmpcfg_9[2];
-      4'b1010 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_17 = PmpPlugin_pmpcfg_10[2];
-      4'b1011 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_17 = PmpPlugin_pmpcfg_11[2];
-      4'b1100 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_17 = PmpPlugin_pmpcfg_12[2];
-      4'b1101 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_17 = PmpPlugin_pmpcfg_13[2];
-      4'b1110 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_17 = PmpPlugin_pmpcfg_14[2];
-      default : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_17 = PmpPlugin_pmpcfg_15[2];
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_when_PmpPlugin_l209_1)
-      4'b0000 : _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_0;
-      4'b0001 : _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_1;
-      4'b0010 : _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_2;
-      4'b0011 : _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_3;
-      4'b0100 : _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_4;
-      4'b0101 : _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_5;
-      4'b0110 : _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_6;
-      4'b0111 : _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_7;
-      4'b1000 : _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_8;
-      4'b1001 : _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_9;
-      4'b1010 : _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_10;
-      4'b1011 : _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_11;
-      4'b1100 : _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_12;
-      4'b1101 : _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_13;
-      4'b1110 : _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_14;
-      default : _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_when_PmpPlugin_l209_1_2)
-      4'b0000 : _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_0;
-      4'b0001 : _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_1;
-      4'b0010 : _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_2;
-      4'b0011 : _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_3;
-      4'b0100 : _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_4;
-      4'b0101 : _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_5;
-      4'b0110 : _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_6;
-      4'b0111 : _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_7;
-      4'b1000 : _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_8;
-      4'b1001 : _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_9;
-      4'b1010 : _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_10;
-      4'b1011 : _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_11;
-      4'b1100 : _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_12;
-      4'b1101 : _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_13;
-      4'b1110 : _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_14;
-      default : _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_when_PmpPlugin_l209_2_1)
-      4'b0000 : _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_0;
-      4'b0001 : _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_1;
-      4'b0010 : _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_2;
-      4'b0011 : _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_3;
-      4'b0100 : _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_4;
-      4'b0101 : _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_5;
-      4'b0110 : _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_6;
-      4'b0111 : _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_7;
-      4'b1000 : _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_8;
-      4'b1001 : _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_9;
-      4'b1010 : _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_10;
-      4'b1011 : _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_11;
-      4'b1100 : _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_12;
-      4'b1101 : _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_13;
-      4'b1110 : _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_14;
-      default : _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_when_PmpPlugin_l209_3_1)
-      4'b0000 : _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_0;
-      4'b0001 : _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_1;
-      4'b0010 : _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_2;
-      4'b0011 : _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_3;
-      4'b0100 : _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_4;
-      4'b0101 : _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_5;
-      4'b0110 : _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_6;
-      4'b0111 : _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_7;
-      4'b1000 : _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_8;
-      4'b1001 : _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_9;
-      4'b1010 : _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_10;
-      4'b1011 : _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_11;
-      4'b1100 : _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_12;
-      4'b1101 : _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_13;
-      4'b1110 : _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_14;
-      default : _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(execute_PmpPlugin_pmpNcfg_)
-      4'b0000 : _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_0;
-      4'b0001 : _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_1;
-      4'b0010 : _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_2;
-      4'b0011 : _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_3;
-      4'b0100 : _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_4;
-      4'b0101 : _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_5;
-      4'b0110 : _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_6;
-      4'b0111 : _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_7;
-      4'b1000 : _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_8;
-      4'b1001 : _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_9;
-      4'b1010 : _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_10;
-      4'b1011 : _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_11;
-      4'b1100 : _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_12;
-      4'b1101 : _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_13;
-      4'b1110 : _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_14;
-      default : _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_CsrPlugin_csrMapping_readDataSignal_1)
-      4'b0000 : _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_0;
-      4'b0001 : _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_1;
-      4'b0010 : _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_2;
-      4'b0011 : _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_3;
-      4'b0100 : _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_4;
-      4'b0101 : _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_5;
-      4'b0110 : _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_6;
-      4'b0111 : _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_7;
-      4'b1000 : _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_8;
-      4'b1001 : _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_9;
-      4'b1010 : _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_10;
-      4'b1011 : _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_11;
-      4'b1100 : _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_12;
-      4'b1101 : _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_13;
-      4'b1110 : _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_14;
-      default : _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_CsrPlugin_csrMapping_readDataSignal_3)
-      4'b0000 : _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_0;
-      4'b0001 : _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_1;
-      4'b0010 : _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_2;
-      4'b0011 : _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_3;
-      4'b0100 : _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_4;
-      4'b0101 : _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_5;
-      4'b0110 : _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_6;
-      4'b0111 : _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_7;
-      4'b1000 : _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_8;
-      4'b1001 : _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_9;
-      4'b1010 : _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_10;
-      4'b1011 : _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_11;
-      4'b1100 : _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_12;
-      4'b1101 : _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_13;
-      4'b1110 : _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_14;
-      default : _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_CsrPlugin_csrMapping_readDataSignal_5)
-      4'b0000 : _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_0;
-      4'b0001 : _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_1;
-      4'b0010 : _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_2;
-      4'b0011 : _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_3;
-      4'b0100 : _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_4;
-      4'b0101 : _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_5;
-      4'b0110 : _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_6;
-      4'b0111 : _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_7;
-      4'b1000 : _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_8;
-      4'b1001 : _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_9;
-      4'b1010 : _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_10;
-      4'b1011 : _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_11;
-      4'b1100 : _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_12;
-      4'b1101 : _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_13;
-      4'b1110 : _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_14;
-      default : _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_CsrPlugin_csrMapping_readDataSignal_7)
-      4'b0000 : _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_0;
-      4'b0001 : _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_1;
-      4'b0010 : _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_2;
-      4'b0011 : _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_3;
-      4'b0100 : _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_4;
-      4'b0101 : _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_5;
-      4'b0110 : _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_6;
-      4'b0111 : _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_7;
-      4'b1000 : _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_8;
-      4'b1001 : _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_9;
-      4'b1010 : _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_10;
-      4'b1011 : _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_11;
-      4'b1100 : _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_12;
-      4'b1101 : _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_13;
-      4'b1110 : _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_14;
-      default : _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_15;
+    case(_zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_18)
+      4'b0000 : _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute;
+      4'b0001 : _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_2;
+      4'b0010 : _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_4;
+      4'b0011 : _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_6;
+      4'b0100 : _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_8;
+      4'b0101 : _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_10;
+      4'b0110 : _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_12;
+      4'b0111 : _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_14;
+      4'b1000 : _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_16;
+      4'b1001 : _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_18;
+      4'b1010 : _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_20;
+      4'b1011 : _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_22;
+      4'b1100 : _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_24;
+      4'b1101 : _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_26;
+      4'b1110 : _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_28;
+      default : _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_30;
     endcase
   end
 
@@ -4535,50 +3651,9 @@ module VexRiscv (
       default : memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
-  always @(*) begin
-    case(execute_PmpPlugin_fsm_stateReg)
-      execute_PmpPlugin_fsm_enumDef_BOOT : execute_PmpPlugin_fsm_stateReg_string = "BOOT      ";
-      execute_PmpPlugin_fsm_enumDef_stateIdle : execute_PmpPlugin_fsm_stateReg_string = "stateIdle ";
-      execute_PmpPlugin_fsm_enumDef_stateWrite : execute_PmpPlugin_fsm_stateReg_string = "stateWrite";
-      execute_PmpPlugin_fsm_enumDef_stateCfg : execute_PmpPlugin_fsm_stateReg_string = "stateCfg  ";
-      execute_PmpPlugin_fsm_enumDef_stateAddr : execute_PmpPlugin_fsm_stateReg_string = "stateAddr ";
-      default : execute_PmpPlugin_fsm_stateReg_string = "??????????";
-    endcase
-  end
-  always @(*) begin
-    case(execute_PmpPlugin_fsm_stateNext)
-      execute_PmpPlugin_fsm_enumDef_BOOT : execute_PmpPlugin_fsm_stateNext_string = "BOOT      ";
-      execute_PmpPlugin_fsm_enumDef_stateIdle : execute_PmpPlugin_fsm_stateNext_string = "stateIdle ";
-      execute_PmpPlugin_fsm_enumDef_stateWrite : execute_PmpPlugin_fsm_stateNext_string = "stateWrite";
-      execute_PmpPlugin_fsm_enumDef_stateCfg : execute_PmpPlugin_fsm_stateNext_string = "stateCfg  ";
-      execute_PmpPlugin_fsm_enumDef_stateAddr : execute_PmpPlugin_fsm_stateNext_string = "stateAddr ";
-      default : execute_PmpPlugin_fsm_stateNext_string = "??????????";
-    endcase
-  end
   `endif
 
-  always @(*) begin
-    _zz_1 = 1'b0;
-    case(execute_PmpPlugin_fsm_stateReg)
-      execute_PmpPlugin_fsm_enumDef_stateIdle : begin
-      end
-      execute_PmpPlugin_fsm_enumDef_stateWrite : begin
-        if(execute_PmpPlugin_pmpaddrCsr_) begin
-          if(when_PmpPlugin_l216) begin
-            _zz_1 = 1'b1;
-          end
-        end
-      end
-      execute_PmpPlugin_fsm_enumDef_stateCfg : begin
-      end
-      execute_PmpPlugin_fsm_enumDef_stateAddr : begin
-      end
-      default : begin
-      end
-    endcase
-  end
-
-  assign memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW) + $signed(_zz_memory_MUL_LOW_7));
+  assign memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW) + $signed(_zz_memory_MUL_LOW_6));
   assign memory_MUL_HH = execute_to_memory_MUL_HH;
   assign execute_MUL_HH = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bHigh));
   assign execute_MUL_HL = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bSLow));
@@ -4591,7 +3666,7 @@ module VexRiscv (
   assign memory_MEMORY_STORE_DATA_RF = execute_to_memory_MEMORY_STORE_DATA_RF;
   assign execute_MEMORY_STORE_DATA_RF = _zz_execute_MEMORY_STORE_DATA_RF;
   assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
-  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
+  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h00)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h00))));
   assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
   assign decode_IS_RS2_SIGNED = _zz_decode_IS_RS2_SIGNED[31];
@@ -4656,7 +3731,7 @@ module VexRiscv (
   assign decode_RS1_USE = _zz_decode_IS_RS2_SIGNED[5];
   always @(*) begin
     _zz_decode_RS2 = execute_REGFILE_WRITE_DATA;
-    if(when_CsrPlugin_l1189) begin
+    if(when_CsrPlugin_l1587) begin
       _zz_decode_RS2 = CsrPlugin_csrMapping_readDataSignal;
     end
   end
@@ -4752,7 +3827,7 @@ module VexRiscv (
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_execute_SRC2 = execute_PC;
+  assign _zz_execute_to_memory_PC = execute_PC;
   assign execute_SRC2_CTRL = _zz_execute_SRC2_CTRL;
   assign execute_SRC1_CTRL = _zz_execute_SRC1_CTRL;
   assign decode_SRC_USE_SUB_LESS = _zz_decode_IS_RS2_SIGNED[3];
@@ -4760,15 +3835,15 @@ module VexRiscv (
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
   assign execute_ALU_CTRL = _zz_execute_ALU_CTRL;
-  assign execute_SRC2 = _zz_execute_SRC2_5;
+  assign execute_SRC2 = _zz_execute_SRC2_4;
   assign execute_SRC1 = _zz_execute_SRC1;
   assign execute_ALU_BITWISE_CTRL = _zz_execute_ALU_BITWISE_CTRL;
   assign _zz_lastStageRegFileWrite_payload_address = writeBack_INSTRUCTION;
   assign _zz_lastStageRegFileWrite_valid = writeBack_REGFILE_WRITE_VALID;
   always @(*) begin
-    _zz_2 = 1'b0;
+    _zz_1 = 1'b0;
     if(lastStageRegFileWrite_valid) begin
-      _zz_2 = 1'b1;
+      _zz_1 = 1'b1;
     end
   end
 
@@ -4780,10 +3855,10 @@ module VexRiscv (
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00001073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
+  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000107f) == 32'h00001073),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00002073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
   always @(*) begin
     _zz_decode_RS2_2 = writeBack_REGFILE_WRITE_DATA;
-    if(when_DBusCachedPlugin_l492) begin
+    if(when_DBusCachedPlugin_l580) begin
       _zz_decode_RS2_2 = writeBack_DBusCachedPlugin_rspFormated;
     end
     if(when_MulPlugin_l147) begin
@@ -4816,28 +3891,28 @@ module VexRiscv (
   assign decode_FLUSH_ALL = _zz_decode_IS_RS2_SIGNED[0];
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_4 = IBusCachedPlugin_rsp_issueDetected_3;
-    if(when_IBusCachedPlugin_l256) begin
+    if(when_IBusCachedPlugin_l262) begin
       IBusCachedPlugin_rsp_issueDetected_4 = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_3 = IBusCachedPlugin_rsp_issueDetected_2;
-    if(when_IBusCachedPlugin_l250) begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_rsp_issueDetected_3 = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
-    if(when_IBusCachedPlugin_l244) begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
-    if(when_IBusCachedPlugin_l239) begin
+    if(when_IBusCachedPlugin_l245) begin
       IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
@@ -4863,7 +3938,7 @@ module VexRiscv (
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
   always @(*) begin
     decode_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l308) begin
+    if(when_DBusCachedPlugin_l352) begin
       decode_arbitration_haltItself = 1'b1;
     end
   end
@@ -4876,7 +3951,7 @@ module VexRiscv (
     if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(when_CsrPlugin_l1129) begin
+    if(when_CsrPlugin_l1527) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
@@ -4904,29 +3979,24 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l350) begin
+    if(when_DBusCachedPlugin_l394) begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(when_CsrPlugin_l1121) begin
-      if(when_CsrPlugin_l1123) begin
+    if(when_CsrPlugin_l1519) begin
+      if(when_CsrPlugin_l1521) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(when_CsrPlugin_l1193) begin
+    if(when_CsrPlugin_l1591) begin
       if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
-      end
-    end
-    if(execute_CsrPlugin_writeInstruction) begin
-      if(when_PmpPlugin_l172) begin
-        execute_arbitration_haltItself = (! execute_PmpPlugin_fsmComplete);
       end
     end
   end
 
   always @(*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if(when_DBusCachedPlugin_l366) begin
+    if(when_DBusCachedPlugin_l410) begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
@@ -4982,7 +4052,7 @@ module VexRiscv (
 
   always @(*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l466) begin
+    if(when_DBusCachedPlugin_l553) begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
@@ -5013,10 +4083,10 @@ module VexRiscv (
     if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -5027,13 +4097,13 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @(*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(when_CsrPlugin_l935) begin
+    if(when_CsrPlugin_l1272) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
@@ -5041,7 +4111,7 @@ module VexRiscv (
   assign IBusCachedPlugin_forceNoDecodeCond = 1'b0;
   always @(*) begin
     IBusCachedPlugin_incomingInstruction = 1'b0;
-    if(when_Fetcher_l243) begin
+    if(when_Fetcher_l242) begin
       IBusCachedPlugin_incomingInstruction = 1'b1;
     end
   end
@@ -5049,40 +4119,39 @@ module VexRiscv (
   assign BranchPlugin_inDebugNoFetchFlag = 1'b0;
   always @(*) begin
     CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
-    if(execute_CsrPlugin_readInstruction) begin
-      if(when_PmpPlugin_l155) begin
-        if(execute_PmpPlugin_pmpcfgCsr) begin
-          CsrPlugin_csrMapping_allowCsrSignal = 1'b1;
-        end
-        if(execute_PmpPlugin_pmpaddrCsr) begin
-          CsrPlugin_csrMapping_allowCsrSignal = 1'b1;
-        end
-      end
-    end
-    if(execute_CsrPlugin_writeInstruction) begin
-      if(when_PmpPlugin_l172) begin
-        CsrPlugin_csrMapping_allowCsrSignal = 1'b1;
-      end
+    if(when_CsrPlugin_l1709) begin
+      CsrPlugin_csrMapping_allowCsrSignal = 1'b1;
     end
   end
 
   always @(*) begin
-    CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
-    if(execute_CsrPlugin_readInstruction) begin
-      if(when_PmpPlugin_l155) begin
-        if(execute_PmpPlugin_pmpcfgCsr) begin
-          CsrPlugin_csrMapping_readDataSignal = {{{_zz_CsrPlugin_csrMapping_readDataSignal,_zz_CsrPlugin_csrMapping_readDataSignal_2},_zz_CsrPlugin_csrMapping_readDataSignal_4},_zz_CsrPlugin_csrMapping_readDataSignal_6};
-        end
-        if(execute_PmpPlugin_pmpaddrCsr) begin
-          CsrPlugin_csrMapping_readDataSignal = _zz_PmpPlugin_pmpaddr_port2;
-        end
+    CsrPlugin_csrMapping_doForceFailCsr = 1'b0;
+    if(execute_CsrPlugin_csr_3072) begin
+      if(when_CsrPlugin_l1076) begin
+        CsrPlugin_csrMapping_doForceFailCsr = 1'b1;
+      end
+    end
+    if(execute_CsrPlugin_csr_3200) begin
+      if(when_CsrPlugin_l1076_1) begin
+        CsrPlugin_csrMapping_doForceFailCsr = 1'b1;
+      end
+    end
+    if(execute_CsrPlugin_csr_3074) begin
+      if(when_CsrPlugin_l1076_2) begin
+        CsrPlugin_csrMapping_doForceFailCsr = 1'b1;
+      end
+    end
+    if(execute_CsrPlugin_csr_3202) begin
+      if(when_CsrPlugin_l1076_3) begin
+        CsrPlugin_csrMapping_doForceFailCsr = 1'b1;
       end
     end
   end
 
+  assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
   always @(*) begin
     CsrPlugin_inWfi = 1'b0;
-    if(when_CsrPlugin_l1121) begin
+    if(when_CsrPlugin_l1519) begin
       CsrPlugin_inWfi = 1'b1;
     end
   end
@@ -5090,21 +4159,21 @@ module VexRiscv (
   assign CsrPlugin_thirdPartyWake = 1'b0;
   always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(when_CsrPlugin_l1077) begin
-      case(switch_CsrPlugin_l1081)
+    if(when_CsrPlugin_l1456) begin
+      case(switch_CsrPlugin_l1460)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -5118,6 +4187,21 @@ module VexRiscv (
   assign CsrPlugin_allowInterrupts = 1'b1;
   assign CsrPlugin_allowException = 1'b1;
   assign CsrPlugin_allowEbreakException = 1'b1;
+  always @(*) begin
+    CsrPlugin_xretAwayFromMachine = 1'b0;
+    if(when_CsrPlugin_l1456) begin
+      case(switch_CsrPlugin_l1460)
+        2'b11 : begin
+          if(when_CsrPlugin_l1468) begin
+            CsrPlugin_xretAwayFromMachine = 1'b1;
+          end
+        end
+        default : begin
+        end
+      endcase
+    end
+  end
+
   assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
   assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusCachedPlugin_redoBranch_valid,IBusCachedPlugin_predictionJumpInterface_valid}}} != 4'b0000);
   assign _zz_IBusCachedPlugin_jump_pcLoad_payload = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
@@ -5145,9 +4229,8 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l134 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
-  assign IBusCachedPlugin_fetchPc_output_fire_1 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
-  assign when_Fetcher_l134_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
+  assign when_Fetcher_l133 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l133_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
   always @(*) begin
     IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_IBusCachedPlugin_fetchPc_pc);
     if(IBusCachedPlugin_fetchPc_redo_valid) begin
@@ -5170,7 +4253,7 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l161 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
+  assign when_Fetcher_l160 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
   assign IBusCachedPlugin_fetchPc_output_valid = ((! IBusCachedPlugin_fetcherHalt) && IBusCachedPlugin_fetchPc_booted);
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
   always @(*) begin
@@ -5207,7 +4290,7 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_1_output_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b0;
-    if(when_IBusCachedPlugin_l267) begin
+    if(when_IBusCachedPlugin_l273) begin
       IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b1;
     end
   end
@@ -5220,9 +4303,9 @@ module VexRiscv (
   assign IBusCachedPlugin_fetchPc_redo_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_iBusRsp_flush = ((decode_arbitration_removeIt || (decode_arbitration_flushNext && (! decode_arbitration_isStuck))) || IBusCachedPlugin_iBusRsp_redoFetch);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
-  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1 = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
   assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid)) || IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready);
   assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
@@ -5232,18 +4315,18 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
   always @(*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
-    if(when_Fetcher_l323) begin
+    if(when_Fetcher_l322) begin
       IBusCachedPlugin_iBusRsp_readyForError = 1'b0;
     end
   end
 
-  assign when_Fetcher_l243 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
-  assign when_Fetcher_l323 = (! IBusCachedPlugin_pcValids_0);
-  assign when_Fetcher_l332 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
-  assign when_Fetcher_l332_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
-  assign when_Fetcher_l332_2 = (! execute_arbitration_isStuck);
-  assign when_Fetcher_l332_3 = (! memory_arbitration_isStuck);
-  assign when_Fetcher_l332_4 = (! writeBack_arbitration_isStuck);
+  assign when_Fetcher_l242 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
+  assign when_Fetcher_l322 = (! IBusCachedPlugin_pcValids_0);
+  assign when_Fetcher_l331 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l331_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
+  assign when_Fetcher_l331_2 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l331_3 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l331_4 = (! writeBack_arbitration_isStuck);
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
@@ -5281,56 +4364,56 @@ module VexRiscv (
 
   always @(*) begin
     IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == BranchCtrlEnum_JAL) || ((decode_BRANCH_CTRL == BranchCtrlEnum_B) && _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2[31]));
-    if(_zz_7) begin
+    if(_zz_6) begin
       IBusCachedPlugin_decodePrediction_cmd_hadBranch = 1'b0;
     end
   end
 
-  assign _zz_3 = _zz__zz_3[19];
+  assign _zz_2 = _zz__zz_2[19];
   always @(*) begin
-    _zz_4[10] = _zz_3;
-    _zz_4[9] = _zz_3;
-    _zz_4[8] = _zz_3;
-    _zz_4[7] = _zz_3;
-    _zz_4[6] = _zz_3;
-    _zz_4[5] = _zz_3;
-    _zz_4[4] = _zz_3;
-    _zz_4[3] = _zz_3;
-    _zz_4[2] = _zz_3;
-    _zz_4[1] = _zz_3;
-    _zz_4[0] = _zz_3;
+    _zz_3[10] = _zz_2;
+    _zz_3[9] = _zz_2;
+    _zz_3[8] = _zz_2;
+    _zz_3[7] = _zz_2;
+    _zz_3[6] = _zz_2;
+    _zz_3[5] = _zz_2;
+    _zz_3[4] = _zz_2;
+    _zz_3[3] = _zz_2;
+    _zz_3[2] = _zz_2;
+    _zz_3[1] = _zz_2;
+    _zz_3[0] = _zz_2;
   end
 
-  assign _zz_5 = _zz__zz_5[11];
+  assign _zz_4 = _zz__zz_4[11];
   always @(*) begin
-    _zz_6[18] = _zz_5;
-    _zz_6[17] = _zz_5;
-    _zz_6[16] = _zz_5;
-    _zz_6[15] = _zz_5;
-    _zz_6[14] = _zz_5;
-    _zz_6[13] = _zz_5;
-    _zz_6[12] = _zz_5;
-    _zz_6[11] = _zz_5;
-    _zz_6[10] = _zz_5;
-    _zz_6[9] = _zz_5;
-    _zz_6[8] = _zz_5;
-    _zz_6[7] = _zz_5;
-    _zz_6[6] = _zz_5;
-    _zz_6[5] = _zz_5;
-    _zz_6[4] = _zz_5;
-    _zz_6[3] = _zz_5;
-    _zz_6[2] = _zz_5;
-    _zz_6[1] = _zz_5;
-    _zz_6[0] = _zz_5;
+    _zz_5[18] = _zz_4;
+    _zz_5[17] = _zz_4;
+    _zz_5[16] = _zz_4;
+    _zz_5[15] = _zz_4;
+    _zz_5[14] = _zz_4;
+    _zz_5[13] = _zz_4;
+    _zz_5[12] = _zz_4;
+    _zz_5[11] = _zz_4;
+    _zz_5[10] = _zz_4;
+    _zz_5[9] = _zz_4;
+    _zz_5[8] = _zz_4;
+    _zz_5[7] = _zz_4;
+    _zz_5[6] = _zz_4;
+    _zz_5[5] = _zz_4;
+    _zz_5[4] = _zz_4;
+    _zz_5[3] = _zz_4;
+    _zz_5[2] = _zz_4;
+    _zz_5[1] = _zz_4;
+    _zz_5[0] = _zz_4;
   end
 
   always @(*) begin
     case(decode_BRANCH_CTRL)
       BranchCtrlEnum_JAL : begin
-        _zz_7 = _zz__zz_7[1];
+        _zz_6 = _zz__zz_6[1];
       end
       default : begin
-        _zz_7 = _zz__zz_7_1[1];
+        _zz_6 = _zz__zz_6_1[1];
       end
     endcase
   end
@@ -5398,87 +4481,86 @@ module VexRiscv (
   assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
   always @(*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(when_IBusCachedPlugin_l239) begin
+    if(when_IBusCachedPlugin_l245) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(when_IBusCachedPlugin_l250) begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_cache_io_cpu_fill_valid = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
-    if(when_IBusCachedPlugin_l250) begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_cache_io_cpu_fill_valid = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_valid = 1'b0;
-    if(when_IBusCachedPlugin_l244) begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
-    if(when_IBusCachedPlugin_l256) begin
+    if(when_IBusCachedPlugin_l262) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_payload_code = 4'bxxxx;
-    if(when_IBusCachedPlugin_l244) begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b1100;
     end
-    if(when_IBusCachedPlugin_l256) begin
+    if(when_IBusCachedPlugin_l262) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b0001;
     end
   end
 
   assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_2_input_payload[31 : 2],2'b00};
-  assign when_IBusCachedPlugin_l239 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign when_IBusCachedPlugin_l244 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
-  assign when_IBusCachedPlugin_l250 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
-  assign when_IBusCachedPlugin_l256 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
-  assign when_IBusCachedPlugin_l267 = (IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt);
+  assign when_IBusCachedPlugin_l245 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign when_IBusCachedPlugin_l250 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign when_IBusCachedPlugin_l256 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
+  assign when_IBusCachedPlugin_l262 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
+  assign when_IBusCachedPlugin_l273 = (IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt);
   assign IBusCachedPlugin_iBusRsp_output_valid = IBusCachedPlugin_iBusRsp_stages_2_output_valid;
   assign IBusCachedPlugin_iBusRsp_stages_2_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
   assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_decode_data;
   assign IBusCachedPlugin_iBusRsp_output_payload_pc = IBusCachedPlugin_iBusRsp_stages_2_output_payload;
   assign IBusCachedPlugin_cache_io_flush = (decode_arbitration_isValid && decode_FLUSH_ALL);
-  assign dataCache_1_io_mem_cmd_ready = (! dataCache_1_io_mem_cmd_rValid);
-  assign dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || dataCache_1_io_mem_cmd_rValid);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_wr : dataCache_1_io_mem_cmd_payload_wr);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_uncached : dataCache_1_io_mem_cmd_payload_uncached);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_address = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_address : dataCache_1_io_mem_cmd_payload_address);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_data = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_data : dataCache_1_io_mem_cmd_payload_data);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_mask : dataCache_1_io_mem_cmd_payload_mask);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_size = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_size : dataCache_1_io_mem_cmd_payload_size);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_last : dataCache_1_io_mem_cmd_payload_last);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || (! toplevel_dataCache_1_io_mem_cmd_rValidN));
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_wr : toplevel_dataCache_1_io_mem_cmd_rData_wr);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_uncached : toplevel_dataCache_1_io_mem_cmd_rData_uncached);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_address = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_address : toplevel_dataCache_1_io_mem_cmd_rData_address);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_data = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_data : toplevel_dataCache_1_io_mem_cmd_rData_data);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_mask : toplevel_dataCache_1_io_mem_cmd_rData_mask);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_size = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_size : toplevel_dataCache_1_io_mem_cmd_rData_size);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_last = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_last : toplevel_dataCache_1_io_mem_cmd_rData_last);
   always @(*) begin
-    dataCache_1_io_mem_cmd_s2mPipe_ready = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
-    if(when_Stream_l368) begin
-      dataCache_1_io_mem_cmd_s2mPipe_ready = 1'b1;
+    toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
+    if(when_Stream_l369) begin
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l368 = (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_rValid;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_rData_address;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_rData_data;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size = dataCache_1_io_mem_cmd_s2mPipe_rData_size;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_rData_last;
-  assign dBus_cmd_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
-  assign dBus_cmd_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
-  assign dBus_cmd_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
-  assign dBus_cmd_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
-  assign dBus_cmd_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
-  assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  assign dBus_cmd_payload_size = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
-  assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  assign when_DBusCachedPlugin_l308 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
+  assign when_Stream_l369 = (! toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_address;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_data;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_size;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  assign dBus_cmd_valid = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
+  assign dBus_cmd_payload_wr = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
+  assign dBus_cmd_payload_uncached = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
+  assign dBus_cmd_payload_address = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
+  assign dBus_cmd_payload_data = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
+  assign dBus_cmd_payload_mask = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
+  assign dBus_cmd_payload_size = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
+  assign dBus_cmd_payload_last = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  assign when_DBusCachedPlugin_l352 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
   assign dataCache_1_io_cpu_execute_isValid = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
   assign dataCache_1_io_cpu_execute_address = execute_SRC_ADD;
@@ -5497,11 +4579,11 @@ module VexRiscv (
   end
 
   assign dataCache_1_io_cpu_flush_valid = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
-  assign dataCache_1_io_cpu_flush_payload_singleLine = (execute_INSTRUCTION[19 : 15] != 5'h0);
+  assign dataCache_1_io_cpu_flush_payload_singleLine = (execute_INSTRUCTION[19 : 15] != 5'h00);
   assign dataCache_1_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId[6:0];
-  assign dataCache_1_io_cpu_flush_isStall = (dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready));
-  assign when_DBusCachedPlugin_l350 = (dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
-  assign when_DBusCachedPlugin_l366 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
+  assign toplevel_dataCache_1_io_cpu_flush_isStall = (dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready));
+  assign when_DBusCachedPlugin_l394 = (toplevel_dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
+  assign when_DBusCachedPlugin_l410 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
   assign dataCache_1_io_cpu_memory_isValid = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
   assign dataCache_1_io_cpu_memory_address = memory_REGFILE_WRITE_DATA;
   assign DBusCachedPlugin_mmuBus_cmd_0_isValid = dataCache_1_io_cpu_memory_isValid;
@@ -5511,12 +4593,12 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
   always @(*) begin
     dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if(when_DBusCachedPlugin_l393) begin
+    if(when_DBusCachedPlugin_l472) begin
       dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = 1'b1;
     end
   end
 
-  assign when_DBusCachedPlugin_l393 = (1'b0 && (! dataCache_1_io_cpu_memory_isWrite));
+  assign when_DBusCachedPlugin_l472 = (1'b0 && (! dataCache_1_io_cpu_memory_isWrite));
   always @(*) begin
     dataCache_1_io_cpu_writeBack_isValid = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
     if(writeBack_arbitration_haltByOther) begin
@@ -5529,7 +4611,7 @@ module VexRiscv (
   assign dataCache_1_io_cpu_writeBack_storeData[31 : 0] = writeBack_MEMORY_STORE_DATA_RF;
   always @(*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(when_DBusCachedPlugin_l446) begin
+    if(when_DBusCachedPlugin_l533) begin
       if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
@@ -5539,7 +4621,7 @@ module VexRiscv (
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(when_DBusCachedPlugin_l446) begin
+    if(when_DBusCachedPlugin_l533) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
@@ -5558,7 +4640,7 @@ module VexRiscv (
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
-    if(when_DBusCachedPlugin_l446) begin
+    if(when_DBusCachedPlugin_l533) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code};
       end
@@ -5571,12 +4653,13 @@ module VexRiscv (
     end
   end
 
-  assign when_DBusCachedPlugin_l446 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign when_DBusCachedPlugin_l466 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
-  assign writeBack_DBusCachedPlugin_rspSplits_0 = dataCache_1_io_cpu_writeBack_data[7 : 0];
-  assign writeBack_DBusCachedPlugin_rspSplits_1 = dataCache_1_io_cpu_writeBack_data[15 : 8];
-  assign writeBack_DBusCachedPlugin_rspSplits_2 = dataCache_1_io_cpu_writeBack_data[23 : 16];
-  assign writeBack_DBusCachedPlugin_rspSplits_3 = dataCache_1_io_cpu_writeBack_data[31 : 24];
+  assign when_DBusCachedPlugin_l533 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l553 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
+  assign writeBack_DBusCachedPlugin_rspData = dataCache_1_io_cpu_writeBack_data;
+  assign writeBack_DBusCachedPlugin_rspSplits_0 = writeBack_DBusCachedPlugin_rspData[7 : 0];
+  assign writeBack_DBusCachedPlugin_rspSplits_1 = writeBack_DBusCachedPlugin_rspData[15 : 8];
+  assign writeBack_DBusCachedPlugin_rspSplits_2 = writeBack_DBusCachedPlugin_rspData[23 : 16];
+  assign writeBack_DBusCachedPlugin_rspSplits_3 = writeBack_DBusCachedPlugin_rspData[31 : 24];
   always @(*) begin
     writeBack_DBusCachedPlugin_rspShifted[7 : 0] = _zz_writeBack_DBusCachedPlugin_rspShifted;
     writeBack_DBusCachedPlugin_rspShifted[15 : 8] = _zz_writeBack_DBusCachedPlugin_rspShifted_2;
@@ -5585,7 +4668,7 @@ module VexRiscv (
   end
 
   assign writeBack_DBusCachedPlugin_rspRf = writeBack_DBusCachedPlugin_rspShifted[31 : 0];
-  assign switch_Misc_l210 = writeBack_INSTRUCTION[13 : 12];
+  assign switch_Misc_l232 = writeBack_INSTRUCTION[13 : 12];
   assign _zz_writeBack_DBusCachedPlugin_rspFormated = (writeBack_DBusCachedPlugin_rspRf[7] && (! writeBack_INSTRUCTION[14]));
   always @(*) begin
     _zz_writeBack_DBusCachedPlugin_rspFormated_1[31] = _zz_writeBack_DBusCachedPlugin_rspFormated;
@@ -5637,7 +4720,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    case(switch_Misc_l210)
+    case(switch_Misc_l232)
       2'b00 : begin
         writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_1;
       end
@@ -5650,77 +4733,1885 @@ module VexRiscv (
     endcase
   end
 
-  assign when_DBusCachedPlugin_l492 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign when_PmpPlugin_l138 = (! execute_arbitration_isStuck);
+  assign when_DBusCachedPlugin_l580 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
   always @(*) begin
-    execute_PmpPlugin_fsmComplete = 1'b0;
-    if(when_StateMachine_l249) begin
-      execute_PmpPlugin_fsmComplete = 1'b1;
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_1 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead;
+    if(execute_CsrPlugin_csr_928) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_1 = CsrPlugin_csrMapping_writeDataSignal[0];
+      end
     end
   end
 
-  assign execute_PmpPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
-  assign execute_PmpPlugin_pmpNcfg = execute_PmpPlugin_csrAddress[3 : 0];
-  assign execute_PmpPlugin_pmpcfgN = execute_PmpPlugin_pmpNcfg[1 : 0];
-  assign execute_PmpPlugin_pmpcfgCsr = (execute_INSTRUCTION[31 : 24] == 8'h3a);
-  assign execute_PmpPlugin_pmpaddrCsr = (execute_INSTRUCTION[31 : 24] == 8'h3b);
-  assign execute_PmpPlugin_fsm_wantExit = 1'b0;
   always @(*) begin
-    execute_PmpPlugin_fsm_wantStart = 1'b0;
-    case(execute_PmpPlugin_fsm_stateReg)
-      execute_PmpPlugin_fsm_enumDef_stateIdle : begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_1 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite;
+    if(execute_CsrPlugin_csr_928) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_1 = CsrPlugin_csrMapping_writeDataSignal[1];
       end
-      execute_PmpPlugin_fsm_enumDef_stateWrite : begin
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute;
+    if(execute_CsrPlugin_csr_928) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1 = CsrPlugin_csrMapping_writeDataSignal[2];
       end
-      execute_PmpPlugin_fsm_enumDef_stateCfg : begin
+    end
+  end
+
+  always @(*) begin
+    _zz_when_PmpPlugin_l126_1 = _zz_when_PmpPlugin_l126;
+    if(execute_CsrPlugin_csr_928) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_when_PmpPlugin_l126_1 = CsrPlugin_csrMapping_writeDataSignal[7];
       end
-      execute_PmpPlugin_fsm_enumDef_stateAddr : begin
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_2 = _zz_CsrPlugin_csrMapping_readDataInit;
+    if(execute_CsrPlugin_csr_928) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_2 = CsrPlugin_csrMapping_writeDataSignal[4 : 3];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_3 = _zz_CsrPlugin_csrMapping_readDataInit_1;
+    if(execute_CsrPlugin_csr_944) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_3 = CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+      end
+    end
+  end
+
+  assign when_PmpPlugin_l126 = (! _zz_when_PmpPlugin_l126);
+  assign _zz_PmpPlugin_ports_0_hits_0_4 = {2'b00,_zz_CsrPlugin_csrMapping_readDataInit_1};
+  assign _zz_PmpPlugin_ports_0_hits_0_5 = ({2'd0,_zz_PmpPlugin_ports_0_hits_0_4} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_0_6 = (_zz_PmpPlugin_ports_0_hits_0_4 ^ _zz__zz_PmpPlugin_ports_0_hits_0_6);
+  assign _zz_PmpPlugin_ports_0_hits_0_7 = ({2'd0,(_zz_PmpPlugin_ports_0_hits_0_4 & (~ _zz_PmpPlugin_ports_0_hits_0_6))} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_0_1 = _zz_when_PmpPlugin_l126;
+  always @(*) begin
+    _zz_PmpPlugin_ports_0_hits_0 = 1'b1;
+    case(_zz_CsrPlugin_csrMapping_readDataInit_2)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
       end
       default : begin
-        execute_PmpPlugin_fsm_wantStart = 1'b1;
+        _zz_PmpPlugin_ports_0_hits_0 = 1'b0;
       end
     endcase
   end
 
-  assign execute_PmpPlugin_fsm_wantKill = 1'b0;
   always @(*) begin
-    if(execute_PmpPlugin_pmpaddrCsr_) begin
-      PmpPlugin_setter_io_addr = execute_PmpPlugin_writeData_;
-    end else begin
-      PmpPlugin_setter_io_addr = _zz_PmpPlugin_pmpaddr_port0;
+    case(_zz_CsrPlugin_csrMapping_readDataInit_2)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_0_2 = 36'h000000000;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_0_2 = _zz_PmpPlugin_ports_0_hits_0_5;
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_0_2 = _zz_PmpPlugin_ports_0_hits_0_7;
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_0_2 = 36'h000000000;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_2)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_0_3 = _zz_PmpPlugin_ports_0_hits_0_5;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_0_3 = (_zz_PmpPlugin_ports_0_hits_0_5 + 36'h000000004);
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_0_3 = (_zz_PmpPlugin_ports_0_hits_0_7 + _zz__zz_PmpPlugin_ports_0_hits_0_3);
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_0_3 = _zz_PmpPlugin_ports_0_hits_0_5;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_3 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_2;
+    if(execute_CsrPlugin_csr_928) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_3 = CsrPlugin_csrMapping_writeDataSignal[8];
+      end
     end
   end
 
-  assign when_PmpPlugin_l246 = (execute_PmpPlugin_fsm_fsmEnable && (! _zz_when_PmpPlugin_l246[7]));
-  assign _zz_8 = ({15'd0,1'b1} <<< execute_PmpPlugin_fsm_fsmCounter);
-  assign _zz_9 = ({15'd0,1'b1} <<< execute_PmpPlugin_fsm_fsmCounter);
-  assign DBusCachedPlugin_mmuBus_rsp_physicalAddress = DBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
-  assign DBusCachedPlugin_mmuBus_rsp_isIoAccess = DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31];
-  assign DBusCachedPlugin_mmuBus_rsp_isPaging = 1'b0;
-  assign DBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
-  assign DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
-  assign DBusCachedPlugin_mmuBus_rsp_allowExecute = 1'b0;
-  assign DBusCachedPlugin_mmuBus_busy = 1'b0;
-  assign _zz_PmpPlugin_dGuard_hits_0 = DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 7];
-  assign PmpPlugin_dGuard_hits_0 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_0_1) == _zz_PmpPlugin_dGuard_hits_0_3) && (PmpPlugin_pmpcfg_0[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_0[4 : 3] == 2'b11));
-  assign PmpPlugin_dGuard_hits_1 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_1) == _zz_PmpPlugin_dGuard_hits_1_2) && (PmpPlugin_pmpcfg_1[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_1[4 : 3] == 2'b11));
-  assign PmpPlugin_dGuard_hits_2 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_2) == _zz_PmpPlugin_dGuard_hits_2_2) && (PmpPlugin_pmpcfg_2[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_2[4 : 3] == 2'b11));
-  assign PmpPlugin_dGuard_hits_3 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_3) == _zz_PmpPlugin_dGuard_hits_3_2) && (PmpPlugin_pmpcfg_3[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_3[4 : 3] == 2'b11));
-  assign PmpPlugin_dGuard_hits_4 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_4) == _zz_PmpPlugin_dGuard_hits_4_2) && (PmpPlugin_pmpcfg_4[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_4[4 : 3] == 2'b11));
-  assign PmpPlugin_dGuard_hits_5 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_5) == _zz_PmpPlugin_dGuard_hits_5_2) && (PmpPlugin_pmpcfg_5[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_5[4 : 3] == 2'b11));
-  assign PmpPlugin_dGuard_hits_6 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_6) == _zz_PmpPlugin_dGuard_hits_6_2) && (PmpPlugin_pmpcfg_6[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_6[4 : 3] == 2'b11));
-  assign PmpPlugin_dGuard_hits_7 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_7) == _zz_PmpPlugin_dGuard_hits_7_2) && (PmpPlugin_pmpcfg_7[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_7[4 : 3] == 2'b11));
-  assign PmpPlugin_dGuard_hits_8 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_8) == _zz_PmpPlugin_dGuard_hits_8_2) && (PmpPlugin_pmpcfg_8[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_8[4 : 3] == 2'b11));
-  assign PmpPlugin_dGuard_hits_9 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_9) == _zz_PmpPlugin_dGuard_hits_9_2) && (PmpPlugin_pmpcfg_9[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_9[4 : 3] == 2'b11));
-  assign PmpPlugin_dGuard_hits_10 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_10) == _zz_PmpPlugin_dGuard_hits_10_2) && (PmpPlugin_pmpcfg_10[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_10[4 : 3] == 2'b11));
-  assign PmpPlugin_dGuard_hits_11 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_11) == _zz_PmpPlugin_dGuard_hits_11_2) && (PmpPlugin_pmpcfg_11[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_11[4 : 3] == 2'b11));
-  assign PmpPlugin_dGuard_hits_12 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_12) == _zz_PmpPlugin_dGuard_hits_12_2) && (PmpPlugin_pmpcfg_12[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_12[4 : 3] == 2'b11));
-  assign PmpPlugin_dGuard_hits_13 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_13) == _zz_PmpPlugin_dGuard_hits_13_2) && (PmpPlugin_pmpcfg_13[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_13[4 : 3] == 2'b11));
-  assign PmpPlugin_dGuard_hits_14 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_14) == _zz_PmpPlugin_dGuard_hits_14_2) && (PmpPlugin_pmpcfg_14[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_14[4 : 3] == 2'b11));
-  assign PmpPlugin_dGuard_hits_15 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_15) == _zz_PmpPlugin_dGuard_hits_15_2) && (PmpPlugin_pmpcfg_15[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_15[4 : 3] == 2'b11));
-  assign when_PmpPlugin_l277 = (! ({PmpPlugin_dGuard_hits_15,{PmpPlugin_dGuard_hits_14,{PmpPlugin_dGuard_hits_13,{PmpPlugin_dGuard_hits_12,{PmpPlugin_dGuard_hits_11,{PmpPlugin_dGuard_hits_10,{PmpPlugin_dGuard_hits_9,{PmpPlugin_dGuard_hits_8,{PmpPlugin_dGuard_hits_7,{_zz_when_PmpPlugin_l277,_zz_when_PmpPlugin_l277_1}}}}}}}}}} != 16'h0));
   always @(*) begin
-    if(when_PmpPlugin_l277) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_3 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_2;
+    if(execute_CsrPlugin_csr_928) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_3 = CsrPlugin_csrMapping_writeDataSignal[9];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_3 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_2;
+    if(execute_CsrPlugin_csr_928) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_3 = CsrPlugin_csrMapping_writeDataSignal[10];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_when_PmpPlugin_l126_3 = _zz_when_PmpPlugin_l126_2;
+    if(execute_CsrPlugin_csr_928) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_when_PmpPlugin_l126_3 = CsrPlugin_csrMapping_writeDataSignal[15];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_6 = _zz_CsrPlugin_csrMapping_readDataInit_4;
+    if(execute_CsrPlugin_csr_928) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_6 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_7 = _zz_CsrPlugin_csrMapping_readDataInit_5;
+    if(execute_CsrPlugin_csr_945) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_7 = CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+      end
+    end
+  end
+
+  assign when_PmpPlugin_l126_1 = (! _zz_when_PmpPlugin_l126_2);
+  assign _zz_PmpPlugin_ports_0_hits_1_4 = {2'b00,_zz_CsrPlugin_csrMapping_readDataInit_5};
+  assign _zz_PmpPlugin_ports_0_hits_1_5 = ({2'd0,_zz_PmpPlugin_ports_0_hits_1_4} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_1_6 = (_zz_PmpPlugin_ports_0_hits_1_4 ^ _zz__zz_PmpPlugin_ports_0_hits_1_6);
+  assign _zz_PmpPlugin_ports_0_hits_1_7 = ({2'd0,(_zz_PmpPlugin_ports_0_hits_1_4 & (~ _zz_PmpPlugin_ports_0_hits_1_6))} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_1_1 = _zz_when_PmpPlugin_l126_2;
+  always @(*) begin
+    _zz_PmpPlugin_ports_0_hits_1 = 1'b1;
+    case(_zz_CsrPlugin_csrMapping_readDataInit_6)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_1 = 1'b0;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_6)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_1_2 = _zz_PmpPlugin_ports_0_hits_0_3;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_1_2 = _zz_PmpPlugin_ports_0_hits_1_5;
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_1_2 = _zz_PmpPlugin_ports_0_hits_1_7;
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_1_2 = 36'h000000000;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_6)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_1_3 = _zz_PmpPlugin_ports_0_hits_1_5;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_1_3 = (_zz_PmpPlugin_ports_0_hits_1_5 + 36'h000000004);
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_1_3 = (_zz_PmpPlugin_ports_0_hits_1_7 + _zz__zz_PmpPlugin_ports_0_hits_1_3);
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_1_3 = _zz_PmpPlugin_ports_0_hits_1_5;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_5 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_4;
+    if(execute_CsrPlugin_csr_928) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_5 = CsrPlugin_csrMapping_writeDataSignal[16];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_5 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_4;
+    if(execute_CsrPlugin_csr_928) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_5 = CsrPlugin_csrMapping_writeDataSignal[17];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_5 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_4;
+    if(execute_CsrPlugin_csr_928) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_5 = CsrPlugin_csrMapping_writeDataSignal[18];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_when_PmpPlugin_l126_5 = _zz_when_PmpPlugin_l126_4;
+    if(execute_CsrPlugin_csr_928) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_when_PmpPlugin_l126_5 = CsrPlugin_csrMapping_writeDataSignal[23];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_10 = _zz_CsrPlugin_csrMapping_readDataInit_8;
+    if(execute_CsrPlugin_csr_928) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_10 = CsrPlugin_csrMapping_writeDataSignal[20 : 19];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_11 = _zz_CsrPlugin_csrMapping_readDataInit_9;
+    if(execute_CsrPlugin_csr_946) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_11 = CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+      end
+    end
+  end
+
+  assign when_PmpPlugin_l126_2 = (! _zz_when_PmpPlugin_l126_4);
+  assign _zz_PmpPlugin_ports_0_hits_2_4 = {2'b00,_zz_CsrPlugin_csrMapping_readDataInit_9};
+  assign _zz_PmpPlugin_ports_0_hits_2_5 = ({2'd0,_zz_PmpPlugin_ports_0_hits_2_4} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_2_6 = (_zz_PmpPlugin_ports_0_hits_2_4 ^ _zz__zz_PmpPlugin_ports_0_hits_2_6);
+  assign _zz_PmpPlugin_ports_0_hits_2_7 = ({2'd0,(_zz_PmpPlugin_ports_0_hits_2_4 & (~ _zz_PmpPlugin_ports_0_hits_2_6))} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_2_1 = _zz_when_PmpPlugin_l126_4;
+  always @(*) begin
+    _zz_PmpPlugin_ports_0_hits_2 = 1'b1;
+    case(_zz_CsrPlugin_csrMapping_readDataInit_10)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_2 = 1'b0;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_10)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_2_2 = _zz_PmpPlugin_ports_0_hits_1_3;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_2_2 = _zz_PmpPlugin_ports_0_hits_2_5;
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_2_2 = _zz_PmpPlugin_ports_0_hits_2_7;
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_2_2 = 36'h000000000;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_10)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_2_3 = _zz_PmpPlugin_ports_0_hits_2_5;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_2_3 = (_zz_PmpPlugin_ports_0_hits_2_5 + 36'h000000004);
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_2_3 = (_zz_PmpPlugin_ports_0_hits_2_7 + _zz__zz_PmpPlugin_ports_0_hits_2_3);
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_2_3 = _zz_PmpPlugin_ports_0_hits_2_5;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_7 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_6;
+    if(execute_CsrPlugin_csr_928) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_7 = CsrPlugin_csrMapping_writeDataSignal[24];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_7 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_6;
+    if(execute_CsrPlugin_csr_928) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_7 = CsrPlugin_csrMapping_writeDataSignal[25];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_7 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_6;
+    if(execute_CsrPlugin_csr_928) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_7 = CsrPlugin_csrMapping_writeDataSignal[26];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_when_PmpPlugin_l126_7 = _zz_when_PmpPlugin_l126_6;
+    if(execute_CsrPlugin_csr_928) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_when_PmpPlugin_l126_7 = CsrPlugin_csrMapping_writeDataSignal[31];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_14 = _zz_CsrPlugin_csrMapping_readDataInit_12;
+    if(execute_CsrPlugin_csr_928) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_14 = CsrPlugin_csrMapping_writeDataSignal[28 : 27];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_15 = _zz_CsrPlugin_csrMapping_readDataInit_13;
+    if(execute_CsrPlugin_csr_947) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_15 = CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+      end
+    end
+  end
+
+  assign when_PmpPlugin_l126_3 = (! _zz_when_PmpPlugin_l126_6);
+  assign _zz_PmpPlugin_ports_0_hits_3_4 = {2'b00,_zz_CsrPlugin_csrMapping_readDataInit_13};
+  assign _zz_PmpPlugin_ports_0_hits_3_5 = ({2'd0,_zz_PmpPlugin_ports_0_hits_3_4} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_3_6 = (_zz_PmpPlugin_ports_0_hits_3_4 ^ _zz__zz_PmpPlugin_ports_0_hits_3_6);
+  assign _zz_PmpPlugin_ports_0_hits_3_7 = ({2'd0,(_zz_PmpPlugin_ports_0_hits_3_4 & (~ _zz_PmpPlugin_ports_0_hits_3_6))} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_3_1 = _zz_when_PmpPlugin_l126_6;
+  always @(*) begin
+    _zz_PmpPlugin_ports_0_hits_3 = 1'b1;
+    case(_zz_CsrPlugin_csrMapping_readDataInit_14)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_3 = 1'b0;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_14)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_3_2 = _zz_PmpPlugin_ports_0_hits_2_3;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_3_2 = _zz_PmpPlugin_ports_0_hits_3_5;
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_3_2 = _zz_PmpPlugin_ports_0_hits_3_7;
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_3_2 = 36'h000000000;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_14)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_3_3 = _zz_PmpPlugin_ports_0_hits_3_5;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_3_3 = (_zz_PmpPlugin_ports_0_hits_3_5 + 36'h000000004);
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_3_3 = (_zz_PmpPlugin_ports_0_hits_3_7 + _zz__zz_PmpPlugin_ports_0_hits_3_3);
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_3_3 = _zz_PmpPlugin_ports_0_hits_3_5;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_9 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_8;
+    if(execute_CsrPlugin_csr_929) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_9 = CsrPlugin_csrMapping_writeDataSignal[0];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_9 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_8;
+    if(execute_CsrPlugin_csr_929) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_9 = CsrPlugin_csrMapping_writeDataSignal[1];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_9 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_8;
+    if(execute_CsrPlugin_csr_929) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_9 = CsrPlugin_csrMapping_writeDataSignal[2];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_when_PmpPlugin_l126_9 = _zz_when_PmpPlugin_l126_8;
+    if(execute_CsrPlugin_csr_929) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_when_PmpPlugin_l126_9 = CsrPlugin_csrMapping_writeDataSignal[7];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_18 = _zz_CsrPlugin_csrMapping_readDataInit_16;
+    if(execute_CsrPlugin_csr_929) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_18 = CsrPlugin_csrMapping_writeDataSignal[4 : 3];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_19 = _zz_CsrPlugin_csrMapping_readDataInit_17;
+    if(execute_CsrPlugin_csr_948) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_19 = CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+      end
+    end
+  end
+
+  assign when_PmpPlugin_l126_4 = (! _zz_when_PmpPlugin_l126_8);
+  assign _zz_PmpPlugin_ports_0_hits_4_4 = {2'b00,_zz_CsrPlugin_csrMapping_readDataInit_17};
+  assign _zz_PmpPlugin_ports_0_hits_4_5 = ({2'd0,_zz_PmpPlugin_ports_0_hits_4_4} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_4_6 = (_zz_PmpPlugin_ports_0_hits_4_4 ^ _zz__zz_PmpPlugin_ports_0_hits_4_6);
+  assign _zz_PmpPlugin_ports_0_hits_4_7 = ({2'd0,(_zz_PmpPlugin_ports_0_hits_4_4 & (~ _zz_PmpPlugin_ports_0_hits_4_6))} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_4_1 = _zz_when_PmpPlugin_l126_8;
+  always @(*) begin
+    _zz_PmpPlugin_ports_0_hits_4 = 1'b1;
+    case(_zz_CsrPlugin_csrMapping_readDataInit_18)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_4 = 1'b0;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_18)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_4_2 = _zz_PmpPlugin_ports_0_hits_3_3;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_4_2 = _zz_PmpPlugin_ports_0_hits_4_5;
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_4_2 = _zz_PmpPlugin_ports_0_hits_4_7;
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_4_2 = 36'h000000000;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_18)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_4_3 = _zz_PmpPlugin_ports_0_hits_4_5;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_4_3 = (_zz_PmpPlugin_ports_0_hits_4_5 + 36'h000000004);
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_4_3 = (_zz_PmpPlugin_ports_0_hits_4_7 + _zz__zz_PmpPlugin_ports_0_hits_4_3);
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_4_3 = _zz_PmpPlugin_ports_0_hits_4_5;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_11 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_10;
+    if(execute_CsrPlugin_csr_929) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_11 = CsrPlugin_csrMapping_writeDataSignal[8];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_11 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_10;
+    if(execute_CsrPlugin_csr_929) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_11 = CsrPlugin_csrMapping_writeDataSignal[9];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_11 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_10;
+    if(execute_CsrPlugin_csr_929) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_11 = CsrPlugin_csrMapping_writeDataSignal[10];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_when_PmpPlugin_l126_11 = _zz_when_PmpPlugin_l126_10;
+    if(execute_CsrPlugin_csr_929) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_when_PmpPlugin_l126_11 = CsrPlugin_csrMapping_writeDataSignal[15];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_22 = _zz_CsrPlugin_csrMapping_readDataInit_20;
+    if(execute_CsrPlugin_csr_929) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_22 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_23 = _zz_CsrPlugin_csrMapping_readDataInit_21;
+    if(execute_CsrPlugin_csr_949) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_23 = CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+      end
+    end
+  end
+
+  assign when_PmpPlugin_l126_5 = (! _zz_when_PmpPlugin_l126_10);
+  assign _zz_PmpPlugin_ports_0_hits_5_4 = {2'b00,_zz_CsrPlugin_csrMapping_readDataInit_21};
+  assign _zz_PmpPlugin_ports_0_hits_5_5 = ({2'd0,_zz_PmpPlugin_ports_0_hits_5_4} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_5_6 = (_zz_PmpPlugin_ports_0_hits_5_4 ^ _zz__zz_PmpPlugin_ports_0_hits_5_6);
+  assign _zz_PmpPlugin_ports_0_hits_5_7 = ({2'd0,(_zz_PmpPlugin_ports_0_hits_5_4 & (~ _zz_PmpPlugin_ports_0_hits_5_6))} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_5_1 = _zz_when_PmpPlugin_l126_10;
+  always @(*) begin
+    _zz_PmpPlugin_ports_0_hits_5 = 1'b1;
+    case(_zz_CsrPlugin_csrMapping_readDataInit_22)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_5 = 1'b0;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_22)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_5_2 = _zz_PmpPlugin_ports_0_hits_4_3;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_5_2 = _zz_PmpPlugin_ports_0_hits_5_5;
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_5_2 = _zz_PmpPlugin_ports_0_hits_5_7;
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_5_2 = 36'h000000000;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_22)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_5_3 = _zz_PmpPlugin_ports_0_hits_5_5;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_5_3 = (_zz_PmpPlugin_ports_0_hits_5_5 + 36'h000000004);
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_5_3 = (_zz_PmpPlugin_ports_0_hits_5_7 + _zz__zz_PmpPlugin_ports_0_hits_5_3);
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_5_3 = _zz_PmpPlugin_ports_0_hits_5_5;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_13 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_12;
+    if(execute_CsrPlugin_csr_929) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_13 = CsrPlugin_csrMapping_writeDataSignal[16];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_13 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_12;
+    if(execute_CsrPlugin_csr_929) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_13 = CsrPlugin_csrMapping_writeDataSignal[17];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_13 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_12;
+    if(execute_CsrPlugin_csr_929) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_13 = CsrPlugin_csrMapping_writeDataSignal[18];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_when_PmpPlugin_l126_13 = _zz_when_PmpPlugin_l126_12;
+    if(execute_CsrPlugin_csr_929) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_when_PmpPlugin_l126_13 = CsrPlugin_csrMapping_writeDataSignal[23];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_26 = _zz_CsrPlugin_csrMapping_readDataInit_24;
+    if(execute_CsrPlugin_csr_929) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_26 = CsrPlugin_csrMapping_writeDataSignal[20 : 19];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_27 = _zz_CsrPlugin_csrMapping_readDataInit_25;
+    if(execute_CsrPlugin_csr_950) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_27 = CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+      end
+    end
+  end
+
+  assign when_PmpPlugin_l126_6 = (! _zz_when_PmpPlugin_l126_12);
+  assign _zz_PmpPlugin_ports_0_hits_6_4 = {2'b00,_zz_CsrPlugin_csrMapping_readDataInit_25};
+  assign _zz_PmpPlugin_ports_0_hits_6_5 = ({2'd0,_zz_PmpPlugin_ports_0_hits_6_4} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_6_6 = (_zz_PmpPlugin_ports_0_hits_6_4 ^ _zz__zz_PmpPlugin_ports_0_hits_6_6);
+  assign _zz_PmpPlugin_ports_0_hits_6_7 = ({2'd0,(_zz_PmpPlugin_ports_0_hits_6_4 & (~ _zz_PmpPlugin_ports_0_hits_6_6))} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_6_1 = _zz_when_PmpPlugin_l126_12;
+  always @(*) begin
+    _zz_PmpPlugin_ports_0_hits_6 = 1'b1;
+    case(_zz_CsrPlugin_csrMapping_readDataInit_26)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_6 = 1'b0;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_26)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_6_2 = _zz_PmpPlugin_ports_0_hits_5_3;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_6_2 = _zz_PmpPlugin_ports_0_hits_6_5;
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_6_2 = _zz_PmpPlugin_ports_0_hits_6_7;
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_6_2 = 36'h000000000;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_26)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_6_3 = _zz_PmpPlugin_ports_0_hits_6_5;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_6_3 = (_zz_PmpPlugin_ports_0_hits_6_5 + 36'h000000004);
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_6_3 = (_zz_PmpPlugin_ports_0_hits_6_7 + _zz__zz_PmpPlugin_ports_0_hits_6_3);
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_6_3 = _zz_PmpPlugin_ports_0_hits_6_5;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_15 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_14;
+    if(execute_CsrPlugin_csr_929) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_15 = CsrPlugin_csrMapping_writeDataSignal[24];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_15 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_14;
+    if(execute_CsrPlugin_csr_929) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_15 = CsrPlugin_csrMapping_writeDataSignal[25];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_15 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_14;
+    if(execute_CsrPlugin_csr_929) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_15 = CsrPlugin_csrMapping_writeDataSignal[26];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_when_PmpPlugin_l126_15 = _zz_when_PmpPlugin_l126_14;
+    if(execute_CsrPlugin_csr_929) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_when_PmpPlugin_l126_15 = CsrPlugin_csrMapping_writeDataSignal[31];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_30 = _zz_CsrPlugin_csrMapping_readDataInit_28;
+    if(execute_CsrPlugin_csr_929) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_30 = CsrPlugin_csrMapping_writeDataSignal[28 : 27];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_31 = _zz_CsrPlugin_csrMapping_readDataInit_29;
+    if(execute_CsrPlugin_csr_951) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_31 = CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+      end
+    end
+  end
+
+  assign when_PmpPlugin_l126_7 = (! _zz_when_PmpPlugin_l126_14);
+  assign _zz_PmpPlugin_ports_0_hits_7_4 = {2'b00,_zz_CsrPlugin_csrMapping_readDataInit_29};
+  assign _zz_PmpPlugin_ports_0_hits_7_5 = ({2'd0,_zz_PmpPlugin_ports_0_hits_7_4} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_7_6 = (_zz_PmpPlugin_ports_0_hits_7_4 ^ _zz__zz_PmpPlugin_ports_0_hits_7_6);
+  assign _zz_PmpPlugin_ports_0_hits_7_7 = ({2'd0,(_zz_PmpPlugin_ports_0_hits_7_4 & (~ _zz_PmpPlugin_ports_0_hits_7_6))} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_7_1 = _zz_when_PmpPlugin_l126_14;
+  always @(*) begin
+    _zz_PmpPlugin_ports_0_hits_7 = 1'b1;
+    case(_zz_CsrPlugin_csrMapping_readDataInit_30)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_7 = 1'b0;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_30)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_7_2 = _zz_PmpPlugin_ports_0_hits_6_3;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_7_2 = _zz_PmpPlugin_ports_0_hits_7_5;
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_7_2 = _zz_PmpPlugin_ports_0_hits_7_7;
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_7_2 = 36'h000000000;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_30)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_7_3 = _zz_PmpPlugin_ports_0_hits_7_5;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_7_3 = (_zz_PmpPlugin_ports_0_hits_7_5 + 36'h000000004);
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_7_3 = (_zz_PmpPlugin_ports_0_hits_7_7 + _zz__zz_PmpPlugin_ports_0_hits_7_3);
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_7_3 = _zz_PmpPlugin_ports_0_hits_7_5;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_16;
+    if(execute_CsrPlugin_csr_930) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_17 = CsrPlugin_csrMapping_writeDataSignal[0];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_16;
+    if(execute_CsrPlugin_csr_930) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_17 = CsrPlugin_csrMapping_writeDataSignal[1];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_16;
+    if(execute_CsrPlugin_csr_930) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_17 = CsrPlugin_csrMapping_writeDataSignal[2];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_when_PmpPlugin_l126_17 = _zz_when_PmpPlugin_l126_16;
+    if(execute_CsrPlugin_csr_930) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_when_PmpPlugin_l126_17 = CsrPlugin_csrMapping_writeDataSignal[7];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_34 = _zz_CsrPlugin_csrMapping_readDataInit_32;
+    if(execute_CsrPlugin_csr_930) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_34 = CsrPlugin_csrMapping_writeDataSignal[4 : 3];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_35 = _zz_CsrPlugin_csrMapping_readDataInit_33;
+    if(execute_CsrPlugin_csr_952) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_35 = CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+      end
+    end
+  end
+
+  assign when_PmpPlugin_l126_8 = (! _zz_when_PmpPlugin_l126_16);
+  assign _zz_PmpPlugin_ports_0_hits_8_4 = {2'b00,_zz_CsrPlugin_csrMapping_readDataInit_33};
+  assign _zz_PmpPlugin_ports_0_hits_8_5 = ({2'd0,_zz_PmpPlugin_ports_0_hits_8_4} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_8_6 = (_zz_PmpPlugin_ports_0_hits_8_4 ^ _zz__zz_PmpPlugin_ports_0_hits_8_6);
+  assign _zz_PmpPlugin_ports_0_hits_8_7 = ({2'd0,(_zz_PmpPlugin_ports_0_hits_8_4 & (~ _zz_PmpPlugin_ports_0_hits_8_6))} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_8_1 = _zz_when_PmpPlugin_l126_16;
+  always @(*) begin
+    _zz_PmpPlugin_ports_0_hits_8 = 1'b1;
+    case(_zz_CsrPlugin_csrMapping_readDataInit_34)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_8 = 1'b0;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_34)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_8_2 = _zz_PmpPlugin_ports_0_hits_7_3;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_8_2 = _zz_PmpPlugin_ports_0_hits_8_5;
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_8_2 = _zz_PmpPlugin_ports_0_hits_8_7;
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_8_2 = 36'h000000000;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_34)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_8_3 = _zz_PmpPlugin_ports_0_hits_8_5;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_8_3 = (_zz_PmpPlugin_ports_0_hits_8_5 + 36'h000000004);
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_8_3 = (_zz_PmpPlugin_ports_0_hits_8_7 + _zz__zz_PmpPlugin_ports_0_hits_8_3);
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_8_3 = _zz_PmpPlugin_ports_0_hits_8_5;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_19 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_18;
+    if(execute_CsrPlugin_csr_930) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_19 = CsrPlugin_csrMapping_writeDataSignal[8];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_19 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_18;
+    if(execute_CsrPlugin_csr_930) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_19 = CsrPlugin_csrMapping_writeDataSignal[9];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_19 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_18;
+    if(execute_CsrPlugin_csr_930) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_19 = CsrPlugin_csrMapping_writeDataSignal[10];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_when_PmpPlugin_l126_19 = _zz_when_PmpPlugin_l126_18;
+    if(execute_CsrPlugin_csr_930) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_when_PmpPlugin_l126_19 = CsrPlugin_csrMapping_writeDataSignal[15];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_38 = _zz_CsrPlugin_csrMapping_readDataInit_36;
+    if(execute_CsrPlugin_csr_930) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_38 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_39 = _zz_CsrPlugin_csrMapping_readDataInit_37;
+    if(execute_CsrPlugin_csr_953) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_39 = CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+      end
+    end
+  end
+
+  assign when_PmpPlugin_l126_9 = (! _zz_when_PmpPlugin_l126_18);
+  assign _zz_PmpPlugin_ports_0_hits_9_4 = {2'b00,_zz_CsrPlugin_csrMapping_readDataInit_37};
+  assign _zz_PmpPlugin_ports_0_hits_9_5 = ({2'd0,_zz_PmpPlugin_ports_0_hits_9_4} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_9_6 = (_zz_PmpPlugin_ports_0_hits_9_4 ^ _zz__zz_PmpPlugin_ports_0_hits_9_6);
+  assign _zz_PmpPlugin_ports_0_hits_9_7 = ({2'd0,(_zz_PmpPlugin_ports_0_hits_9_4 & (~ _zz_PmpPlugin_ports_0_hits_9_6))} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_9_1 = _zz_when_PmpPlugin_l126_18;
+  always @(*) begin
+    _zz_PmpPlugin_ports_0_hits_9 = 1'b1;
+    case(_zz_CsrPlugin_csrMapping_readDataInit_38)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_9 = 1'b0;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_38)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_9_2 = _zz_PmpPlugin_ports_0_hits_8_3;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_9_2 = _zz_PmpPlugin_ports_0_hits_9_5;
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_9_2 = _zz_PmpPlugin_ports_0_hits_9_7;
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_9_2 = 36'h000000000;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_38)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_9_3 = _zz_PmpPlugin_ports_0_hits_9_5;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_9_3 = (_zz_PmpPlugin_ports_0_hits_9_5 + 36'h000000004);
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_9_3 = (_zz_PmpPlugin_ports_0_hits_9_7 + _zz__zz_PmpPlugin_ports_0_hits_9_3);
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_9_3 = _zz_PmpPlugin_ports_0_hits_9_5;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_21 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_20;
+    if(execute_CsrPlugin_csr_930) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_21 = CsrPlugin_csrMapping_writeDataSignal[16];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_21 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_20;
+    if(execute_CsrPlugin_csr_930) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_21 = CsrPlugin_csrMapping_writeDataSignal[17];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_21 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_20;
+    if(execute_CsrPlugin_csr_930) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_21 = CsrPlugin_csrMapping_writeDataSignal[18];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_when_PmpPlugin_l126_21 = _zz_when_PmpPlugin_l126_20;
+    if(execute_CsrPlugin_csr_930) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_when_PmpPlugin_l126_21 = CsrPlugin_csrMapping_writeDataSignal[23];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_42 = _zz_CsrPlugin_csrMapping_readDataInit_40;
+    if(execute_CsrPlugin_csr_930) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_42 = CsrPlugin_csrMapping_writeDataSignal[20 : 19];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_43 = _zz_CsrPlugin_csrMapping_readDataInit_41;
+    if(execute_CsrPlugin_csr_954) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_43 = CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+      end
+    end
+  end
+
+  assign when_PmpPlugin_l126_10 = (! _zz_when_PmpPlugin_l126_20);
+  assign _zz_PmpPlugin_ports_0_hits_10_4 = {2'b00,_zz_CsrPlugin_csrMapping_readDataInit_41};
+  assign _zz_PmpPlugin_ports_0_hits_10_5 = ({2'd0,_zz_PmpPlugin_ports_0_hits_10_4} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_10_6 = (_zz_PmpPlugin_ports_0_hits_10_4 ^ _zz__zz_PmpPlugin_ports_0_hits_10_6);
+  assign _zz_PmpPlugin_ports_0_hits_10_7 = ({2'd0,(_zz_PmpPlugin_ports_0_hits_10_4 & (~ _zz_PmpPlugin_ports_0_hits_10_6))} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_10_1 = _zz_when_PmpPlugin_l126_20;
+  always @(*) begin
+    _zz_PmpPlugin_ports_0_hits_10 = 1'b1;
+    case(_zz_CsrPlugin_csrMapping_readDataInit_42)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_10 = 1'b0;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_42)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_10_2 = _zz_PmpPlugin_ports_0_hits_9_3;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_10_2 = _zz_PmpPlugin_ports_0_hits_10_5;
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_10_2 = _zz_PmpPlugin_ports_0_hits_10_7;
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_10_2 = 36'h000000000;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_42)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_10_3 = _zz_PmpPlugin_ports_0_hits_10_5;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_10_3 = (_zz_PmpPlugin_ports_0_hits_10_5 + 36'h000000004);
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_10_3 = (_zz_PmpPlugin_ports_0_hits_10_7 + _zz__zz_PmpPlugin_ports_0_hits_10_3);
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_10_3 = _zz_PmpPlugin_ports_0_hits_10_5;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_23 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_22;
+    if(execute_CsrPlugin_csr_930) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_23 = CsrPlugin_csrMapping_writeDataSignal[24];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_23 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_22;
+    if(execute_CsrPlugin_csr_930) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_23 = CsrPlugin_csrMapping_writeDataSignal[25];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_23 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_22;
+    if(execute_CsrPlugin_csr_930) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_23 = CsrPlugin_csrMapping_writeDataSignal[26];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_when_PmpPlugin_l126_23 = _zz_when_PmpPlugin_l126_22;
+    if(execute_CsrPlugin_csr_930) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_when_PmpPlugin_l126_23 = CsrPlugin_csrMapping_writeDataSignal[31];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_46 = _zz_CsrPlugin_csrMapping_readDataInit_44;
+    if(execute_CsrPlugin_csr_930) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_46 = CsrPlugin_csrMapping_writeDataSignal[28 : 27];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_47 = _zz_CsrPlugin_csrMapping_readDataInit_45;
+    if(execute_CsrPlugin_csr_955) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_47 = CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+      end
+    end
+  end
+
+  assign when_PmpPlugin_l126_11 = (! _zz_when_PmpPlugin_l126_22);
+  assign _zz_PmpPlugin_ports_0_hits_11_4 = {2'b00,_zz_CsrPlugin_csrMapping_readDataInit_45};
+  assign _zz_PmpPlugin_ports_0_hits_11_5 = ({2'd0,_zz_PmpPlugin_ports_0_hits_11_4} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_11_6 = (_zz_PmpPlugin_ports_0_hits_11_4 ^ _zz__zz_PmpPlugin_ports_0_hits_11_6);
+  assign _zz_PmpPlugin_ports_0_hits_11_7 = ({2'd0,(_zz_PmpPlugin_ports_0_hits_11_4 & (~ _zz_PmpPlugin_ports_0_hits_11_6))} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_11_1 = _zz_when_PmpPlugin_l126_22;
+  always @(*) begin
+    _zz_PmpPlugin_ports_0_hits_11 = 1'b1;
+    case(_zz_CsrPlugin_csrMapping_readDataInit_46)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_11 = 1'b0;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_46)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_11_2 = _zz_PmpPlugin_ports_0_hits_10_3;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_11_2 = _zz_PmpPlugin_ports_0_hits_11_5;
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_11_2 = _zz_PmpPlugin_ports_0_hits_11_7;
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_11_2 = 36'h000000000;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_46)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_11_3 = _zz_PmpPlugin_ports_0_hits_11_5;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_11_3 = (_zz_PmpPlugin_ports_0_hits_11_5 + 36'h000000004);
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_11_3 = (_zz_PmpPlugin_ports_0_hits_11_7 + _zz__zz_PmpPlugin_ports_0_hits_11_3);
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_11_3 = _zz_PmpPlugin_ports_0_hits_11_5;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_25 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_24;
+    if(execute_CsrPlugin_csr_931) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_25 = CsrPlugin_csrMapping_writeDataSignal[0];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_25 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_24;
+    if(execute_CsrPlugin_csr_931) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_25 = CsrPlugin_csrMapping_writeDataSignal[1];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_25 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_24;
+    if(execute_CsrPlugin_csr_931) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_25 = CsrPlugin_csrMapping_writeDataSignal[2];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_when_PmpPlugin_l126_25 = _zz_when_PmpPlugin_l126_24;
+    if(execute_CsrPlugin_csr_931) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_when_PmpPlugin_l126_25 = CsrPlugin_csrMapping_writeDataSignal[7];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_50 = _zz_CsrPlugin_csrMapping_readDataInit_48;
+    if(execute_CsrPlugin_csr_931) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_50 = CsrPlugin_csrMapping_writeDataSignal[4 : 3];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_51 = _zz_CsrPlugin_csrMapping_readDataInit_49;
+    if(execute_CsrPlugin_csr_956) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_51 = CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+      end
+    end
+  end
+
+  assign when_PmpPlugin_l126_12 = (! _zz_when_PmpPlugin_l126_24);
+  assign _zz_PmpPlugin_ports_0_hits_12_4 = {2'b00,_zz_CsrPlugin_csrMapping_readDataInit_49};
+  assign _zz_PmpPlugin_ports_0_hits_12_5 = ({2'd0,_zz_PmpPlugin_ports_0_hits_12_4} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_12_6 = (_zz_PmpPlugin_ports_0_hits_12_4 ^ _zz__zz_PmpPlugin_ports_0_hits_12_6);
+  assign _zz_PmpPlugin_ports_0_hits_12_7 = ({2'd0,(_zz_PmpPlugin_ports_0_hits_12_4 & (~ _zz_PmpPlugin_ports_0_hits_12_6))} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_12_1 = _zz_when_PmpPlugin_l126_24;
+  always @(*) begin
+    _zz_PmpPlugin_ports_0_hits_12 = 1'b1;
+    case(_zz_CsrPlugin_csrMapping_readDataInit_50)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_12 = 1'b0;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_50)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_12_2 = _zz_PmpPlugin_ports_0_hits_11_3;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_12_2 = _zz_PmpPlugin_ports_0_hits_12_5;
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_12_2 = _zz_PmpPlugin_ports_0_hits_12_7;
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_12_2 = 36'h000000000;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_50)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_12_3 = _zz_PmpPlugin_ports_0_hits_12_5;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_12_3 = (_zz_PmpPlugin_ports_0_hits_12_5 + 36'h000000004);
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_12_3 = (_zz_PmpPlugin_ports_0_hits_12_7 + _zz__zz_PmpPlugin_ports_0_hits_12_3);
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_12_3 = _zz_PmpPlugin_ports_0_hits_12_5;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_27 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_26;
+    if(execute_CsrPlugin_csr_931) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_27 = CsrPlugin_csrMapping_writeDataSignal[8];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_27 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_26;
+    if(execute_CsrPlugin_csr_931) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_27 = CsrPlugin_csrMapping_writeDataSignal[9];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_27 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_26;
+    if(execute_CsrPlugin_csr_931) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_27 = CsrPlugin_csrMapping_writeDataSignal[10];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_when_PmpPlugin_l126_27 = _zz_when_PmpPlugin_l126_26;
+    if(execute_CsrPlugin_csr_931) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_when_PmpPlugin_l126_27 = CsrPlugin_csrMapping_writeDataSignal[15];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_54 = _zz_CsrPlugin_csrMapping_readDataInit_52;
+    if(execute_CsrPlugin_csr_931) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_54 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_55 = _zz_CsrPlugin_csrMapping_readDataInit_53;
+    if(execute_CsrPlugin_csr_957) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_55 = CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+      end
+    end
+  end
+
+  assign when_PmpPlugin_l126_13 = (! _zz_when_PmpPlugin_l126_26);
+  assign _zz_PmpPlugin_ports_0_hits_13_4 = {2'b00,_zz_CsrPlugin_csrMapping_readDataInit_53};
+  assign _zz_PmpPlugin_ports_0_hits_13_5 = ({2'd0,_zz_PmpPlugin_ports_0_hits_13_4} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_13_6 = (_zz_PmpPlugin_ports_0_hits_13_4 ^ _zz__zz_PmpPlugin_ports_0_hits_13_6);
+  assign _zz_PmpPlugin_ports_0_hits_13_7 = ({2'd0,(_zz_PmpPlugin_ports_0_hits_13_4 & (~ _zz_PmpPlugin_ports_0_hits_13_6))} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_13_1 = _zz_when_PmpPlugin_l126_26;
+  always @(*) begin
+    _zz_PmpPlugin_ports_0_hits_13 = 1'b1;
+    case(_zz_CsrPlugin_csrMapping_readDataInit_54)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_13 = 1'b0;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_54)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_13_2 = _zz_PmpPlugin_ports_0_hits_12_3;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_13_2 = _zz_PmpPlugin_ports_0_hits_13_5;
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_13_2 = _zz_PmpPlugin_ports_0_hits_13_7;
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_13_2 = 36'h000000000;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_54)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_13_3 = _zz_PmpPlugin_ports_0_hits_13_5;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_13_3 = (_zz_PmpPlugin_ports_0_hits_13_5 + 36'h000000004);
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_13_3 = (_zz_PmpPlugin_ports_0_hits_13_7 + _zz__zz_PmpPlugin_ports_0_hits_13_3);
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_13_3 = _zz_PmpPlugin_ports_0_hits_13_5;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_29 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_28;
+    if(execute_CsrPlugin_csr_931) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_29 = CsrPlugin_csrMapping_writeDataSignal[16];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_29 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_28;
+    if(execute_CsrPlugin_csr_931) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_29 = CsrPlugin_csrMapping_writeDataSignal[17];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_29 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_28;
+    if(execute_CsrPlugin_csr_931) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_29 = CsrPlugin_csrMapping_writeDataSignal[18];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_when_PmpPlugin_l126_29 = _zz_when_PmpPlugin_l126_28;
+    if(execute_CsrPlugin_csr_931) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_when_PmpPlugin_l126_29 = CsrPlugin_csrMapping_writeDataSignal[23];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_58 = _zz_CsrPlugin_csrMapping_readDataInit_56;
+    if(execute_CsrPlugin_csr_931) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_58 = CsrPlugin_csrMapping_writeDataSignal[20 : 19];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_59 = _zz_CsrPlugin_csrMapping_readDataInit_57;
+    if(execute_CsrPlugin_csr_958) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_59 = CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+      end
+    end
+  end
+
+  assign when_PmpPlugin_l126_14 = (! _zz_when_PmpPlugin_l126_28);
+  assign _zz_PmpPlugin_ports_0_hits_14_4 = {2'b00,_zz_CsrPlugin_csrMapping_readDataInit_57};
+  assign _zz_PmpPlugin_ports_0_hits_14_5 = ({2'd0,_zz_PmpPlugin_ports_0_hits_14_4} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_14_6 = (_zz_PmpPlugin_ports_0_hits_14_4 ^ _zz__zz_PmpPlugin_ports_0_hits_14_6);
+  assign _zz_PmpPlugin_ports_0_hits_14_7 = ({2'd0,(_zz_PmpPlugin_ports_0_hits_14_4 & (~ _zz_PmpPlugin_ports_0_hits_14_6))} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_14_1 = _zz_when_PmpPlugin_l126_28;
+  always @(*) begin
+    _zz_PmpPlugin_ports_0_hits_14 = 1'b1;
+    case(_zz_CsrPlugin_csrMapping_readDataInit_58)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_14 = 1'b0;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_58)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_14_2 = _zz_PmpPlugin_ports_0_hits_13_3;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_14_2 = _zz_PmpPlugin_ports_0_hits_14_5;
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_14_2 = _zz_PmpPlugin_ports_0_hits_14_7;
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_14_2 = 36'h000000000;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_58)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_14_3 = _zz_PmpPlugin_ports_0_hits_14_5;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_14_3 = (_zz_PmpPlugin_ports_0_hits_14_5 + 36'h000000004);
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_14_3 = (_zz_PmpPlugin_ports_0_hits_14_7 + _zz__zz_PmpPlugin_ports_0_hits_14_3);
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_14_3 = _zz_PmpPlugin_ports_0_hits_14_5;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_31 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_30;
+    if(execute_CsrPlugin_csr_931) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_31 = CsrPlugin_csrMapping_writeDataSignal[24];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_31 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_30;
+    if(execute_CsrPlugin_csr_931) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_31 = CsrPlugin_csrMapping_writeDataSignal[25];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_31 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_30;
+    if(execute_CsrPlugin_csr_931) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_31 = CsrPlugin_csrMapping_writeDataSignal[26];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_when_PmpPlugin_l126_31 = _zz_when_PmpPlugin_l126_30;
+    if(execute_CsrPlugin_csr_931) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_when_PmpPlugin_l126_31 = CsrPlugin_csrMapping_writeDataSignal[31];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_62 = _zz_CsrPlugin_csrMapping_readDataInit_60;
+    if(execute_CsrPlugin_csr_931) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_62 = CsrPlugin_csrMapping_writeDataSignal[28 : 27];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_63 = _zz_CsrPlugin_csrMapping_readDataInit_61;
+    if(execute_CsrPlugin_csr_959) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_63 = CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+      end
+    end
+  end
+
+  assign when_PmpPlugin_l126_15 = (! _zz_when_PmpPlugin_l126_30);
+  assign _zz_PmpPlugin_ports_0_hits_15_4 = {2'b00,_zz_CsrPlugin_csrMapping_readDataInit_61};
+  assign _zz_PmpPlugin_ports_0_hits_15_5 = ({2'd0,_zz_PmpPlugin_ports_0_hits_15_4} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_15_6 = (_zz_PmpPlugin_ports_0_hits_15_4 ^ _zz__zz_PmpPlugin_ports_0_hits_15_6);
+  assign _zz_PmpPlugin_ports_0_hits_15_7 = ({2'd0,(_zz_PmpPlugin_ports_0_hits_15_4 & (~ _zz_PmpPlugin_ports_0_hits_15_6))} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_15_1 = _zz_when_PmpPlugin_l126_30;
+  always @(*) begin
+    _zz_PmpPlugin_ports_0_hits_15 = 1'b1;
+    case(_zz_CsrPlugin_csrMapping_readDataInit_62)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_15 = 1'b0;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_62)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_15_2 = _zz_PmpPlugin_ports_0_hits_14_3;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_15_2 = _zz_PmpPlugin_ports_0_hits_15_5;
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_15_2 = _zz_PmpPlugin_ports_0_hits_15_7;
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_15_2 = 36'h000000000;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_62)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_15_3 = _zz_PmpPlugin_ports_0_hits_15_5;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_15_3 = (_zz_PmpPlugin_ports_0_hits_15_5 + 36'h000000004);
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_15_3 = (_zz_PmpPlugin_ports_0_hits_15_7 + _zz__zz_PmpPlugin_ports_0_hits_15_3);
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_15_3 = _zz_PmpPlugin_ports_0_hits_15_5;
+      end
+    endcase
+  end
+
+  assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
+  assign PmpPlugin_ports_0_hits_0 = (((_zz_PmpPlugin_ports_0_hits_0 && (_zz_PmpPlugin_ports_0_hits_0_2 <= _zz_PmpPlugin_ports_0_hits_0_8)) && (_zz_PmpPlugin_ports_0_hits_0_9 < _zz_PmpPlugin_ports_0_hits_0_3)) && (_zz_PmpPlugin_ports_0_hits_0_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_1 = (((_zz_PmpPlugin_ports_0_hits_1 && (_zz_PmpPlugin_ports_0_hits_1_2 <= _zz_PmpPlugin_ports_0_hits_1_8)) && (_zz_PmpPlugin_ports_0_hits_1_9 < _zz_PmpPlugin_ports_0_hits_1_3)) && (_zz_PmpPlugin_ports_0_hits_1_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_2 = (((_zz_PmpPlugin_ports_0_hits_2 && (_zz_PmpPlugin_ports_0_hits_2_2 <= _zz_PmpPlugin_ports_0_hits_2_8)) && (_zz_PmpPlugin_ports_0_hits_2_9 < _zz_PmpPlugin_ports_0_hits_2_3)) && (_zz_PmpPlugin_ports_0_hits_2_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_3 = (((_zz_PmpPlugin_ports_0_hits_3 && (_zz_PmpPlugin_ports_0_hits_3_2 <= _zz_PmpPlugin_ports_0_hits_3_8)) && (_zz_PmpPlugin_ports_0_hits_3_9 < _zz_PmpPlugin_ports_0_hits_3_3)) && (_zz_PmpPlugin_ports_0_hits_3_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_4 = (((_zz_PmpPlugin_ports_0_hits_4 && (_zz_PmpPlugin_ports_0_hits_4_2 <= _zz_PmpPlugin_ports_0_hits_4_8)) && (_zz_PmpPlugin_ports_0_hits_4_9 < _zz_PmpPlugin_ports_0_hits_4_3)) && (_zz_PmpPlugin_ports_0_hits_4_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_5 = (((_zz_PmpPlugin_ports_0_hits_5 && (_zz_PmpPlugin_ports_0_hits_5_2 <= _zz_PmpPlugin_ports_0_hits_5_8)) && (_zz_PmpPlugin_ports_0_hits_5_9 < _zz_PmpPlugin_ports_0_hits_5_3)) && (_zz_PmpPlugin_ports_0_hits_5_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_6 = (((_zz_PmpPlugin_ports_0_hits_6 && (_zz_PmpPlugin_ports_0_hits_6_2 <= _zz_PmpPlugin_ports_0_hits_6_8)) && (_zz_PmpPlugin_ports_0_hits_6_9 < _zz_PmpPlugin_ports_0_hits_6_3)) && (_zz_PmpPlugin_ports_0_hits_6_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_7 = (((_zz_PmpPlugin_ports_0_hits_7 && (_zz_PmpPlugin_ports_0_hits_7_2 <= _zz_PmpPlugin_ports_0_hits_7_8)) && (_zz_PmpPlugin_ports_0_hits_7_9 < _zz_PmpPlugin_ports_0_hits_7_3)) && (_zz_PmpPlugin_ports_0_hits_7_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_8 = (((_zz_PmpPlugin_ports_0_hits_8 && (_zz_PmpPlugin_ports_0_hits_8_2 <= _zz_PmpPlugin_ports_0_hits_8_8)) && (_zz_PmpPlugin_ports_0_hits_8_9 < _zz_PmpPlugin_ports_0_hits_8_3)) && (_zz_PmpPlugin_ports_0_hits_8_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_9 = (((_zz_PmpPlugin_ports_0_hits_9 && (_zz_PmpPlugin_ports_0_hits_9_2 <= _zz_PmpPlugin_ports_0_hits_9_8)) && (_zz_PmpPlugin_ports_0_hits_9_9 < _zz_PmpPlugin_ports_0_hits_9_3)) && (_zz_PmpPlugin_ports_0_hits_9_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_10 = (((_zz_PmpPlugin_ports_0_hits_10 && (_zz_PmpPlugin_ports_0_hits_10_2 <= _zz_PmpPlugin_ports_0_hits_10_8)) && (_zz_PmpPlugin_ports_0_hits_10_9 < _zz_PmpPlugin_ports_0_hits_10_3)) && (_zz_PmpPlugin_ports_0_hits_10_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_11 = (((_zz_PmpPlugin_ports_0_hits_11 && (_zz_PmpPlugin_ports_0_hits_11_2 <= _zz_PmpPlugin_ports_0_hits_11_8)) && (_zz_PmpPlugin_ports_0_hits_11_9 < _zz_PmpPlugin_ports_0_hits_11_3)) && (_zz_PmpPlugin_ports_0_hits_11_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_12 = (((_zz_PmpPlugin_ports_0_hits_12 && (_zz_PmpPlugin_ports_0_hits_12_2 <= _zz_PmpPlugin_ports_0_hits_12_8)) && (_zz_PmpPlugin_ports_0_hits_12_9 < _zz_PmpPlugin_ports_0_hits_12_3)) && (_zz_PmpPlugin_ports_0_hits_12_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_13 = (((_zz_PmpPlugin_ports_0_hits_13 && (_zz_PmpPlugin_ports_0_hits_13_2 <= _zz_PmpPlugin_ports_0_hits_13_8)) && (_zz_PmpPlugin_ports_0_hits_13_9 < _zz_PmpPlugin_ports_0_hits_13_3)) && (_zz_PmpPlugin_ports_0_hits_13_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_14 = (((_zz_PmpPlugin_ports_0_hits_14 && (_zz_PmpPlugin_ports_0_hits_14_2 <= _zz_PmpPlugin_ports_0_hits_14_8)) && (_zz_PmpPlugin_ports_0_hits_14_9 < _zz_PmpPlugin_ports_0_hits_14_3)) && (_zz_PmpPlugin_ports_0_hits_14_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_15 = (((_zz_PmpPlugin_ports_0_hits_15 && (_zz_PmpPlugin_ports_0_hits_15_2 <= _zz_PmpPlugin_ports_0_hits_15_8)) && (_zz_PmpPlugin_ports_0_hits_15_9 < _zz_PmpPlugin_ports_0_hits_15_3)) && (_zz_PmpPlugin_ports_0_hits_15_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign _zz_when_PmpPlugin_l250 = 5'h00;
+  assign _zz_when_PmpPlugin_l250_1 = 5'h01;
+  assign _zz_when_PmpPlugin_l250_2 = 5'h01;
+  assign _zz_when_PmpPlugin_l250_3 = 5'h02;
+  assign _zz_when_PmpPlugin_l250_4 = 5'h01;
+  assign _zz_when_PmpPlugin_l250_5 = 5'h02;
+  assign _zz_when_PmpPlugin_l250_6 = 5'h02;
+  assign _zz_when_PmpPlugin_l250_7 = 5'h03;
+  assign when_PmpPlugin_l250 = (_zz_when_PmpPlugin_l250_16 == 5'h00);
+  always @(*) begin
+    if(when_PmpPlugin_l250) begin
+      IBusCachedPlugin_mmuBus_rsp_allowRead = (CsrPlugin_privilege == 2'b11);
+    end else begin
+      IBusCachedPlugin_mmuBus_rsp_allowRead = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_49;
+    end
+  end
+
+  always @(*) begin
+    if(when_PmpPlugin_l250) begin
+      IBusCachedPlugin_mmuBus_rsp_allowWrite = (CsrPlugin_privilege == 2'b11);
+    end else begin
+      IBusCachedPlugin_mmuBus_rsp_allowWrite = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_49;
+    end
+  end
+
+  always @(*) begin
+    if(when_PmpPlugin_l250) begin
+      IBusCachedPlugin_mmuBus_rsp_allowExecute = (CsrPlugin_privilege == 2'b11);
+    end else begin
+      IBusCachedPlugin_mmuBus_rsp_allowExecute = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_49;
+    end
+  end
+
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_32 = {PmpPlugin_ports_0_hits_15,{PmpPlugin_ports_0_hits_14,{PmpPlugin_ports_0_hits_13,{PmpPlugin_ports_0_hits_12,{PmpPlugin_ports_0_hits_11,{PmpPlugin_ports_0_hits_10,{PmpPlugin_ports_0_hits_9,{PmpPlugin_ports_0_hits_8,{PmpPlugin_ports_0_hits_7,{PmpPlugin_ports_0_hits_6,{_zz__zz_IBusCachedPlugin_mmuBus_rsp_allowRead_32,_zz__zz_IBusCachedPlugin_mmuBus_rsp_allowRead_32_1}}}}}}}}}}};
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_33 = (_zz_IBusCachedPlugin_mmuBus_rsp_allowRead_32 & (~ _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowRead_33));
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_34 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_33[3];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_35 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_33[5];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_36 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_33[6];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_37 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_33[7];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_38 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_33[9];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_39 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_33[10];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_40 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_33[11];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_41 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_33[12];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_42 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_33[13];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_43 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_33[14];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_44 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_33[15];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_45 = (((((((_zz_IBusCachedPlugin_mmuBus_rsp_allowRead_33[1] || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_34) || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_35) || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_37) || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_38) || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_40) || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_42) || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_44);
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_46 = (((((((_zz_IBusCachedPlugin_mmuBus_rsp_allowRead_33[2] || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_34) || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_36) || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_37) || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_39) || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_40) || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_43) || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_44);
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_47 = (((((((_zz_IBusCachedPlugin_mmuBus_rsp_allowRead_33[4] || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_35) || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_36) || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_37) || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_41) || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_42) || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_43) || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_44);
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_48 = (((((((_zz_IBusCachedPlugin_mmuBus_rsp_allowRead_33[8] || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_38) || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_39) || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_40) || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_41) || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_42) || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_43) || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_44);
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_32 = {PmpPlugin_ports_0_hits_15,{PmpPlugin_ports_0_hits_14,{PmpPlugin_ports_0_hits_13,{PmpPlugin_ports_0_hits_12,{PmpPlugin_ports_0_hits_11,{PmpPlugin_ports_0_hits_10,{PmpPlugin_ports_0_hits_9,{PmpPlugin_ports_0_hits_8,{PmpPlugin_ports_0_hits_7,{PmpPlugin_ports_0_hits_6,{_zz__zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_32,_zz__zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_32_1}}}}}}}}}}};
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_33 = (_zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_32 & (~ _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_33));
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_34 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_33[3];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_35 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_33[5];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_36 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_33[6];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_37 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_33[7];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_38 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_33[9];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_39 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_33[10];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_40 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_33[11];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_41 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_33[12];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_42 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_33[13];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_43 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_33[14];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_44 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_33[15];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_45 = (((((((_zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_33[1] || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_34) || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_35) || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_37) || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_38) || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_40) || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_42) || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_44);
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_46 = (((((((_zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_33[2] || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_34) || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_36) || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_37) || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_39) || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_40) || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_43) || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_44);
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_47 = (((((((_zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_33[4] || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_35) || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_36) || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_37) || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_41) || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_42) || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_43) || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_44);
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_48 = (((((((_zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_33[8] || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_38) || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_39) || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_40) || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_41) || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_42) || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_43) || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_44);
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_32 = {PmpPlugin_ports_0_hits_15,{PmpPlugin_ports_0_hits_14,{PmpPlugin_ports_0_hits_13,{PmpPlugin_ports_0_hits_12,{PmpPlugin_ports_0_hits_11,{PmpPlugin_ports_0_hits_10,{PmpPlugin_ports_0_hits_9,{PmpPlugin_ports_0_hits_8,{PmpPlugin_ports_0_hits_7,{PmpPlugin_ports_0_hits_6,{_zz__zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_32,_zz__zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_32_1}}}}}}}}}}};
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_33 = (_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_32 & (~ _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_33));
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_34 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_33[3];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_35 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_33[5];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_36 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_33[6];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_37 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_33[7];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_38 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_33[9];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_39 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_33[10];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_40 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_33[11];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_41 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_33[12];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_42 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_33[13];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_43 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_33[14];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_44 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_33[15];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_45 = (((((((_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_33[1] || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_34) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_35) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_37) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_38) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_40) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_42) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_44);
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_46 = (((((((_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_33[2] || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_34) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_36) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_37) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_39) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_40) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_43) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_44);
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_47 = (((((((_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_33[4] || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_35) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_36) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_37) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_41) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_42) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_43) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_44);
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_48 = (((((((_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_33[8] || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_38) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_39) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_40) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_41) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_42) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_43) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_44);
+  assign IBusCachedPlugin_mmuBus_rsp_isIoAccess = IBusCachedPlugin_mmuBus_rsp_physicalAddress[31];
+  assign IBusCachedPlugin_mmuBus_rsp_isPaging = 1'b0;
+  assign IBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
+  assign IBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
+  assign IBusCachedPlugin_mmuBus_busy = 1'b0;
+  assign DBusCachedPlugin_mmuBus_rsp_physicalAddress = DBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
+  assign PmpPlugin_ports_1_hits_0 = (((_zz_PmpPlugin_ports_0_hits_0 && (_zz_PmpPlugin_ports_0_hits_0_2 <= _zz_PmpPlugin_ports_1_hits_0)) && (_zz_PmpPlugin_ports_1_hits_0_1 < _zz_PmpPlugin_ports_0_hits_0_3)) && (_zz_PmpPlugin_ports_0_hits_0_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_1 = (((_zz_PmpPlugin_ports_0_hits_1 && (_zz_PmpPlugin_ports_0_hits_1_2 <= _zz_PmpPlugin_ports_1_hits_1)) && (_zz_PmpPlugin_ports_1_hits_1_1 < _zz_PmpPlugin_ports_0_hits_1_3)) && (_zz_PmpPlugin_ports_0_hits_1_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_2 = (((_zz_PmpPlugin_ports_0_hits_2 && (_zz_PmpPlugin_ports_0_hits_2_2 <= _zz_PmpPlugin_ports_1_hits_2)) && (_zz_PmpPlugin_ports_1_hits_2_1 < _zz_PmpPlugin_ports_0_hits_2_3)) && (_zz_PmpPlugin_ports_0_hits_2_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_3 = (((_zz_PmpPlugin_ports_0_hits_3 && (_zz_PmpPlugin_ports_0_hits_3_2 <= _zz_PmpPlugin_ports_1_hits_3)) && (_zz_PmpPlugin_ports_1_hits_3_1 < _zz_PmpPlugin_ports_0_hits_3_3)) && (_zz_PmpPlugin_ports_0_hits_3_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_4 = (((_zz_PmpPlugin_ports_0_hits_4 && (_zz_PmpPlugin_ports_0_hits_4_2 <= _zz_PmpPlugin_ports_1_hits_4)) && (_zz_PmpPlugin_ports_1_hits_4_1 < _zz_PmpPlugin_ports_0_hits_4_3)) && (_zz_PmpPlugin_ports_0_hits_4_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_5 = (((_zz_PmpPlugin_ports_0_hits_5 && (_zz_PmpPlugin_ports_0_hits_5_2 <= _zz_PmpPlugin_ports_1_hits_5)) && (_zz_PmpPlugin_ports_1_hits_5_1 < _zz_PmpPlugin_ports_0_hits_5_3)) && (_zz_PmpPlugin_ports_0_hits_5_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_6 = (((_zz_PmpPlugin_ports_0_hits_6 && (_zz_PmpPlugin_ports_0_hits_6_2 <= _zz_PmpPlugin_ports_1_hits_6)) && (_zz_PmpPlugin_ports_1_hits_6_1 < _zz_PmpPlugin_ports_0_hits_6_3)) && (_zz_PmpPlugin_ports_0_hits_6_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_7 = (((_zz_PmpPlugin_ports_0_hits_7 && (_zz_PmpPlugin_ports_0_hits_7_2 <= _zz_PmpPlugin_ports_1_hits_7)) && (_zz_PmpPlugin_ports_1_hits_7_1 < _zz_PmpPlugin_ports_0_hits_7_3)) && (_zz_PmpPlugin_ports_0_hits_7_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_8 = (((_zz_PmpPlugin_ports_0_hits_8 && (_zz_PmpPlugin_ports_0_hits_8_2 <= _zz_PmpPlugin_ports_1_hits_8)) && (_zz_PmpPlugin_ports_1_hits_8_1 < _zz_PmpPlugin_ports_0_hits_8_3)) && (_zz_PmpPlugin_ports_0_hits_8_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_9 = (((_zz_PmpPlugin_ports_0_hits_9 && (_zz_PmpPlugin_ports_0_hits_9_2 <= _zz_PmpPlugin_ports_1_hits_9)) && (_zz_PmpPlugin_ports_1_hits_9_1 < _zz_PmpPlugin_ports_0_hits_9_3)) && (_zz_PmpPlugin_ports_0_hits_9_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_10 = (((_zz_PmpPlugin_ports_0_hits_10 && (_zz_PmpPlugin_ports_0_hits_10_2 <= _zz_PmpPlugin_ports_1_hits_10)) && (_zz_PmpPlugin_ports_1_hits_10_1 < _zz_PmpPlugin_ports_0_hits_10_3)) && (_zz_PmpPlugin_ports_0_hits_10_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_11 = (((_zz_PmpPlugin_ports_0_hits_11 && (_zz_PmpPlugin_ports_0_hits_11_2 <= _zz_PmpPlugin_ports_1_hits_11)) && (_zz_PmpPlugin_ports_1_hits_11_1 < _zz_PmpPlugin_ports_0_hits_11_3)) && (_zz_PmpPlugin_ports_0_hits_11_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_12 = (((_zz_PmpPlugin_ports_0_hits_12 && (_zz_PmpPlugin_ports_0_hits_12_2 <= _zz_PmpPlugin_ports_1_hits_12)) && (_zz_PmpPlugin_ports_1_hits_12_1 < _zz_PmpPlugin_ports_0_hits_12_3)) && (_zz_PmpPlugin_ports_0_hits_12_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_13 = (((_zz_PmpPlugin_ports_0_hits_13 && (_zz_PmpPlugin_ports_0_hits_13_2 <= _zz_PmpPlugin_ports_1_hits_13)) && (_zz_PmpPlugin_ports_1_hits_13_1 < _zz_PmpPlugin_ports_0_hits_13_3)) && (_zz_PmpPlugin_ports_0_hits_13_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_14 = (((_zz_PmpPlugin_ports_0_hits_14 && (_zz_PmpPlugin_ports_0_hits_14_2 <= _zz_PmpPlugin_ports_1_hits_14)) && (_zz_PmpPlugin_ports_1_hits_14_1 < _zz_PmpPlugin_ports_0_hits_14_3)) && (_zz_PmpPlugin_ports_0_hits_14_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_15 = (((_zz_PmpPlugin_ports_0_hits_15 && (_zz_PmpPlugin_ports_0_hits_15_2 <= _zz_PmpPlugin_ports_1_hits_15)) && (_zz_PmpPlugin_ports_1_hits_15_1 < _zz_PmpPlugin_ports_0_hits_15_3)) && (_zz_PmpPlugin_ports_0_hits_15_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign _zz_when_PmpPlugin_l250_8 = 5'h00;
+  assign _zz_when_PmpPlugin_l250_9 = 5'h01;
+  assign _zz_when_PmpPlugin_l250_10 = 5'h01;
+  assign _zz_when_PmpPlugin_l250_11 = 5'h02;
+  assign _zz_when_PmpPlugin_l250_12 = 5'h01;
+  assign _zz_when_PmpPlugin_l250_13 = 5'h02;
+  assign _zz_when_PmpPlugin_l250_14 = 5'h02;
+  assign _zz_when_PmpPlugin_l250_15 = 5'h03;
+  assign when_PmpPlugin_l250_1 = (_zz_when_PmpPlugin_l250_1_1 == 5'h00);
+  always @(*) begin
+    if(when_PmpPlugin_l250_1) begin
       DBusCachedPlugin_mmuBus_rsp_allowRead = (CsrPlugin_privilege == 2'b11);
     end else begin
       DBusCachedPlugin_mmuBus_rsp_allowRead = _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17;
@@ -5728,14 +6619,22 @@ module VexRiscv (
   end
 
   always @(*) begin
-    if(when_PmpPlugin_l277) begin
+    if(when_PmpPlugin_l250_1) begin
       DBusCachedPlugin_mmuBus_rsp_allowWrite = (CsrPlugin_privilege == 2'b11);
     end else begin
       DBusCachedPlugin_mmuBus_rsp_allowWrite = _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17;
     end
   end
 
-  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowRead = {PmpPlugin_dGuard_hits_15,{PmpPlugin_dGuard_hits_14,{PmpPlugin_dGuard_hits_13,{PmpPlugin_dGuard_hits_12,{PmpPlugin_dGuard_hits_11,{PmpPlugin_dGuard_hits_10,{PmpPlugin_dGuard_hits_9,{PmpPlugin_dGuard_hits_8,{PmpPlugin_dGuard_hits_7,{PmpPlugin_dGuard_hits_6,{_zz__zz_DBusCachedPlugin_mmuBus_rsp_allowRead,_zz__zz_DBusCachedPlugin_mmuBus_rsp_allowRead_1}}}}}}}}}}};
+  always @(*) begin
+    if(when_PmpPlugin_l250_1) begin
+      DBusCachedPlugin_mmuBus_rsp_allowExecute = (CsrPlugin_privilege == 2'b11);
+    end else begin
+      DBusCachedPlugin_mmuBus_rsp_allowExecute = _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_17;
+    end
+  end
+
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowRead = {PmpPlugin_ports_1_hits_15,{PmpPlugin_ports_1_hits_14,{PmpPlugin_ports_1_hits_13,{PmpPlugin_ports_1_hits_12,{PmpPlugin_ports_1_hits_11,{PmpPlugin_ports_1_hits_10,{PmpPlugin_ports_1_hits_9,{PmpPlugin_ports_1_hits_8,{PmpPlugin_ports_1_hits_7,{PmpPlugin_ports_1_hits_6,{_zz__zz_DBusCachedPlugin_mmuBus_rsp_allowRead,_zz__zz_DBusCachedPlugin_mmuBus_rsp_allowRead_1}}}}}}}}}}};
   assign _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_1 = (_zz_DBusCachedPlugin_mmuBus_rsp_allowRead & (~ _zz__zz_DBusCachedPlugin_mmuBus_rsp_allowRead_1_1));
   assign _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_2 = _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_1[3];
   assign _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_3 = _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_1[5];
@@ -5752,7 +6651,7 @@ module VexRiscv (
   assign _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_14 = (((((((_zz_DBusCachedPlugin_mmuBus_rsp_allowRead_1[2] || _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_2) || _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_4) || _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_5) || _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_7) || _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_8) || _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_11) || _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_12);
   assign _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_15 = (((((((_zz_DBusCachedPlugin_mmuBus_rsp_allowRead_1[4] || _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_3) || _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_4) || _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_5) || _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_9) || _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_10) || _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_11) || _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_12);
   assign _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_16 = (((((((_zz_DBusCachedPlugin_mmuBus_rsp_allowRead_1[8] || _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_6) || _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_7) || _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_8) || _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_9) || _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_10) || _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_11) || _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_12);
-  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite = {PmpPlugin_dGuard_hits_15,{PmpPlugin_dGuard_hits_14,{PmpPlugin_dGuard_hits_13,{PmpPlugin_dGuard_hits_12,{PmpPlugin_dGuard_hits_11,{PmpPlugin_dGuard_hits_10,{PmpPlugin_dGuard_hits_9,{PmpPlugin_dGuard_hits_8,{PmpPlugin_dGuard_hits_7,{PmpPlugin_dGuard_hits_6,{_zz__zz_DBusCachedPlugin_mmuBus_rsp_allowWrite,_zz__zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_1}}}}}}}}}}};
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite = {PmpPlugin_ports_1_hits_15,{PmpPlugin_ports_1_hits_14,{PmpPlugin_ports_1_hits_13,{PmpPlugin_ports_1_hits_12,{PmpPlugin_ports_1_hits_11,{PmpPlugin_ports_1_hits_10,{PmpPlugin_ports_1_hits_9,{PmpPlugin_ports_1_hits_8,{PmpPlugin_ports_1_hits_7,{PmpPlugin_ports_1_hits_6,{_zz__zz_DBusCachedPlugin_mmuBus_rsp_allowWrite,_zz__zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_1}}}}}}}}}}};
   assign _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_1 = (_zz_DBusCachedPlugin_mmuBus_rsp_allowWrite & (~ _zz__zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_1_1));
   assign _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_2 = _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_1[3];
   assign _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_3 = _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_1[5];
@@ -5769,62 +6668,33 @@ module VexRiscv (
   assign _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_14 = (((((((_zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_1[2] || _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_2) || _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_4) || _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_5) || _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_7) || _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_8) || _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_11) || _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_12);
   assign _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_15 = (((((((_zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_1[4] || _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_3) || _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_4) || _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_5) || _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_9) || _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_10) || _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_11) || _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_12);
   assign _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_16 = (((((((_zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_1[8] || _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_6) || _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_7) || _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_8) || _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_9) || _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_10) || _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_11) || _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_12);
-  assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
-  assign IBusCachedPlugin_mmuBus_rsp_isIoAccess = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31];
-  assign IBusCachedPlugin_mmuBus_rsp_isPaging = 1'b0;
-  assign IBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
-  assign IBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
-  assign IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b0;
-  assign IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b0;
-  assign IBusCachedPlugin_mmuBus_busy = 1'b0;
-  assign _zz_PmpPlugin_iGuard_hits_0 = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 7];
-  assign PmpPlugin_iGuard_hits_0 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_0_1) == _zz_PmpPlugin_iGuard_hits_0_3) && (PmpPlugin_pmpcfg_0[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_0[4 : 3] == 2'b11));
-  assign PmpPlugin_iGuard_hits_1 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_1) == _zz_PmpPlugin_iGuard_hits_1_2) && (PmpPlugin_pmpcfg_1[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_1[4 : 3] == 2'b11));
-  assign PmpPlugin_iGuard_hits_2 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_2) == _zz_PmpPlugin_iGuard_hits_2_2) && (PmpPlugin_pmpcfg_2[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_2[4 : 3] == 2'b11));
-  assign PmpPlugin_iGuard_hits_3 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_3) == _zz_PmpPlugin_iGuard_hits_3_2) && (PmpPlugin_pmpcfg_3[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_3[4 : 3] == 2'b11));
-  assign PmpPlugin_iGuard_hits_4 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_4) == _zz_PmpPlugin_iGuard_hits_4_2) && (PmpPlugin_pmpcfg_4[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_4[4 : 3] == 2'b11));
-  assign PmpPlugin_iGuard_hits_5 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_5) == _zz_PmpPlugin_iGuard_hits_5_2) && (PmpPlugin_pmpcfg_5[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_5[4 : 3] == 2'b11));
-  assign PmpPlugin_iGuard_hits_6 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_6) == _zz_PmpPlugin_iGuard_hits_6_2) && (PmpPlugin_pmpcfg_6[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_6[4 : 3] == 2'b11));
-  assign PmpPlugin_iGuard_hits_7 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_7) == _zz_PmpPlugin_iGuard_hits_7_2) && (PmpPlugin_pmpcfg_7[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_7[4 : 3] == 2'b11));
-  assign PmpPlugin_iGuard_hits_8 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_8) == _zz_PmpPlugin_iGuard_hits_8_2) && (PmpPlugin_pmpcfg_8[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_8[4 : 3] == 2'b11));
-  assign PmpPlugin_iGuard_hits_9 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_9) == _zz_PmpPlugin_iGuard_hits_9_2) && (PmpPlugin_pmpcfg_9[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_9[4 : 3] == 2'b11));
-  assign PmpPlugin_iGuard_hits_10 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_10) == _zz_PmpPlugin_iGuard_hits_10_2) && (PmpPlugin_pmpcfg_10[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_10[4 : 3] == 2'b11));
-  assign PmpPlugin_iGuard_hits_11 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_11) == _zz_PmpPlugin_iGuard_hits_11_2) && (PmpPlugin_pmpcfg_11[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_11[4 : 3] == 2'b11));
-  assign PmpPlugin_iGuard_hits_12 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_12) == _zz_PmpPlugin_iGuard_hits_12_2) && (PmpPlugin_pmpcfg_12[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_12[4 : 3] == 2'b11));
-  assign PmpPlugin_iGuard_hits_13 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_13) == _zz_PmpPlugin_iGuard_hits_13_2) && (PmpPlugin_pmpcfg_13[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_13[4 : 3] == 2'b11));
-  assign PmpPlugin_iGuard_hits_14 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_14) == _zz_PmpPlugin_iGuard_hits_14_2) && (PmpPlugin_pmpcfg_14[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_14[4 : 3] == 2'b11));
-  assign PmpPlugin_iGuard_hits_15 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_15) == _zz_PmpPlugin_iGuard_hits_15_2) && (PmpPlugin_pmpcfg_15[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_15[4 : 3] == 2'b11));
-  assign when_PmpPlugin_l299 = (! ({PmpPlugin_iGuard_hits_15,{PmpPlugin_iGuard_hits_14,{PmpPlugin_iGuard_hits_13,{PmpPlugin_iGuard_hits_12,{PmpPlugin_iGuard_hits_11,{PmpPlugin_iGuard_hits_10,{PmpPlugin_iGuard_hits_9,{PmpPlugin_iGuard_hits_8,{PmpPlugin_iGuard_hits_7,{_zz_when_PmpPlugin_l299,_zz_when_PmpPlugin_l299_1}}}}}}}}}} != 16'h0));
-  always @(*) begin
-    if(when_PmpPlugin_l299) begin
-      IBusCachedPlugin_mmuBus_rsp_allowExecute = (CsrPlugin_privilege == 2'b11);
-    end else begin
-      IBusCachedPlugin_mmuBus_rsp_allowExecute = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_17;
-    end
-  end
-
-  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute = {PmpPlugin_iGuard_hits_15,{PmpPlugin_iGuard_hits_14,{PmpPlugin_iGuard_hits_13,{PmpPlugin_iGuard_hits_12,{PmpPlugin_iGuard_hits_11,{PmpPlugin_iGuard_hits_10,{PmpPlugin_iGuard_hits_9,{PmpPlugin_iGuard_hits_8,{PmpPlugin_iGuard_hits_7,{PmpPlugin_iGuard_hits_6,{_zz__zz_IBusCachedPlugin_mmuBus_rsp_allowExecute,_zz__zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1}}}}}}}}}}};
-  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1 = (_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute & (~ _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1_1));
-  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_2 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1[3];
-  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_3 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1[5];
-  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_4 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1[6];
-  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_5 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1[7];
-  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_6 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1[9];
-  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_7 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1[10];
-  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_8 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1[11];
-  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_9 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1[12];
-  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_10 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1[13];
-  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_11 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1[14];
-  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_12 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1[15];
-  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_13 = (((((((_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1[1] || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_2) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_3) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_5) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_6) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_8) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_10) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_12);
-  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_14 = (((((((_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1[2] || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_2) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_4) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_5) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_7) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_8) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_11) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_12);
-  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_15 = (((((((_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1[4] || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_3) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_4) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_5) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_9) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_10) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_11) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_12);
-  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_16 = (((((((_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1[8] || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_6) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_7) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_8) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_9) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_10) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_11) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_12);
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute = {PmpPlugin_ports_1_hits_15,{PmpPlugin_ports_1_hits_14,{PmpPlugin_ports_1_hits_13,{PmpPlugin_ports_1_hits_12,{PmpPlugin_ports_1_hits_11,{PmpPlugin_ports_1_hits_10,{PmpPlugin_ports_1_hits_9,{PmpPlugin_ports_1_hits_8,{PmpPlugin_ports_1_hits_7,{PmpPlugin_ports_1_hits_6,{_zz__zz_DBusCachedPlugin_mmuBus_rsp_allowExecute,_zz__zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_1}}}}}}}}}}};
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_1 = (_zz_DBusCachedPlugin_mmuBus_rsp_allowExecute & (~ _zz__zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_1_1));
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_2 = _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_1[3];
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_3 = _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_1[5];
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_4 = _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_1[6];
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_5 = _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_1[7];
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_6 = _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_1[9];
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_7 = _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_1[10];
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_8 = _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_1[11];
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_9 = _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_1[12];
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_10 = _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_1[13];
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_11 = _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_1[14];
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_12 = _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_1[15];
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_13 = (((((((_zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_1[1] || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_2) || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_3) || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_5) || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_6) || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_8) || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_10) || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_12);
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_14 = (((((((_zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_1[2] || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_2) || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_4) || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_5) || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_7) || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_8) || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_11) || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_12);
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_15 = (((((((_zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_1[4] || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_3) || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_4) || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_5) || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_9) || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_10) || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_11) || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_12);
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_16 = (((((((_zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_1[8] || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_6) || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_7) || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_8) || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_9) || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_10) || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_11) || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_12);
+  assign DBusCachedPlugin_mmuBus_rsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_physicalAddress[31];
+  assign DBusCachedPlugin_mmuBus_rsp_isPaging = 1'b0;
+  assign DBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
+  assign DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
+  assign DBusCachedPlugin_mmuBus_busy = 1'b0;
   assign _zz_decode_IS_RS2_SIGNED_1 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_decode_IS_RS2_SIGNED_2 = ((decode_INSTRUCTION & 32'h00000018) == 32'h0);
+  assign _zz_decode_IS_RS2_SIGNED_2 = ((decode_INSTRUCTION & 32'h00000018) == 32'h00000000);
   assign _zz_decode_IS_RS2_SIGNED_3 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
   assign _zz_decode_IS_RS2_SIGNED_4 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_decode_IS_RS2_SIGNED_5 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
+  assign _zz_decode_IS_RS2_SIGNED_5 = ((decode_INSTRUCTION & 32'h00001000) == 32'h00000000);
   assign _zz_decode_IS_RS2_SIGNED = {(|_zz_decode_IS_RS2_SIGNED_5),{(|_zz_decode_IS_RS2_SIGNED_5),{(|(_zz__zz_decode_IS_RS2_SIGNED == _zz__zz_decode_IS_RS2_SIGNED_1)),{(|_zz__zz_decode_IS_RS2_SIGNED_2),{(|_zz__zz_decode_IS_RS2_SIGNED_3),{_zz__zz_decode_IS_RS2_SIGNED_4,{_zz__zz_decode_IS_RS2_SIGNED_6,_zz__zz_decode_IS_RS2_SIGNED_9}}}}}}};
   assign _zz_decode_SRC1_CTRL_2 = _zz_decode_IS_RS2_SIGNED[2 : 1];
   assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
@@ -5843,7 +6713,7 @@ module VexRiscv (
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
-  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h0);
+  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h00);
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
   assign decode_RegFilePlugin_rs1Data = _zz_RegFilePlugin_regFile_port0;
@@ -5858,14 +6728,14 @@ module VexRiscv (
   always @(*) begin
     lastStageRegFileWrite_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
     if(_zz_10) begin
-      lastStageRegFileWrite_payload_address = 5'h0;
+      lastStageRegFileWrite_payload_address = 5'h00;
     end
   end
 
   always @(*) begin
     lastStageRegFileWrite_payload_data = _zz_decode_RS2_2;
     if(_zz_10) begin
-      lastStageRegFileWrite_payload_data = 32'h0;
+      lastStageRegFileWrite_payload_data = 32'h00000000;
     end
   end
 
@@ -5906,7 +6776,7 @@ module VexRiscv (
         _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
       Src1CtrlEnum_IMU : begin
-        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h000};
       end
       default : begin
         _zz_execute_SRC1 = {27'd0, _zz__zz_execute_SRC1_1};
@@ -5914,67 +6784,67 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_execute_SRC2_1 = execute_INSTRUCTION[31];
+  assign _zz_execute_SRC2 = execute_INSTRUCTION[31];
   always @(*) begin
-    _zz_execute_SRC2_2[19] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[18] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[17] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[16] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[15] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[14] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[13] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[12] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[11] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[10] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[9] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[8] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[7] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[6] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[5] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[4] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[3] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[2] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[1] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[0] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_1[19] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[18] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[17] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[16] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[15] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[14] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[13] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[12] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[11] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[10] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[9] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[8] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[7] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[6] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[5] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[4] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[3] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[2] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[1] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[0] = _zz_execute_SRC2;
   end
 
-  assign _zz_execute_SRC2_3 = _zz__zz_execute_SRC2_3[11];
+  assign _zz_execute_SRC2_2 = _zz__zz_execute_SRC2_2[11];
   always @(*) begin
-    _zz_execute_SRC2_4[19] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[18] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[17] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[16] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[15] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[14] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[13] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[12] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[11] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[10] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[9] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[8] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[7] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[6] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[5] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[4] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[3] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[2] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[1] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[0] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_3[19] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[18] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[17] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[16] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[15] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[14] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[13] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[12] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[11] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[10] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[9] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[8] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[7] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[6] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[5] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[4] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[3] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[2] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[1] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[0] = _zz_execute_SRC2_2;
   end
 
   always @(*) begin
     case(execute_SRC2_CTRL)
       Src2CtrlEnum_RS : begin
-        _zz_execute_SRC2_5 = execute_RS2;
+        _zz_execute_SRC2_4 = execute_RS2;
       end
       Src2CtrlEnum_IMI : begin
-        _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
+        _zz_execute_SRC2_4 = {_zz_execute_SRC2_1,execute_INSTRUCTION[31 : 20]};
       end
       Src2CtrlEnum_IMS : begin
-        _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_execute_SRC2_4 = {_zz_execute_SRC2_3,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_execute_SRC2_5 = _zz_execute_SRC2;
+        _zz_execute_SRC2_4 = _zz_execute_to_memory_PC;
       end
     endcase
   end
@@ -6140,16 +7010,19 @@ module VexRiscv (
   assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
   assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign switch_Misc_l210_1 = execute_INSTRUCTION[14 : 12];
+  assign switch_Misc_l232_1 = execute_INSTRUCTION[14 : 12];
   always @(*) begin
-    casez(switch_Misc_l210_1)
+    case(switch_Misc_l232_1)
       3'b000 : begin
         _zz_execute_BRANCH_COND_RESULT = execute_BranchPlugin_eq;
       end
       3'b001 : begin
         _zz_execute_BRANCH_COND_RESULT = (! execute_BranchPlugin_eq);
       end
-      3'b1?1 : begin
+      3'b101 : begin
+        _zz_execute_BRANCH_COND_RESULT = (! execute_SRC_LESS);
+      end
+      3'b111 : begin
         _zz_execute_BRANCH_COND_RESULT = (! execute_SRC_LESS);
       end
       default : begin
@@ -6353,9 +7226,12 @@ module VexRiscv (
     end
   end
 
-  assign _zz_when_CsrPlugin_l965 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_when_CsrPlugin_l965_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_when_CsrPlugin_l965_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign CsrPlugin_misa_base = 2'b01;
+  assign CsrPlugin_misa_extensions = 26'h0101064;
+  assign CsrPlugin_mcounteren_TM = 1'b1;
+  assign _zz_when_CsrPlugin_l1302 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l1302_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l1302_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
   assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
@@ -6400,28 +7276,28 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l922 = (! decode_arbitration_isStuck);
-  assign when_CsrPlugin_l922_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l922_2 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l922_3 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l935 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
+  assign when_CsrPlugin_l1259 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l1272 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-  assign when_CsrPlugin_l959 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign when_CsrPlugin_l965 = ((_zz_when_CsrPlugin_l965 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l965_1 = ((_zz_when_CsrPlugin_l965_1 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l965_2 = ((_zz_when_CsrPlugin_l965_2 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1296 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l1302 = ((_zz_when_CsrPlugin_l1302 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1302_1 = ((_zz_when_CsrPlugin_l1302_1 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1302_2 = ((_zz_when_CsrPlugin_l1302_2 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  assign when_CsrPlugin_l993 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l993_1 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l993_2 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l998 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  assign when_CsrPlugin_l1335 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1335_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l1335_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l1340 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
   always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(when_CsrPlugin_l1004) begin
+    if(when_CsrPlugin_l1346) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException) begin
@@ -6429,7 +7305,7 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l1004 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
+  assign when_CsrPlugin_l1346 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
   always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
@@ -6445,6 +7321,7 @@ module VexRiscv (
     end
   end
 
+  assign CsrPlugin_trapCauseEbreakDebug = 1'b0;
   always @(*) begin
     CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
@@ -6467,13 +7344,16 @@ module VexRiscv (
     endcase
   end
 
-  assign when_CsrPlugin_l1032 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign when_CsrPlugin_l1077 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
-  assign switch_CsrPlugin_l1081 = writeBack_INSTRUCTION[29 : 28];
+  assign CsrPlugin_trapEnterDebug = 1'b0;
+  assign when_CsrPlugin_l1390 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1398 = (! CsrPlugin_trapEnterDebug);
+  assign when_CsrPlugin_l1456 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign switch_CsrPlugin_l1460 = writeBack_INSTRUCTION[29 : 28];
+  assign when_CsrPlugin_l1468 = (CsrPlugin_mstatus_MPP < 2'b11);
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign when_CsrPlugin_l1121 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_WFI));
-  assign when_CsrPlugin_l1123 = (! execute_CsrPlugin_wfiWake);
-  assign when_CsrPlugin_l1129 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
+  assign when_CsrPlugin_l1519 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_WFI));
+  assign when_CsrPlugin_l1521 = (! execute_CsrPlugin_wfiWake);
+  assign when_CsrPlugin_l1527 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
   assign execute_CsrPlugin_blockedBySideEffects = ((|{writeBack_arbitration_isValid,memory_arbitration_isValid}) || 1'b0);
   always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
@@ -6481,6 +7361,66 @@ module VexRiscv (
       if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
+    end
+    if(execute_CsrPlugin_csr_944) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(execute_CsrPlugin_csr_945) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(execute_CsrPlugin_csr_946) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(execute_CsrPlugin_csr_947) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(execute_CsrPlugin_csr_948) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(execute_CsrPlugin_csr_949) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(execute_CsrPlugin_csr_950) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(execute_CsrPlugin_csr_951) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(execute_CsrPlugin_csr_952) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(execute_CsrPlugin_csr_953) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(execute_CsrPlugin_csr_954) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(execute_CsrPlugin_csr_955) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(execute_CsrPlugin_csr_956) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(execute_CsrPlugin_csr_957) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(execute_CsrPlugin_csr_958) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(execute_CsrPlugin_csr_959) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(execute_CsrPlugin_csr_928) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(execute_CsrPlugin_csr_929) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(execute_CsrPlugin_csr_930) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(execute_CsrPlugin_csr_931) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
     end
     if(execute_CsrPlugin_csr_3857) begin
       if(execute_CSR_READ_OPCODE) begin
@@ -6561,6 +7501,9 @@ module VexRiscv (
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
+    if(execute_CsrPlugin_csr_774) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
     if(execute_CsrPlugin_csr_3008) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
@@ -6572,18 +7515,18 @@ module VexRiscv (
     if(CsrPlugin_csrMapping_allowCsrSignal) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(when_CsrPlugin_l1315) begin
+    if(when_CsrPlugin_l1725) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if(when_CsrPlugin_l1149) begin
-      if(when_CsrPlugin_l1150) begin
+    if(when_CsrPlugin_l1547) begin
+      if(when_CsrPlugin_l1548) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
@@ -6591,20 +7534,20 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(when_CsrPlugin_l1142) begin
+    if(when_CsrPlugin_l1540) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1157) begin
+    if(when_CsrPlugin_l1555) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(when_CsrPlugin_l1142) begin
+    if(when_CsrPlugin_l1540) begin
       CsrPlugin_selfException_payload_code = 4'b0010;
     end
-    if(when_CsrPlugin_l1157) begin
+    if(when_CsrPlugin_l1555) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -6617,20 +7560,20 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  assign when_CsrPlugin_l1142 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
-  assign when_CsrPlugin_l1149 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
-  assign when_CsrPlugin_l1150 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
-  assign when_CsrPlugin_l1157 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
+  assign when_CsrPlugin_l1540 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
+  assign when_CsrPlugin_l1547 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign when_CsrPlugin_l1548 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1555 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
   always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -6639,9 +7582,9 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
   assign execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
-  assign switch_Misc_l210_2 = execute_INSTRUCTION[13];
+  assign switch_Misc_l232_2 = execute_INSTRUCTION[13];
   always @(*) begin
-    case(switch_Misc_l210_2)
+    case(switch_Misc_l232_2)
       1'b0 : begin
         _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
@@ -6652,8 +7595,8 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
-  assign when_CsrPlugin_l1189 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign when_CsrPlugin_l1193 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
+  assign when_CsrPlugin_l1587 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1591 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
@@ -6716,12 +7659,12 @@ module VexRiscv (
   assign memory_DivPlugin_div_counter_willOverflow = (memory_DivPlugin_div_counter_willOverflowIfInc && memory_DivPlugin_div_counter_willIncrement);
   always @(*) begin
     if(memory_DivPlugin_div_counter_willOverflow) begin
-      memory_DivPlugin_div_counter_valueNext = 6'h0;
+      memory_DivPlugin_div_counter_valueNext = 6'h00;
     end else begin
       memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_memory_DivPlugin_div_counter_valueNext);
     end
     if(memory_DivPlugin_div_counter_willClear) begin
-      memory_DivPlugin_div_counter_valueNext = 6'h0;
+      memory_DivPlugin_div_counter_valueNext = 6'h00;
     end
   end
 
@@ -6745,8 +7688,8 @@ module VexRiscv (
     _zz_memory_DivPlugin_rs1_1[31 : 0] = execute_RS1;
   end
 
-  assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
-  assign externalInterrupt = (|_zz_CsrPlugin_csrMapping_readDataInit_1);
+  assign _zz_externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit_64 & externalInterruptArray_regNext);
+  assign externalInterrupt = (|_zz_externalInterrupt);
   assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
@@ -6862,261 +7805,462 @@ module VexRiscv (
   assign when_Pipeline_l154_1 = ((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt));
   assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
   assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
+  assign when_CsrPlugin_l1669 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_8 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_9 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_10 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_11 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_12 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_13 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_14 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_15 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_16 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_17 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_18 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_19 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_20 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_21 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_22 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_23 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_24 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_25 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_26 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_27 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_28 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_29 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_30 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_31 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_32 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_33 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_34 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_35 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_36 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_37 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_38 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_39 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_40 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_41 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_42 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_43 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_44 = (! execute_arbitration_isStuck);
   always @(*) begin
-    execute_PmpPlugin_fsm_stateNext = execute_PmpPlugin_fsm_stateReg;
-    case(execute_PmpPlugin_fsm_stateReg)
-      execute_PmpPlugin_fsm_enumDef_stateIdle : begin
-        if(execute_PmpPlugin_fsmPending) begin
-          execute_PmpPlugin_fsm_stateNext = execute_PmpPlugin_fsm_enumDef_stateWrite;
-        end
-      end
-      execute_PmpPlugin_fsm_enumDef_stateWrite : begin
-        if(execute_PmpPlugin_pmpcfgCsr_) begin
-          execute_PmpPlugin_fsm_stateNext = execute_PmpPlugin_fsm_enumDef_stateCfg;
-        end
-        if(execute_PmpPlugin_pmpaddrCsr_) begin
-          execute_PmpPlugin_fsm_stateNext = execute_PmpPlugin_fsm_enumDef_stateAddr;
-        end
-      end
-      execute_PmpPlugin_fsm_enumDef_stateCfg : begin
-        if(when_PmpPlugin_l229) begin
-          execute_PmpPlugin_fsm_stateNext = execute_PmpPlugin_fsm_enumDef_stateIdle;
-        end
-      end
-      execute_PmpPlugin_fsm_enumDef_stateAddr : begin
-        execute_PmpPlugin_fsm_stateNext = execute_PmpPlugin_fsm_enumDef_stateIdle;
-      end
-      default : begin
-      end
-    endcase
-    if(execute_PmpPlugin_fsm_wantStart) begin
-      execute_PmpPlugin_fsm_stateNext = execute_PmpPlugin_fsm_enumDef_stateIdle;
-    end
-    if(execute_PmpPlugin_fsm_wantKill) begin
-      execute_PmpPlugin_fsm_stateNext = execute_PmpPlugin_fsm_enumDef_BOOT;
-    end
-  end
-
-  assign _zz_PmpPlugin_pmpcfg_0 = execute_PmpPlugin_writeData_[7 : 0];
-  assign _zz_PmpPlugin_pmpcfg_0_1 = execute_PmpPlugin_writeData_[15 : 8];
-  assign _zz_PmpPlugin_pmpcfg_0_2 = execute_PmpPlugin_writeData_[23 : 16];
-  assign _zz_PmpPlugin_pmpcfg_0_3 = execute_PmpPlugin_writeData_[31 : 24];
-  assign when_PmpPlugin_l209 = (! _zz_when_PmpPlugin_l209[7]);
-  assign _zz_11 = ({15'd0,1'b1} <<< {execute_PmpPlugin_pmpcfgN_,2'b00});
-  assign when_PmpPlugin_l209_1 = (! _zz_when_PmpPlugin_l209_1_1[7]);
-  assign _zz_12 = ({15'd0,1'b1} <<< {execute_PmpPlugin_pmpcfgN_,2'b01});
-  assign when_PmpPlugin_l209_2 = (! _zz_when_PmpPlugin_l209_2[7]);
-  assign _zz_13 = ({15'd0,1'b1} <<< {execute_PmpPlugin_pmpcfgN_,2'b10});
-  assign when_PmpPlugin_l209_3 = (! _zz_when_PmpPlugin_l209_3[7]);
-  assign _zz_14 = ({15'd0,1'b1} <<< {execute_PmpPlugin_pmpcfgN_,2'b11});
-  assign when_PmpPlugin_l216 = (! _zz_when_PmpPlugin_l216[7]);
-  assign when_PmpPlugin_l229 = (execute_PmpPlugin_fsm_fsmCounter[1 : 0] == 2'b11);
-  assign when_StateMachine_l233 = ((execute_PmpPlugin_fsm_stateReg == execute_PmpPlugin_fsm_enumDef_stateWrite) && (! (execute_PmpPlugin_fsm_stateNext == execute_PmpPlugin_fsm_enumDef_stateWrite)));
-  assign when_StateMachine_l249 = ((! (execute_PmpPlugin_fsm_stateReg == execute_PmpPlugin_fsm_enumDef_stateIdle)) && (execute_PmpPlugin_fsm_stateNext == execute_PmpPlugin_fsm_enumDef_stateIdle));
-  assign when_StateMachine_l249_1 = ((! (execute_PmpPlugin_fsm_stateReg == execute_PmpPlugin_fsm_enumDef_stateCfg)) && (execute_PmpPlugin_fsm_stateNext == execute_PmpPlugin_fsm_enumDef_stateCfg));
-  assign when_StateMachine_l249_2 = ((! (execute_PmpPlugin_fsm_stateReg == execute_PmpPlugin_fsm_enumDef_stateAddr)) && (execute_PmpPlugin_fsm_stateNext == execute_PmpPlugin_fsm_enumDef_stateAddr));
-  assign when_CsrPlugin_l1277 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_2 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_3 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_4 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_5 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_6 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_7 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_8 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_9 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_10 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_11 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_12 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_13 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_14 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_15 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_16 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_17 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_18 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_19 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_20 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_21 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_22 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_23 = (! execute_arbitration_isStuck);
-  always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_65 = 32'h00000000;
     if(execute_CsrPlugin_csr_3264) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_2[12 : 0] = 13'h1000;
-      _zz_CsrPlugin_csrMapping_readDataInit_2[25 : 20] = 6'h20;
+      _zz_CsrPlugin_csrMapping_readDataInit_65[12 : 0] = 13'h1000;
+      _zz_CsrPlugin_csrMapping_readDataInit_65[25 : 20] = 6'h20;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_66 = 32'h00000000;
+    if(execute_CsrPlugin_csr_944) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_66[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_1;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_67 = 32'h00000000;
+    if(execute_CsrPlugin_csr_945) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_67[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_5;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_68 = 32'h00000000;
+    if(execute_CsrPlugin_csr_946) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_68[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_9;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_69 = 32'h00000000;
+    if(execute_CsrPlugin_csr_947) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_69[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_13;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_70 = 32'h00000000;
+    if(execute_CsrPlugin_csr_948) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_70[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_17;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_71 = 32'h00000000;
+    if(execute_CsrPlugin_csr_949) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_71[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_21;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_72 = 32'h00000000;
+    if(execute_CsrPlugin_csr_950) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_72[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_25;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_73 = 32'h00000000;
+    if(execute_CsrPlugin_csr_951) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_73[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_29;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_74 = 32'h00000000;
+    if(execute_CsrPlugin_csr_952) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_74[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_33;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_75 = 32'h00000000;
+    if(execute_CsrPlugin_csr_953) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_75[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_37;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_76 = 32'h00000000;
+    if(execute_CsrPlugin_csr_954) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_76[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_41;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_77 = 32'h00000000;
+    if(execute_CsrPlugin_csr_955) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_77[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_45;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_78 = 32'h00000000;
+    if(execute_CsrPlugin_csr_956) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_78[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_49;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_79 = 32'h00000000;
+    if(execute_CsrPlugin_csr_957) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_79[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_53;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_80 = 32'h00000000;
+    if(execute_CsrPlugin_csr_958) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_80[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_57;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_81 = 32'h00000000;
+    if(execute_CsrPlugin_csr_959) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_81[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_61;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_82 = 32'h00000000;
+    if(execute_CsrPlugin_csr_928) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_82[31 : 31] = _zz_when_PmpPlugin_l126_6;
+      _zz_CsrPlugin_csrMapping_readDataInit_82[23 : 23] = _zz_when_PmpPlugin_l126_4;
+      _zz_CsrPlugin_csrMapping_readDataInit_82[15 : 15] = _zz_when_PmpPlugin_l126_2;
+      _zz_CsrPlugin_csrMapping_readDataInit_82[7 : 7] = _zz_when_PmpPlugin_l126;
+      _zz_CsrPlugin_csrMapping_readDataInit_82[28 : 27] = _zz_CsrPlugin_csrMapping_readDataInit_12;
+      _zz_CsrPlugin_csrMapping_readDataInit_82[26 : 26] = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_6;
+      _zz_CsrPlugin_csrMapping_readDataInit_82[25 : 25] = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_6;
+      _zz_CsrPlugin_csrMapping_readDataInit_82[24 : 24] = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_6;
+      _zz_CsrPlugin_csrMapping_readDataInit_82[20 : 19] = _zz_CsrPlugin_csrMapping_readDataInit_8;
+      _zz_CsrPlugin_csrMapping_readDataInit_82[18 : 18] = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_4;
+      _zz_CsrPlugin_csrMapping_readDataInit_82[17 : 17] = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_4;
+      _zz_CsrPlugin_csrMapping_readDataInit_82[16 : 16] = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_4;
+      _zz_CsrPlugin_csrMapping_readDataInit_82[12 : 11] = _zz_CsrPlugin_csrMapping_readDataInit_4;
+      _zz_CsrPlugin_csrMapping_readDataInit_82[10 : 10] = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_2;
+      _zz_CsrPlugin_csrMapping_readDataInit_82[9 : 9] = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_2;
+      _zz_CsrPlugin_csrMapping_readDataInit_82[8 : 8] = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_2;
+      _zz_CsrPlugin_csrMapping_readDataInit_82[4 : 3] = _zz_CsrPlugin_csrMapping_readDataInit;
+      _zz_CsrPlugin_csrMapping_readDataInit_82[2 : 2] = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute;
+      _zz_CsrPlugin_csrMapping_readDataInit_82[1 : 1] = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite;
+      _zz_CsrPlugin_csrMapping_readDataInit_82[0 : 0] = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_83 = 32'h00000000;
+    if(execute_CsrPlugin_csr_929) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_83[31 : 31] = _zz_when_PmpPlugin_l126_14;
+      _zz_CsrPlugin_csrMapping_readDataInit_83[23 : 23] = _zz_when_PmpPlugin_l126_12;
+      _zz_CsrPlugin_csrMapping_readDataInit_83[15 : 15] = _zz_when_PmpPlugin_l126_10;
+      _zz_CsrPlugin_csrMapping_readDataInit_83[7 : 7] = _zz_when_PmpPlugin_l126_8;
+      _zz_CsrPlugin_csrMapping_readDataInit_83[28 : 27] = _zz_CsrPlugin_csrMapping_readDataInit_28;
+      _zz_CsrPlugin_csrMapping_readDataInit_83[26 : 26] = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_14;
+      _zz_CsrPlugin_csrMapping_readDataInit_83[25 : 25] = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_14;
+      _zz_CsrPlugin_csrMapping_readDataInit_83[24 : 24] = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_14;
+      _zz_CsrPlugin_csrMapping_readDataInit_83[20 : 19] = _zz_CsrPlugin_csrMapping_readDataInit_24;
+      _zz_CsrPlugin_csrMapping_readDataInit_83[18 : 18] = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_12;
+      _zz_CsrPlugin_csrMapping_readDataInit_83[17 : 17] = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_12;
+      _zz_CsrPlugin_csrMapping_readDataInit_83[16 : 16] = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_12;
+      _zz_CsrPlugin_csrMapping_readDataInit_83[12 : 11] = _zz_CsrPlugin_csrMapping_readDataInit_20;
+      _zz_CsrPlugin_csrMapping_readDataInit_83[10 : 10] = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_10;
+      _zz_CsrPlugin_csrMapping_readDataInit_83[9 : 9] = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_10;
+      _zz_CsrPlugin_csrMapping_readDataInit_83[8 : 8] = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_10;
+      _zz_CsrPlugin_csrMapping_readDataInit_83[4 : 3] = _zz_CsrPlugin_csrMapping_readDataInit_16;
+      _zz_CsrPlugin_csrMapping_readDataInit_83[2 : 2] = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_8;
+      _zz_CsrPlugin_csrMapping_readDataInit_83[1 : 1] = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_8;
+      _zz_CsrPlugin_csrMapping_readDataInit_83[0 : 0] = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_8;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_84 = 32'h00000000;
+    if(execute_CsrPlugin_csr_930) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_84[31 : 31] = _zz_when_PmpPlugin_l126_22;
+      _zz_CsrPlugin_csrMapping_readDataInit_84[23 : 23] = _zz_when_PmpPlugin_l126_20;
+      _zz_CsrPlugin_csrMapping_readDataInit_84[15 : 15] = _zz_when_PmpPlugin_l126_18;
+      _zz_CsrPlugin_csrMapping_readDataInit_84[7 : 7] = _zz_when_PmpPlugin_l126_16;
+      _zz_CsrPlugin_csrMapping_readDataInit_84[28 : 27] = _zz_CsrPlugin_csrMapping_readDataInit_44;
+      _zz_CsrPlugin_csrMapping_readDataInit_84[26 : 26] = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_22;
+      _zz_CsrPlugin_csrMapping_readDataInit_84[25 : 25] = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_22;
+      _zz_CsrPlugin_csrMapping_readDataInit_84[24 : 24] = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_22;
+      _zz_CsrPlugin_csrMapping_readDataInit_84[20 : 19] = _zz_CsrPlugin_csrMapping_readDataInit_40;
+      _zz_CsrPlugin_csrMapping_readDataInit_84[18 : 18] = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_20;
+      _zz_CsrPlugin_csrMapping_readDataInit_84[17 : 17] = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_20;
+      _zz_CsrPlugin_csrMapping_readDataInit_84[16 : 16] = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_20;
+      _zz_CsrPlugin_csrMapping_readDataInit_84[12 : 11] = _zz_CsrPlugin_csrMapping_readDataInit_36;
+      _zz_CsrPlugin_csrMapping_readDataInit_84[10 : 10] = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_18;
+      _zz_CsrPlugin_csrMapping_readDataInit_84[9 : 9] = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_18;
+      _zz_CsrPlugin_csrMapping_readDataInit_84[8 : 8] = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_18;
+      _zz_CsrPlugin_csrMapping_readDataInit_84[4 : 3] = _zz_CsrPlugin_csrMapping_readDataInit_32;
+      _zz_CsrPlugin_csrMapping_readDataInit_84[2 : 2] = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_16;
+      _zz_CsrPlugin_csrMapping_readDataInit_84[1 : 1] = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_16;
+      _zz_CsrPlugin_csrMapping_readDataInit_84[0 : 0] = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_16;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_85 = 32'h00000000;
+    if(execute_CsrPlugin_csr_931) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_85[31 : 31] = _zz_when_PmpPlugin_l126_30;
+      _zz_CsrPlugin_csrMapping_readDataInit_85[23 : 23] = _zz_when_PmpPlugin_l126_28;
+      _zz_CsrPlugin_csrMapping_readDataInit_85[15 : 15] = _zz_when_PmpPlugin_l126_26;
+      _zz_CsrPlugin_csrMapping_readDataInit_85[7 : 7] = _zz_when_PmpPlugin_l126_24;
+      _zz_CsrPlugin_csrMapping_readDataInit_85[28 : 27] = _zz_CsrPlugin_csrMapping_readDataInit_60;
+      _zz_CsrPlugin_csrMapping_readDataInit_85[26 : 26] = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_30;
+      _zz_CsrPlugin_csrMapping_readDataInit_85[25 : 25] = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_30;
+      _zz_CsrPlugin_csrMapping_readDataInit_85[24 : 24] = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_30;
+      _zz_CsrPlugin_csrMapping_readDataInit_85[20 : 19] = _zz_CsrPlugin_csrMapping_readDataInit_56;
+      _zz_CsrPlugin_csrMapping_readDataInit_85[18 : 18] = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_28;
+      _zz_CsrPlugin_csrMapping_readDataInit_85[17 : 17] = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_28;
+      _zz_CsrPlugin_csrMapping_readDataInit_85[16 : 16] = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_28;
+      _zz_CsrPlugin_csrMapping_readDataInit_85[12 : 11] = _zz_CsrPlugin_csrMapping_readDataInit_52;
+      _zz_CsrPlugin_csrMapping_readDataInit_85[10 : 10] = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_26;
+      _zz_CsrPlugin_csrMapping_readDataInit_85[9 : 9] = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_26;
+      _zz_CsrPlugin_csrMapping_readDataInit_85[8 : 8] = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_26;
+      _zz_CsrPlugin_csrMapping_readDataInit_85[4 : 3] = _zz_CsrPlugin_csrMapping_readDataInit_48;
+      _zz_CsrPlugin_csrMapping_readDataInit_85[2 : 2] = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_24;
+      _zz_CsrPlugin_csrMapping_readDataInit_85[1 : 1] = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_24;
+      _zz_CsrPlugin_csrMapping_readDataInit_85[0 : 0] = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_24;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_86 = 32'h00000000;
     if(execute_CsrPlugin_csr_3857) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_3[0 : 0] = 1'b1;
+      _zz_CsrPlugin_csrMapping_readDataInit_86[0 : 0] = 1'b1;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_87 = 32'h00000000;
     if(execute_CsrPlugin_csr_3858) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_4[1 : 0] = 2'b10;
+      _zz_CsrPlugin_csrMapping_readDataInit_87[1 : 0] = 2'b10;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_88 = 32'h00000000;
     if(execute_CsrPlugin_csr_3859) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_5[1 : 0] = 2'b11;
+      _zz_CsrPlugin_csrMapping_readDataInit_88[1 : 0] = 2'b11;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_89 = 32'h00000000;
     if(execute_CsrPlugin_csr_769) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_6[31 : 30] = CsrPlugin_misa_base;
-      _zz_CsrPlugin_csrMapping_readDataInit_6[25 : 0] = CsrPlugin_misa_extensions;
+      _zz_CsrPlugin_csrMapping_readDataInit_89[31 : 30] = CsrPlugin_misa_base;
+      _zz_CsrPlugin_csrMapping_readDataInit_89[25 : 0] = CsrPlugin_misa_extensions;
     end
   end
 
-  assign switch_CsrPlugin_l723 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
+  assign switch_CsrPlugin_l1031 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_90 = 32'h00000000;
     if(execute_CsrPlugin_csr_768) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_7[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_7[3 : 3] = CsrPlugin_mstatus_MIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_7[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_CsrPlugin_csrMapping_readDataInit_90[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_90[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_90[12 : 11] = CsrPlugin_mstatus_MPP;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_91 = 32'h00000000;
     if(execute_CsrPlugin_csr_836) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_8[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_8[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_8[3 : 3] = CsrPlugin_mip_MSIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_91[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_91[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_91[3 : 3] = CsrPlugin_mip_MSIP;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_92 = 32'h00000000;
     if(execute_CsrPlugin_csr_772) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_9[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_9[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_9[3 : 3] = CsrPlugin_mie_MSIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_92[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_92[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_92[3 : 3] = CsrPlugin_mie_MSIE;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_10 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_93 = 32'h00000000;
     if(execute_CsrPlugin_csr_773) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_10[31 : 2] = CsrPlugin_mtvec_base;
-      _zz_CsrPlugin_csrMapping_readDataInit_10[1 : 0] = CsrPlugin_mtvec_mode;
+      _zz_CsrPlugin_csrMapping_readDataInit_93[31 : 2] = CsrPlugin_mtvec_base;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_11 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_94 = 32'h00000000;
     if(execute_CsrPlugin_csr_833) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_11[31 : 0] = CsrPlugin_mepc;
+      _zz_CsrPlugin_csrMapping_readDataInit_94[31 : 0] = CsrPlugin_mepc;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_12 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_95 = 32'h00000000;
     if(execute_CsrPlugin_csr_832) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_12[31 : 0] = CsrPlugin_mscratch;
+      _zz_CsrPlugin_csrMapping_readDataInit_95[31 : 0] = CsrPlugin_mscratch;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_13 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_96 = 32'h00000000;
     if(execute_CsrPlugin_csr_834) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_13[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_CsrPlugin_csrMapping_readDataInit_13[3 : 0] = CsrPlugin_mcause_exceptionCode;
+      _zz_CsrPlugin_csrMapping_readDataInit_96[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_CsrPlugin_csrMapping_readDataInit_96[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_14 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_97 = 32'h00000000;
     if(execute_CsrPlugin_csr_835) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_14[31 : 0] = CsrPlugin_mtval;
+      _zz_CsrPlugin_csrMapping_readDataInit_97[31 : 0] = CsrPlugin_mtval;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_15 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_98 = 32'h00000000;
     if(execute_CsrPlugin_csr_2816) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_15[31 : 0] = CsrPlugin_mcycle[31 : 0];
+      _zz_CsrPlugin_csrMapping_readDataInit_98[31 : 0] = CsrPlugin_mcycle[31 : 0];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_16 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_99 = 32'h00000000;
     if(execute_CsrPlugin_csr_2944) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_16[31 : 0] = CsrPlugin_mcycle[63 : 32];
+      _zz_CsrPlugin_csrMapping_readDataInit_99[31 : 0] = CsrPlugin_mcycle[63 : 32];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_17 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_100 = 32'h00000000;
     if(execute_CsrPlugin_csr_2818) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_17[31 : 0] = CsrPlugin_minstret[31 : 0];
+      _zz_CsrPlugin_csrMapping_readDataInit_100[31 : 0] = CsrPlugin_minstret[31 : 0];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_18 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_101 = 32'h00000000;
     if(execute_CsrPlugin_csr_2946) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_18[31 : 0] = CsrPlugin_minstret[63 : 32];
+      _zz_CsrPlugin_csrMapping_readDataInit_101[31 : 0] = CsrPlugin_minstret[63 : 32];
     end
   end
 
+  assign when_CsrPlugin_l1076 = ((CsrPlugin_privilege < 2'b11) && (! CsrPlugin_mcounteren_CY));
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_19 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_102 = 32'h00000000;
     if(execute_CsrPlugin_csr_3072) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_19[31 : 0] = CsrPlugin_mcycle[31 : 0];
+      _zz_CsrPlugin_csrMapping_readDataInit_102[31 : 0] = CsrPlugin_mcycle[31 : 0];
     end
   end
 
+  assign when_CsrPlugin_l1076_1 = ((CsrPlugin_privilege < 2'b11) && (! CsrPlugin_mcounteren_CY));
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_20 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_103 = 32'h00000000;
     if(execute_CsrPlugin_csr_3200) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_20[31 : 0] = CsrPlugin_mcycle[63 : 32];
+      _zz_CsrPlugin_csrMapping_readDataInit_103[31 : 0] = CsrPlugin_mcycle[63 : 32];
     end
   end
 
+  assign when_CsrPlugin_l1076_2 = ((CsrPlugin_privilege < 2'b11) && (! CsrPlugin_mcounteren_IR));
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_21 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_104 = 32'h00000000;
     if(execute_CsrPlugin_csr_3074) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_21[31 : 0] = CsrPlugin_minstret[31 : 0];
+      _zz_CsrPlugin_csrMapping_readDataInit_104[31 : 0] = CsrPlugin_minstret[31 : 0];
     end
   end
 
+  assign when_CsrPlugin_l1076_3 = ((CsrPlugin_privilege < 2'b11) && (! CsrPlugin_mcounteren_IR));
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_22 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_105 = 32'h00000000;
     if(execute_CsrPlugin_csr_3202) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_22[31 : 0] = CsrPlugin_minstret[63 : 32];
+      _zz_CsrPlugin_csrMapping_readDataInit_105[31 : 0] = CsrPlugin_minstret[63 : 32];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_23 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_106 = 32'h00000000;
+    if(execute_CsrPlugin_csr_774) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_106[0 : 0] = CsrPlugin_mcounteren_CY;
+      _zz_CsrPlugin_csrMapping_readDataInit_106[2 : 2] = CsrPlugin_mcounteren_IR;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_107 = 32'h00000000;
     if(execute_CsrPlugin_csr_3008) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_23[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
+      _zz_CsrPlugin_csrMapping_readDataInit_107[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_64;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_24 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_108 = 32'h00000000;
     if(execute_CsrPlugin_csr_4032) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_24[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_1;
+      _zz_CsrPlugin_csrMapping_readDataInit_108[31 : 0] = _zz_externalInterrupt;
     end
   end
 
-  assign CsrPlugin_csrMapping_readDataInit = (((((_zz_CsrPlugin_csrMapping_readDataInit_2 | _zz_CsrPlugin_csrMapping_readDataInit_3) | (_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5)) | ((_zz_CsrPlugin_csrMapping_readDataInit_25 | _zz_CsrPlugin_csrMapping_readDataInit_6) | (_zz_CsrPlugin_csrMapping_readDataInit_7 | _zz_CsrPlugin_csrMapping_readDataInit_8))) | (((_zz_CsrPlugin_csrMapping_readDataInit_9 | _zz_CsrPlugin_csrMapping_readDataInit_10) | (_zz_CsrPlugin_csrMapping_readDataInit_11 | _zz_CsrPlugin_csrMapping_readDataInit_12)) | ((_zz_CsrPlugin_csrMapping_readDataInit_13 | _zz_CsrPlugin_csrMapping_readDataInit_14) | (_zz_CsrPlugin_csrMapping_readDataInit_15 | _zz_CsrPlugin_csrMapping_readDataInit_16)))) | (((_zz_CsrPlugin_csrMapping_readDataInit_17 | _zz_CsrPlugin_csrMapping_readDataInit_18) | (_zz_CsrPlugin_csrMapping_readDataInit_19 | _zz_CsrPlugin_csrMapping_readDataInit_20)) | ((_zz_CsrPlugin_csrMapping_readDataInit_21 | _zz_CsrPlugin_csrMapping_readDataInit_22) | (_zz_CsrPlugin_csrMapping_readDataInit_23 | _zz_CsrPlugin_csrMapping_readDataInit_24))));
-  assign when_PmpPlugin_l155 = (CsrPlugin_privilege == 2'b11);
-  assign when_PmpPlugin_l172 = ((execute_PmpPlugin_pmpcfgCsr || execute_PmpPlugin_pmpaddrCsr) && (CsrPlugin_privilege == 2'b11));
-  assign when_PmpPlugin_l175 = ((! execute_PmpPlugin_fsmPending) && CsrPlugin_csrMapping_hazardFree);
-  assign when_CsrPlugin_l1310 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign when_CsrPlugin_l1315 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign CsrPlugin_csrMapping_readDataInit = (((((_zz_CsrPlugin_csrMapping_readDataInit_109 | _zz_CsrPlugin_csrMapping_readDataInit_110) | (_zz_CsrPlugin_csrMapping_readDataInit_111 | _zz_CsrPlugin_csrMapping_readDataInit_112)) | ((_zz_CsrPlugin_csrMapping_readDataInit_113 | _zz_CsrPlugin_csrMapping_readDataInit_114) | (_zz_CsrPlugin_csrMapping_readDataInit_115 | _zz_CsrPlugin_csrMapping_readDataInit_116))) | (((_zz_CsrPlugin_csrMapping_readDataInit_117 | _zz_CsrPlugin_csrMapping_readDataInit_118) | (_zz_CsrPlugin_csrMapping_readDataInit_119 | _zz_CsrPlugin_csrMapping_readDataInit_120)) | ((_zz_CsrPlugin_csrMapping_readDataInit_121 | _zz_CsrPlugin_csrMapping_readDataInit_123) | (_zz_CsrPlugin_csrMapping_readDataInit_124 | _zz_CsrPlugin_csrMapping_readDataInit_125)))) | ((((_zz_CsrPlugin_csrMapping_readDataInit_96 | _zz_CsrPlugin_csrMapping_readDataInit_97) | (_zz_CsrPlugin_csrMapping_readDataInit_98 | _zz_CsrPlugin_csrMapping_readDataInit_99)) | ((_zz_CsrPlugin_csrMapping_readDataInit_100 | _zz_CsrPlugin_csrMapping_readDataInit_101) | (_zz_CsrPlugin_csrMapping_readDataInit_102 | _zz_CsrPlugin_csrMapping_readDataInit_103))) | (((_zz_CsrPlugin_csrMapping_readDataInit_104 | _zz_CsrPlugin_csrMapping_readDataInit_105) | (_zz_CsrPlugin_csrMapping_readDataInit_106 | _zz_CsrPlugin_csrMapping_readDataInit_107)) | _zz_CsrPlugin_csrMapping_readDataInit_108)));
+  assign _zz_when_CsrPlugin_l1709 = (execute_CsrPlugin_csrAddress & 12'hf60);
+  assign when_CsrPlugin_l1709 = (((execute_arbitration_isValid && execute_IS_CSR) && (5'h03 <= execute_CsrPlugin_csrAddress[4 : 0])) && (((_zz_when_CsrPlugin_l1709 == 12'hb00) || (((_zz_when_CsrPlugin_l1709 == 12'hc00) && (! execute_CsrPlugin_writeInstruction)) && (CsrPlugin_privilege == 2'b11))) || ((execute_CsrPlugin_csrAddress & 12'hfe0) == 12'h320)));
+  always @(*) begin
+    when_CsrPlugin_l1719 = CsrPlugin_csrMapping_doForceFailCsr;
+    if(when_CsrPlugin_l1717) begin
+      when_CsrPlugin_l1719 = 1'b1;
+    end
+  end
+
+  assign when_CsrPlugin_l1717 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1725 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
   assign iBusWishbone_ADR = {_zz_iBusWishbone_ADR_1,_zz_iBusWishbone_ADR};
   assign iBusWishbone_CTI = ((_zz_iBusWishbone_ADR == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
@@ -7142,20 +8286,20 @@ module VexRiscv (
   assign iBus_rsp_valid = _zz_iBus_rsp_valid;
   assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
   assign iBus_rsp_payload_error = 1'b0;
-  assign _zz_dBus_cmd_ready_5 = (dBus_cmd_payload_size == 3'b101);
-  assign _zz_dBus_cmd_ready_1 = dBus_cmd_valid;
-  assign _zz_dBus_cmd_ready_3 = dBus_cmd_payload_wr;
-  assign _zz_dBus_cmd_ready_4 = ((! _zz_dBus_cmd_ready_5) || (_zz_dBus_cmd_ready == 3'b111));
-  assign dBus_cmd_ready = (_zz_dBus_cmd_ready_2 && (_zz_dBus_cmd_ready_3 || _zz_dBus_cmd_ready_4));
-  assign dBusWishbone_ADR = ((_zz_dBus_cmd_ready_5 ? {{dBus_cmd_payload_address[31 : 5],_zz_dBus_cmd_ready},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
-  assign dBusWishbone_CTI = (_zz_dBus_cmd_ready_5 ? (_zz_dBus_cmd_ready_4 ? 3'b111 : 3'b010) : 3'b000);
+  assign _zz_dBusWishbone_ADR_1 = (dBus_cmd_payload_size == 3'b101);
+  assign _zz_dBusWishbone_CYC = dBus_cmd_valid;
+  assign _zz_dBus_cmd_ready_1 = dBus_cmd_payload_wr;
+  assign _zz_dBus_cmd_ready_2 = ((! _zz_dBusWishbone_ADR_1) || (_zz_dBusWishbone_ADR == 3'b111));
+  assign dBus_cmd_ready = (_zz_dBus_cmd_ready && (_zz_dBus_cmd_ready_1 || _zz_dBus_cmd_ready_2));
+  assign dBusWishbone_ADR = ((_zz_dBusWishbone_ADR_1 ? {{dBus_cmd_payload_address[31 : 5],_zz_dBusWishbone_ADR},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2'd2);
+  assign dBusWishbone_CTI = (_zz_dBusWishbone_ADR_1 ? (_zz_dBus_cmd_ready_2 ? 3'b111 : 3'b010) : 3'b000);
   assign dBusWishbone_BTE = 2'b00;
-  assign dBusWishbone_SEL = (_zz_dBus_cmd_ready_3 ? dBus_cmd_payload_mask : 4'b1111);
-  assign dBusWishbone_WE = _zz_dBus_cmd_ready_3;
+  assign dBusWishbone_SEL = (_zz_dBus_cmd_ready_1 ? dBus_cmd_payload_mask : 4'b1111);
+  assign dBusWishbone_WE = _zz_dBus_cmd_ready_1;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_payload_data;
-  assign _zz_dBus_cmd_ready_2 = (_zz_dBus_cmd_ready_1 && dBusWishbone_ACK);
-  assign dBusWishbone_CYC = _zz_dBus_cmd_ready_1;
-  assign dBusWishbone_STB = _zz_dBus_cmd_ready_1;
+  assign _zz_dBus_cmd_ready = (_zz_dBusWishbone_CYC && dBusWishbone_ACK);
+  assign dBusWishbone_CYC = _zz_dBusWishbone_CYC;
+  assign dBusWishbone_STB = _zz_dBusWishbone_CYC;
   assign dBus_rsp_valid = _zz_dBus_rsp_valid;
   assign dBus_rsp_payload_data = dBusWishbone_DAT_MISO_regNext;
   assign dBus_rsp_payload_error = 1'b0;
@@ -7165,51 +8309,62 @@ module VexRiscv (
       IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
-      _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+      _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= 1'b0;
       _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= 32'h0;
-      dataCache_1_io_mem_cmd_rValid <= 1'b0;
-      dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= 32'h0;
-      PmpPlugin_pmpcfg_0 <= 8'h0;
-      PmpPlugin_pmpcfg_1 <= 8'h0;
-      PmpPlugin_pmpcfg_2 <= 8'h0;
-      PmpPlugin_pmpcfg_3 <= 8'h0;
-      PmpPlugin_pmpcfg_4 <= 8'h0;
-      PmpPlugin_pmpcfg_5 <= 8'h0;
-      PmpPlugin_pmpcfg_6 <= 8'h0;
-      PmpPlugin_pmpcfg_7 <= 8'h0;
-      PmpPlugin_pmpcfg_8 <= 8'h0;
-      PmpPlugin_pmpcfg_9 <= 8'h0;
-      PmpPlugin_pmpcfg_10 <= 8'h0;
-      PmpPlugin_pmpcfg_11 <= 8'h0;
-      PmpPlugin_pmpcfg_12 <= 8'h0;
-      PmpPlugin_pmpcfg_13 <= 8'h0;
-      PmpPlugin_pmpcfg_14 <= 8'h0;
-      PmpPlugin_pmpcfg_15 <= 8'h0;
-      execute_PmpPlugin_fsmPending <= 1'b0;
-      execute_PmpPlugin_pmpcfgCsr_ <= 1'b0;
-      execute_PmpPlugin_pmpaddrCsr_ <= 1'b0;
-      execute_PmpPlugin_fsm_fsmEnable <= 1'b0;
-      execute_PmpPlugin_fsm_fsmCounter <= 4'b0000;
+      IBusCachedPlugin_rspCounter <= 32'h00000000;
+      toplevel_dataCache_1_io_mem_cmd_rValidN <= 1'b1;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
+      DBusCachedPlugin_rspCounter <= 32'h00000000;
+      _zz_when_PmpPlugin_l126 <= 1'b0;
+      _zz_CsrPlugin_csrMapping_readDataInit <= 2'b00;
+      _zz_when_PmpPlugin_l126_2 <= 1'b0;
+      _zz_CsrPlugin_csrMapping_readDataInit_4 <= 2'b00;
+      _zz_when_PmpPlugin_l126_4 <= 1'b0;
+      _zz_CsrPlugin_csrMapping_readDataInit_8 <= 2'b00;
+      _zz_when_PmpPlugin_l126_6 <= 1'b0;
+      _zz_CsrPlugin_csrMapping_readDataInit_12 <= 2'b00;
+      _zz_when_PmpPlugin_l126_8 <= 1'b0;
+      _zz_CsrPlugin_csrMapping_readDataInit_16 <= 2'b00;
+      _zz_when_PmpPlugin_l126_10 <= 1'b0;
+      _zz_CsrPlugin_csrMapping_readDataInit_20 <= 2'b00;
+      _zz_when_PmpPlugin_l126_12 <= 1'b0;
+      _zz_CsrPlugin_csrMapping_readDataInit_24 <= 2'b00;
+      _zz_when_PmpPlugin_l126_14 <= 1'b0;
+      _zz_CsrPlugin_csrMapping_readDataInit_28 <= 2'b00;
+      _zz_when_PmpPlugin_l126_16 <= 1'b0;
+      _zz_CsrPlugin_csrMapping_readDataInit_32 <= 2'b00;
+      _zz_when_PmpPlugin_l126_18 <= 1'b0;
+      _zz_CsrPlugin_csrMapping_readDataInit_36 <= 2'b00;
+      _zz_when_PmpPlugin_l126_20 <= 1'b0;
+      _zz_CsrPlugin_csrMapping_readDataInit_40 <= 2'b00;
+      _zz_when_PmpPlugin_l126_22 <= 1'b0;
+      _zz_CsrPlugin_csrMapping_readDataInit_44 <= 2'b00;
+      _zz_when_PmpPlugin_l126_24 <= 1'b0;
+      _zz_CsrPlugin_csrMapping_readDataInit_48 <= 2'b00;
+      _zz_when_PmpPlugin_l126_26 <= 1'b0;
+      _zz_CsrPlugin_csrMapping_readDataInit_52 <= 2'b00;
+      _zz_when_PmpPlugin_l126_28 <= 1'b0;
+      _zz_CsrPlugin_csrMapping_readDataInit_56 <= 2'b00;
+      _zz_when_PmpPlugin_l126_30 <= 1'b0;
+      _zz_CsrPlugin_csrMapping_readDataInit_60 <= 2'b00;
       _zz_10 <= 1'b1;
       HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
       _zz_CsrPlugin_privilege <= 2'b11;
-      CsrPlugin_misa_base <= 2'b01;
-      CsrPlugin_misa_extensions <= 26'h0101064;
       CsrPlugin_mstatus_MIE <= 1'b0;
       CsrPlugin_mstatus_MPIE <= 1'b0;
       CsrPlugin_mstatus_MPP <= 2'b11;
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
-      CsrPlugin_mcycle <= 64'h0;
-      CsrPlugin_minstret <= 64'h0;
+      CsrPlugin_mcycle <= 64'h0000000000000000;
+      CsrPlugin_minstret <= 64'h0000000000000000;
+      CsrPlugin_mcounteren_IR <= 1'b1;
+      CsrPlugin_mcounteren_CY <= 1'b1;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= 1'b0;
@@ -7221,15 +8376,14 @@ module VexRiscv (
       CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
-      memory_DivPlugin_div_counter_value <= 6'h0;
-      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h0;
+      memory_DivPlugin_div_counter_value <= 6'h00;
+      _zz_CsrPlugin_csrMapping_readDataInit_64 <= 32'h00000000;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
-      execute_PmpPlugin_fsm_stateReg <= execute_PmpPlugin_fsm_enumDef_BOOT;
       _zz_iBusWishbone_ADR <= 3'b000;
       _zz_iBus_rsp_valid <= 1'b0;
-      _zz_dBus_cmd_ready <= 3'b000;
+      _zz_dBusWishbone_ADR <= 3'b000;
       _zz_dBus_rsp_valid <= 1'b0;
     end else begin
       if(IBusCachedPlugin_fetchPc_correction) begin
@@ -7239,23 +8393,23 @@ module VexRiscv (
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusCachedPlugin_fetchPc_booted <= 1'b1;
-      if(when_Fetcher_l134) begin
+      if(when_Fetcher_l133) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_output_fire_1) begin
+      if(IBusCachedPlugin_fetchPc_output_fire) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b1;
       end
-      if(when_Fetcher_l134_1) begin
+      if(when_Fetcher_l133_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(when_Fetcher_l161) begin
+      if(when_Fetcher_l160) begin
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
       if(IBusCachedPlugin_iBusRsp_flush) begin
-        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= 1'b0;
       end
       if(_zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready) begin
-        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
       if(IBusCachedPlugin_iBusRsp_flush) begin
         _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
@@ -7266,13 +8420,13 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if(when_Fetcher_l332) begin
+      if(when_Fetcher_l331) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(when_Fetcher_l332_1) begin
+      if(when_Fetcher_l331_1) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= IBusCachedPlugin_injector_nextPcCalc_valids_0;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -7281,7 +8435,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(when_Fetcher_l332_2) begin
+      if(when_Fetcher_l331_2) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= IBusCachedPlugin_injector_nextPcCalc_valids_1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -7290,7 +8444,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(when_Fetcher_l332_3) begin
+      if(when_Fetcher_l331_3) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -7299,7 +8453,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if(when_Fetcher_l332_4) begin
+      if(when_Fetcher_l331_4) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= IBusCachedPlugin_injector_nextPcCalc_valids_3;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -7309,19 +8463,80 @@ module VexRiscv (
         IBusCachedPlugin_rspCounter <= (IBusCachedPlugin_rspCounter + 32'h00000001);
       end
       if(dataCache_1_io_mem_cmd_valid) begin
-        dataCache_1_io_mem_cmd_rValid <= 1'b1;
+        toplevel_dataCache_1_io_mem_cmd_rValidN <= 1'b0;
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
-        dataCache_1_io_mem_cmd_rValid <= 1'b0;
+      if(toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+        toplevel_dataCache_1_io_mem_cmd_rValidN <= 1'b1;
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
-        dataCache_1_io_mem_cmd_s2mPipe_rValid <= dataCache_1_io_mem_cmd_s2mPipe_valid;
+      if(toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+        toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_valid;
       end
       if(dBus_rsp_valid) begin
         DBusCachedPlugin_rspCounter <= (DBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      if(when_PmpPlugin_l138) begin
-        execute_PmpPlugin_fsmPending <= 1'b0;
+      if(when_PmpPlugin_l126) begin
+        _zz_when_PmpPlugin_l126 <= _zz_when_PmpPlugin_l126_1;
+        _zz_CsrPlugin_csrMapping_readDataInit <= _zz_CsrPlugin_csrMapping_readDataInit_2;
+      end
+      if(when_PmpPlugin_l126_1) begin
+        _zz_when_PmpPlugin_l126_2 <= _zz_when_PmpPlugin_l126_3;
+        _zz_CsrPlugin_csrMapping_readDataInit_4 <= _zz_CsrPlugin_csrMapping_readDataInit_6;
+      end
+      if(when_PmpPlugin_l126_2) begin
+        _zz_when_PmpPlugin_l126_4 <= _zz_when_PmpPlugin_l126_5;
+        _zz_CsrPlugin_csrMapping_readDataInit_8 <= _zz_CsrPlugin_csrMapping_readDataInit_10;
+      end
+      if(when_PmpPlugin_l126_3) begin
+        _zz_when_PmpPlugin_l126_6 <= _zz_when_PmpPlugin_l126_7;
+        _zz_CsrPlugin_csrMapping_readDataInit_12 <= _zz_CsrPlugin_csrMapping_readDataInit_14;
+      end
+      if(when_PmpPlugin_l126_4) begin
+        _zz_when_PmpPlugin_l126_8 <= _zz_when_PmpPlugin_l126_9;
+        _zz_CsrPlugin_csrMapping_readDataInit_16 <= _zz_CsrPlugin_csrMapping_readDataInit_18;
+      end
+      if(when_PmpPlugin_l126_5) begin
+        _zz_when_PmpPlugin_l126_10 <= _zz_when_PmpPlugin_l126_11;
+        _zz_CsrPlugin_csrMapping_readDataInit_20 <= _zz_CsrPlugin_csrMapping_readDataInit_22;
+      end
+      if(when_PmpPlugin_l126_6) begin
+        _zz_when_PmpPlugin_l126_12 <= _zz_when_PmpPlugin_l126_13;
+        _zz_CsrPlugin_csrMapping_readDataInit_24 <= _zz_CsrPlugin_csrMapping_readDataInit_26;
+      end
+      if(when_PmpPlugin_l126_7) begin
+        _zz_when_PmpPlugin_l126_14 <= _zz_when_PmpPlugin_l126_15;
+        _zz_CsrPlugin_csrMapping_readDataInit_28 <= _zz_CsrPlugin_csrMapping_readDataInit_30;
+      end
+      if(when_PmpPlugin_l126_8) begin
+        _zz_when_PmpPlugin_l126_16 <= _zz_when_PmpPlugin_l126_17;
+        _zz_CsrPlugin_csrMapping_readDataInit_32 <= _zz_CsrPlugin_csrMapping_readDataInit_34;
+      end
+      if(when_PmpPlugin_l126_9) begin
+        _zz_when_PmpPlugin_l126_18 <= _zz_when_PmpPlugin_l126_19;
+        _zz_CsrPlugin_csrMapping_readDataInit_36 <= _zz_CsrPlugin_csrMapping_readDataInit_38;
+      end
+      if(when_PmpPlugin_l126_10) begin
+        _zz_when_PmpPlugin_l126_20 <= _zz_when_PmpPlugin_l126_21;
+        _zz_CsrPlugin_csrMapping_readDataInit_40 <= _zz_CsrPlugin_csrMapping_readDataInit_42;
+      end
+      if(when_PmpPlugin_l126_11) begin
+        _zz_when_PmpPlugin_l126_22 <= _zz_when_PmpPlugin_l126_23;
+        _zz_CsrPlugin_csrMapping_readDataInit_44 <= _zz_CsrPlugin_csrMapping_readDataInit_46;
+      end
+      if(when_PmpPlugin_l126_12) begin
+        _zz_when_PmpPlugin_l126_24 <= _zz_when_PmpPlugin_l126_25;
+        _zz_CsrPlugin_csrMapping_readDataInit_48 <= _zz_CsrPlugin_csrMapping_readDataInit_50;
+      end
+      if(when_PmpPlugin_l126_13) begin
+        _zz_when_PmpPlugin_l126_26 <= _zz_when_PmpPlugin_l126_27;
+        _zz_CsrPlugin_csrMapping_readDataInit_52 <= _zz_CsrPlugin_csrMapping_readDataInit_54;
+      end
+      if(when_PmpPlugin_l126_14) begin
+        _zz_when_PmpPlugin_l126_28 <= _zz_when_PmpPlugin_l126_29;
+        _zz_CsrPlugin_csrMapping_readDataInit_56 <= _zz_CsrPlugin_csrMapping_readDataInit_58;
+      end
+      if(when_PmpPlugin_l126_15) begin
+        _zz_when_PmpPlugin_l126_30 <= _zz_when_PmpPlugin_l126_31;
+        _zz_CsrPlugin_csrMapping_readDataInit_60 <= _zz_CsrPlugin_csrMapping_readDataInit_62;
       end
       _zz_10 <= 1'b0;
       HazardSimplePlugin_writeBackBuffer_valid <= HazardSimplePlugin_writeBackWrites_valid;
@@ -7329,51 +8544,51 @@ module VexRiscv (
       if(writeBack_arbitration_isFiring) begin
         CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
       end
-      if(when_CsrPlugin_l922) begin
+      if(when_CsrPlugin_l1259) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if(when_CsrPlugin_l922_1) begin
+      if(when_CsrPlugin_l1259_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if(when_CsrPlugin_l922_2) begin
+      if(when_CsrPlugin_l1259_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if(when_CsrPlugin_l922_3) begin
+      if(when_CsrPlugin_l1259_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(when_CsrPlugin_l959) begin
-        if(when_CsrPlugin_l965) begin
+      if(when_CsrPlugin_l1296) begin
+        if(when_CsrPlugin_l1302) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_1) begin
+        if(when_CsrPlugin_l1302_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_2) begin
+        if(when_CsrPlugin_l1302_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
       CsrPlugin_lastStageWasWfi <= (writeBack_arbitration_isFiring && (writeBack_ENV_CTRL == EnvCtrlEnum_WFI));
       if(CsrPlugin_pipelineLiberator_active) begin
-        if(when_CsrPlugin_l993) begin
+        if(when_CsrPlugin_l1335) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if(when_CsrPlugin_l993_1) begin
+        if(when_CsrPlugin_l1335_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if(when_CsrPlugin_l993_2) begin
+        if(when_CsrPlugin_l1335_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(when_CsrPlugin_l998) begin
+      if(when_CsrPlugin_l1340) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
@@ -7382,20 +8597,22 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(when_CsrPlugin_l1032) begin
-        _zz_CsrPlugin_privilege <= CsrPlugin_targetPrivilege;
-        case(CsrPlugin_targetPrivilege)
-          2'b11 : begin
-            CsrPlugin_mstatus_MIE <= 1'b0;
-            CsrPlugin_mstatus_MPIE <= CsrPlugin_mstatus_MIE;
-            CsrPlugin_mstatus_MPP <= CsrPlugin_privilege;
-          end
-          default : begin
-          end
-        endcase
+      if(when_CsrPlugin_l1390) begin
+        if(when_CsrPlugin_l1398) begin
+          _zz_CsrPlugin_privilege <= CsrPlugin_targetPrivilege;
+          case(CsrPlugin_targetPrivilege)
+            2'b11 : begin
+              CsrPlugin_mstatus_MIE <= 1'b0;
+              CsrPlugin_mstatus_MPIE <= CsrPlugin_mstatus_MIE;
+              CsrPlugin_mstatus_MPP <= CsrPlugin_privilege;
+            end
+            default : begin
+            end
+          endcase
+        end
       end
-      if(when_CsrPlugin_l1077) begin
-        case(switch_CsrPlugin_l1081)
+      if(when_CsrPlugin_l1456) begin
+        case(switch_CsrPlugin_l1460)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -7406,7 +8623,7 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l965_2,{_zz_when_CsrPlugin_l965_1,_zz_when_CsrPlugin_l965}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l1302_2,{_zz_when_CsrPlugin_l1302_1,_zz_when_CsrPlugin_l1302}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
       if(when_Pipeline_l151) begin
         execute_arbitration_isValid <= 1'b0;
@@ -7426,247 +8643,11 @@ module VexRiscv (
       if(when_Pipeline_l154_2) begin
         writeBack_arbitration_isValid <= memory_arbitration_isValid;
       end
-      execute_PmpPlugin_fsm_stateReg <= execute_PmpPlugin_fsm_stateNext;
-      case(execute_PmpPlugin_fsm_stateReg)
-        execute_PmpPlugin_fsm_enumDef_stateIdle : begin
-        end
-        execute_PmpPlugin_fsm_enumDef_stateWrite : begin
-          if(execute_PmpPlugin_pmpcfgCsr_) begin
-            if(when_PmpPlugin_l209) begin
-              if(_zz_11[0]) begin
-                PmpPlugin_pmpcfg_0 <= _zz_PmpPlugin_pmpcfg_0;
-              end
-              if(_zz_11[1]) begin
-                PmpPlugin_pmpcfg_1 <= _zz_PmpPlugin_pmpcfg_0;
-              end
-              if(_zz_11[2]) begin
-                PmpPlugin_pmpcfg_2 <= _zz_PmpPlugin_pmpcfg_0;
-              end
-              if(_zz_11[3]) begin
-                PmpPlugin_pmpcfg_3 <= _zz_PmpPlugin_pmpcfg_0;
-              end
-              if(_zz_11[4]) begin
-                PmpPlugin_pmpcfg_4 <= _zz_PmpPlugin_pmpcfg_0;
-              end
-              if(_zz_11[5]) begin
-                PmpPlugin_pmpcfg_5 <= _zz_PmpPlugin_pmpcfg_0;
-              end
-              if(_zz_11[6]) begin
-                PmpPlugin_pmpcfg_6 <= _zz_PmpPlugin_pmpcfg_0;
-              end
-              if(_zz_11[7]) begin
-                PmpPlugin_pmpcfg_7 <= _zz_PmpPlugin_pmpcfg_0;
-              end
-              if(_zz_11[8]) begin
-                PmpPlugin_pmpcfg_8 <= _zz_PmpPlugin_pmpcfg_0;
-              end
-              if(_zz_11[9]) begin
-                PmpPlugin_pmpcfg_9 <= _zz_PmpPlugin_pmpcfg_0;
-              end
-              if(_zz_11[10]) begin
-                PmpPlugin_pmpcfg_10 <= _zz_PmpPlugin_pmpcfg_0;
-              end
-              if(_zz_11[11]) begin
-                PmpPlugin_pmpcfg_11 <= _zz_PmpPlugin_pmpcfg_0;
-              end
-              if(_zz_11[12]) begin
-                PmpPlugin_pmpcfg_12 <= _zz_PmpPlugin_pmpcfg_0;
-              end
-              if(_zz_11[13]) begin
-                PmpPlugin_pmpcfg_13 <= _zz_PmpPlugin_pmpcfg_0;
-              end
-              if(_zz_11[14]) begin
-                PmpPlugin_pmpcfg_14 <= _zz_PmpPlugin_pmpcfg_0;
-              end
-              if(_zz_11[15]) begin
-                PmpPlugin_pmpcfg_15 <= _zz_PmpPlugin_pmpcfg_0;
-              end
-            end
-            if(when_PmpPlugin_l209_1) begin
-              if(_zz_12[0]) begin
-                PmpPlugin_pmpcfg_0 <= _zz_PmpPlugin_pmpcfg_0_1;
-              end
-              if(_zz_12[1]) begin
-                PmpPlugin_pmpcfg_1 <= _zz_PmpPlugin_pmpcfg_0_1;
-              end
-              if(_zz_12[2]) begin
-                PmpPlugin_pmpcfg_2 <= _zz_PmpPlugin_pmpcfg_0_1;
-              end
-              if(_zz_12[3]) begin
-                PmpPlugin_pmpcfg_3 <= _zz_PmpPlugin_pmpcfg_0_1;
-              end
-              if(_zz_12[4]) begin
-                PmpPlugin_pmpcfg_4 <= _zz_PmpPlugin_pmpcfg_0_1;
-              end
-              if(_zz_12[5]) begin
-                PmpPlugin_pmpcfg_5 <= _zz_PmpPlugin_pmpcfg_0_1;
-              end
-              if(_zz_12[6]) begin
-                PmpPlugin_pmpcfg_6 <= _zz_PmpPlugin_pmpcfg_0_1;
-              end
-              if(_zz_12[7]) begin
-                PmpPlugin_pmpcfg_7 <= _zz_PmpPlugin_pmpcfg_0_1;
-              end
-              if(_zz_12[8]) begin
-                PmpPlugin_pmpcfg_8 <= _zz_PmpPlugin_pmpcfg_0_1;
-              end
-              if(_zz_12[9]) begin
-                PmpPlugin_pmpcfg_9 <= _zz_PmpPlugin_pmpcfg_0_1;
-              end
-              if(_zz_12[10]) begin
-                PmpPlugin_pmpcfg_10 <= _zz_PmpPlugin_pmpcfg_0_1;
-              end
-              if(_zz_12[11]) begin
-                PmpPlugin_pmpcfg_11 <= _zz_PmpPlugin_pmpcfg_0_1;
-              end
-              if(_zz_12[12]) begin
-                PmpPlugin_pmpcfg_12 <= _zz_PmpPlugin_pmpcfg_0_1;
-              end
-              if(_zz_12[13]) begin
-                PmpPlugin_pmpcfg_13 <= _zz_PmpPlugin_pmpcfg_0_1;
-              end
-              if(_zz_12[14]) begin
-                PmpPlugin_pmpcfg_14 <= _zz_PmpPlugin_pmpcfg_0_1;
-              end
-              if(_zz_12[15]) begin
-                PmpPlugin_pmpcfg_15 <= _zz_PmpPlugin_pmpcfg_0_1;
-              end
-            end
-            if(when_PmpPlugin_l209_2) begin
-              if(_zz_13[0]) begin
-                PmpPlugin_pmpcfg_0 <= _zz_PmpPlugin_pmpcfg_0_2;
-              end
-              if(_zz_13[1]) begin
-                PmpPlugin_pmpcfg_1 <= _zz_PmpPlugin_pmpcfg_0_2;
-              end
-              if(_zz_13[2]) begin
-                PmpPlugin_pmpcfg_2 <= _zz_PmpPlugin_pmpcfg_0_2;
-              end
-              if(_zz_13[3]) begin
-                PmpPlugin_pmpcfg_3 <= _zz_PmpPlugin_pmpcfg_0_2;
-              end
-              if(_zz_13[4]) begin
-                PmpPlugin_pmpcfg_4 <= _zz_PmpPlugin_pmpcfg_0_2;
-              end
-              if(_zz_13[5]) begin
-                PmpPlugin_pmpcfg_5 <= _zz_PmpPlugin_pmpcfg_0_2;
-              end
-              if(_zz_13[6]) begin
-                PmpPlugin_pmpcfg_6 <= _zz_PmpPlugin_pmpcfg_0_2;
-              end
-              if(_zz_13[7]) begin
-                PmpPlugin_pmpcfg_7 <= _zz_PmpPlugin_pmpcfg_0_2;
-              end
-              if(_zz_13[8]) begin
-                PmpPlugin_pmpcfg_8 <= _zz_PmpPlugin_pmpcfg_0_2;
-              end
-              if(_zz_13[9]) begin
-                PmpPlugin_pmpcfg_9 <= _zz_PmpPlugin_pmpcfg_0_2;
-              end
-              if(_zz_13[10]) begin
-                PmpPlugin_pmpcfg_10 <= _zz_PmpPlugin_pmpcfg_0_2;
-              end
-              if(_zz_13[11]) begin
-                PmpPlugin_pmpcfg_11 <= _zz_PmpPlugin_pmpcfg_0_2;
-              end
-              if(_zz_13[12]) begin
-                PmpPlugin_pmpcfg_12 <= _zz_PmpPlugin_pmpcfg_0_2;
-              end
-              if(_zz_13[13]) begin
-                PmpPlugin_pmpcfg_13 <= _zz_PmpPlugin_pmpcfg_0_2;
-              end
-              if(_zz_13[14]) begin
-                PmpPlugin_pmpcfg_14 <= _zz_PmpPlugin_pmpcfg_0_2;
-              end
-              if(_zz_13[15]) begin
-                PmpPlugin_pmpcfg_15 <= _zz_PmpPlugin_pmpcfg_0_2;
-              end
-            end
-            if(when_PmpPlugin_l209_3) begin
-              if(_zz_14[0]) begin
-                PmpPlugin_pmpcfg_0 <= _zz_PmpPlugin_pmpcfg_0_3;
-              end
-              if(_zz_14[1]) begin
-                PmpPlugin_pmpcfg_1 <= _zz_PmpPlugin_pmpcfg_0_3;
-              end
-              if(_zz_14[2]) begin
-                PmpPlugin_pmpcfg_2 <= _zz_PmpPlugin_pmpcfg_0_3;
-              end
-              if(_zz_14[3]) begin
-                PmpPlugin_pmpcfg_3 <= _zz_PmpPlugin_pmpcfg_0_3;
-              end
-              if(_zz_14[4]) begin
-                PmpPlugin_pmpcfg_4 <= _zz_PmpPlugin_pmpcfg_0_3;
-              end
-              if(_zz_14[5]) begin
-                PmpPlugin_pmpcfg_5 <= _zz_PmpPlugin_pmpcfg_0_3;
-              end
-              if(_zz_14[6]) begin
-                PmpPlugin_pmpcfg_6 <= _zz_PmpPlugin_pmpcfg_0_3;
-              end
-              if(_zz_14[7]) begin
-                PmpPlugin_pmpcfg_7 <= _zz_PmpPlugin_pmpcfg_0_3;
-              end
-              if(_zz_14[8]) begin
-                PmpPlugin_pmpcfg_8 <= _zz_PmpPlugin_pmpcfg_0_3;
-              end
-              if(_zz_14[9]) begin
-                PmpPlugin_pmpcfg_9 <= _zz_PmpPlugin_pmpcfg_0_3;
-              end
-              if(_zz_14[10]) begin
-                PmpPlugin_pmpcfg_10 <= _zz_PmpPlugin_pmpcfg_0_3;
-              end
-              if(_zz_14[11]) begin
-                PmpPlugin_pmpcfg_11 <= _zz_PmpPlugin_pmpcfg_0_3;
-              end
-              if(_zz_14[12]) begin
-                PmpPlugin_pmpcfg_12 <= _zz_PmpPlugin_pmpcfg_0_3;
-              end
-              if(_zz_14[13]) begin
-                PmpPlugin_pmpcfg_13 <= _zz_PmpPlugin_pmpcfg_0_3;
-              end
-              if(_zz_14[14]) begin
-                PmpPlugin_pmpcfg_14 <= _zz_PmpPlugin_pmpcfg_0_3;
-              end
-              if(_zz_14[15]) begin
-                PmpPlugin_pmpcfg_15 <= _zz_PmpPlugin_pmpcfg_0_3;
-              end
-            end
-          end
-        end
-        execute_PmpPlugin_fsm_enumDef_stateCfg : begin
-          execute_PmpPlugin_fsm_fsmCounter <= (execute_PmpPlugin_fsm_fsmCounter + 4'b0001);
-        end
-        execute_PmpPlugin_fsm_enumDef_stateAddr : begin
-        end
-        default : begin
-        end
-      endcase
-      if(when_StateMachine_l233) begin
-        execute_PmpPlugin_fsm_fsmEnable <= 1'b1;
-      end
-      if(when_StateMachine_l249) begin
-        execute_PmpPlugin_fsmPending <= 1'b0;
-        execute_PmpPlugin_fsm_fsmEnable <= 1'b0;
-        execute_PmpPlugin_fsm_fsmCounter <= 4'b0000;
-      end
-      if(when_StateMachine_l249_1) begin
-        execute_PmpPlugin_fsm_fsmCounter <= {execute_PmpPlugin_pmpcfgN_,2'b00};
-      end
-      if(when_StateMachine_l249_2) begin
-        execute_PmpPlugin_fsm_fsmCounter <= execute_PmpPlugin_pmpNcfg_;
-      end
-      if(execute_CsrPlugin_csr_769) begin
-        if(execute_CsrPlugin_writeEnable) begin
-          CsrPlugin_misa_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 30];
-          CsrPlugin_misa_extensions <= CsrPlugin_csrMapping_writeDataSignal[25 : 0];
-        end
-      end
       if(execute_CsrPlugin_csr_768) begin
         if(execute_CsrPlugin_writeEnable) begin
           CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
           CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
-          case(switch_CsrPlugin_l723)
+          case(switch_CsrPlugin_l1031)
             2'b11 : begin
               CsrPlugin_mstatus_MPP <= 2'b11;
             end
@@ -7705,18 +8686,15 @@ module VexRiscv (
           CsrPlugin_minstret[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
         end
       end
-      if(execute_CsrPlugin_csr_3008) begin
+      if(execute_CsrPlugin_csr_774) begin
         if(execute_CsrPlugin_writeEnable) begin
-          _zz_CsrPlugin_csrMapping_readDataInit <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+          CsrPlugin_mcounteren_CY <= CsrPlugin_csrMapping_writeDataSignal[0];
+          CsrPlugin_mcounteren_IR <= CsrPlugin_csrMapping_writeDataSignal[2];
         end
       end
-      if(execute_CsrPlugin_writeInstruction) begin
-        if(when_PmpPlugin_l172) begin
-          if(when_PmpPlugin_l175) begin
-            execute_PmpPlugin_fsmPending <= 1'b1;
-            execute_PmpPlugin_pmpcfgCsr_ <= execute_PmpPlugin_pmpcfgCsr;
-            execute_PmpPlugin_pmpaddrCsr_ <= execute_PmpPlugin_pmpaddrCsr;
-          end
+      if(execute_CsrPlugin_csr_3008) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          _zz_CsrPlugin_csrMapping_readDataInit_64 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
         end
       end
       if(when_InstructionCache_l239) begin
@@ -7725,13 +8703,13 @@ module VexRiscv (
         end
       end
       _zz_iBus_rsp_valid <= (iBusWishbone_CYC && iBusWishbone_ACK);
-      if((_zz_dBus_cmd_ready_1 && _zz_dBus_cmd_ready_2)) begin
-        _zz_dBus_cmd_ready <= (_zz_dBus_cmd_ready + 3'b001);
-        if(_zz_dBus_cmd_ready_4) begin
-          _zz_dBus_cmd_ready <= 3'b000;
+      if((_zz_dBusWishbone_CYC && _zz_dBus_cmd_ready)) begin
+        _zz_dBusWishbone_ADR <= (_zz_dBusWishbone_ADR + 3'b001);
+        if(_zz_dBus_cmd_ready_2) begin
+          _zz_dBusWishbone_ADR <= 3'b000;
         end
       end
-      _zz_dBus_rsp_valid <= ((_zz_dBus_cmd_ready_1 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
+      _zz_dBus_rsp_valid <= ((_zz_dBusWishbone_CYC && (! dBusWishbone_WE)) && dBusWishbone_ACK);
     end
   end
 
@@ -7745,121 +8723,119 @@ module VexRiscv (
     if(IBusCachedPlugin_iBusRsp_stages_2_input_ready) begin
       IBusCachedPlugin_s2_tightlyCoupledHit <= IBusCachedPlugin_s1_tightlyCoupledHit;
     end
-    if(dataCache_1_io_mem_cmd_ready) begin
-      dataCache_1_io_mem_cmd_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
-      dataCache_1_io_mem_cmd_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
-      dataCache_1_io_mem_cmd_rData_address <= dataCache_1_io_mem_cmd_payload_address;
-      dataCache_1_io_mem_cmd_rData_data <= dataCache_1_io_mem_cmd_payload_data;
-      dataCache_1_io_mem_cmd_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
-      dataCache_1_io_mem_cmd_rData_size <= dataCache_1_io_mem_cmd_payload_size;
-      dataCache_1_io_mem_cmd_rData_last <= dataCache_1_io_mem_cmd_payload_last;
+    if(toplevel_dataCache_1_io_mem_cmd_rValidN) begin
+      toplevel_dataCache_1_io_mem_cmd_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
+      toplevel_dataCache_1_io_mem_cmd_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
+      toplevel_dataCache_1_io_mem_cmd_rData_address <= dataCache_1_io_mem_cmd_payload_address;
+      toplevel_dataCache_1_io_mem_cmd_rData_data <= dataCache_1_io_mem_cmd_payload_data;
+      toplevel_dataCache_1_io_mem_cmd_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
+      toplevel_dataCache_1_io_mem_cmd_rData_size <= dataCache_1_io_mem_cmd_payload_size;
+      toplevel_dataCache_1_io_mem_cmd_rData_last <= dataCache_1_io_mem_cmd_payload_last;
     end
-    if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
-      dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_address <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_data <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_size <= dataCache_1_io_mem_cmd_s2mPipe_payload_size;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_last <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+    if(toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_address <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_data <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_size <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_size;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_last <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_last;
     end
-    if(when_PmpPlugin_l246) begin
-      if(_zz_8[0]) begin
-        PmpPlugin_base_0 <= PmpPlugin_setter_io_base;
-      end
-      if(_zz_8[1]) begin
-        PmpPlugin_base_1 <= PmpPlugin_setter_io_base;
-      end
-      if(_zz_8[2]) begin
-        PmpPlugin_base_2 <= PmpPlugin_setter_io_base;
-      end
-      if(_zz_8[3]) begin
-        PmpPlugin_base_3 <= PmpPlugin_setter_io_base;
-      end
-      if(_zz_8[4]) begin
-        PmpPlugin_base_4 <= PmpPlugin_setter_io_base;
-      end
-      if(_zz_8[5]) begin
-        PmpPlugin_base_5 <= PmpPlugin_setter_io_base;
-      end
-      if(_zz_8[6]) begin
-        PmpPlugin_base_6 <= PmpPlugin_setter_io_base;
-      end
-      if(_zz_8[7]) begin
-        PmpPlugin_base_7 <= PmpPlugin_setter_io_base;
-      end
-      if(_zz_8[8]) begin
-        PmpPlugin_base_8 <= PmpPlugin_setter_io_base;
-      end
-      if(_zz_8[9]) begin
-        PmpPlugin_base_9 <= PmpPlugin_setter_io_base;
-      end
-      if(_zz_8[10]) begin
-        PmpPlugin_base_10 <= PmpPlugin_setter_io_base;
-      end
-      if(_zz_8[11]) begin
-        PmpPlugin_base_11 <= PmpPlugin_setter_io_base;
-      end
-      if(_zz_8[12]) begin
-        PmpPlugin_base_12 <= PmpPlugin_setter_io_base;
-      end
-      if(_zz_8[13]) begin
-        PmpPlugin_base_13 <= PmpPlugin_setter_io_base;
-      end
-      if(_zz_8[14]) begin
-        PmpPlugin_base_14 <= PmpPlugin_setter_io_base;
-      end
-      if(_zz_8[15]) begin
-        PmpPlugin_base_15 <= PmpPlugin_setter_io_base;
-      end
-      if(_zz_9[0]) begin
-        PmpPlugin_mask_0 <= PmpPlugin_setter_io_mask;
-      end
-      if(_zz_9[1]) begin
-        PmpPlugin_mask_1 <= PmpPlugin_setter_io_mask;
-      end
-      if(_zz_9[2]) begin
-        PmpPlugin_mask_2 <= PmpPlugin_setter_io_mask;
-      end
-      if(_zz_9[3]) begin
-        PmpPlugin_mask_3 <= PmpPlugin_setter_io_mask;
-      end
-      if(_zz_9[4]) begin
-        PmpPlugin_mask_4 <= PmpPlugin_setter_io_mask;
-      end
-      if(_zz_9[5]) begin
-        PmpPlugin_mask_5 <= PmpPlugin_setter_io_mask;
-      end
-      if(_zz_9[6]) begin
-        PmpPlugin_mask_6 <= PmpPlugin_setter_io_mask;
-      end
-      if(_zz_9[7]) begin
-        PmpPlugin_mask_7 <= PmpPlugin_setter_io_mask;
-      end
-      if(_zz_9[8]) begin
-        PmpPlugin_mask_8 <= PmpPlugin_setter_io_mask;
-      end
-      if(_zz_9[9]) begin
-        PmpPlugin_mask_9 <= PmpPlugin_setter_io_mask;
-      end
-      if(_zz_9[10]) begin
-        PmpPlugin_mask_10 <= PmpPlugin_setter_io_mask;
-      end
-      if(_zz_9[11]) begin
-        PmpPlugin_mask_11 <= PmpPlugin_setter_io_mask;
-      end
-      if(_zz_9[12]) begin
-        PmpPlugin_mask_12 <= PmpPlugin_setter_io_mask;
-      end
-      if(_zz_9[13]) begin
-        PmpPlugin_mask_13 <= PmpPlugin_setter_io_mask;
-      end
-      if(_zz_9[14]) begin
-        PmpPlugin_mask_14 <= PmpPlugin_setter_io_mask;
-      end
-      if(_zz_9[15]) begin
-        PmpPlugin_mask_15 <= PmpPlugin_setter_io_mask;
-      end
+    if(when_PmpPlugin_l126) begin
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowRead <= _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_1;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite <= _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_1;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute <= _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1;
+      _zz_CsrPlugin_csrMapping_readDataInit_1 <= _zz_CsrPlugin_csrMapping_readDataInit_3;
+    end
+    if(when_PmpPlugin_l126_1) begin
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_2 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_3;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_2 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_3;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_2 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_3;
+      _zz_CsrPlugin_csrMapping_readDataInit_5 <= _zz_CsrPlugin_csrMapping_readDataInit_7;
+    end
+    if(when_PmpPlugin_l126_2) begin
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_4 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_5;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_4 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_5;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_4 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_5;
+      _zz_CsrPlugin_csrMapping_readDataInit_9 <= _zz_CsrPlugin_csrMapping_readDataInit_11;
+    end
+    if(when_PmpPlugin_l126_3) begin
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_6 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_7;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_6 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_7;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_6 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_7;
+      _zz_CsrPlugin_csrMapping_readDataInit_13 <= _zz_CsrPlugin_csrMapping_readDataInit_15;
+    end
+    if(when_PmpPlugin_l126_4) begin
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_8 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_9;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_8 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_9;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_8 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_9;
+      _zz_CsrPlugin_csrMapping_readDataInit_17 <= _zz_CsrPlugin_csrMapping_readDataInit_19;
+    end
+    if(when_PmpPlugin_l126_5) begin
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_10 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_11;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_10 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_11;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_10 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_11;
+      _zz_CsrPlugin_csrMapping_readDataInit_21 <= _zz_CsrPlugin_csrMapping_readDataInit_23;
+    end
+    if(when_PmpPlugin_l126_6) begin
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_12 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_13;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_12 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_13;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_12 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_13;
+      _zz_CsrPlugin_csrMapping_readDataInit_25 <= _zz_CsrPlugin_csrMapping_readDataInit_27;
+    end
+    if(when_PmpPlugin_l126_7) begin
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_14 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_15;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_14 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_15;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_14 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_15;
+      _zz_CsrPlugin_csrMapping_readDataInit_29 <= _zz_CsrPlugin_csrMapping_readDataInit_31;
+    end
+    if(when_PmpPlugin_l126_8) begin
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_16 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_17;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_16 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_17;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_16 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_17;
+      _zz_CsrPlugin_csrMapping_readDataInit_33 <= _zz_CsrPlugin_csrMapping_readDataInit_35;
+    end
+    if(when_PmpPlugin_l126_9) begin
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_18 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_19;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_18 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_19;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_18 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_19;
+      _zz_CsrPlugin_csrMapping_readDataInit_37 <= _zz_CsrPlugin_csrMapping_readDataInit_39;
+    end
+    if(when_PmpPlugin_l126_10) begin
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_20 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_21;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_20 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_21;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_20 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_21;
+      _zz_CsrPlugin_csrMapping_readDataInit_41 <= _zz_CsrPlugin_csrMapping_readDataInit_43;
+    end
+    if(when_PmpPlugin_l126_11) begin
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_22 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_23;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_22 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_23;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_22 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_23;
+      _zz_CsrPlugin_csrMapping_readDataInit_45 <= _zz_CsrPlugin_csrMapping_readDataInit_47;
+    end
+    if(when_PmpPlugin_l126_12) begin
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_24 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_25;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_24 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_25;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_24 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_25;
+      _zz_CsrPlugin_csrMapping_readDataInit_49 <= _zz_CsrPlugin_csrMapping_readDataInit_51;
+    end
+    if(when_PmpPlugin_l126_13) begin
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_26 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_27;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_26 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_27;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_26 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_27;
+      _zz_CsrPlugin_csrMapping_readDataInit_53 <= _zz_CsrPlugin_csrMapping_readDataInit_55;
+    end
+    if(when_PmpPlugin_l126_14) begin
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_28 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_29;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_28 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_29;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_28 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_29;
+      _zz_CsrPlugin_csrMapping_readDataInit_57 <= _zz_CsrPlugin_csrMapping_readDataInit_59;
+    end
+    if(when_PmpPlugin_l126_15) begin
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_30 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_31;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_30 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_31;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_30 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_31;
+      _zz_CsrPlugin_csrMapping_readDataInit_61 <= _zz_CsrPlugin_csrMapping_readDataInit_63;
     end
     HazardSimplePlugin_writeBackBuffer_payload_address <= HazardSimplePlugin_writeBackWrites_payload_address;
     HazardSimplePlugin_writeBackBuffer_payload_data <= HazardSimplePlugin_writeBackWrites_payload_data;
@@ -7882,33 +8858,35 @@ module VexRiscv (
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(when_CsrPlugin_l959) begin
-      if(when_CsrPlugin_l965) begin
+    if(when_CsrPlugin_l1296) begin
+      if(when_CsrPlugin_l1302) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l965_1) begin
+      if(when_CsrPlugin_l1302_1) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l965_2) begin
+      if(when_CsrPlugin_l1302_2) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(when_CsrPlugin_l1032) begin
-      case(CsrPlugin_targetPrivilege)
-        2'b11 : begin
-          CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
-          CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
-          CsrPlugin_mepc <= writeBack_PC;
-          if(CsrPlugin_hadException) begin
-            CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
+    if(when_CsrPlugin_l1390) begin
+      if(when_CsrPlugin_l1398) begin
+        case(CsrPlugin_targetPrivilege)
+          2'b11 : begin
+            CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
+            CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
+            CsrPlugin_mepc <= writeBack_PC;
+            if(CsrPlugin_hadException) begin
+              CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
+            end
           end
-        end
-        default : begin
-        end
-      endcase
+          default : begin
+          end
+        endcase
+      end
     end
     if(when_MulDivIterativePlugin_l126) begin
       memory_DivPlugin_div_done <= 1'b1;
@@ -7926,17 +8904,17 @@ module VexRiscv (
       end
     end
     if(when_MulDivIterativePlugin_l162) begin
-      memory_DivPlugin_accumulator <= 65'h0;
+      memory_DivPlugin_accumulator <= 65'h00000000000000000;
       memory_DivPlugin_rs1 <= ((_zz_memory_DivPlugin_rs1 ? (~ _zz_memory_DivPlugin_rs1_1) : _zz_memory_DivPlugin_rs1_1) + _zz_memory_DivPlugin_rs1_2);
       memory_DivPlugin_rs2 <= ((_zz_memory_DivPlugin_rs2 ? (~ execute_RS2) : execute_RS2) + _zz_memory_DivPlugin_rs2_1);
-      memory_DivPlugin_div_needRevert <= ((_zz_memory_DivPlugin_rs1 ^ (_zz_memory_DivPlugin_rs2 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
+      memory_DivPlugin_div_needRevert <= ((_zz_memory_DivPlugin_rs1 ^ (_zz_memory_DivPlugin_rs2 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h00000000) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
     end
     externalInterruptArray_regNext <= externalInterruptArray;
     if(when_Pipeline_l124) begin
       decode_to_execute_PC <= decode_PC;
     end
     if(when_Pipeline_l124_1) begin
-      execute_to_memory_PC <= _zz_execute_SRC2;
+      execute_to_memory_PC <= _zz_execute_to_memory_PC;
     end
     if(when_Pipeline_l124_2) begin
       memory_to_writeBack_PC <= memory_PC;
@@ -8118,76 +9096,139 @@ module VexRiscv (
     if(when_Pipeline_l124_61) begin
       memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
     end
-    if(when_CsrPlugin_l1277) begin
+    if(when_CsrPlugin_l1669) begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
     end
-    if(when_CsrPlugin_l1277_1) begin
+    if(when_CsrPlugin_l1669_1) begin
+      execute_CsrPlugin_csr_944 <= (decode_INSTRUCTION[31 : 20] == 12'h3b0);
+    end
+    if(when_CsrPlugin_l1669_2) begin
+      execute_CsrPlugin_csr_945 <= (decode_INSTRUCTION[31 : 20] == 12'h3b1);
+    end
+    if(when_CsrPlugin_l1669_3) begin
+      execute_CsrPlugin_csr_946 <= (decode_INSTRUCTION[31 : 20] == 12'h3b2);
+    end
+    if(when_CsrPlugin_l1669_4) begin
+      execute_CsrPlugin_csr_947 <= (decode_INSTRUCTION[31 : 20] == 12'h3b3);
+    end
+    if(when_CsrPlugin_l1669_5) begin
+      execute_CsrPlugin_csr_948 <= (decode_INSTRUCTION[31 : 20] == 12'h3b4);
+    end
+    if(when_CsrPlugin_l1669_6) begin
+      execute_CsrPlugin_csr_949 <= (decode_INSTRUCTION[31 : 20] == 12'h3b5);
+    end
+    if(when_CsrPlugin_l1669_7) begin
+      execute_CsrPlugin_csr_950 <= (decode_INSTRUCTION[31 : 20] == 12'h3b6);
+    end
+    if(when_CsrPlugin_l1669_8) begin
+      execute_CsrPlugin_csr_951 <= (decode_INSTRUCTION[31 : 20] == 12'h3b7);
+    end
+    if(when_CsrPlugin_l1669_9) begin
+      execute_CsrPlugin_csr_952 <= (decode_INSTRUCTION[31 : 20] == 12'h3b8);
+    end
+    if(when_CsrPlugin_l1669_10) begin
+      execute_CsrPlugin_csr_953 <= (decode_INSTRUCTION[31 : 20] == 12'h3b9);
+    end
+    if(when_CsrPlugin_l1669_11) begin
+      execute_CsrPlugin_csr_954 <= (decode_INSTRUCTION[31 : 20] == 12'h3ba);
+    end
+    if(when_CsrPlugin_l1669_12) begin
+      execute_CsrPlugin_csr_955 <= (decode_INSTRUCTION[31 : 20] == 12'h3bb);
+    end
+    if(when_CsrPlugin_l1669_13) begin
+      execute_CsrPlugin_csr_956 <= (decode_INSTRUCTION[31 : 20] == 12'h3bc);
+    end
+    if(when_CsrPlugin_l1669_14) begin
+      execute_CsrPlugin_csr_957 <= (decode_INSTRUCTION[31 : 20] == 12'h3bd);
+    end
+    if(when_CsrPlugin_l1669_15) begin
+      execute_CsrPlugin_csr_958 <= (decode_INSTRUCTION[31 : 20] == 12'h3be);
+    end
+    if(when_CsrPlugin_l1669_16) begin
+      execute_CsrPlugin_csr_959 <= (decode_INSTRUCTION[31 : 20] == 12'h3bf);
+    end
+    if(when_CsrPlugin_l1669_17) begin
+      execute_CsrPlugin_csr_928 <= (decode_INSTRUCTION[31 : 20] == 12'h3a0);
+    end
+    if(when_CsrPlugin_l1669_18) begin
+      execute_CsrPlugin_csr_929 <= (decode_INSTRUCTION[31 : 20] == 12'h3a1);
+    end
+    if(when_CsrPlugin_l1669_19) begin
+      execute_CsrPlugin_csr_930 <= (decode_INSTRUCTION[31 : 20] == 12'h3a2);
+    end
+    if(when_CsrPlugin_l1669_20) begin
+      execute_CsrPlugin_csr_931 <= (decode_INSTRUCTION[31 : 20] == 12'h3a3);
+    end
+    if(when_CsrPlugin_l1669_21) begin
       execute_CsrPlugin_csr_3857 <= (decode_INSTRUCTION[31 : 20] == 12'hf11);
     end
-    if(when_CsrPlugin_l1277_2) begin
+    if(when_CsrPlugin_l1669_22) begin
       execute_CsrPlugin_csr_3858 <= (decode_INSTRUCTION[31 : 20] == 12'hf12);
     end
-    if(when_CsrPlugin_l1277_3) begin
+    if(when_CsrPlugin_l1669_23) begin
       execute_CsrPlugin_csr_3859 <= (decode_INSTRUCTION[31 : 20] == 12'hf13);
     end
-    if(when_CsrPlugin_l1277_4) begin
+    if(when_CsrPlugin_l1669_24) begin
       execute_CsrPlugin_csr_3860 <= (decode_INSTRUCTION[31 : 20] == 12'hf14);
     end
-    if(when_CsrPlugin_l1277_5) begin
+    if(when_CsrPlugin_l1669_25) begin
       execute_CsrPlugin_csr_769 <= (decode_INSTRUCTION[31 : 20] == 12'h301);
     end
-    if(when_CsrPlugin_l1277_6) begin
+    if(when_CsrPlugin_l1669_26) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if(when_CsrPlugin_l1277_7) begin
+    if(when_CsrPlugin_l1669_27) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if(when_CsrPlugin_l1277_8) begin
+    if(when_CsrPlugin_l1669_28) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if(when_CsrPlugin_l1277_9) begin
+    if(when_CsrPlugin_l1669_29) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if(when_CsrPlugin_l1277_10) begin
+    if(when_CsrPlugin_l1669_30) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if(when_CsrPlugin_l1277_11) begin
+    if(when_CsrPlugin_l1669_31) begin
       execute_CsrPlugin_csr_832 <= (decode_INSTRUCTION[31 : 20] == 12'h340);
     end
-    if(when_CsrPlugin_l1277_12) begin
+    if(when_CsrPlugin_l1669_32) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if(when_CsrPlugin_l1277_13) begin
+    if(when_CsrPlugin_l1669_33) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if(when_CsrPlugin_l1277_14) begin
+    if(when_CsrPlugin_l1669_34) begin
       execute_CsrPlugin_csr_2816 <= (decode_INSTRUCTION[31 : 20] == 12'hb00);
     end
-    if(when_CsrPlugin_l1277_15) begin
+    if(when_CsrPlugin_l1669_35) begin
       execute_CsrPlugin_csr_2944 <= (decode_INSTRUCTION[31 : 20] == 12'hb80);
     end
-    if(when_CsrPlugin_l1277_16) begin
+    if(when_CsrPlugin_l1669_36) begin
       execute_CsrPlugin_csr_2818 <= (decode_INSTRUCTION[31 : 20] == 12'hb02);
     end
-    if(when_CsrPlugin_l1277_17) begin
+    if(when_CsrPlugin_l1669_37) begin
       execute_CsrPlugin_csr_2946 <= (decode_INSTRUCTION[31 : 20] == 12'hb82);
     end
-    if(when_CsrPlugin_l1277_18) begin
+    if(when_CsrPlugin_l1669_38) begin
       execute_CsrPlugin_csr_3072 <= (decode_INSTRUCTION[31 : 20] == 12'hc00);
     end
-    if(when_CsrPlugin_l1277_19) begin
+    if(when_CsrPlugin_l1669_39) begin
       execute_CsrPlugin_csr_3200 <= (decode_INSTRUCTION[31 : 20] == 12'hc80);
     end
-    if(when_CsrPlugin_l1277_20) begin
+    if(when_CsrPlugin_l1669_40) begin
       execute_CsrPlugin_csr_3074 <= (decode_INSTRUCTION[31 : 20] == 12'hc02);
     end
-    if(when_CsrPlugin_l1277_21) begin
+    if(when_CsrPlugin_l1669_41) begin
       execute_CsrPlugin_csr_3202 <= (decode_INSTRUCTION[31 : 20] == 12'hc82);
     end
-    if(when_CsrPlugin_l1277_22) begin
+    if(when_CsrPlugin_l1669_42) begin
+      execute_CsrPlugin_csr_774 <= (decode_INSTRUCTION[31 : 20] == 12'h306);
+    end
+    if(when_CsrPlugin_l1669_43) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if(when_CsrPlugin_l1277_23) begin
+    if(when_CsrPlugin_l1669_44) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
     if(execute_CsrPlugin_csr_836) begin
@@ -8198,7 +9239,6 @@ module VexRiscv (
     if(execute_CsrPlugin_csr_773) begin
       if(execute_CsrPlugin_writeEnable) begin
         CsrPlugin_mtvec_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 2];
-        CsrPlugin_mtvec_mode <= CsrPlugin_csrMapping_writeDataSignal[1 : 0];
       end
     end
     if(execute_CsrPlugin_csr_833) begin
@@ -8222,15 +9262,6 @@ module VexRiscv (
         CsrPlugin_mtval <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_writeInstruction) begin
-      if(when_PmpPlugin_l172) begin
-        if(when_PmpPlugin_l175) begin
-          execute_PmpPlugin_writeData_ <= CsrPlugin_csrMapping_writeDataSignal;
-          execute_PmpPlugin_pmpNcfg_ <= execute_PmpPlugin_pmpNcfg;
-          execute_PmpPlugin_pmpcfgN_ <= execute_PmpPlugin_pmpcfgN;
-        end
-      end
-    end
     iBusWishbone_DAT_MISO_regNext <= iBusWishbone_DAT_MISO;
     dBusWishbone_DAT_MISO_regNext <= dBusWishbone_DAT_MISO;
   end
@@ -8239,76 +9270,75 @@ module VexRiscv (
 endmodule
 
 module DataCache (
-  input               io_cpu_execute_isValid,
-  input      [31:0]   io_cpu_execute_address,
-  output reg          io_cpu_execute_haltIt,
-  input               io_cpu_execute_args_wr,
-  input      [1:0]    io_cpu_execute_args_size,
-  input               io_cpu_execute_args_totalyConsistent,
-  output              io_cpu_execute_refilling,
-  input               io_cpu_memory_isValid,
-  input               io_cpu_memory_isStuck,
-  output              io_cpu_memory_isWrite,
-  input      [31:0]   io_cpu_memory_address,
-  input      [31:0]   io_cpu_memory_mmuRsp_physicalAddress,
-  input               io_cpu_memory_mmuRsp_isIoAccess,
-  input               io_cpu_memory_mmuRsp_isPaging,
-  input               io_cpu_memory_mmuRsp_allowRead,
-  input               io_cpu_memory_mmuRsp_allowWrite,
-  input               io_cpu_memory_mmuRsp_allowExecute,
-  input               io_cpu_memory_mmuRsp_exception,
-  input               io_cpu_memory_mmuRsp_refilling,
-  input               io_cpu_memory_mmuRsp_bypassTranslation,
-  input               io_cpu_writeBack_isValid,
-  input               io_cpu_writeBack_isStuck,
-  input               io_cpu_writeBack_isFiring,
-  input               io_cpu_writeBack_isUser,
-  output reg          io_cpu_writeBack_haltIt,
-  output              io_cpu_writeBack_isWrite,
-  input      [31:0]   io_cpu_writeBack_storeData,
-  output reg [31:0]   io_cpu_writeBack_data,
-  input      [31:0]   io_cpu_writeBack_address,
-  output              io_cpu_writeBack_mmuException,
-  output              io_cpu_writeBack_unalignedAccess,
-  output reg          io_cpu_writeBack_accessError,
-  output              io_cpu_writeBack_keepMemRspData,
-  input               io_cpu_writeBack_fence_SW,
-  input               io_cpu_writeBack_fence_SR,
-  input               io_cpu_writeBack_fence_SO,
-  input               io_cpu_writeBack_fence_SI,
-  input               io_cpu_writeBack_fence_PW,
-  input               io_cpu_writeBack_fence_PR,
-  input               io_cpu_writeBack_fence_PO,
-  input               io_cpu_writeBack_fence_PI,
-  input      [3:0]    io_cpu_writeBack_fence_FM,
-  output              io_cpu_writeBack_exclusiveOk,
-  output reg          io_cpu_redo,
-  input               io_cpu_flush_valid,
-  output              io_cpu_flush_ready,
-  input               io_cpu_flush_payload_singleLine,
-  input      [6:0]    io_cpu_flush_payload_lineId,
-  output reg          io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output reg          io_mem_cmd_payload_wr,
-  output              io_mem_cmd_payload_uncached,
-  output reg [31:0]   io_mem_cmd_payload_address,
-  output     [31:0]   io_mem_cmd_payload_data,
-  output     [3:0]    io_mem_cmd_payload_mask,
-  output reg [2:0]    io_mem_cmd_payload_size,
-  output              io_mem_cmd_payload_last,
-  input               io_mem_rsp_valid,
-  input               io_mem_rsp_payload_last,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input               clk,
-  input               reset
+  input  wire          io_cpu_execute_isValid,
+  input  wire [31:0]   io_cpu_execute_address,
+  output reg           io_cpu_execute_haltIt,
+  input  wire          io_cpu_execute_args_wr,
+  input  wire [1:0]    io_cpu_execute_args_size,
+  input  wire          io_cpu_execute_args_totalyConsistent,
+  output wire          io_cpu_execute_refilling,
+  input  wire          io_cpu_memory_isValid,
+  input  wire          io_cpu_memory_isStuck,
+  output wire          io_cpu_memory_isWrite,
+  input  wire [31:0]   io_cpu_memory_address,
+  input  wire [31:0]   io_cpu_memory_mmuRsp_physicalAddress,
+  input  wire          io_cpu_memory_mmuRsp_isIoAccess,
+  input  wire          io_cpu_memory_mmuRsp_isPaging,
+  input  wire          io_cpu_memory_mmuRsp_allowRead,
+  input  wire          io_cpu_memory_mmuRsp_allowWrite,
+  input  wire          io_cpu_memory_mmuRsp_allowExecute,
+  input  wire          io_cpu_memory_mmuRsp_exception,
+  input  wire          io_cpu_memory_mmuRsp_refilling,
+  input  wire          io_cpu_memory_mmuRsp_bypassTranslation,
+  input  wire          io_cpu_writeBack_isValid,
+  input  wire          io_cpu_writeBack_isStuck,
+  input  wire          io_cpu_writeBack_isFiring,
+  input  wire          io_cpu_writeBack_isUser,
+  output reg           io_cpu_writeBack_haltIt,
+  output wire          io_cpu_writeBack_isWrite,
+  input  wire [31:0]   io_cpu_writeBack_storeData,
+  output reg  [31:0]   io_cpu_writeBack_data,
+  input  wire [31:0]   io_cpu_writeBack_address,
+  output wire          io_cpu_writeBack_mmuException,
+  output wire          io_cpu_writeBack_unalignedAccess,
+  output reg           io_cpu_writeBack_accessError,
+  output wire          io_cpu_writeBack_keepMemRspData,
+  input  wire          io_cpu_writeBack_fence_SW,
+  input  wire          io_cpu_writeBack_fence_SR,
+  input  wire          io_cpu_writeBack_fence_SO,
+  input  wire          io_cpu_writeBack_fence_SI,
+  input  wire          io_cpu_writeBack_fence_PW,
+  input  wire          io_cpu_writeBack_fence_PR,
+  input  wire          io_cpu_writeBack_fence_PO,
+  input  wire          io_cpu_writeBack_fence_PI,
+  input  wire [3:0]    io_cpu_writeBack_fence_FM,
+  output wire          io_cpu_writeBack_exclusiveOk,
+  output reg           io_cpu_redo,
+  input  wire          io_cpu_flush_valid,
+  output wire          io_cpu_flush_ready,
+  input  wire          io_cpu_flush_payload_singleLine,
+  input  wire [6:0]    io_cpu_flush_payload_lineId,
+  output wire          io_cpu_writesPending,
+  output reg           io_mem_cmd_valid,
+  input  wire          io_mem_cmd_ready,
+  output reg           io_mem_cmd_payload_wr,
+  output wire          io_mem_cmd_payload_uncached,
+  output reg  [31:0]   io_mem_cmd_payload_address,
+  output wire [31:0]   io_mem_cmd_payload_data,
+  output wire [3:0]    io_mem_cmd_payload_mask,
+  output reg  [2:0]    io_mem_cmd_payload_size,
+  output wire          io_mem_cmd_payload_last,
+  input  wire          io_mem_rsp_valid,
+  input  wire          io_mem_rsp_payload_last,
+  input  wire [31:0]   io_mem_rsp_payload_data,
+  input  wire          io_mem_rsp_payload_error,
+  input  wire          clk,
+  input  wire          reset
 );
 
   reg        [21:0]   _zz_ways_0_tags_port0;
   reg        [31:0]   _zz_ways_0_data_port0;
   wire       [21:0]   _zz_ways_0_tags_port;
-  wire       [9:0]    _zz_stage0_dataColisions;
-  wire       [9:0]    _zz__zz_stageA_dataColisions;
   wire       [0:0]    _zz_when;
   wire       [2:0]    _zz_loader_counter_valueNext;
   wire       [0:0]    _zz_loader_counter_valueNext_1;
@@ -8345,40 +9375,40 @@ module DataCache (
   wire                _zz_ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRsp;
-  wire                when_DataCache_l642;
   wire                when_DataCache_l645;
-  wire                when_DataCache_l664;
+  wire                when_DataCache_l648;
+  wire                when_DataCache_l667;
   wire                rspSync;
   wire                rspLast;
   reg                 memCmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_DataCache_l686;
+  wire                when_DataCache_l689;
   reg        [3:0]    _zz_stage0_mask;
   wire       [3:0]    stage0_mask;
   wire       [0:0]    stage0_dataColisions;
   wire       [0:0]    stage0_wayInvalidate;
   wire                stage0_isAmo;
-  wire                when_DataCache_l771;
+  wire                when_DataCache_l776;
   reg                 stageA_request_wr;
   reg        [1:0]    stageA_request_size;
   reg                 stageA_request_totalyConsistent;
-  wire                when_DataCache_l771_1;
+  wire                when_DataCache_l776_1;
   reg        [3:0]    stageA_mask;
   wire                stageA_isAmo;
   wire                stageA_isLrsc;
   wire       [0:0]    stageA_wayHits;
-  wire                when_DataCache_l771_2;
+  wire                when_DataCache_l776_2;
   reg        [0:0]    stageA_wayInvalidate;
-  wire                when_DataCache_l771_3;
+  wire                when_DataCache_l776_3;
   reg        [0:0]    stage0_dataColisions_regNextWhen;
   wire       [0:0]    _zz_stageA_dataColisions;
   wire       [0:0]    stageA_dataColisions;
-  wire                when_DataCache_l822;
+  wire                when_DataCache_l827;
   reg                 stageB_request_wr;
   reg        [1:0]    stageB_request_size;
   reg                 stageB_request_totalyConsistent;
   reg                 stageB_mmuRspFreeze;
-  wire                when_DataCache_l824;
+  wire                when_DataCache_l829;
   reg        [31:0]   stageB_mmuRsp_physicalAddress;
   reg                 stageB_mmuRsp_isIoAccess;
   reg                 stageB_mmuRsp_isPaging;
@@ -8388,52 +9418,54 @@ module DataCache (
   reg                 stageB_mmuRsp_exception;
   reg                 stageB_mmuRsp_refilling;
   reg                 stageB_mmuRsp_bypassTranslation;
-  wire                when_DataCache_l821;
+  wire                when_DataCache_l826;
   reg                 stageB_tagsReadRsp_0_valid;
   reg                 stageB_tagsReadRsp_0_error;
   reg        [19:0]   stageB_tagsReadRsp_0_address;
-  wire                when_DataCache_l821_1;
+  wire                when_DataCache_l826_1;
   reg        [31:0]   stageB_dataReadRsp_0;
-  wire                when_DataCache_l820;
+  wire                when_DataCache_l825;
   reg        [0:0]    stageB_wayInvalidate;
   wire                stageB_consistancyHazard;
-  wire                when_DataCache_l820_1;
+  wire                when_DataCache_l825_1;
   reg        [0:0]    stageB_dataColisions;
-  wire                when_DataCache_l820_2;
+  wire                when_DataCache_l825_2;
   reg                 stageB_unaligned;
-  wire                when_DataCache_l820_3;
+  wire                when_DataCache_l825_3;
   reg        [0:0]    stageB_waysHitsBeforeInvalidate;
   wire       [0:0]    stageB_waysHits;
   wire                stageB_waysHit;
   wire       [31:0]   stageB_dataMux;
-  wire                when_DataCache_l820_4;
+  wire                when_DataCache_l825_4;
   reg        [3:0]    stageB_mask;
   reg                 stageB_loaderValid;
   wire       [31:0]   stageB_ioMemRspMuxed;
   reg                 stageB_flusher_waitDone;
   wire                stageB_flusher_hold;
   reg        [7:0]    stageB_flusher_counter;
-  wire                when_DataCache_l850;
-  wire                when_DataCache_l856;
+  wire                when_DataCache_l855;
+  wire                when_DataCache_l861;
+  wire                when_DataCache_l863;
   reg                 stageB_flusher_start;
+  wire                when_DataCache_l877;
   wire                stageB_isAmo;
   wire                stageB_isAmoCached;
   wire                stageB_isExternalLsrc;
   wire                stageB_isExternalAmo;
   wire       [31:0]   stageB_requestDataBypass;
   reg                 stageB_cpuWriteToCache;
-  wire                when_DataCache_l926;
+  wire                when_DataCache_l931;
   wire                stageB_badPermissions;
   wire                stageB_loadStoreFault;
   wire                stageB_bypassCache;
-  wire                when_DataCache_l995;
-  wire                when_DataCache_l1004;
+  wire                when_DataCache_l1000;
   wire                when_DataCache_l1009;
-  wire                when_DataCache_l1020;
-  wire                when_DataCache_l1032;
-  wire                when_DataCache_l991;
-  wire                when_DataCache_l1066;
-  wire                when_DataCache_l1075;
+  wire                when_DataCache_l1014;
+  wire                when_DataCache_l1025;
+  wire                when_DataCache_l1037;
+  wire                when_DataCache_l996;
+  wire                when_DataCache_l1072;
+  wire                when_DataCache_l1081;
   reg                 loader_valid;
   reg                 loader_counter_willIncrement;
   wire                loader_counter_willClear;
@@ -8445,12 +9477,12 @@ module DataCache (
   reg                 loader_error;
   wire                loader_kill;
   reg                 loader_killReg;
-  wire                when_DataCache_l1090;
+  wire                when_DataCache_l1097;
   wire                loader_done;
-  wire                when_DataCache_l1118;
-  reg                 loader_valid_regNext;
-  wire                when_DataCache_l1122;
   wire                when_DataCache_l1125;
+  reg                 loader_valid_regNext;
+  wire                when_DataCache_l1129;
+  wire                when_DataCache_l1132;
   (* no_rw_check , ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
   (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
   (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
@@ -8461,8 +9493,6 @@ module DataCache (
   reg [7:0] _zz_ways_0_datasymbol_read_2;
   reg [7:0] _zz_ways_0_datasymbol_read_3;
 
-  assign _zz_stage0_dataColisions = (io_cpu_execute_address[11 : 2] >>> 0);
-  assign _zz__zz_stageA_dataColisions = (io_cpu_memory_address[11 : 2] >>> 0);
   assign _zz_when = 1'b1;
   assign _zz_loader_counter_valueNext_1 = loader_counter_willIncrement;
   assign _zz_loader_counter_valueNext = {2'd0, _zz_loader_counter_valueNext_1};
@@ -8509,14 +9539,14 @@ module DataCache (
 
   always @(*) begin
     _zz_1 = 1'b0;
-    if(when_DataCache_l645) begin
+    if(when_DataCache_l648) begin
       _zz_1 = 1'b1;
     end
   end
 
   always @(*) begin
     _zz_2 = 1'b0;
-    if(when_DataCache_l642) begin
+    if(when_DataCache_l645) begin
       _zz_2 = 1'b1;
     end
   end
@@ -8530,43 +9560,45 @@ module DataCache (
   assign _zz_ways_0_dataReadRspMem = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
   assign ways_0_dataReadRspMem = _zz_ways_0_data_port0;
   assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
-  assign when_DataCache_l642 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
-  assign when_DataCache_l645 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
+  assign when_DataCache_l645 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
+  assign when_DataCache_l648 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
   always @(*) begin
     tagsReadCmd_valid = 1'b0;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       tagsReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     tagsReadCmd_payload = 7'bxxxxxxx;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
     end
   end
 
   always @(*) begin
     dataReadCmd_valid = 1'b0;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       dataReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     dataReadCmd_payload = 10'bxxxxxxxxxx;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       dataReadCmd_payload = io_cpu_execute_address[11 : 2];
     end
   end
 
   always @(*) begin
     tagsWriteCmd_valid = 1'b0;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_valid = 1'b1;
     end
-    if(when_DataCache_l1066) begin
-      tagsWriteCmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        tagsWriteCmd_valid = 1'b0;
+      end
     end
     if(loader_done) begin
       tagsWriteCmd_valid = 1'b1;
@@ -8575,7 +9607,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_way = 1'bx;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_payload_way = 1'b1;
     end
     if(loader_done) begin
@@ -8585,7 +9617,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_address = 7'bxxxxxxx;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_payload_address = stageB_flusher_counter[6:0];
     end
     if(loader_done) begin
@@ -8595,7 +9627,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_data_valid = 1'bx;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_payload_data_valid = 1'b0;
     end
     if(loader_done) begin
@@ -8620,14 +9652,16 @@ module DataCache (
   always @(*) begin
     dataWriteCmd_valid = 1'b0;
     if(stageB_cpuWriteToCache) begin
-      if(when_DataCache_l926) begin
+      if(when_DataCache_l931) begin
         dataWriteCmd_valid = 1'b1;
       end
     end
-    if(when_DataCache_l1066) begin
-      dataWriteCmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        dataWriteCmd_valid = 1'b0;
+      end
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_valid = 1'b1;
     end
   end
@@ -8637,7 +9671,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_way = stageB_waysHits;
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_way = loader_waysAllocator;
     end
   end
@@ -8647,7 +9681,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
     end
   end
@@ -8657,7 +9691,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_data = io_mem_rsp_payload_data;
     end
   end
@@ -8670,15 +9704,15 @@ module DataCache (
         dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
       end
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_mask = 4'b1111;
     end
   end
 
-  assign when_DataCache_l664 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  assign when_DataCache_l667 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
   always @(*) begin
     io_cpu_execute_haltIt = 1'b0;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       io_cpu_execute_haltIt = 1'b1;
     end
   end
@@ -8686,7 +9720,7 @@ module DataCache (
   assign rspSync = 1'b1;
   assign rspLast = 1'b1;
   assign io_mem_cmd_fire = (io_mem_cmd_valid && io_mem_cmd_ready);
-  assign when_DataCache_l686 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l689 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     _zz_stage0_mask = 4'bxxxx;
     case(io_cpu_execute_args_size)
@@ -8705,45 +9739,45 @@ module DataCache (
   end
 
   assign stage0_mask = (_zz_stage0_mask <<< io_cpu_execute_address[1 : 0]);
-  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_stage0_dataColisions)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_execute_address[11 : 2])) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stage0_wayInvalidate = 1'b0;
   assign stage0_isAmo = 1'b0;
-  assign when_DataCache_l771 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l771_1 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l776 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l776_1 = (! io_cpu_memory_isStuck);
   assign io_cpu_memory_isWrite = stageA_request_wr;
   assign stageA_isAmo = 1'b0;
   assign stageA_isLrsc = 1'b0;
   assign stageA_wayHits = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign when_DataCache_l771_2 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l771_3 = (! io_cpu_memory_isStuck);
-  assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz__zz_stageA_dataColisions)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign when_DataCache_l776_2 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l776_3 = (! io_cpu_memory_isStuck);
+  assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_memory_address[11 : 2])) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_stageA_dataColisions);
-  assign when_DataCache_l822 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l827 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_mmuRspFreeze = 1'b0;
-    if(when_DataCache_l1125) begin
+    if(when_DataCache_l1132) begin
       stageB_mmuRspFreeze = 1'b1;
     end
   end
 
-  assign when_DataCache_l824 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
-  assign when_DataCache_l821 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l821_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l820 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l829 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
+  assign when_DataCache_l826 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l826_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825 = (! io_cpu_writeBack_isStuck);
   assign stageB_consistancyHazard = 1'b0;
-  assign when_DataCache_l820_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l820_2 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l820_3 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_2 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_3 = (! io_cpu_writeBack_isStuck);
   assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
   assign stageB_waysHit = (|stageB_waysHits);
   assign stageB_dataMux = stageB_dataReadRsp_0;
-  assign when_DataCache_l820_4 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_4 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_loaderValid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
             if(io_mem_cmd_ready) begin
               stageB_loaderValid = 1'b1;
             end
@@ -8751,8 +9785,10 @@ module DataCache (
         end
       end
     end
-    if(when_DataCache_l1066) begin
-      stageB_loaderValid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        stageB_loaderValid = 1'b0;
+      end
     end
   end
 
@@ -8761,28 +9797,32 @@ module DataCache (
     io_cpu_writeBack_haltIt = 1'b1;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l991) begin
-          if(when_DataCache_l995) begin
+        if(when_DataCache_l996) begin
+          if(when_DataCache_l1000) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
         end else begin
-          if(when_DataCache_l1004) begin
-            if(when_DataCache_l1009) begin
+          if(when_DataCache_l1009) begin
+            if(when_DataCache_l1014) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1066) begin
-      io_cpu_writeBack_haltIt = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        io_cpu_writeBack_haltIt = 1'b0;
+      end
     end
   end
 
   assign stageB_flusher_hold = 1'b0;
-  assign when_DataCache_l850 = (! stageB_flusher_counter[7]);
-  assign when_DataCache_l856 = (! stageB_flusher_hold);
+  assign when_DataCache_l855 = (! stageB_flusher_counter[7]);
+  assign when_DataCache_l861 = (! stageB_flusher_hold);
+  assign when_DataCache_l863 = (io_cpu_flush_valid && io_cpu_flush_payload_singleLine);
   assign io_cpu_flush_ready = (stageB_flusher_waitDone && stageB_flusher_counter[7]);
+  assign when_DataCache_l877 = (io_cpu_flush_valid && io_cpu_flush_payload_singleLine);
   assign stageB_isAmo = 1'b0;
   assign stageB_isAmoCached = 1'b0;
   assign stageB_isExternalLsrc = 1'b0;
@@ -8792,8 +9832,8 @@ module DataCache (
     stageB_cpuWriteToCache = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(when_DataCache_l1009) begin
             stageB_cpuWriteToCache = 1'b1;
           end
         end
@@ -8801,26 +9841,28 @@ module DataCache (
     end
   end
 
-  assign when_DataCache_l926 = (stageB_request_wr && stageB_waysHit);
+  assign when_DataCache_l931 = (stageB_request_wr && stageB_waysHit);
   assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_isAmo)));
   assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
   always @(*) begin
     io_cpu_redo = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(when_DataCache_l1004) begin
-            if(when_DataCache_l1020) begin
+        if(!when_DataCache_l996) begin
+          if(when_DataCache_l1009) begin
+            if(when_DataCache_l1025) begin
               io_cpu_redo = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1075) begin
-      io_cpu_redo = 1'b1;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1081) begin
+        io_cpu_redo = 1'b1;
+      end
     end
-    if(when_DataCache_l1122) begin
+    if(when_DataCache_l1129) begin
       io_cpu_redo = 1'b1;
     end
   end
@@ -8841,23 +9883,25 @@ module DataCache (
     io_mem_cmd_valid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l991) begin
+        if(when_DataCache_l996) begin
           io_mem_cmd_valid = (! memCmdSent);
         end else begin
-          if(when_DataCache_l1004) begin
+          if(when_DataCache_l1009) begin
             if(stageB_request_wr) begin
               io_mem_cmd_valid = 1'b1;
             end
           end else begin
-            if(when_DataCache_l1032) begin
+            if(when_DataCache_l1037) begin
               io_mem_cmd_valid = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1066) begin
-      io_mem_cmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        io_mem_cmd_valid = 1'b0;
+      end
     end
   end
 
@@ -8865,9 +9909,9 @@ module DataCache (
     io_mem_cmd_payload_address = stageB_mmuRsp_physicalAddress;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
-            io_mem_cmd_payload_address[4 : 0] = 5'h0;
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
+            io_mem_cmd_payload_address[4 : 0] = 5'h00;
           end
         end
       end
@@ -8879,8 +9923,8 @@ module DataCache (
     io_mem_cmd_payload_wr = stageB_request_wr;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
             io_mem_cmd_payload_wr = 1'b0;
           end
         end
@@ -8895,8 +9939,8 @@ module DataCache (
     io_mem_cmd_payload_size = {1'd0, stageB_request_size};
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
             io_mem_cmd_payload_size = 3'b101;
           end
         end
@@ -8906,12 +9950,12 @@ module DataCache (
 
   assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
   assign io_cpu_writeBack_keepMemRspData = 1'b0;
-  assign when_DataCache_l995 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
-  assign when_DataCache_l1004 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
-  assign when_DataCache_l1009 = ((! stageB_request_wr) || io_mem_cmd_ready);
-  assign when_DataCache_l1020 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
-  assign when_DataCache_l1032 = (! memCmdSent);
-  assign when_DataCache_l991 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  assign when_DataCache_l1000 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
+  assign when_DataCache_l1009 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
+  assign when_DataCache_l1014 = ((! stageB_request_wr) || io_mem_cmd_ready);
+  assign when_DataCache_l1025 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
+  assign when_DataCache_l1037 = (! memCmdSent);
+  assign when_DataCache_l996 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
   always @(*) begin
     if(stageB_bypassCache) begin
       io_cpu_writeBack_data = stageB_ioMemRspMuxed;
@@ -8920,11 +9964,11 @@ module DataCache (
     end
   end
 
-  assign when_DataCache_l1066 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign when_DataCache_l1075 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
+  assign when_DataCache_l1072 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign when_DataCache_l1081 = (stageB_mmuRsp_refilling || stageB_consistancyHazard);
   always @(*) begin
     loader_counter_willIncrement = 1'b0;
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       loader_counter_willIncrement = 1'b1;
     end
   end
@@ -8940,12 +9984,12 @@ module DataCache (
   end
 
   assign loader_kill = 1'b0;
-  assign when_DataCache_l1090 = ((loader_valid && io_mem_rsp_valid) && rspLast);
+  assign when_DataCache_l1097 = ((loader_valid && io_mem_rsp_valid) && rspLast);
   assign loader_done = loader_counter_willOverflow;
-  assign when_DataCache_l1118 = (! loader_valid);
-  assign when_DataCache_l1122 = (loader_valid && (! loader_valid_regNext));
+  assign when_DataCache_l1125 = (! loader_valid);
+  assign when_DataCache_l1129 = (loader_valid && (! loader_valid_regNext));
   assign io_cpu_execute_refilling = loader_valid;
-  assign when_DataCache_l1125 = (stageB_loaderValid || loader_valid);
+  assign when_DataCache_l1132 = (stageB_loaderValid || loader_valid);
   always @(posedge clk) begin
     tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
     tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
@@ -8953,26 +9997,26 @@ module DataCache (
     tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
     tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
     tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if(when_DataCache_l771) begin
+    if(when_DataCache_l776) begin
       stageA_request_wr <= io_cpu_execute_args_wr;
       stageA_request_size <= io_cpu_execute_args_size;
       stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
     end
-    if(when_DataCache_l771_1) begin
+    if(when_DataCache_l776_1) begin
       stageA_mask <= stage0_mask;
     end
-    if(when_DataCache_l771_2) begin
+    if(when_DataCache_l776_2) begin
       stageA_wayInvalidate <= stage0_wayInvalidate;
     end
-    if(when_DataCache_l771_3) begin
+    if(when_DataCache_l776_3) begin
       stage0_dataColisions_regNextWhen <= stage0_dataColisions;
     end
-    if(when_DataCache_l822) begin
+    if(when_DataCache_l827) begin
       stageB_request_wr <= stageA_request_wr;
       stageB_request_size <= stageA_request_size;
       stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
     end
-    if(when_DataCache_l824) begin
+    if(when_DataCache_l829) begin
       stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
       stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
       stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
@@ -8983,27 +10027,27 @@ module DataCache (
       stageB_mmuRsp_refilling <= io_cpu_memory_mmuRsp_refilling;
       stageB_mmuRsp_bypassTranslation <= io_cpu_memory_mmuRsp_bypassTranslation;
     end
-    if(when_DataCache_l821) begin
+    if(when_DataCache_l826) begin
       stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
       stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
       stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
     end
-    if(when_DataCache_l821_1) begin
+    if(when_DataCache_l826_1) begin
       stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
     end
-    if(when_DataCache_l820) begin
+    if(when_DataCache_l825) begin
       stageB_wayInvalidate <= stageA_wayInvalidate;
     end
-    if(when_DataCache_l820_1) begin
+    if(when_DataCache_l825_1) begin
       stageB_dataColisions <= stageA_dataColisions;
     end
-    if(when_DataCache_l820_2) begin
+    if(when_DataCache_l825_2) begin
       stageB_unaligned <= ({((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)),((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0))} != 2'b00);
     end
-    if(when_DataCache_l820_3) begin
+    if(when_DataCache_l825_3) begin
       stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
     end
-    if(when_DataCache_l820_4) begin
+    if(when_DataCache_l825_4) begin
       stageB_mask <= stageA_mask;
     end
     loader_valid_regNext <= loader_valid;
@@ -9013,7 +10057,7 @@ module DataCache (
     if(reset) begin
       memCmdSent <= 1'b0;
       stageB_flusher_waitDone <= 1'b0;
-      stageB_flusher_counter <= 8'h0;
+      stageB_flusher_counter <= 8'h00;
       stageB_flusher_start <= 1'b1;
       loader_valid <= 1'b0;
       loader_counter_value <= 3'b000;
@@ -9024,16 +10068,16 @@ module DataCache (
       if(io_mem_cmd_fire) begin
         memCmdSent <= 1'b1;
       end
-      if(when_DataCache_l686) begin
+      if(when_DataCache_l689) begin
         memCmdSent <= 1'b0;
       end
       if(io_cpu_flush_ready) begin
         stageB_flusher_waitDone <= 1'b0;
       end
-      if(when_DataCache_l850) begin
-        if(when_DataCache_l856) begin
+      if(when_DataCache_l855) begin
+        if(when_DataCache_l861) begin
           stageB_flusher_counter <= (stageB_flusher_counter + 8'h01);
-          if(io_cpu_flush_payload_singleLine) begin
+          if(when_DataCache_l863) begin
             stageB_flusher_counter[7] <= 1'b1;
           end
         end
@@ -9041,17 +10085,17 @@ module DataCache (
       stageB_flusher_start <= (((((((! stageB_flusher_waitDone) && (! stageB_flusher_start)) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
       if(stageB_flusher_start) begin
         stageB_flusher_waitDone <= 1'b1;
-        stageB_flusher_counter <= 8'h0;
-        if(io_cpu_flush_payload_singleLine) begin
+        stageB_flusher_counter <= 8'h00;
+        if(when_DataCache_l877) begin
           stageB_flusher_counter <= {1'b0,io_cpu_flush_payload_lineId};
         end
       end
       `ifndef SYNTHESIS
         `ifdef FORMAL
-          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))); // DataCache.scala:L1077
+          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))); // DataCache.scala:L1084
         `else
           if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-            $display("ERROR writeBack stuck by another plugin is not allowed"); // DataCache.scala:L1077
+            $display("ERROR writeBack stuck by another plugin is not allowed"); // DataCache.scala:L1084
           end
         `endif
       `endif
@@ -9062,7 +10106,7 @@ module DataCache (
       if(loader_kill) begin
         loader_killReg <= 1'b1;
       end
-      if(when_DataCache_l1090) begin
+      if(when_DataCache_l1097) begin
         loader_error <= (loader_error || io_mem_rsp_payload_error);
       end
       if(loader_done) begin
@@ -9070,7 +10114,7 @@ module DataCache (
         loader_error <= 1'b0;
         loader_killReg <= 1'b0;
       end
-      if(when_DataCache_l1118) begin
+      if(when_DataCache_l1125) begin
         loader_waysAllocator <= _zz_loader_waysAllocator[0:0];
       end
     end
@@ -9080,46 +10124,46 @@ module DataCache (
 endmodule
 
 module InstructionCache (
-  input               io_flush,
-  input               io_cpu_prefetch_isValid,
-  output reg          io_cpu_prefetch_haltIt,
-  input      [31:0]   io_cpu_prefetch_pc,
-  input               io_cpu_fetch_isValid,
-  input               io_cpu_fetch_isStuck,
-  input               io_cpu_fetch_isRemoved,
-  input      [31:0]   io_cpu_fetch_pc,
-  output     [31:0]   io_cpu_fetch_data,
-  input      [31:0]   io_cpu_fetch_mmuRsp_physicalAddress,
-  input               io_cpu_fetch_mmuRsp_isIoAccess,
-  input               io_cpu_fetch_mmuRsp_isPaging,
-  input               io_cpu_fetch_mmuRsp_allowRead,
-  input               io_cpu_fetch_mmuRsp_allowWrite,
-  input               io_cpu_fetch_mmuRsp_allowExecute,
-  input               io_cpu_fetch_mmuRsp_exception,
-  input               io_cpu_fetch_mmuRsp_refilling,
-  input               io_cpu_fetch_mmuRsp_bypassTranslation,
-  output     [31:0]   io_cpu_fetch_physicalAddress,
-  input               io_cpu_decode_isValid,
-  input               io_cpu_decode_isStuck,
-  input      [31:0]   io_cpu_decode_pc,
-  output     [31:0]   io_cpu_decode_physicalAddress,
-  output     [31:0]   io_cpu_decode_data,
-  output              io_cpu_decode_cacheMiss,
-  output              io_cpu_decode_error,
-  output              io_cpu_decode_mmuRefilling,
-  output              io_cpu_decode_mmuException,
-  input               io_cpu_decode_isUser,
-  input               io_cpu_fill_valid,
-  input      [31:0]   io_cpu_fill_payload,
-  output              io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output     [31:0]   io_mem_cmd_payload_address,
-  output     [2:0]    io_mem_cmd_payload_size,
-  input               io_mem_rsp_valid,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input               clk,
-  input               reset
+  input  wire          io_flush,
+  input  wire          io_cpu_prefetch_isValid,
+  output reg           io_cpu_prefetch_haltIt,
+  input  wire [31:0]   io_cpu_prefetch_pc,
+  input  wire          io_cpu_fetch_isValid,
+  input  wire          io_cpu_fetch_isStuck,
+  input  wire          io_cpu_fetch_isRemoved,
+  input  wire [31:0]   io_cpu_fetch_pc,
+  output wire [31:0]   io_cpu_fetch_data,
+  input  wire [31:0]   io_cpu_fetch_mmuRsp_physicalAddress,
+  input  wire          io_cpu_fetch_mmuRsp_isIoAccess,
+  input  wire          io_cpu_fetch_mmuRsp_isPaging,
+  input  wire          io_cpu_fetch_mmuRsp_allowRead,
+  input  wire          io_cpu_fetch_mmuRsp_allowWrite,
+  input  wire          io_cpu_fetch_mmuRsp_allowExecute,
+  input  wire          io_cpu_fetch_mmuRsp_exception,
+  input  wire          io_cpu_fetch_mmuRsp_refilling,
+  input  wire          io_cpu_fetch_mmuRsp_bypassTranslation,
+  output wire [31:0]   io_cpu_fetch_physicalAddress,
+  input  wire          io_cpu_decode_isValid,
+  input  wire          io_cpu_decode_isStuck,
+  input  wire [31:0]   io_cpu_decode_pc,
+  output wire [31:0]   io_cpu_decode_physicalAddress,
+  output wire [31:0]   io_cpu_decode_data,
+  output wire          io_cpu_decode_cacheMiss,
+  output wire          io_cpu_decode_error,
+  output wire          io_cpu_decode_mmuRefilling,
+  output wire          io_cpu_decode_mmuException,
+  input  wire          io_cpu_decode_isUser,
+  input  wire          io_cpu_fill_valid,
+  input  wire [31:0]   io_cpu_fill_payload,
+  output wire          io_mem_cmd_valid,
+  input  wire          io_mem_cmd_ready,
+  output wire [31:0]   io_mem_cmd_payload_address,
+  output wire [2:0]    io_mem_cmd_payload_size,
+  input  wire          io_mem_rsp_valid,
+  input  wire [31:0]   io_mem_rsp_payload_data,
+  input  wire          io_mem_rsp_payload_error,
+  input  wire          clk,
+  input  wire          reset
 );
 
   reg        [31:0]   _zz_banks_0_port1;
@@ -9139,7 +10183,7 @@ module InstructionCache (
   wire                when_InstructionCache_l351;
   reg                 lineLoader_cmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_Utils_l515;
+  wire                when_Utils_l560;
   reg                 lineLoader_wayToAllocate_willIncrement;
   wire                lineLoader_wayToAllocate_willClear;
   wire                lineLoader_wayToAllocate_willOverflowIfInc;
@@ -9254,12 +10298,12 @@ module InstructionCache (
   assign when_InstructionCache_l351 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
   assign io_mem_cmd_fire = (io_mem_cmd_valid && io_mem_cmd_ready);
   assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
-  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
+  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h00};
   assign io_mem_cmd_payload_size = 3'b101;
-  assign when_Utils_l515 = (! lineLoader_valid);
+  assign when_Utils_l560 = (! lineLoader_valid);
   always @(*) begin
     lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if(when_Utils_l515) begin
+    if(when_Utils_l560) begin
       lineLoader_wayToAllocate_willIncrement = 1'b1;
     end
   end
@@ -9350,7 +10394,7 @@ module InstructionCache (
     end
     _zz_when_InstructionCache_l342 <= lineLoader_flushCounter[7];
     if(when_InstructionCache_l351) begin
-      lineLoader_flushCounter <= 8'h0;
+      lineLoader_flushCounter <= 8'h00;
     end
     if(when_InstructionCache_l435) begin
       io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;
@@ -9374,21 +10418,5 @@ module InstructionCache (
     end
   end
 
-
-endmodule
-
-module PmpSetter (
-  input      [31:0]   io_addr,
-  output     [24:0]   io_base,
-  output     [24:0]   io_mask
-);
-
-  wire       [31:0]   _zz_ones;
-  wire       [31:0]   ones;
-
-  assign _zz_ones = (io_addr + 32'h00000001);
-  assign ones = (io_addr & (~ _zz_ones));
-  assign io_base = (io_addr[29 : 5] ^ ones[29 : 5]);
-  assign io_mask = (~ {ones[28 : 5],1'b1});
 
 endmodule

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_SecureDebug.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_SecureDebug.v
@@ -1,46 +1,46 @@
-// Generator : SpinalHDL v1.7.1    git head : 0444bb76ab1d6e19f0ec46bc03c4769776deb7d5
+// Generator : SpinalHDL v1.9.4    git head : 270018552577f3bb8e5339ee2583c9c22d324215
 // Component : VexRiscv
-// Git hash  : 581fcb065adf7ea8b626f939ff51679d4c95872f
+// Git hash  : 63430af99f84cc1d11d58b556debe1cc3f238c67
 
 `timescale 1ns/1ps
 
 module VexRiscv (
-  input      [31:0]   externalResetVector,
-  input               timerInterrupt,
-  input               softwareInterrupt,
-  input      [31:0]   externalInterruptArray,
-  input               debug_bus_cmd_valid,
-  output reg          debug_bus_cmd_ready,
-  input               debug_bus_cmd_payload_wr,
-  input      [7:0]    debug_bus_cmd_payload_address,
-  input      [31:0]   debug_bus_cmd_payload_data,
-  output reg [31:0]   debug_bus_rsp_data,
-  output              debug_resetOut,
-  output reg          iBusWishbone_CYC,
-  output reg          iBusWishbone_STB,
-  input               iBusWishbone_ACK,
-  output              iBusWishbone_WE,
-  output     [29:0]   iBusWishbone_ADR,
-  input      [31:0]   iBusWishbone_DAT_MISO,
-  output     [31:0]   iBusWishbone_DAT_MOSI,
-  output     [3:0]    iBusWishbone_SEL,
-  input               iBusWishbone_ERR,
-  output     [2:0]    iBusWishbone_CTI,
-  output     [1:0]    iBusWishbone_BTE,
-  output              dBusWishbone_CYC,
-  output              dBusWishbone_STB,
-  input               dBusWishbone_ACK,
-  output              dBusWishbone_WE,
-  output     [29:0]   dBusWishbone_ADR,
-  input      [31:0]   dBusWishbone_DAT_MISO,
-  output     [31:0]   dBusWishbone_DAT_MOSI,
-  output     [3:0]    dBusWishbone_SEL,
-  input               dBusWishbone_ERR,
-  output     [2:0]    dBusWishbone_CTI,
-  output     [1:0]    dBusWishbone_BTE,
-  input               clk,
-  input               reset,
-  input               debugReset
+  input  wire [31:0]   externalResetVector,
+  input  wire          timerInterrupt,
+  input  wire          softwareInterrupt,
+  input  wire [31:0]   externalInterruptArray,
+  input  wire          debug_bus_cmd_valid,
+  output reg           debug_bus_cmd_ready,
+  input  wire          debug_bus_cmd_payload_wr,
+  input  wire [7:0]    debug_bus_cmd_payload_address,
+  input  wire [31:0]   debug_bus_cmd_payload_data,
+  output reg  [31:0]   debug_bus_rsp_data,
+  output wire          debug_resetOut,
+  output reg           iBusWishbone_CYC,
+  output reg           iBusWishbone_STB,
+  input  wire          iBusWishbone_ACK,
+  output wire          iBusWishbone_WE,
+  output wire [29:0]   iBusWishbone_ADR,
+  input  wire [31:0]   iBusWishbone_DAT_MISO,
+  output wire [31:0]   iBusWishbone_DAT_MOSI,
+  output wire [3:0]    iBusWishbone_SEL,
+  input  wire          iBusWishbone_ERR,
+  output wire [2:0]    iBusWishbone_CTI,
+  output wire [1:0]    iBusWishbone_BTE,
+  output wire          dBusWishbone_CYC,
+  output wire          dBusWishbone_STB,
+  input  wire          dBusWishbone_ACK,
+  output wire          dBusWishbone_WE,
+  output wire [29:0]   dBusWishbone_ADR,
+  input  wire [31:0]   dBusWishbone_DAT_MISO,
+  output wire [31:0]   dBusWishbone_DAT_MOSI,
+  output wire [3:0]    dBusWishbone_SEL,
+  input  wire          dBusWishbone_ERR,
+  output wire [2:0]    dBusWishbone_CTI,
+  output wire [1:0]    dBusWishbone_BTE,
+  input  wire          clk,
+  input  wire          reset,
+  input  wire          debugReset
 );
   localparam ShiftCtrlEnum_DISABLE_1 = 2'd0;
   localparam ShiftCtrlEnum_SLL_1 = 2'd1;
@@ -68,13 +68,7 @@ module VexRiscv (
   localparam Src1CtrlEnum_IMU = 2'd1;
   localparam Src1CtrlEnum_PC_INCREMENT = 2'd2;
   localparam Src1CtrlEnum_URS1 = 2'd3;
-  localparam execute_PmpPlugin_fsm_enumDef_BOOT = 3'd0;
-  localparam execute_PmpPlugin_fsm_enumDef_stateIdle = 3'd1;
-  localparam execute_PmpPlugin_fsm_enumDef_stateWrite = 3'd2;
-  localparam execute_PmpPlugin_fsm_enumDef_stateCfg = 3'd3;
-  localparam execute_PmpPlugin_fsm_enumDef_stateAddr = 3'd4;
 
-  reg        [31:0]   PmpPlugin_setter_io_addr;
   wire                IBusCachedPlugin_cache_io_flush;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_isValid;
   wire                IBusCachedPlugin_cache_io_cpu_fetch_isValid;
@@ -105,13 +99,8 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_flush_valid;
   wire                dataCache_1_io_cpu_flush_payload_singleLine;
   wire       [6:0]    dataCache_1_io_cpu_flush_payload_lineId;
-  wire                dataCache_1_io_mem_cmd_ready;
-  wire       [31:0]   _zz_PmpPlugin_pmpaddr_port0;
-  wire       [31:0]   _zz_PmpPlugin_pmpaddr_port2;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
-  wire       [24:0]   PmpPlugin_setter_io_base;
-  wire       [24:0]   PmpPlugin_setter_io_mask;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_data;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress;
@@ -137,6 +126,7 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_writeBack_exclusiveOk;
   wire                dataCache_1_io_cpu_flush_ready;
   wire                dataCache_1_io_cpu_redo;
+  wire                dataCache_1_io_cpu_writesPending;
   wire                dataCache_1_io_mem_cmd_valid;
   wire                dataCache_1_io_mem_cmd_payload_wr;
   wire                dataCache_1_io_mem_cmd_payload_uncached;
@@ -148,12 +138,11 @@ module VexRiscv (
   wire       [51:0]   _zz_memory_MUL_LOW;
   wire       [51:0]   _zz_memory_MUL_LOW_1;
   wire       [51:0]   _zz_memory_MUL_LOW_2;
-  wire       [51:0]   _zz_memory_MUL_LOW_3;
-  wire       [32:0]   _zz_memory_MUL_LOW_4;
-  wire       [51:0]   _zz_memory_MUL_LOW_5;
-  wire       [49:0]   _zz_memory_MUL_LOW_6;
-  wire       [51:0]   _zz_memory_MUL_LOW_7;
-  wire       [49:0]   _zz_memory_MUL_LOW_8;
+  wire       [32:0]   _zz_memory_MUL_LOW_3;
+  wire       [51:0]   _zz_memory_MUL_LOW_4;
+  wire       [49:0]   _zz_memory_MUL_LOW_5;
+  wire       [51:0]   _zz_memory_MUL_LOW_6;
+  wire       [49:0]   _zz_memory_MUL_LOW_7;
   wire       [31:0]   _zz_execute_SHIFT_RIGHT;
   wire       [32:0]   _zz_execute_SHIFT_RIGHT_1;
   wire       [32:0]   _zz_execute_SHIFT_RIGHT_2;
@@ -164,19 +153,19 @@ module VexRiscv (
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_2;
   wire                _zz_decode_LEGAL_INSTRUCTION_3;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_4;
-  wire       [13:0]   _zz_decode_LEGAL_INSTRUCTION_5;
+  wire       [12:0]   _zz_decode_LEGAL_INSTRUCTION_5;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_6;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_7;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_8;
   wire                _zz_decode_LEGAL_INSTRUCTION_9;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_10;
-  wire       [7:0]    _zz_decode_LEGAL_INSTRUCTION_11;
+  wire       [6:0]    _zz_decode_LEGAL_INSTRUCTION_11;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_12;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_13;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_14;
   wire                _zz_decode_LEGAL_INSTRUCTION_15;
   wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_16;
-  wire       [1:0]    _zz_decode_LEGAL_INSTRUCTION_17;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_17;
   wire       [3:0]    _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1;
   reg        [31:0]   _zz_IBusCachedPlugin_jump_pcLoad_payload_5;
   wire       [1:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_6;
@@ -184,10 +173,10 @@ module VexRiscv (
   wire       [2:0]    _zz_IBusCachedPlugin_fetchPc_pc_1;
   wire       [11:0]   _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   wire       [31:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2;
-  wire       [19:0]   _zz__zz_3;
-  wire       [11:0]   _zz__zz_5;
-  wire       [31:0]   _zz__zz_7;
-  wire       [31:0]   _zz__zz_7_1;
+  wire       [19:0]   _zz__zz_2;
+  wire       [11:0]   _zz__zz_4;
+  wire       [31:0]   _zz__zz_6;
+  wire       [31:0]   _zz__zz_6_1;
   wire       [19:0]   _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload;
   wire       [11:0]   _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
   wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_4;
@@ -201,73 +190,169 @@ module VexRiscv (
   wire       [1:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_1;
   reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_2;
   wire       [0:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_3;
-  reg        [7:0]    _zz_when_PmpPlugin_l246;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_0_1;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_0_2;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_0_3;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_0_4;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_1;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_1_1;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_1_2;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_1_3;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_2;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_2_1;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_2_2;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_2_3;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_3;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_3_1;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_3_2;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_3_3;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_4;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_4_1;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_4_2;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_4_3;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_5;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_5_1;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_5_2;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_5_3;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_6;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_6_1;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_6_2;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_6_3;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_7;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_7_1;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_7_2;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_7_3;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_8;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_8_1;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_8_2;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_8_3;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_9;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_9_1;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_9_2;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_9_3;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_10;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_10_1;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_10_2;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_10_3;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_11;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_11_1;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_11_2;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_11_3;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_12;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_12_1;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_12_2;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_12_3;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_13;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_13_1;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_13_2;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_13_3;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_14;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_14_1;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_14_2;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_14_3;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_15;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_15_1;
-  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_15_2;
-  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_15_3;
-  wire       [0:0]    _zz_when_PmpPlugin_l277;
-  wire       [5:0]    _zz_when_PmpPlugin_l277_1;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_0_6;
+  wire       [35:0]   _zz__zz_PmpPlugin_ports_0_hits_0_3;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_0_3_1;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_1_6;
+  wire       [35:0]   _zz__zz_PmpPlugin_ports_0_hits_1_3;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_1_3_1;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_2_6;
+  wire       [35:0]   _zz__zz_PmpPlugin_ports_0_hits_2_3;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_2_3_1;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_3_6;
+  wire       [35:0]   _zz__zz_PmpPlugin_ports_0_hits_3_3;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_3_3_1;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_4_6;
+  wire       [35:0]   _zz__zz_PmpPlugin_ports_0_hits_4_3;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_4_3_1;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_5_6;
+  wire       [35:0]   _zz__zz_PmpPlugin_ports_0_hits_5_3;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_5_3_1;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_6_6;
+  wire       [35:0]   _zz__zz_PmpPlugin_ports_0_hits_6_3;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_6_3_1;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_7_6;
+  wire       [35:0]   _zz__zz_PmpPlugin_ports_0_hits_7_3;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_7_3_1;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_8_6;
+  wire       [35:0]   _zz__zz_PmpPlugin_ports_0_hits_8_3;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_8_3_1;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_9_6;
+  wire       [35:0]   _zz__zz_PmpPlugin_ports_0_hits_9_3;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_9_3_1;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_10_6;
+  wire       [35:0]   _zz__zz_PmpPlugin_ports_0_hits_10_3;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_10_3_1;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_11_6;
+  wire       [35:0]   _zz__zz_PmpPlugin_ports_0_hits_11_3;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_11_3_1;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_12_6;
+  wire       [35:0]   _zz__zz_PmpPlugin_ports_0_hits_12_3;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_12_3_1;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_13_6;
+  wire       [35:0]   _zz__zz_PmpPlugin_ports_0_hits_13_3;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_13_3_1;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_14_6;
+  wire       [35:0]   _zz__zz_PmpPlugin_ports_0_hits_14_3;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_14_3_1;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_15_6;
+  wire       [35:0]   _zz__zz_PmpPlugin_ports_0_hits_15_3;
+  wire       [33:0]   _zz__zz_PmpPlugin_ports_0_hits_15_3_1;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_0_8;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_0_9;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_1_8;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_1_9;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_2_8;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_2_9;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_3_8;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_3_9;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_4_8;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_4_9;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_5_8;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_5_9;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_6_8;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_6_9;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_7_8;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_7_9;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_8_8;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_8_9;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_9_8;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_9_9;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_10_8;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_10_9;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_11_8;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_11_9;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_12_8;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_12_9;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_13_8;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_13_9;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_14_8;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_14_9;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_15_8;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_15_9;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_16;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_17;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_18;
+  reg        [4:0]    _zz_when_PmpPlugin_l250_19;
+  wire       [2:0]    _zz_when_PmpPlugin_l250_20;
+  reg        [4:0]    _zz_when_PmpPlugin_l250_21;
+  wire       [2:0]    _zz_when_PmpPlugin_l250_22;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_23;
+  reg        [4:0]    _zz_when_PmpPlugin_l250_24;
+  wire       [2:0]    _zz_when_PmpPlugin_l250_25;
+  reg        [4:0]    _zz_when_PmpPlugin_l250_26;
+  wire       [2:0]    _zz_when_PmpPlugin_l250_27;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_28;
+  reg        [4:0]    _zz_when_PmpPlugin_l250_29;
+  wire       [2:0]    _zz_when_PmpPlugin_l250_30;
+  reg        [4:0]    _zz_when_PmpPlugin_l250_31;
+  wire       [2:0]    _zz_when_PmpPlugin_l250_32;
+  wire       [0:0]    _zz_when_PmpPlugin_l250_33;
+  wire       [0:0]    _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowRead_32;
+  wire       [4:0]    _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowRead_32_1;
+  wire       [15:0]   _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowRead_33;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_49;
+  wire       [3:0]    _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_50;
+  wire       [0:0]    _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_32;
+  wire       [4:0]    _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_32_1;
+  wire       [15:0]   _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_33;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_49;
+  wire       [3:0]    _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_50;
+  wire       [0:0]    _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_32;
+  wire       [4:0]    _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_32_1;
+  wire       [15:0]   _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_33;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_49;
+  wire       [3:0]    _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_50;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_0;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_0_1;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_1;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_1_1;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_2;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_2_1;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_3;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_3_1;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_4;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_4_1;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_5;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_5_1;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_6;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_6_1;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_7;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_7_1;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_8;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_8_1;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_9;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_9_1;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_10;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_10_1;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_11;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_11_1;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_12;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_12_1;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_13;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_13_1;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_14;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_14_1;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_15;
+  wire       [35:0]   _zz_PmpPlugin_ports_1_hits_15_1;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_1_1;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_1_2;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_1_3;
+  reg        [4:0]    _zz_when_PmpPlugin_l250_1_4;
+  wire       [2:0]    _zz_when_PmpPlugin_l250_1_5;
+  reg        [4:0]    _zz_when_PmpPlugin_l250_1_6;
+  wire       [2:0]    _zz_when_PmpPlugin_l250_1_7;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_1_8;
+  reg        [4:0]    _zz_when_PmpPlugin_l250_1_9;
+  wire       [2:0]    _zz_when_PmpPlugin_l250_1_10;
+  reg        [4:0]    _zz_when_PmpPlugin_l250_1_11;
+  wire       [2:0]    _zz_when_PmpPlugin_l250_1_12;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_1_13;
+  reg        [4:0]    _zz_when_PmpPlugin_l250_1_14;
+  wire       [2:0]    _zz_when_PmpPlugin_l250_1_15;
+  reg        [4:0]    _zz_when_PmpPlugin_l250_1_16;
+  wire       [2:0]    _zz_when_PmpPlugin_l250_1_17;
+  wire       [0:0]    _zz_when_PmpPlugin_l250_1_18;
   wire       [0:0]    _zz__zz_DBusCachedPlugin_mmuBus_rsp_allowRead;
   wire       [4:0]    _zz__zz_DBusCachedPlugin_mmuBus_rsp_allowRead_1;
   wire       [15:0]   _zz__zz_DBusCachedPlugin_mmuBus_rsp_allowRead_1_1;
@@ -278,77 +363,11 @@ module VexRiscv (
   wire       [15:0]   _zz__zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_1_1;
   reg                 _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17;
   wire       [3:0]    _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_18;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_0_1;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_0_2;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_0_3;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_0_4;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_1;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_1_1;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_1_2;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_1_3;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_2;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_2_1;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_2_2;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_2_3;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_3;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_3_1;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_3_2;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_3_3;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_4;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_4_1;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_4_2;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_4_3;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_5;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_5_1;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_5_2;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_5_3;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_6;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_6_1;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_6_2;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_6_3;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_7;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_7_1;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_7_2;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_7_3;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_8;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_8_1;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_8_2;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_8_3;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_9;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_9_1;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_9_2;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_9_3;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_10;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_10_1;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_10_2;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_10_3;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_11;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_11_1;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_11_2;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_11_3;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_12;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_12_1;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_12_2;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_12_3;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_13;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_13_1;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_13_2;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_13_3;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_14;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_14_1;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_14_2;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_14_3;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_15;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_15_1;
-  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_15_2;
-  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_15_3;
-  wire       [0:0]    _zz_when_PmpPlugin_l299;
-  wire       [5:0]    _zz_when_PmpPlugin_l299_1;
-  wire       [0:0]    _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowExecute;
-  wire       [4:0]    _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1;
-  wire       [15:0]   _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1_1;
-  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_17;
-  wire       [3:0]    _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_18;
+  wire       [0:0]    _zz__zz_DBusCachedPlugin_mmuBus_rsp_allowExecute;
+  wire       [4:0]    _zz__zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_1;
+  wire       [15:0]   _zz__zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_1_1;
+  reg                 _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_17;
+  wire       [3:0]    _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_18;
   wire                _zz__zz_decode_IS_RS2_SIGNED;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_1;
   wire                _zz__zz_decode_IS_RS2_SIGNED_2;
@@ -371,133 +390,127 @@ module VexRiscv (
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_19;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_20;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_21;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_22;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_23;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_24;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_22;
+  wire       [21:0]   _zz__zz_decode_IS_RS2_SIGNED_23;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_24;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_25;
-  wire       [21:0]   _zz__zz_decode_IS_RS2_SIGNED_26;
-  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_27;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_26;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_27;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_28;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_29;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_30;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_31;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_32;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_33;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_34;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_35;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_36;
-  wire       [18:0]   _zz__zz_decode_IS_RS2_SIGNED_37;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_38;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_39;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_29;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_30;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_31;
+  wire       [18:0]   _zz__zz_decode_IS_RS2_SIGNED_32;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_33;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_34;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_35;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_36;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_37;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_38;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_39;
   wire                _zz__zz_decode_IS_RS2_SIGNED_40;
   wire                _zz__zz_decode_IS_RS2_SIGNED_41;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_42;
+  wire       [14:0]   _zz__zz_decode_IS_RS2_SIGNED_42;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_43;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_44;
-  wire       [15:0]   _zz__zz_decode_IS_RS2_SIGNED_45;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_46;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_44;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_45;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_46;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_47;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_48;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_48;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_49;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_50;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_51;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_52;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_50;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_51;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_52;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_53;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_54;
-  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_55;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_56;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_57;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_58;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_59;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_60;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_54;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_55;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_56;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_57;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_58;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_59;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_60;
   wire                _zz__zz_decode_IS_RS2_SIGNED_61;
-  wire       [12:0]   _zz__zz_decode_IS_RS2_SIGNED_62;
-  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_63;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_62;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_63;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_64;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_65;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_66;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_67;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_68;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_69;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_70;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_71;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_69;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_70;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_71;
   wire                _zz__zz_decode_IS_RS2_SIGNED_72;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_73;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_74;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_75;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_74;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_75;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_76;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_77;
-  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_78;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_79;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_80;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_81;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_82;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_83;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_77;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_78;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_79;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_80;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_81;
+  wire       [10:0]   _zz__zz_decode_IS_RS2_SIGNED_82;
+  wire       [5:0]    _zz__zz_decode_IS_RS2_SIGNED_83;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_84;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_85;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_86;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_87;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_88;
-  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_89;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_90;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_87;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_88;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_89;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_90;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_91;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_92;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_93;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_94;
-  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_95;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_92;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_93;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_94;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_95;
   wire                _zz__zz_decode_IS_RS2_SIGNED_96;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_97;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_98;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_99;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_98;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_99;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_100;
-  wire       [9:0]    _zz__zz_decode_IS_RS2_SIGNED_101;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_101;
   wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_102;
   wire                _zz__zz_decode_IS_RS2_SIGNED_103;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_104;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_105;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_106;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_107;
+  wire       [7:0]    _zz__zz_decode_IS_RS2_SIGNED_105;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_106;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_107;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_108;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_109;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_109;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_110;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_111;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_111;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_112;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_113;
-  wire       [6:0]    _zz__zz_decode_IS_RS2_SIGNED_114;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_115;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_116;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_117;
-  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_118;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_119;
+  wire       [5:0]    _zz__zz_decode_IS_RS2_SIGNED_113;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_114;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_115;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_116;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_117;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_118;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_119;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_120;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_121;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_122;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_123;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_124;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_123;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_124;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_125;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_126;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_127;
-  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_128;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_129;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_126;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_127;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_128;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_129;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_130;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_131;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_132;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_131;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_132;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_133;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_134;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_135;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_136;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_137;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_138;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_134;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_135;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_136;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_137;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_138;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_139;
-  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_140;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_141;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_140;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_141;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_142;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_143;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_144;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_145;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_146;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_147;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_148;
   wire                _zz_RegFilePlugin_regFile_port;
   wire                _zz_decode_RegFilePlugin_rs1Data;
   wire                _zz_RegFilePlugin_regFile_port_1;
@@ -505,14 +518,12 @@ module VexRiscv (
   wire       [0:0]    _zz__zz_execute_REGFILE_WRITE_DATA;
   wire       [2:0]    _zz__zz_execute_SRC1;
   wire       [4:0]    _zz__zz_execute_SRC1_1;
-  wire       [11:0]   _zz__zz_execute_SRC2_3;
+  wire       [11:0]   _zz__zz_execute_SRC2_2;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_1;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_2;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_3;
   wire       [31:0]   _zz_execute_SrcPlugin_addSub_4;
-  wire       [31:0]   _zz_execute_SrcPlugin_addSub_5;
-  wire       [31:0]   _zz_execute_SrcPlugin_addSub_6;
   wire       [19:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_2;
   wire       [11:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_4;
   wire       [31:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_6;
@@ -546,27 +557,24 @@ module VexRiscv (
   wire       [0:0]    _zz_memory_DivPlugin_rs1_3;
   wire       [31:0]   _zz_memory_DivPlugin_rs2_1;
   wire       [0:0]    _zz_memory_DivPlugin_rs2_2;
-  wire       [31:0]   _zz_PmpPlugin_pmpaddr_port;
-  reg        [7:0]    _zz_when_PmpPlugin_l209;
-  wire       [3:0]    _zz_when_PmpPlugin_l209_1;
-  reg        [7:0]    _zz_when_PmpPlugin_l209_1_1;
-  wire       [3:0]    _zz_when_PmpPlugin_l209_1_2;
-  reg        [7:0]    _zz_when_PmpPlugin_l209_2;
-  wire       [3:0]    _zz_when_PmpPlugin_l209_2_1;
-  reg        [7:0]    _zz_when_PmpPlugin_l209_3;
-  wire       [3:0]    _zz_when_PmpPlugin_l209_3_1;
-  reg        [7:0]    _zz_when_PmpPlugin_l216;
-  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_25;
-  reg        [7:0]    _zz_CsrPlugin_csrMapping_readDataSignal;
-  wire       [3:0]    _zz_CsrPlugin_csrMapping_readDataSignal_1;
-  reg        [7:0]    _zz_CsrPlugin_csrMapping_readDataSignal_2;
-  wire       [3:0]    _zz_CsrPlugin_csrMapping_readDataSignal_3;
-  reg        [7:0]    _zz_CsrPlugin_csrMapping_readDataSignal_4;
-  wire       [3:0]    _zz_CsrPlugin_csrMapping_readDataSignal_5;
-  reg        [7:0]    _zz_CsrPlugin_csrMapping_readDataSignal_6;
-  wire       [3:0]    _zz_CsrPlugin_csrMapping_readDataSignal_7;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_109;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_110;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_111;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_112;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_113;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_114;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_115;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_116;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_117;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_118;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_119;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_120;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_121;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_122;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_123;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_124;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_125;
   wire       [26:0]   _zz_iBusWishbone_ADR_1;
-  reg                 _zz_1;
   wire       [51:0]   memory_MUL_LOW;
   wire       [33:0]   memory_MUL_HH;
   wire       [33:0]   execute_MUL_HH;
@@ -684,7 +692,7 @@ module VexRiscv (
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_execute_SRC2;
+  wire       [31:0]   _zz_execute_to_memory_PC;
   wire       [1:0]    execute_SRC2_CTRL;
   wire       [1:0]    _zz_execute_SRC2_CTRL;
   wire       [1:0]    execute_SRC1_CTRL;
@@ -701,7 +709,7 @@ module VexRiscv (
   wire       [1:0]    _zz_execute_ALU_BITWISE_CTRL;
   wire       [31:0]   _zz_lastStageRegFileWrite_payload_address;
   wire                _zz_lastStageRegFileWrite_valid;
-  reg                 _zz_2;
+  reg                 _zz_1;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
@@ -810,8 +818,8 @@ module VexRiscv (
   wire       [31:0]   IBusCachedPlugin_mmuBus_rsp_physicalAddress;
   wire                IBusCachedPlugin_mmuBus_rsp_isIoAccess;
   wire                IBusCachedPlugin_mmuBus_rsp_isPaging;
-  wire                IBusCachedPlugin_mmuBus_rsp_allowRead;
-  wire                IBusCachedPlugin_mmuBus_rsp_allowWrite;
+  reg                 IBusCachedPlugin_mmuBus_rsp_allowRead;
+  reg                 IBusCachedPlugin_mmuBus_rsp_allowWrite;
   reg                 IBusCachedPlugin_mmuBus_rsp_allowExecute;
   wire                IBusCachedPlugin_mmuBus_rsp_exception;
   wire                IBusCachedPlugin_mmuBus_rsp_refilling;
@@ -840,7 +848,7 @@ module VexRiscv (
   wire                DBusCachedPlugin_mmuBus_rsp_isPaging;
   reg                 DBusCachedPlugin_mmuBus_rsp_allowRead;
   reg                 DBusCachedPlugin_mmuBus_rsp_allowWrite;
-  wire                DBusCachedPlugin_mmuBus_rsp_allowExecute;
+  reg                 DBusCachedPlugin_mmuBus_rsp_allowExecute;
   wire                DBusCachedPlugin_mmuBus_rsp_exception;
   wire                DBusCachedPlugin_mmuBus_rsp_refilling;
   wire                DBusCachedPlugin_mmuBus_rsp_bypassTranslation;
@@ -851,7 +859,7 @@ module VexRiscv (
   reg                 DBusCachedPlugin_exceptionBus_valid;
   reg        [3:0]    DBusCachedPlugin_exceptionBus_payload_code;
   wire       [31:0]   DBusCachedPlugin_exceptionBus_payload_badAddr;
-  reg                 _zz_when_DBusCachedPlugin_l393;
+  reg                 _zz_when_DBusCachedPlugin_l472;
   wire                decodeExceptionPort_valid;
   wire       [3:0]    decodeExceptionPort_payload_code;
   wire       [31:0]   decodeExceptionPort_payload_badAddr;
@@ -861,11 +869,12 @@ module VexRiscv (
   wire       [3:0]    BranchPlugin_branchExceptionPort_payload_code;
   wire       [31:0]   BranchPlugin_branchExceptionPort_payload_badAddr;
   reg                 BranchPlugin_inDebugNoFetchFlag;
-  reg        [31:0]   CsrPlugin_csrMapping_readDataSignal;
+  wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
   wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
   wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
   reg                 CsrPlugin_csrMapping_allowCsrSignal;
   wire                CsrPlugin_csrMapping_hazardFree;
+  reg                 CsrPlugin_csrMapping_doForceFailCsr;
   reg                 CsrPlugin_inWfi /* verilator public */ ;
   reg                 CsrPlugin_thirdPartyWake;
   reg                 CsrPlugin_jumpInterface_valid;
@@ -884,9 +893,10 @@ module VexRiscv (
   reg                 CsrPlugin_allowInterrupts;
   reg                 CsrPlugin_allowException;
   reg                 CsrPlugin_allowEbreakException;
-  reg                 IBusCachedPlugin_injectionPort_valid;
-  reg                 IBusCachedPlugin_injectionPort_ready;
-  wire       [31:0]   IBusCachedPlugin_injectionPort_payload;
+  reg                 CsrPlugin_xretAwayFromMachine;
+  reg                 DebugPlugin_injectionPort_valid;
+  reg                 DebugPlugin_injectionPort_ready;
+  wire       [31:0]   DebugPlugin_injectionPort_payload;
   wire                IBusCachedPlugin_externalFlush;
   wire                IBusCachedPlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
@@ -906,14 +916,13 @@ module VexRiscv (
   reg                 IBusCachedPlugin_fetchPc_pcRegPropagate;
   reg                 IBusCachedPlugin_fetchPc_booted;
   reg                 IBusCachedPlugin_fetchPc_inc;
-  wire                when_Fetcher_l134;
-  wire                IBusCachedPlugin_fetchPc_output_fire_1;
-  wire                when_Fetcher_l134_1;
+  wire                when_Fetcher_l133;
+  wire                when_Fetcher_l133_1;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pc;
   wire                IBusCachedPlugin_fetchPc_redo_valid;
   wire       [31:0]   IBusCachedPlugin_fetchPc_redo_payload;
   reg                 IBusCachedPlugin_fetchPc_flushed;
-  wire                when_Fetcher_l161;
+  wire                when_Fetcher_l160;
   reg                 IBusCachedPlugin_iBusRsp_redoFetch;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_ready;
@@ -941,8 +950,8 @@ module VexRiscv (
   wire                _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready;
   wire                IBusCachedPlugin_iBusRsp_flush;
   wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
-  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
-  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid;
+  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1;
   wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
@@ -955,25 +964,25 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_output_payload_rsp_error;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   wire                IBusCachedPlugin_iBusRsp_output_payload_isRvc;
-  wire                when_Fetcher_l243;
-  wire                when_Fetcher_l323;
+  wire                when_Fetcher_l242;
+  wire                when_Fetcher_l322;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
-  wire                when_Fetcher_l332;
+  wire                when_Fetcher_l331;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
-  wire                when_Fetcher_l332_1;
+  wire                when_Fetcher_l331_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
-  wire                when_Fetcher_l332_2;
+  wire                when_Fetcher_l331_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
-  wire                when_Fetcher_l332_3;
+  wire                when_Fetcher_l331_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                when_Fetcher_l332_4;
+  wire                when_Fetcher_l331_4;
   wire                _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   reg        [18:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1;
-  wire                _zz_3;
-  reg        [10:0]   _zz_4;
-  wire                _zz_5;
-  reg        [18:0]   _zz_6;
-  reg                 _zz_7;
+  wire                _zz_2;
+  reg        [10:0]   _zz_3;
+  wire                _zz_4;
+  reg        [18:0]   _zz_5;
+  reg                 _zz_6;
   wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload;
   reg        [10:0]   _zz_IBusCachedPlugin_predictionJumpInterface_payload_1;
   wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
@@ -992,156 +1001,507 @@ module VexRiscv (
   wire                IBusCachedPlugin_rsp_iBusRspOutputHalt;
   wire                IBusCachedPlugin_rsp_issueDetected;
   reg                 IBusCachedPlugin_rsp_redoFetch;
-  wire                when_IBusCachedPlugin_l239;
-  wire                when_IBusCachedPlugin_l244;
+  wire                when_IBusCachedPlugin_l245;
   wire                when_IBusCachedPlugin_l250;
   wire                when_IBusCachedPlugin_l256;
-  wire                when_IBusCachedPlugin_l267;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_valid;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_ready;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_address;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_data;
-  wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_size;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_last;
-  reg                 dataCache_1_io_mem_cmd_rValid;
-  reg                 dataCache_1_io_mem_cmd_rData_wr;
-  reg                 dataCache_1_io_mem_cmd_rData_uncached;
-  reg        [31:0]   dataCache_1_io_mem_cmd_rData_address;
-  reg        [31:0]   dataCache_1_io_mem_cmd_rData_data;
-  reg        [3:0]    dataCache_1_io_mem_cmd_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_rData_size;
-  reg                 dataCache_1_io_mem_cmd_rData_last;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
-  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
-  wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
-  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data;
-  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
-  wire                when_Stream_l368;
+  wire                when_IBusCachedPlugin_l262;
+  wire                when_IBusCachedPlugin_l273;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_valid;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+  wire       [3:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+  wire       [2:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_size;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rValidN;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rData_wr;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rData_uncached;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_rData_address;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_rData_data;
+  reg        [3:0]    toplevel_dataCache_1_io_mem_cmd_rData_mask;
+  reg        [2:0]    toplevel_dataCache_1_io_mem_cmd_rData_size;
+  reg                 toplevel_dataCache_1_io_mem_cmd_rData_last;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
+  wire       [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
+  wire       [3:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
+  wire       [2:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
+  wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_address;
+  reg        [31:0]   toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_data;
+  reg        [3:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
+  reg        [2:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_size;
+  reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  wire                when_Stream_l369;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
-  wire                when_DBusCachedPlugin_l308;
+  wire                when_DBusCachedPlugin_l352;
   wire       [1:0]    execute_DBusCachedPlugin_size;
   reg        [31:0]   _zz_execute_MEMORY_STORE_DATA_RF;
-  wire                dataCache_1_io_cpu_flush_isStall;
-  wire                when_DBusCachedPlugin_l350;
-  wire                when_DBusCachedPlugin_l366;
-  wire                when_DBusCachedPlugin_l393;
-  wire                when_DBusCachedPlugin_l446;
-  wire                when_DBusCachedPlugin_l466;
+  wire                toplevel_dataCache_1_io_cpu_flush_isStall;
+  wire                when_DBusCachedPlugin_l394;
+  wire                when_DBusCachedPlugin_l410;
+  wire                when_DBusCachedPlugin_l472;
+  wire                when_DBusCachedPlugin_l533;
+  wire                when_DBusCachedPlugin_l553;
+  wire       [31:0]   writeBack_DBusCachedPlugin_rspData;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_0;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_1;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_2;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
   wire       [31:0]   writeBack_DBusCachedPlugin_rspRf;
-  wire       [1:0]    switch_Misc_l210;
+  wire       [1:0]    switch_Misc_l232;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_1;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated_2;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
-  wire                when_DBusCachedPlugin_l492;
-  reg        [7:0]    PmpPlugin_pmpcfg_0;
-  reg        [7:0]    PmpPlugin_pmpcfg_1;
-  reg        [7:0]    PmpPlugin_pmpcfg_2;
-  reg        [7:0]    PmpPlugin_pmpcfg_3;
-  reg        [7:0]    PmpPlugin_pmpcfg_4;
-  reg        [7:0]    PmpPlugin_pmpcfg_5;
-  reg        [7:0]    PmpPlugin_pmpcfg_6;
-  reg        [7:0]    PmpPlugin_pmpcfg_7;
-  reg        [7:0]    PmpPlugin_pmpcfg_8;
-  reg        [7:0]    PmpPlugin_pmpcfg_9;
-  reg        [7:0]    PmpPlugin_pmpcfg_10;
-  reg        [7:0]    PmpPlugin_pmpcfg_11;
-  reg        [7:0]    PmpPlugin_pmpcfg_12;
-  reg        [7:0]    PmpPlugin_pmpcfg_13;
-  reg        [7:0]    PmpPlugin_pmpcfg_14;
-  reg        [7:0]    PmpPlugin_pmpcfg_15;
-  reg        [24:0]   PmpPlugin_base_0;
-  reg        [24:0]   PmpPlugin_base_1;
-  reg        [24:0]   PmpPlugin_base_2;
-  reg        [24:0]   PmpPlugin_base_3;
-  reg        [24:0]   PmpPlugin_base_4;
-  reg        [24:0]   PmpPlugin_base_5;
-  reg        [24:0]   PmpPlugin_base_6;
-  reg        [24:0]   PmpPlugin_base_7;
-  reg        [24:0]   PmpPlugin_base_8;
-  reg        [24:0]   PmpPlugin_base_9;
-  reg        [24:0]   PmpPlugin_base_10;
-  reg        [24:0]   PmpPlugin_base_11;
-  reg        [24:0]   PmpPlugin_base_12;
-  reg        [24:0]   PmpPlugin_base_13;
-  reg        [24:0]   PmpPlugin_base_14;
-  reg        [24:0]   PmpPlugin_base_15;
-  reg        [24:0]   PmpPlugin_mask_0;
-  reg        [24:0]   PmpPlugin_mask_1;
-  reg        [24:0]   PmpPlugin_mask_2;
-  reg        [24:0]   PmpPlugin_mask_3;
-  reg        [24:0]   PmpPlugin_mask_4;
-  reg        [24:0]   PmpPlugin_mask_5;
-  reg        [24:0]   PmpPlugin_mask_6;
-  reg        [24:0]   PmpPlugin_mask_7;
-  reg        [24:0]   PmpPlugin_mask_8;
-  reg        [24:0]   PmpPlugin_mask_9;
-  reg        [24:0]   PmpPlugin_mask_10;
-  reg        [24:0]   PmpPlugin_mask_11;
-  reg        [24:0]   PmpPlugin_mask_12;
-  reg        [24:0]   PmpPlugin_mask_13;
-  reg        [24:0]   PmpPlugin_mask_14;
-  reg        [24:0]   PmpPlugin_mask_15;
-  reg                 execute_PmpPlugin_fsmPending;
-  wire                when_PmpPlugin_l138;
-  reg                 execute_PmpPlugin_fsmComplete;
-  wire       [11:0]   execute_PmpPlugin_csrAddress;
-  wire       [3:0]    execute_PmpPlugin_pmpNcfg;
-  wire       [1:0]    execute_PmpPlugin_pmpcfgN;
-  wire                execute_PmpPlugin_pmpcfgCsr;
-  wire                execute_PmpPlugin_pmpaddrCsr;
-  reg        [3:0]    execute_PmpPlugin_pmpNcfg_;
-  reg        [1:0]    execute_PmpPlugin_pmpcfgN_;
-  reg                 execute_PmpPlugin_pmpcfgCsr_;
-  reg                 execute_PmpPlugin_pmpaddrCsr_;
-  reg        [31:0]   execute_PmpPlugin_writeData_;
-  wire                execute_PmpPlugin_fsm_wantExit;
-  reg                 execute_PmpPlugin_fsm_wantStart;
-  wire                execute_PmpPlugin_fsm_wantKill;
-  reg                 execute_PmpPlugin_fsm_fsmEnable;
-  reg        [3:0]    execute_PmpPlugin_fsm_fsmCounter;
-  wire                when_PmpPlugin_l246;
-  wire       [15:0]   _zz_8;
-  wire       [15:0]   _zz_9;
-  wire       [24:0]   _zz_PmpPlugin_dGuard_hits_0;
-  wire                PmpPlugin_dGuard_hits_0;
-  wire                PmpPlugin_dGuard_hits_1;
-  wire                PmpPlugin_dGuard_hits_2;
-  wire                PmpPlugin_dGuard_hits_3;
-  wire                PmpPlugin_dGuard_hits_4;
-  wire                PmpPlugin_dGuard_hits_5;
-  wire                PmpPlugin_dGuard_hits_6;
-  wire                PmpPlugin_dGuard_hits_7;
-  wire                PmpPlugin_dGuard_hits_8;
-  wire                PmpPlugin_dGuard_hits_9;
-  wire                PmpPlugin_dGuard_hits_10;
-  wire                PmpPlugin_dGuard_hits_11;
-  wire                PmpPlugin_dGuard_hits_12;
-  wire                PmpPlugin_dGuard_hits_13;
-  wire                PmpPlugin_dGuard_hits_14;
-  wire                PmpPlugin_dGuard_hits_15;
-  wire                when_PmpPlugin_l277;
+  wire                when_DBusCachedPlugin_l580;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute;
+  reg                 _zz_when_PmpPlugin_l126;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_1;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_1;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1;
+  reg                 _zz_when_PmpPlugin_l126_1;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_2;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
+  reg                 _zz_PmpPlugin_ports_0_hits_0;
+  wire                _zz_PmpPlugin_ports_0_hits_0_1;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_0_2;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_0_3;
+  wire                when_PmpPlugin_l126;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_0_4;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_0_5;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_0_6;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_0_7;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_2;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_2;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_2;
+  reg                 _zz_when_PmpPlugin_l126_2;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_4;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_5;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_3;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_3;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_3;
+  reg                 _zz_when_PmpPlugin_l126_3;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_6;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
+  reg                 _zz_PmpPlugin_ports_0_hits_1;
+  wire                _zz_PmpPlugin_ports_0_hits_1_1;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_1_2;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_1_3;
+  wire                when_PmpPlugin_l126_1;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_1_4;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_1_5;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_1_6;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_1_7;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_4;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_4;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_4;
+  reg                 _zz_when_PmpPlugin_l126_4;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_8;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_5;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_5;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_5;
+  reg                 _zz_when_PmpPlugin_l126_5;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_10;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_11;
+  reg                 _zz_PmpPlugin_ports_0_hits_2;
+  wire                _zz_PmpPlugin_ports_0_hits_2_1;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_2_2;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_2_3;
+  wire                when_PmpPlugin_l126_2;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_2_4;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_2_5;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_2_6;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_2_7;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_6;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_6;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_6;
+  reg                 _zz_when_PmpPlugin_l126_6;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_12;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_13;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_7;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_7;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_7;
+  reg                 _zz_when_PmpPlugin_l126_7;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_14;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_15;
+  reg                 _zz_PmpPlugin_ports_0_hits_3;
+  wire                _zz_PmpPlugin_ports_0_hits_3_1;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_3_2;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_3_3;
+  wire                when_PmpPlugin_l126_3;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_3_4;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_3_5;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_3_6;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_3_7;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_8;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_8;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_8;
+  reg                 _zz_when_PmpPlugin_l126_8;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_16;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_17;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_9;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_9;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_9;
+  reg                 _zz_when_PmpPlugin_l126_9;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_18;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_19;
+  reg                 _zz_PmpPlugin_ports_0_hits_4;
+  wire                _zz_PmpPlugin_ports_0_hits_4_1;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_4_2;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_4_3;
+  wire                when_PmpPlugin_l126_4;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_4_4;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_4_5;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_4_6;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_4_7;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_10;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_10;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_10;
+  reg                 _zz_when_PmpPlugin_l126_10;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_20;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_21;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_11;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_11;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_11;
+  reg                 _zz_when_PmpPlugin_l126_11;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_22;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_23;
+  reg                 _zz_PmpPlugin_ports_0_hits_5;
+  wire                _zz_PmpPlugin_ports_0_hits_5_1;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_5_2;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_5_3;
+  wire                when_PmpPlugin_l126_5;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_5_4;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_5_5;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_5_6;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_5_7;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_12;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_12;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_12;
+  reg                 _zz_when_PmpPlugin_l126_12;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_24;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_25;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_13;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_13;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_13;
+  reg                 _zz_when_PmpPlugin_l126_13;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_26;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_27;
+  reg                 _zz_PmpPlugin_ports_0_hits_6;
+  wire                _zz_PmpPlugin_ports_0_hits_6_1;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_6_2;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_6_3;
+  wire                when_PmpPlugin_l126_6;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_6_4;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_6_5;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_6_6;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_6_7;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_14;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_14;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_14;
+  reg                 _zz_when_PmpPlugin_l126_14;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_28;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_29;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_15;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_15;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_15;
+  reg                 _zz_when_PmpPlugin_l126_15;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_30;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_31;
+  reg                 _zz_PmpPlugin_ports_0_hits_7;
+  wire                _zz_PmpPlugin_ports_0_hits_7_1;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_7_2;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_7_3;
+  wire                when_PmpPlugin_l126_7;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_7_4;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_7_5;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_7_6;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_7_7;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_16;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_16;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_16;
+  reg                 _zz_when_PmpPlugin_l126_16;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_32;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_33;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_17;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_17;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_17;
+  reg                 _zz_when_PmpPlugin_l126_17;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_34;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_35;
+  reg                 _zz_PmpPlugin_ports_0_hits_8;
+  wire                _zz_PmpPlugin_ports_0_hits_8_1;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_8_2;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_8_3;
+  wire                when_PmpPlugin_l126_8;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_8_4;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_8_5;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_8_6;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_8_7;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_18;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_18;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_18;
+  reg                 _zz_when_PmpPlugin_l126_18;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_36;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_37;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_19;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_19;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_19;
+  reg                 _zz_when_PmpPlugin_l126_19;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_38;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_39;
+  reg                 _zz_PmpPlugin_ports_0_hits_9;
+  wire                _zz_PmpPlugin_ports_0_hits_9_1;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_9_2;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_9_3;
+  wire                when_PmpPlugin_l126_9;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_9_4;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_9_5;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_9_6;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_9_7;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_20;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_20;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_20;
+  reg                 _zz_when_PmpPlugin_l126_20;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_40;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_41;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_21;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_21;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_21;
+  reg                 _zz_when_PmpPlugin_l126_21;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_42;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_43;
+  reg                 _zz_PmpPlugin_ports_0_hits_10;
+  wire                _zz_PmpPlugin_ports_0_hits_10_1;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_10_2;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_10_3;
+  wire                when_PmpPlugin_l126_10;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_10_4;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_10_5;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_10_6;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_10_7;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_22;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_22;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_22;
+  reg                 _zz_when_PmpPlugin_l126_22;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_44;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_45;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_23;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_23;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_23;
+  reg                 _zz_when_PmpPlugin_l126_23;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_46;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_47;
+  reg                 _zz_PmpPlugin_ports_0_hits_11;
+  wire                _zz_PmpPlugin_ports_0_hits_11_1;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_11_2;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_11_3;
+  wire                when_PmpPlugin_l126_11;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_11_4;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_11_5;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_11_6;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_11_7;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_24;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_24;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_24;
+  reg                 _zz_when_PmpPlugin_l126_24;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_48;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_49;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_25;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_25;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_25;
+  reg                 _zz_when_PmpPlugin_l126_25;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_50;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_51;
+  reg                 _zz_PmpPlugin_ports_0_hits_12;
+  wire                _zz_PmpPlugin_ports_0_hits_12_1;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_12_2;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_12_3;
+  wire                when_PmpPlugin_l126_12;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_12_4;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_12_5;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_12_6;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_12_7;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_26;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_26;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_26;
+  reg                 _zz_when_PmpPlugin_l126_26;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_52;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_53;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_27;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_27;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_27;
+  reg                 _zz_when_PmpPlugin_l126_27;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_54;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_55;
+  reg                 _zz_PmpPlugin_ports_0_hits_13;
+  wire                _zz_PmpPlugin_ports_0_hits_13_1;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_13_2;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_13_3;
+  wire                when_PmpPlugin_l126_13;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_13_4;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_13_5;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_13_6;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_13_7;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_28;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_28;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_28;
+  reg                 _zz_when_PmpPlugin_l126_28;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_56;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_57;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_29;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_29;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_29;
+  reg                 _zz_when_PmpPlugin_l126_29;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_58;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_59;
+  reg                 _zz_PmpPlugin_ports_0_hits_14;
+  wire                _zz_PmpPlugin_ports_0_hits_14_1;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_14_2;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_14_3;
+  wire                when_PmpPlugin_l126_14;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_14_4;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_14_5;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_14_6;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_14_7;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_30;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_30;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_30;
+  reg                 _zz_when_PmpPlugin_l126_30;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_60;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_61;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_31;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_31;
+  reg                 _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_31;
+  reg                 _zz_when_PmpPlugin_l126_31;
+  reg        [1:0]    _zz_CsrPlugin_csrMapping_readDataInit_62;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_63;
+  reg                 _zz_PmpPlugin_ports_0_hits_15;
+  wire                _zz_PmpPlugin_ports_0_hits_15_1;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_15_2;
+  reg        [35:0]   _zz_PmpPlugin_ports_0_hits_15_3;
+  wire                when_PmpPlugin_l126_15;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_15_4;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_15_5;
+  wire       [33:0]   _zz_PmpPlugin_ports_0_hits_15_6;
+  wire       [35:0]   _zz_PmpPlugin_ports_0_hits_15_7;
+  wire                PmpPlugin_ports_0_hits_0;
+  wire                PmpPlugin_ports_0_hits_1;
+  wire                PmpPlugin_ports_0_hits_2;
+  wire                PmpPlugin_ports_0_hits_3;
+  wire                PmpPlugin_ports_0_hits_4;
+  wire                PmpPlugin_ports_0_hits_5;
+  wire                PmpPlugin_ports_0_hits_6;
+  wire                PmpPlugin_ports_0_hits_7;
+  wire                PmpPlugin_ports_0_hits_8;
+  wire                PmpPlugin_ports_0_hits_9;
+  wire                PmpPlugin_ports_0_hits_10;
+  wire                PmpPlugin_ports_0_hits_11;
+  wire                PmpPlugin_ports_0_hits_12;
+  wire                PmpPlugin_ports_0_hits_13;
+  wire                PmpPlugin_ports_0_hits_14;
+  wire                PmpPlugin_ports_0_hits_15;
+  wire       [4:0]    _zz_when_PmpPlugin_l250;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_1;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_2;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_3;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_4;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_5;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_6;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_7;
+  wire                when_PmpPlugin_l250;
+  wire       [15:0]   _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_32;
+  wire       [15:0]   _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_33;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_34;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_35;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_36;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_37;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_38;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_39;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_40;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_41;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_42;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_43;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_44;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_45;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_46;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_47;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_48;
+  wire       [15:0]   _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_32;
+  wire       [15:0]   _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_33;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_34;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_35;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_36;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_37;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_38;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_39;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_40;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_41;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_42;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_43;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_44;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_45;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_46;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_47;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_48;
+  wire       [15:0]   _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_32;
+  wire       [15:0]   _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_33;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_34;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_35;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_36;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_37;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_38;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_39;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_40;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_41;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_42;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_43;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_44;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_45;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_46;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_47;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_48;
+  wire                PmpPlugin_ports_1_hits_0;
+  wire                PmpPlugin_ports_1_hits_1;
+  wire                PmpPlugin_ports_1_hits_2;
+  wire                PmpPlugin_ports_1_hits_3;
+  wire                PmpPlugin_ports_1_hits_4;
+  wire                PmpPlugin_ports_1_hits_5;
+  wire                PmpPlugin_ports_1_hits_6;
+  wire                PmpPlugin_ports_1_hits_7;
+  wire                PmpPlugin_ports_1_hits_8;
+  wire                PmpPlugin_ports_1_hits_9;
+  wire                PmpPlugin_ports_1_hits_10;
+  wire                PmpPlugin_ports_1_hits_11;
+  wire                PmpPlugin_ports_1_hits_12;
+  wire                PmpPlugin_ports_1_hits_13;
+  wire                PmpPlugin_ports_1_hits_14;
+  wire                PmpPlugin_ports_1_hits_15;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_8;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_9;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_10;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_11;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_12;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_13;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_14;
+  wire       [4:0]    _zz_when_PmpPlugin_l250_15;
+  wire                when_PmpPlugin_l250_1;
   wire       [15:0]   _zz_DBusCachedPlugin_mmuBus_rsp_allowRead;
   wire       [15:0]   _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_1;
   wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_2;
@@ -1176,41 +1536,23 @@ module VexRiscv (
   wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_14;
   wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_15;
   wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_16;
-  wire       [24:0]   _zz_PmpPlugin_iGuard_hits_0;
-  wire                PmpPlugin_iGuard_hits_0;
-  wire                PmpPlugin_iGuard_hits_1;
-  wire                PmpPlugin_iGuard_hits_2;
-  wire                PmpPlugin_iGuard_hits_3;
-  wire                PmpPlugin_iGuard_hits_4;
-  wire                PmpPlugin_iGuard_hits_5;
-  wire                PmpPlugin_iGuard_hits_6;
-  wire                PmpPlugin_iGuard_hits_7;
-  wire                PmpPlugin_iGuard_hits_8;
-  wire                PmpPlugin_iGuard_hits_9;
-  wire                PmpPlugin_iGuard_hits_10;
-  wire                PmpPlugin_iGuard_hits_11;
-  wire                PmpPlugin_iGuard_hits_12;
-  wire                PmpPlugin_iGuard_hits_13;
-  wire                PmpPlugin_iGuard_hits_14;
-  wire                PmpPlugin_iGuard_hits_15;
-  wire                when_PmpPlugin_l299;
-  wire       [15:0]   _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute;
-  wire       [15:0]   _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1;
-  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_2;
-  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_3;
-  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_4;
-  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_5;
-  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_6;
-  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_7;
-  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_8;
-  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_9;
-  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_10;
-  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_11;
-  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_12;
-  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_13;
-  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_14;
-  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_15;
-  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_16;
+  wire       [15:0]   _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute;
+  wire       [15:0]   _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_1;
+  wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_2;
+  wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_3;
+  wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_4;
+  wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_5;
+  wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_6;
+  wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_7;
+  wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_8;
+  wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_9;
+  wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_10;
+  wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_11;
+  wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_12;
+  wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_13;
+  wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_14;
+  wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_15;
+  wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_16;
   wire       [32:0]   _zz_decode_IS_RS2_SIGNED;
   wire                _zz_decode_IS_RS2_SIGNED_1;
   wire                _zz_decode_IS_RS2_SIGNED_2;
@@ -1236,11 +1578,11 @@ module VexRiscv (
   reg        [31:0]   execute_IntAluPlugin_bitwise;
   reg        [31:0]   _zz_execute_REGFILE_WRITE_DATA;
   reg        [31:0]   _zz_execute_SRC1;
-  wire                _zz_execute_SRC2_1;
-  reg        [19:0]   _zz_execute_SRC2_2;
-  wire                _zz_execute_SRC2_3;
-  reg        [19:0]   _zz_execute_SRC2_4;
-  reg        [31:0]   _zz_execute_SRC2_5;
+  wire                _zz_execute_SRC2;
+  reg        [19:0]   _zz_execute_SRC2_1;
+  wire                _zz_execute_SRC2_2;
+  reg        [19:0]   _zz_execute_SRC2_3;
+  reg        [31:0]   _zz_execute_SRC2_4;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   wire       [4:0]    execute_FullBarrelShifterPlugin_amplitude;
@@ -1277,7 +1619,7 @@ module VexRiscv (
   wire                when_HazardSimplePlugin_l108;
   wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    switch_Misc_l210_1;
+  wire       [2:0]    switch_Misc_l232_1;
   reg                 _zz_execute_BRANCH_COND_RESULT;
   reg                 _zz_execute_BRANCH_COND_RESULT_1;
   wire                _zz_execute_BranchPlugin_missAlignedTarget;
@@ -1298,8 +1640,8 @@ module VexRiscv (
   reg        [18:0]   _zz_execute_BranchPlugin_branch_src2_5;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
   reg        [1:0]    _zz_CsrPlugin_privilege;
-  reg        [1:0]    CsrPlugin_misa_base;
-  reg        [25:0]   CsrPlugin_misa_extensions;
+  wire       [1:0]    CsrPlugin_misa_base;
+  wire       [25:0]   CsrPlugin_misa_extensions;
   reg        [1:0]    CsrPlugin_mtvec_mode;
   reg        [29:0]   CsrPlugin_mtvec_base;
   reg        [31:0]   CsrPlugin_mepc;
@@ -1318,9 +1660,12 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_mtval;
   reg        [63:0]   CsrPlugin_mcycle;
   reg        [63:0]   CsrPlugin_minstret;
-  wire                _zz_when_CsrPlugin_l965;
-  wire                _zz_when_CsrPlugin_l965_1;
-  wire                _zz_when_CsrPlugin_l965_2;
+  reg                 CsrPlugin_mcounteren_IR;
+  wire                CsrPlugin_mcounteren_TM;
+  reg                 CsrPlugin_mcounteren_CY;
+  wire                _zz_when_CsrPlugin_l1302;
+  wire                _zz_when_CsrPlugin_l1302_1;
+  wire                _zz_when_CsrPlugin_l1302_2;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -1335,59 +1680,63 @@ module VexRiscv (
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
   wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code;
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
-  wire                when_CsrPlugin_l922;
-  wire                when_CsrPlugin_l922_1;
-  wire                when_CsrPlugin_l922_2;
-  wire                when_CsrPlugin_l922_3;
-  wire                when_CsrPlugin_l935;
+  wire                when_CsrPlugin_l1259;
+  wire                when_CsrPlugin_l1259_1;
+  wire                when_CsrPlugin_l1259_2;
+  wire                when_CsrPlugin_l1259_3;
+  wire                when_CsrPlugin_l1272;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
-  wire                when_CsrPlugin_l959;
-  wire                when_CsrPlugin_l965;
-  wire                when_CsrPlugin_l965_1;
-  wire                when_CsrPlugin_l965_2;
+  wire                when_CsrPlugin_l1296;
+  wire                when_CsrPlugin_l1302;
+  wire                when_CsrPlugin_l1302_1;
+  wire                when_CsrPlugin_l1302_2;
   wire                CsrPlugin_exception;
   reg                 CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
-  wire                when_CsrPlugin_l993;
-  wire                when_CsrPlugin_l993_1;
-  wire                when_CsrPlugin_l993_2;
-  wire                when_CsrPlugin_l998;
+  wire                when_CsrPlugin_l1335;
+  wire                when_CsrPlugin_l1335_1;
+  wire                when_CsrPlugin_l1335_2;
+  wire                when_CsrPlugin_l1340;
   reg                 CsrPlugin_pipelineLiberator_done;
-  wire                when_CsrPlugin_l1004;
+  wire                when_CsrPlugin_l1346;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
+  wire                CsrPlugin_trapCauseEbreakDebug;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
-  wire                when_CsrPlugin_l1032;
-  wire                when_CsrPlugin_l1077;
-  wire       [1:0]    switch_CsrPlugin_l1081;
+  wire                CsrPlugin_trapEnterDebug;
+  wire                when_CsrPlugin_l1390;
+  wire                when_CsrPlugin_l1398;
+  wire                when_CsrPlugin_l1456;
+  wire       [1:0]    switch_CsrPlugin_l1460;
+  wire                when_CsrPlugin_l1468;
   reg                 execute_CsrPlugin_wfiWake;
-  wire                when_CsrPlugin_l1121;
-  wire                when_CsrPlugin_l1123;
-  wire                when_CsrPlugin_l1129;
+  wire                when_CsrPlugin_l1519;
+  wire                when_CsrPlugin_l1521;
+  wire                when_CsrPlugin_l1527;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire                when_CsrPlugin_l1142;
-  wire                when_CsrPlugin_l1149;
-  wire                when_CsrPlugin_l1150;
-  wire                when_CsrPlugin_l1157;
+  wire                when_CsrPlugin_l1540;
+  wire                when_CsrPlugin_l1547;
+  wire                when_CsrPlugin_l1548;
+  wire                when_CsrPlugin_l1555;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   wire       [31:0]   execute_CsrPlugin_readToWriteData;
-  wire                switch_Misc_l210_2;
+  wire                switch_Misc_l232_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
-  wire                when_CsrPlugin_l1189;
-  wire                when_CsrPlugin_l1193;
+  wire                when_CsrPlugin_l1587;
+  wire                when_CsrPlugin_l1591;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg                 execute_MulPlugin_aSigned;
   reg                 execute_MulPlugin_bSigned;
@@ -1433,8 +1782,8 @@ module VexRiscv (
   wire                _zz_memory_DivPlugin_rs1;
   reg        [32:0]   _zz_memory_DivPlugin_rs1_1;
   reg        [31:0]   externalInterruptArray_regNext;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit;
-  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_64;
+  wire       [31:0]   _zz_externalInterrupt;
   reg                 DebugPlugin_firstCycle;
   reg                 DebugPlugin_secondCycle;
   reg                 DebugPlugin_resetIt;
@@ -1442,7 +1791,7 @@ module VexRiscv (
   reg                 DebugPlugin_stepIt;
   reg                 DebugPlugin_isPipBusy;
   reg                 DebugPlugin_godmode;
-  wire                when_DebugPlugin_l225;
+  wire                when_DebugPlugin_l238;
   reg                 DebugPlugin_haltedByBreak;
   reg                 DebugPlugin_debugUsed /* verilator public */ ;
   reg                 DebugPlugin_disableEbreak;
@@ -1452,22 +1801,22 @@ module VexRiscv (
   reg                 DebugPlugin_hardwareBreakpoints_1_valid;
   reg        [30:0]   DebugPlugin_hardwareBreakpoints_1_pc;
   reg        [31:0]   DebugPlugin_busReadDataReg;
-  reg                 _zz_when_DebugPlugin_l244;
-  wire                when_DebugPlugin_l244;
-  wire       [5:0]    switch_DebugPlugin_l267;
-  wire                when_DebugPlugin_l271;
-  wire                when_DebugPlugin_l271_1;
-  wire                when_DebugPlugin_l272;
-  wire                when_DebugPlugin_l272_1;
-  wire                when_DebugPlugin_l273;
-  wire                when_DebugPlugin_l274;
-  wire                when_DebugPlugin_l275;
-  wire                when_DebugPlugin_l275_1;
-  wire                when_DebugPlugin_l295;
-  wire                when_DebugPlugin_l298;
+  reg                 _zz_when_DebugPlugin_l257;
+  wire                when_DebugPlugin_l257;
+  wire       [5:0]    switch_DebugPlugin_l280;
+  wire                when_DebugPlugin_l284;
+  wire                when_DebugPlugin_l284_1;
+  wire                when_DebugPlugin_l285;
+  wire                when_DebugPlugin_l285_1;
+  wire                when_DebugPlugin_l286;
+  wire                when_DebugPlugin_l287;
+  wire                when_DebugPlugin_l288;
+  wire                when_DebugPlugin_l288_1;
+  wire                when_DebugPlugin_l308;
   wire                when_DebugPlugin_l311;
+  wire                when_DebugPlugin_l324;
   reg                 DebugPlugin_resetIt_regNext;
-  wire                when_DebugPlugin_l331;
+  wire                when_DebugPlugin_l344;
   wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
   wire                when_Pipeline_l124_1;
@@ -1600,115 +1949,162 @@ module VexRiscv (
   wire                when_Pipeline_l154_1;
   wire                when_Pipeline_l151_2;
   wire                when_Pipeline_l154_2;
-  reg        [2:0]    switch_Fetcher_l365;
-  wire                when_Fetcher_l381;
-  reg        [2:0]    execute_PmpPlugin_fsm_stateReg;
-  reg        [2:0]    execute_PmpPlugin_fsm_stateNext;
-  wire       [7:0]    _zz_PmpPlugin_pmpcfg_0;
-  wire       [7:0]    _zz_PmpPlugin_pmpcfg_0_1;
-  wire       [7:0]    _zz_PmpPlugin_pmpcfg_0_2;
-  wire       [7:0]    _zz_PmpPlugin_pmpcfg_0_3;
-  wire                when_PmpPlugin_l209;
-  wire       [15:0]   _zz_11;
-  wire                when_PmpPlugin_l209_1;
-  wire       [15:0]   _zz_12;
-  wire                when_PmpPlugin_l209_2;
-  wire       [15:0]   _zz_13;
-  wire                when_PmpPlugin_l209_3;
-  wire       [15:0]   _zz_14;
-  wire                when_PmpPlugin_l216;
-  wire                when_PmpPlugin_l229;
-  wire                when_StateMachine_l233;
-  wire                when_StateMachine_l249;
-  wire                when_StateMachine_l249_1;
-  wire                when_StateMachine_l249_2;
-  wire                when_CsrPlugin_l1277;
+  reg        [2:0]    IBusCachedPlugin_injector_port_state;
+  wire                when_Fetcher_l391;
+  wire                when_CsrPlugin_l1669;
   reg                 execute_CsrPlugin_csr_3264;
-  wire                when_CsrPlugin_l1277_1;
+  wire                when_CsrPlugin_l1669_1;
+  reg                 execute_CsrPlugin_csr_944;
+  wire                when_CsrPlugin_l1669_2;
+  reg                 execute_CsrPlugin_csr_945;
+  wire                when_CsrPlugin_l1669_3;
+  reg                 execute_CsrPlugin_csr_946;
+  wire                when_CsrPlugin_l1669_4;
+  reg                 execute_CsrPlugin_csr_947;
+  wire                when_CsrPlugin_l1669_5;
+  reg                 execute_CsrPlugin_csr_948;
+  wire                when_CsrPlugin_l1669_6;
+  reg                 execute_CsrPlugin_csr_949;
+  wire                when_CsrPlugin_l1669_7;
+  reg                 execute_CsrPlugin_csr_950;
+  wire                when_CsrPlugin_l1669_8;
+  reg                 execute_CsrPlugin_csr_951;
+  wire                when_CsrPlugin_l1669_9;
+  reg                 execute_CsrPlugin_csr_952;
+  wire                when_CsrPlugin_l1669_10;
+  reg                 execute_CsrPlugin_csr_953;
+  wire                when_CsrPlugin_l1669_11;
+  reg                 execute_CsrPlugin_csr_954;
+  wire                when_CsrPlugin_l1669_12;
+  reg                 execute_CsrPlugin_csr_955;
+  wire                when_CsrPlugin_l1669_13;
+  reg                 execute_CsrPlugin_csr_956;
+  wire                when_CsrPlugin_l1669_14;
+  reg                 execute_CsrPlugin_csr_957;
+  wire                when_CsrPlugin_l1669_15;
+  reg                 execute_CsrPlugin_csr_958;
+  wire                when_CsrPlugin_l1669_16;
+  reg                 execute_CsrPlugin_csr_959;
+  wire                when_CsrPlugin_l1669_17;
+  reg                 execute_CsrPlugin_csr_928;
+  wire                when_CsrPlugin_l1669_18;
+  reg                 execute_CsrPlugin_csr_929;
+  wire                when_CsrPlugin_l1669_19;
+  reg                 execute_CsrPlugin_csr_930;
+  wire                when_CsrPlugin_l1669_20;
+  reg                 execute_CsrPlugin_csr_931;
+  wire                when_CsrPlugin_l1669_21;
   reg                 execute_CsrPlugin_csr_3857;
-  wire                when_CsrPlugin_l1277_2;
+  wire                when_CsrPlugin_l1669_22;
   reg                 execute_CsrPlugin_csr_3858;
-  wire                when_CsrPlugin_l1277_3;
+  wire                when_CsrPlugin_l1669_23;
   reg                 execute_CsrPlugin_csr_3859;
-  wire                when_CsrPlugin_l1277_4;
+  wire                when_CsrPlugin_l1669_24;
   reg                 execute_CsrPlugin_csr_3860;
-  wire                when_CsrPlugin_l1277_5;
+  wire                when_CsrPlugin_l1669_25;
   reg                 execute_CsrPlugin_csr_769;
-  wire                when_CsrPlugin_l1277_6;
+  wire                when_CsrPlugin_l1669_26;
   reg                 execute_CsrPlugin_csr_768;
-  wire                when_CsrPlugin_l1277_7;
+  wire                when_CsrPlugin_l1669_27;
   reg                 execute_CsrPlugin_csr_836;
-  wire                when_CsrPlugin_l1277_8;
+  wire                when_CsrPlugin_l1669_28;
   reg                 execute_CsrPlugin_csr_772;
-  wire                when_CsrPlugin_l1277_9;
+  wire                when_CsrPlugin_l1669_29;
   reg                 execute_CsrPlugin_csr_773;
-  wire                when_CsrPlugin_l1277_10;
+  wire                when_CsrPlugin_l1669_30;
   reg                 execute_CsrPlugin_csr_833;
-  wire                when_CsrPlugin_l1277_11;
+  wire                when_CsrPlugin_l1669_31;
   reg                 execute_CsrPlugin_csr_832;
-  wire                when_CsrPlugin_l1277_12;
+  wire                when_CsrPlugin_l1669_32;
   reg                 execute_CsrPlugin_csr_834;
-  wire                when_CsrPlugin_l1277_13;
+  wire                when_CsrPlugin_l1669_33;
   reg                 execute_CsrPlugin_csr_835;
-  wire                when_CsrPlugin_l1277_14;
+  wire                when_CsrPlugin_l1669_34;
   reg                 execute_CsrPlugin_csr_2816;
-  wire                when_CsrPlugin_l1277_15;
+  wire                when_CsrPlugin_l1669_35;
   reg                 execute_CsrPlugin_csr_2944;
-  wire                when_CsrPlugin_l1277_16;
+  wire                when_CsrPlugin_l1669_36;
   reg                 execute_CsrPlugin_csr_2818;
-  wire                when_CsrPlugin_l1277_17;
+  wire                when_CsrPlugin_l1669_37;
   reg                 execute_CsrPlugin_csr_2946;
-  wire                when_CsrPlugin_l1277_18;
+  wire                when_CsrPlugin_l1669_38;
   reg                 execute_CsrPlugin_csr_3072;
-  wire                when_CsrPlugin_l1277_19;
+  wire                when_CsrPlugin_l1669_39;
   reg                 execute_CsrPlugin_csr_3200;
-  wire                when_CsrPlugin_l1277_20;
+  wire                when_CsrPlugin_l1669_40;
   reg                 execute_CsrPlugin_csr_3074;
-  wire                when_CsrPlugin_l1277_21;
+  wire                when_CsrPlugin_l1669_41;
   reg                 execute_CsrPlugin_csr_3202;
-  wire                when_CsrPlugin_l1277_22;
+  wire                when_CsrPlugin_l1669_42;
+  reg                 execute_CsrPlugin_csr_774;
+  wire                when_CsrPlugin_l1669_43;
   reg                 execute_CsrPlugin_csr_3008;
-  wire                when_CsrPlugin_l1277_23;
+  wire                when_CsrPlugin_l1669_44;
   reg                 execute_CsrPlugin_csr_4032;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_5;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_6;
-  wire       [1:0]    switch_CsrPlugin_l723;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_8;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_10;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_11;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_12;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_13;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_14;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_15;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_16;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_17;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_18;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_19;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_20;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_21;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_22;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_23;
-  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_24;
-  wire                when_PmpPlugin_l155;
-  wire                when_PmpPlugin_l172;
-  wire                when_PmpPlugin_l175;
-  wire                when_CsrPlugin_l1310;
-  wire                when_CsrPlugin_l1315;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_65;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_66;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_67;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_68;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_69;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_70;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_71;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_72;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_73;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_74;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_75;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_76;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_77;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_78;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_79;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_80;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_81;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_82;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_83;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_84;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_85;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_86;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_87;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_88;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_89;
+  wire       [1:0]    switch_CsrPlugin_l1031;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_90;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_91;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_92;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_93;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_94;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_95;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_96;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_97;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_98;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_99;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_100;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_101;
+  wire                when_CsrPlugin_l1076;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_102;
+  wire                when_CsrPlugin_l1076_1;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_103;
+  wire                when_CsrPlugin_l1076_2;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_104;
+  wire                when_CsrPlugin_l1076_3;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_105;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_106;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_107;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_108;
+  wire       [11:0]   _zz_when_CsrPlugin_l1709;
+  wire                when_CsrPlugin_l1709;
+  reg                 when_CsrPlugin_l1719;
+  wire                when_CsrPlugin_l1717;
+  wire                when_CsrPlugin_l1725;
   reg        [2:0]    _zz_iBusWishbone_ADR;
   wire                when_InstructionCache_l239;
   reg                 _zz_iBus_rsp_valid;
   reg        [31:0]   iBusWishbone_DAT_MISO_regNext;
-  reg        [2:0]    _zz_dBus_cmd_ready;
+  reg        [2:0]    _zz_dBusWishbone_ADR;
+  wire                _zz_dBusWishbone_CYC;
+  wire                _zz_dBus_cmd_ready;
   wire                _zz_dBus_cmd_ready_1;
   wire                _zz_dBus_cmd_ready_2;
-  wire                _zz_dBus_cmd_ready_3;
-  wire                _zz_dBus_cmd_ready_4;
-  wire                _zz_dBus_cmd_ready_5;
+  wire                _zz_dBusWishbone_ADR_1;
   reg                 _zz_dBus_rsp_valid;
   reg        [31:0]   dBusWishbone_DAT_MISO_regNext;
   `ifndef SYNTHESIS
@@ -1790,57 +2186,180 @@ module VexRiscv (
   reg [39:0] decode_to_execute_ENV_CTRL_string;
   reg [39:0] execute_to_memory_ENV_CTRL_string;
   reg [39:0] memory_to_writeBack_ENV_CTRL_string;
-  reg [79:0] execute_PmpPlugin_fsm_stateReg_string;
-  reg [79:0] execute_PmpPlugin_fsm_stateNext_string;
   `endif
 
-  (* ram_style = "distributed" *) reg [31:0] PmpPlugin_pmpaddr [0:15];
   (* no_rw_check , ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
   assign _zz_when = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
-  assign _zz_memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW_1) + $signed(_zz_memory_MUL_LOW_5));
-  assign _zz_memory_MUL_LOW_1 = ($signed(_zz_memory_MUL_LOW_2) + $signed(_zz_memory_MUL_LOW_3));
-  assign _zz_memory_MUL_LOW_2 = 52'h0;
-  assign _zz_memory_MUL_LOW_4 = {1'b0,memory_MUL_LL};
-  assign _zz_memory_MUL_LOW_3 = {{19{_zz_memory_MUL_LOW_4[32]}}, _zz_memory_MUL_LOW_4};
-  assign _zz_memory_MUL_LOW_6 = ({16'd0,memory_MUL_LH} <<< 16);
-  assign _zz_memory_MUL_LOW_5 = {{2{_zz_memory_MUL_LOW_6[49]}}, _zz_memory_MUL_LOW_6};
-  assign _zz_memory_MUL_LOW_8 = ({16'd0,memory_MUL_HL} <<< 16);
-  assign _zz_memory_MUL_LOW_7 = {{2{_zz_memory_MUL_LOW_8[49]}}, _zz_memory_MUL_LOW_8};
+  assign _zz_memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW_1) + $signed(_zz_memory_MUL_LOW_4));
+  assign _zz_memory_MUL_LOW_1 = ($signed(52'h0000000000000) + $signed(_zz_memory_MUL_LOW_2));
+  assign _zz_memory_MUL_LOW_3 = {1'b0,memory_MUL_LL};
+  assign _zz_memory_MUL_LOW_2 = {{19{_zz_memory_MUL_LOW_3[32]}}, _zz_memory_MUL_LOW_3};
+  assign _zz_memory_MUL_LOW_5 = ({16'd0,memory_MUL_LH} <<< 5'd16);
+  assign _zz_memory_MUL_LOW_4 = {{2{_zz_memory_MUL_LOW_5[49]}}, _zz_memory_MUL_LOW_5};
+  assign _zz_memory_MUL_LOW_7 = ({16'd0,memory_MUL_HL} <<< 5'd16);
+  assign _zz_memory_MUL_LOW_6 = {{2{_zz_memory_MUL_LOW_7[49]}}, _zz_memory_MUL_LOW_7};
   assign _zz_execute_SHIFT_RIGHT_1 = ($signed(_zz_execute_SHIFT_RIGHT_2) >>> execute_FullBarrelShifterPlugin_amplitude);
   assign _zz_execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT_1[31 : 0];
   assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == ShiftCtrlEnum_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
-  assign _zz_decode_DO_EBREAK = (decode_PC >>> 1);
-  assign _zz_decode_DO_EBREAK_1 = (decode_PC >>> 1);
+  assign _zz_decode_DO_EBREAK = (decode_PC >>> 1'd1);
+  assign _zz_decode_DO_EBREAK_1 = (decode_PC >>> 1'd1);
   assign _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload - 4'b0001);
   assign _zz_IBusCachedPlugin_fetchPc_pc_1 = {IBusCachedPlugin_fetchPc_inc,2'b00};
   assign _zz_IBusCachedPlugin_fetchPc_pc = {29'd0, _zz_IBusCachedPlugin_fetchPc_pc_1};
   assign _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
   assign _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2 = {{_zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz__zz_3 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz__zz_5 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz__zz_7 = {{_zz_4,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz__zz_7_1 = {{_zz_6,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz__zz_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz__zz_4 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz__zz_6 = {{_zz_3,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
+  assign _zz__zz_6_1 = {{_zz_5,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
   assign _zz_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId_1;
-  assign _zz_io_cpu_flush_payload_lineId_1 = (execute_RS1 >>> 5);
+  assign _zz_io_cpu_flush_payload_lineId_1 = (execute_RS1 >>> 3'd5);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code_1 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
+  assign _zz__zz_PmpPlugin_ports_0_hits_0_6 = (_zz_PmpPlugin_ports_0_hits_0_4 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_0_3 = ({2'd0,_zz__zz_PmpPlugin_ports_0_hits_0_3_1} <<< 2'd2);
+  assign _zz__zz_PmpPlugin_ports_0_hits_0_3_1 = (_zz_PmpPlugin_ports_0_hits_0_6 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_1_6 = (_zz_PmpPlugin_ports_0_hits_1_4 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_1_3 = ({2'd0,_zz__zz_PmpPlugin_ports_0_hits_1_3_1} <<< 2'd2);
+  assign _zz__zz_PmpPlugin_ports_0_hits_1_3_1 = (_zz_PmpPlugin_ports_0_hits_1_6 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_2_6 = (_zz_PmpPlugin_ports_0_hits_2_4 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_2_3 = ({2'd0,_zz__zz_PmpPlugin_ports_0_hits_2_3_1} <<< 2'd2);
+  assign _zz__zz_PmpPlugin_ports_0_hits_2_3_1 = (_zz_PmpPlugin_ports_0_hits_2_6 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_3_6 = (_zz_PmpPlugin_ports_0_hits_3_4 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_3_3 = ({2'd0,_zz__zz_PmpPlugin_ports_0_hits_3_3_1} <<< 2'd2);
+  assign _zz__zz_PmpPlugin_ports_0_hits_3_3_1 = (_zz_PmpPlugin_ports_0_hits_3_6 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_4_6 = (_zz_PmpPlugin_ports_0_hits_4_4 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_4_3 = ({2'd0,_zz__zz_PmpPlugin_ports_0_hits_4_3_1} <<< 2'd2);
+  assign _zz__zz_PmpPlugin_ports_0_hits_4_3_1 = (_zz_PmpPlugin_ports_0_hits_4_6 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_5_6 = (_zz_PmpPlugin_ports_0_hits_5_4 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_5_3 = ({2'd0,_zz__zz_PmpPlugin_ports_0_hits_5_3_1} <<< 2'd2);
+  assign _zz__zz_PmpPlugin_ports_0_hits_5_3_1 = (_zz_PmpPlugin_ports_0_hits_5_6 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_6_6 = (_zz_PmpPlugin_ports_0_hits_6_4 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_6_3 = ({2'd0,_zz__zz_PmpPlugin_ports_0_hits_6_3_1} <<< 2'd2);
+  assign _zz__zz_PmpPlugin_ports_0_hits_6_3_1 = (_zz_PmpPlugin_ports_0_hits_6_6 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_7_6 = (_zz_PmpPlugin_ports_0_hits_7_4 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_7_3 = ({2'd0,_zz__zz_PmpPlugin_ports_0_hits_7_3_1} <<< 2'd2);
+  assign _zz__zz_PmpPlugin_ports_0_hits_7_3_1 = (_zz_PmpPlugin_ports_0_hits_7_6 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_8_6 = (_zz_PmpPlugin_ports_0_hits_8_4 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_8_3 = ({2'd0,_zz__zz_PmpPlugin_ports_0_hits_8_3_1} <<< 2'd2);
+  assign _zz__zz_PmpPlugin_ports_0_hits_8_3_1 = (_zz_PmpPlugin_ports_0_hits_8_6 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_9_6 = (_zz_PmpPlugin_ports_0_hits_9_4 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_9_3 = ({2'd0,_zz__zz_PmpPlugin_ports_0_hits_9_3_1} <<< 2'd2);
+  assign _zz__zz_PmpPlugin_ports_0_hits_9_3_1 = (_zz_PmpPlugin_ports_0_hits_9_6 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_10_6 = (_zz_PmpPlugin_ports_0_hits_10_4 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_10_3 = ({2'd0,_zz__zz_PmpPlugin_ports_0_hits_10_3_1} <<< 2'd2);
+  assign _zz__zz_PmpPlugin_ports_0_hits_10_3_1 = (_zz_PmpPlugin_ports_0_hits_10_6 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_11_6 = (_zz_PmpPlugin_ports_0_hits_11_4 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_11_3 = ({2'd0,_zz__zz_PmpPlugin_ports_0_hits_11_3_1} <<< 2'd2);
+  assign _zz__zz_PmpPlugin_ports_0_hits_11_3_1 = (_zz_PmpPlugin_ports_0_hits_11_6 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_12_6 = (_zz_PmpPlugin_ports_0_hits_12_4 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_12_3 = ({2'd0,_zz__zz_PmpPlugin_ports_0_hits_12_3_1} <<< 2'd2);
+  assign _zz__zz_PmpPlugin_ports_0_hits_12_3_1 = (_zz_PmpPlugin_ports_0_hits_12_6 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_13_6 = (_zz_PmpPlugin_ports_0_hits_13_4 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_13_3 = ({2'd0,_zz__zz_PmpPlugin_ports_0_hits_13_3_1} <<< 2'd2);
+  assign _zz__zz_PmpPlugin_ports_0_hits_13_3_1 = (_zz_PmpPlugin_ports_0_hits_13_6 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_14_6 = (_zz_PmpPlugin_ports_0_hits_14_4 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_14_3 = ({2'd0,_zz__zz_PmpPlugin_ports_0_hits_14_3_1} <<< 2'd2);
+  assign _zz__zz_PmpPlugin_ports_0_hits_14_3_1 = (_zz_PmpPlugin_ports_0_hits_14_6 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_15_6 = (_zz_PmpPlugin_ports_0_hits_15_4 + 34'h000000001);
+  assign _zz__zz_PmpPlugin_ports_0_hits_15_3 = ({2'd0,_zz__zz_PmpPlugin_ports_0_hits_15_3_1} <<< 2'd2);
+  assign _zz__zz_PmpPlugin_ports_0_hits_15_3_1 = (_zz_PmpPlugin_ports_0_hits_15_6 + 34'h000000001);
+  assign _zz_PmpPlugin_ports_0_hits_0_8 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_0_9 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_1_8 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_1_9 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_2_8 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_2_9 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_3_8 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_3_9 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_4_8 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_4_9 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_5_8 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_5_9 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_6_8 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_6_9 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_7_8 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_7_9 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_8_8 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_8_9 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_9_8 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_9_9 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_10_8 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_10_9 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_11_8 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_11_9 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_12_8 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_12_9 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_13_8 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_13_9 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_14_8 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_14_9 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_15_8 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_0_hits_15_9 = {4'd0, IBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_when_PmpPlugin_l250_16 = (_zz_when_PmpPlugin_l250_17 + _zz_when_PmpPlugin_l250_28);
+  assign _zz_when_PmpPlugin_l250_17 = (_zz_when_PmpPlugin_l250_18 + _zz_when_PmpPlugin_l250_23);
+  assign _zz_when_PmpPlugin_l250_18 = (_zz_when_PmpPlugin_l250_19 + _zz_when_PmpPlugin_l250_21);
+  assign _zz_when_PmpPlugin_l250_23 = (_zz_when_PmpPlugin_l250_24 + _zz_when_PmpPlugin_l250_26);
+  assign _zz_when_PmpPlugin_l250_28 = (_zz_when_PmpPlugin_l250_29 + _zz_when_PmpPlugin_l250_31);
+  assign _zz_when_PmpPlugin_l250_33 = PmpPlugin_ports_0_hits_15;
+  assign _zz_when_PmpPlugin_l250_32 = {2'd0, _zz_when_PmpPlugin_l250_33};
+  assign _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowRead_33 = (_zz_IBusCachedPlugin_mmuBus_rsp_allowRead_32 - 16'h0001);
+  assign _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_33 = (_zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_32 - 16'h0001);
+  assign _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_33 = (_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_32 - 16'h0001);
+  assign _zz_PmpPlugin_ports_1_hits_0 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_0_1 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_1 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_1_1 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_2 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_2_1 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_3 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_3_1 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_4 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_4_1 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_5 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_5_1 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_6 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_6_1 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_7 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_7_1 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_8 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_8_1 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_9 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_9_1 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_10 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_10_1 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_11 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_11_1 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_12 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_12_1 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_13 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_13_1 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_14 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_14_1 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_15 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_PmpPlugin_ports_1_hits_15_1 = {4'd0, DBusCachedPlugin_mmuBus_cmd_0_virtualAddress};
+  assign _zz_when_PmpPlugin_l250_1_1 = (_zz_when_PmpPlugin_l250_1_2 + _zz_when_PmpPlugin_l250_1_13);
+  assign _zz_when_PmpPlugin_l250_1_2 = (_zz_when_PmpPlugin_l250_1_3 + _zz_when_PmpPlugin_l250_1_8);
+  assign _zz_when_PmpPlugin_l250_1_3 = (_zz_when_PmpPlugin_l250_1_4 + _zz_when_PmpPlugin_l250_1_6);
+  assign _zz_when_PmpPlugin_l250_1_8 = (_zz_when_PmpPlugin_l250_1_9 + _zz_when_PmpPlugin_l250_1_11);
+  assign _zz_when_PmpPlugin_l250_1_13 = (_zz_when_PmpPlugin_l250_1_14 + _zz_when_PmpPlugin_l250_1_16);
+  assign _zz_when_PmpPlugin_l250_1_18 = PmpPlugin_ports_1_hits_15;
+  assign _zz_when_PmpPlugin_l250_1_17 = {2'd0, _zz_when_PmpPlugin_l250_1_18};
   assign _zz__zz_DBusCachedPlugin_mmuBus_rsp_allowRead_1_1 = (_zz_DBusCachedPlugin_mmuBus_rsp_allowRead - 16'h0001);
   assign _zz__zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_1_1 = (_zz_DBusCachedPlugin_mmuBus_rsp_allowWrite - 16'h0001);
-  assign _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1_1 = (_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute - 16'h0001);
+  assign _zz__zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_1_1 = (_zz_DBusCachedPlugin_mmuBus_rsp_allowExecute - 16'h0001);
   assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
   assign _zz__zz_execute_SRC1 = 3'b100;
   assign _zz__zz_execute_SRC1_1 = execute_INSTRUCTION[19 : 15];
-  assign _zz__zz_execute_SRC2_3 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz__zz_execute_SRC2_2 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
   assign _zz_execute_SrcPlugin_addSub = ($signed(_zz_execute_SrcPlugin_addSub_1) + $signed(_zz_execute_SrcPlugin_addSub_4));
   assign _zz_execute_SrcPlugin_addSub_1 = ($signed(_zz_execute_SrcPlugin_addSub_2) + $signed(_zz_execute_SrcPlugin_addSub_3));
   assign _zz_execute_SrcPlugin_addSub_2 = execute_SRC1;
   assign _zz_execute_SrcPlugin_addSub_3 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? _zz_execute_SrcPlugin_addSub_5 : _zz_execute_SrcPlugin_addSub_6);
-  assign _zz_execute_SrcPlugin_addSub_5 = 32'h00000001;
-  assign _zz_execute_SrcPlugin_addSub_6 = 32'h0;
+  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? 32'h00000001 : 32'h00000000);
   assign _zz__zz_execute_BranchPlugin_missAlignedTarget_2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
   assign _zz__zz_execute_BranchPlugin_missAlignedTarget_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
   assign _zz__zz_execute_BranchPlugin_missAlignedTarget_6 = {_zz_execute_BranchPlugin_missAlignedTarget_1,execute_INSTRUCTION[31 : 20]};
@@ -1852,7 +2371,7 @@ module VexRiscv (
   assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code & (~ _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1));
   assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code - 2'b01);
   assign _zz_writeBack_MulPlugin_result = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
-  assign _zz_writeBack_MulPlugin_result_1 = ({32'd0,writeBack_MUL_HH} <<< 32);
+  assign _zz_writeBack_MulPlugin_result_1 = ({32'd0,writeBack_MUL_HH} <<< 6'd32);
   assign _zz__zz_decode_RS2_2 = writeBack_MUL_LOW[31 : 0];
   assign _zz__zz_decode_RS2_2_1 = writeBack_MulPlugin_result[63 : 32];
   assign _zz_memory_DivPlugin_div_counter_valueNext_1 = memory_DivPlugin_div_counter_willIncrement;
@@ -1870,124 +2389,66 @@ module VexRiscv (
   assign _zz_memory_DivPlugin_rs1_2 = {32'd0, _zz_memory_DivPlugin_rs1_3};
   assign _zz_memory_DivPlugin_rs2_2 = _zz_memory_DivPlugin_rs2;
   assign _zz_memory_DivPlugin_rs2_1 = {31'd0, _zz_memory_DivPlugin_rs2_2};
-  assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 5);
-  assign _zz_PmpPlugin_pmpaddr_port = execute_PmpPlugin_writeData_;
+  assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 3'd5);
   assign _zz_decode_RegFilePlugin_rs1Data = 1'b1;
   assign _zz_decode_RegFilePlugin_rs2Data = 1'b1;
   assign _zz_IBusCachedPlugin_jump_pcLoad_payload_6 = {_zz_IBusCachedPlugin_jump_pcLoad_payload_4,_zz_IBusCachedPlugin_jump_pcLoad_payload_3};
   assign _zz_writeBack_DBusCachedPlugin_rspShifted_1 = dataCache_1_io_cpu_writeBack_address[1 : 0];
   assign _zz_writeBack_DBusCachedPlugin_rspShifted_3 = dataCache_1_io_cpu_writeBack_address[1 : 1];
-  assign _zz_PmpPlugin_dGuard_hits_0_2 = 4'b0000;
-  assign _zz_PmpPlugin_dGuard_hits_0_4 = 4'b0000;
-  assign _zz_PmpPlugin_dGuard_hits_1_1 = 4'b0001;
-  assign _zz_PmpPlugin_dGuard_hits_1_3 = 4'b0001;
-  assign _zz_PmpPlugin_dGuard_hits_2_1 = 4'b0010;
-  assign _zz_PmpPlugin_dGuard_hits_2_3 = 4'b0010;
-  assign _zz_PmpPlugin_dGuard_hits_3_1 = 4'b0011;
-  assign _zz_PmpPlugin_dGuard_hits_3_3 = 4'b0011;
-  assign _zz_PmpPlugin_dGuard_hits_4_1 = 4'b0100;
-  assign _zz_PmpPlugin_dGuard_hits_4_3 = 4'b0100;
-  assign _zz_PmpPlugin_dGuard_hits_5_1 = 4'b0101;
-  assign _zz_PmpPlugin_dGuard_hits_5_3 = 4'b0101;
-  assign _zz_PmpPlugin_dGuard_hits_6_1 = 4'b0110;
-  assign _zz_PmpPlugin_dGuard_hits_6_3 = 4'b0110;
-  assign _zz_PmpPlugin_dGuard_hits_7_1 = 4'b0111;
-  assign _zz_PmpPlugin_dGuard_hits_7_3 = 4'b0111;
-  assign _zz_PmpPlugin_dGuard_hits_8_1 = 4'b1000;
-  assign _zz_PmpPlugin_dGuard_hits_8_3 = 4'b1000;
-  assign _zz_PmpPlugin_dGuard_hits_9_1 = 4'b1001;
-  assign _zz_PmpPlugin_dGuard_hits_9_3 = 4'b1001;
-  assign _zz_PmpPlugin_dGuard_hits_10_1 = 4'b1010;
-  assign _zz_PmpPlugin_dGuard_hits_10_3 = 4'b1010;
-  assign _zz_PmpPlugin_dGuard_hits_11_1 = 4'b1011;
-  assign _zz_PmpPlugin_dGuard_hits_11_3 = 4'b1011;
-  assign _zz_PmpPlugin_dGuard_hits_12_1 = 4'b1100;
-  assign _zz_PmpPlugin_dGuard_hits_12_3 = 4'b1100;
-  assign _zz_PmpPlugin_dGuard_hits_13_1 = 4'b1101;
-  assign _zz_PmpPlugin_dGuard_hits_13_3 = 4'b1101;
-  assign _zz_PmpPlugin_dGuard_hits_14_1 = 4'b1110;
-  assign _zz_PmpPlugin_dGuard_hits_14_3 = 4'b1110;
-  assign _zz_PmpPlugin_dGuard_hits_15_1 = 4'b1111;
-  assign _zz_PmpPlugin_dGuard_hits_15_3 = 4'b1111;
+  assign _zz_when_PmpPlugin_l250_20 = {PmpPlugin_ports_0_hits_2,{PmpPlugin_ports_0_hits_1,PmpPlugin_ports_0_hits_0}};
+  assign _zz_when_PmpPlugin_l250_22 = {PmpPlugin_ports_0_hits_5,{PmpPlugin_ports_0_hits_4,PmpPlugin_ports_0_hits_3}};
+  assign _zz_when_PmpPlugin_l250_25 = {PmpPlugin_ports_0_hits_8,{PmpPlugin_ports_0_hits_7,PmpPlugin_ports_0_hits_6}};
+  assign _zz_when_PmpPlugin_l250_27 = {PmpPlugin_ports_0_hits_11,{PmpPlugin_ports_0_hits_10,PmpPlugin_ports_0_hits_9}};
+  assign _zz_when_PmpPlugin_l250_30 = {PmpPlugin_ports_0_hits_14,{PmpPlugin_ports_0_hits_13,PmpPlugin_ports_0_hits_12}};
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_50 = {_zz_IBusCachedPlugin_mmuBus_rsp_allowRead_48,{_zz_IBusCachedPlugin_mmuBus_rsp_allowRead_47,{_zz_IBusCachedPlugin_mmuBus_rsp_allowRead_46,_zz_IBusCachedPlugin_mmuBus_rsp_allowRead_45}}};
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_50 = {_zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_48,{_zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_47,{_zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_46,_zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_45}}};
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_50 = {_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_48,{_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_47,{_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_46,_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_45}}};
+  assign _zz_when_PmpPlugin_l250_1_5 = {PmpPlugin_ports_1_hits_2,{PmpPlugin_ports_1_hits_1,PmpPlugin_ports_1_hits_0}};
+  assign _zz_when_PmpPlugin_l250_1_7 = {PmpPlugin_ports_1_hits_5,{PmpPlugin_ports_1_hits_4,PmpPlugin_ports_1_hits_3}};
+  assign _zz_when_PmpPlugin_l250_1_10 = {PmpPlugin_ports_1_hits_8,{PmpPlugin_ports_1_hits_7,PmpPlugin_ports_1_hits_6}};
+  assign _zz_when_PmpPlugin_l250_1_12 = {PmpPlugin_ports_1_hits_11,{PmpPlugin_ports_1_hits_10,PmpPlugin_ports_1_hits_9}};
+  assign _zz_when_PmpPlugin_l250_1_15 = {PmpPlugin_ports_1_hits_14,{PmpPlugin_ports_1_hits_13,PmpPlugin_ports_1_hits_12}};
   assign _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_18 = {_zz_DBusCachedPlugin_mmuBus_rsp_allowRead_16,{_zz_DBusCachedPlugin_mmuBus_rsp_allowRead_15,{_zz_DBusCachedPlugin_mmuBus_rsp_allowRead_14,_zz_DBusCachedPlugin_mmuBus_rsp_allowRead_13}}};
   assign _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_18 = {_zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_16,{_zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_15,{_zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_14,_zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_13}}};
-  assign _zz_PmpPlugin_iGuard_hits_0_2 = 4'b0000;
-  assign _zz_PmpPlugin_iGuard_hits_0_4 = 4'b0000;
-  assign _zz_PmpPlugin_iGuard_hits_1_1 = 4'b0001;
-  assign _zz_PmpPlugin_iGuard_hits_1_3 = 4'b0001;
-  assign _zz_PmpPlugin_iGuard_hits_2_1 = 4'b0010;
-  assign _zz_PmpPlugin_iGuard_hits_2_3 = 4'b0010;
-  assign _zz_PmpPlugin_iGuard_hits_3_1 = 4'b0011;
-  assign _zz_PmpPlugin_iGuard_hits_3_3 = 4'b0011;
-  assign _zz_PmpPlugin_iGuard_hits_4_1 = 4'b0100;
-  assign _zz_PmpPlugin_iGuard_hits_4_3 = 4'b0100;
-  assign _zz_PmpPlugin_iGuard_hits_5_1 = 4'b0101;
-  assign _zz_PmpPlugin_iGuard_hits_5_3 = 4'b0101;
-  assign _zz_PmpPlugin_iGuard_hits_6_1 = 4'b0110;
-  assign _zz_PmpPlugin_iGuard_hits_6_3 = 4'b0110;
-  assign _zz_PmpPlugin_iGuard_hits_7_1 = 4'b0111;
-  assign _zz_PmpPlugin_iGuard_hits_7_3 = 4'b0111;
-  assign _zz_PmpPlugin_iGuard_hits_8_1 = 4'b1000;
-  assign _zz_PmpPlugin_iGuard_hits_8_3 = 4'b1000;
-  assign _zz_PmpPlugin_iGuard_hits_9_1 = 4'b1001;
-  assign _zz_PmpPlugin_iGuard_hits_9_3 = 4'b1001;
-  assign _zz_PmpPlugin_iGuard_hits_10_1 = 4'b1010;
-  assign _zz_PmpPlugin_iGuard_hits_10_3 = 4'b1010;
-  assign _zz_PmpPlugin_iGuard_hits_11_1 = 4'b1011;
-  assign _zz_PmpPlugin_iGuard_hits_11_3 = 4'b1011;
-  assign _zz_PmpPlugin_iGuard_hits_12_1 = 4'b1100;
-  assign _zz_PmpPlugin_iGuard_hits_12_3 = 4'b1100;
-  assign _zz_PmpPlugin_iGuard_hits_13_1 = 4'b1101;
-  assign _zz_PmpPlugin_iGuard_hits_13_3 = 4'b1101;
-  assign _zz_PmpPlugin_iGuard_hits_14_1 = 4'b1110;
-  assign _zz_PmpPlugin_iGuard_hits_14_3 = 4'b1110;
-  assign _zz_PmpPlugin_iGuard_hits_15_1 = 4'b1111;
-  assign _zz_PmpPlugin_iGuard_hits_15_3 = 4'b1111;
-  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_18 = {_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_16,{_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_15,{_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_14,_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_13}}};
-  assign _zz_when_PmpPlugin_l209_1 = {execute_PmpPlugin_pmpcfgN_,2'b00};
-  assign _zz_when_PmpPlugin_l209_1_2 = {execute_PmpPlugin_pmpcfgN_,2'b01};
-  assign _zz_when_PmpPlugin_l209_2_1 = {execute_PmpPlugin_pmpcfgN_,2'b10};
-  assign _zz_when_PmpPlugin_l209_3_1 = {execute_PmpPlugin_pmpcfgN_,2'b11};
-  assign _zz_CsrPlugin_csrMapping_readDataSignal_1 = {execute_PmpPlugin_pmpcfgN,2'b11};
-  assign _zz_CsrPlugin_csrMapping_readDataSignal_3 = {execute_PmpPlugin_pmpcfgN,2'b10};
-  assign _zz_CsrPlugin_csrMapping_readDataSignal_5 = {execute_PmpPlugin_pmpcfgN,2'b01};
-  assign _zz_CsrPlugin_csrMapping_readDataSignal_7 = {execute_PmpPlugin_pmpcfgN,2'b00};
-  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000107f;
-  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00002073;
-  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_18 = {_zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_16,{_zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_15,{_zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_14,_zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_13}}};
+  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000207f;
+  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000407f);
+  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00004063;
+  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000107f) == 32'h00000013);
   assign _zz_decode_LEGAL_INSTRUCTION_5 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_6) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_7 == _zz_decode_LEGAL_INSTRUCTION_8),{_zz_decode_LEGAL_INSTRUCTION_9,{_zz_decode_LEGAL_INSTRUCTION_10,_zz_decode_LEGAL_INSTRUCTION_11}}}}}};
   assign _zz_decode_LEGAL_INSTRUCTION_6 = 32'h0000505f;
   assign _zz_decode_LEGAL_INSTRUCTION_7 = (decode_INSTRUCTION & 32'h0000707b);
   assign _zz_decode_LEGAL_INSTRUCTION_8 = 32'h00000063;
   assign _zz_decode_LEGAL_INSTRUCTION_9 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
   assign _zz_decode_LEGAL_INSTRUCTION_10 = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
-  assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h00001013),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,{_zz_decode_LEGAL_INSTRUCTION_16,_zz_decode_LEGAL_INSTRUCTION_17}}}}}};
-  assign _zz_decode_LEGAL_INSTRUCTION_12 = 32'hfc00307f;
+  assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & 32'hbe00705f) == 32'h00005013),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h00001013),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,{_zz_decode_LEGAL_INSTRUCTION_16,_zz_decode_LEGAL_INSTRUCTION_17}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_12 = 32'hfe00305f;
   assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'hbe00707f);
-  assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h00005033;
-  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
-  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
-  assign _zz_decode_LEGAL_INSTRUCTION_17 = {((decode_INSTRUCTION & 32'hffefffff) == 32'h00000073),((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073)};
+  assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h00000033;
+  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
+  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hffefffff) == 32'h00000073);
+  assign _zz_decode_LEGAL_INSTRUCTION_17 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073);
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_4 = decode_INSTRUCTION[31];
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_5 = decode_INSTRUCTION[31];
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_6 = decode_INSTRUCTION[7];
-  assign _zz_when_PmpPlugin_l277 = PmpPlugin_dGuard_hits_6;
-  assign _zz_when_PmpPlugin_l277_1 = {PmpPlugin_dGuard_hits_5,{PmpPlugin_dGuard_hits_4,{PmpPlugin_dGuard_hits_3,{PmpPlugin_dGuard_hits_2,{PmpPlugin_dGuard_hits_1,PmpPlugin_dGuard_hits_0}}}}};
-  assign _zz__zz_DBusCachedPlugin_mmuBus_rsp_allowRead = PmpPlugin_dGuard_hits_5;
-  assign _zz__zz_DBusCachedPlugin_mmuBus_rsp_allowRead_1 = {PmpPlugin_dGuard_hits_4,{PmpPlugin_dGuard_hits_3,{PmpPlugin_dGuard_hits_2,{PmpPlugin_dGuard_hits_1,PmpPlugin_dGuard_hits_0}}}};
-  assign _zz__zz_DBusCachedPlugin_mmuBus_rsp_allowWrite = PmpPlugin_dGuard_hits_5;
-  assign _zz__zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_1 = {PmpPlugin_dGuard_hits_4,{PmpPlugin_dGuard_hits_3,{PmpPlugin_dGuard_hits_2,{PmpPlugin_dGuard_hits_1,PmpPlugin_dGuard_hits_0}}}};
-  assign _zz_when_PmpPlugin_l299 = PmpPlugin_iGuard_hits_6;
-  assign _zz_when_PmpPlugin_l299_1 = {PmpPlugin_iGuard_hits_5,{PmpPlugin_iGuard_hits_4,{PmpPlugin_iGuard_hits_3,{PmpPlugin_iGuard_hits_2,{PmpPlugin_iGuard_hits_1,PmpPlugin_iGuard_hits_0}}}}};
-  assign _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowExecute = PmpPlugin_iGuard_hits_5;
-  assign _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1 = {PmpPlugin_iGuard_hits_4,{PmpPlugin_iGuard_hits_3,{PmpPlugin_iGuard_hits_2,{PmpPlugin_iGuard_hits_1,PmpPlugin_iGuard_hits_0}}}};
+  assign _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowRead_32 = PmpPlugin_ports_0_hits_5;
+  assign _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowRead_32_1 = {PmpPlugin_ports_0_hits_4,{PmpPlugin_ports_0_hits_3,{PmpPlugin_ports_0_hits_2,{PmpPlugin_ports_0_hits_1,PmpPlugin_ports_0_hits_0}}}};
+  assign _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_32 = PmpPlugin_ports_0_hits_5;
+  assign _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_32_1 = {PmpPlugin_ports_0_hits_4,{PmpPlugin_ports_0_hits_3,{PmpPlugin_ports_0_hits_2,{PmpPlugin_ports_0_hits_1,PmpPlugin_ports_0_hits_0}}}};
+  assign _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_32 = PmpPlugin_ports_0_hits_5;
+  assign _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_32_1 = {PmpPlugin_ports_0_hits_4,{PmpPlugin_ports_0_hits_3,{PmpPlugin_ports_0_hits_2,{PmpPlugin_ports_0_hits_1,PmpPlugin_ports_0_hits_0}}}};
+  assign _zz__zz_DBusCachedPlugin_mmuBus_rsp_allowRead = PmpPlugin_ports_1_hits_5;
+  assign _zz__zz_DBusCachedPlugin_mmuBus_rsp_allowRead_1 = {PmpPlugin_ports_1_hits_4,{PmpPlugin_ports_1_hits_3,{PmpPlugin_ports_1_hits_2,{PmpPlugin_ports_1_hits_1,PmpPlugin_ports_1_hits_0}}}};
+  assign _zz__zz_DBusCachedPlugin_mmuBus_rsp_allowWrite = PmpPlugin_ports_1_hits_5;
+  assign _zz__zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_1 = {PmpPlugin_ports_1_hits_4,{PmpPlugin_ports_1_hits_3,{PmpPlugin_ports_1_hits_2,{PmpPlugin_ports_1_hits_1,PmpPlugin_ports_1_hits_0}}}};
+  assign _zz__zz_DBusCachedPlugin_mmuBus_rsp_allowExecute = PmpPlugin_ports_1_hits_5;
+  assign _zz__zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_1 = {PmpPlugin_ports_1_hits_4,{PmpPlugin_ports_1_hits_3,{PmpPlugin_ports_1_hits_2,{PmpPlugin_ports_1_hits_1,PmpPlugin_ports_1_hits_0}}}};
   assign _zz__zz_decode_IS_RS2_SIGNED = ((decode_INSTRUCTION & 32'h02004064) == 32'h02004020);
   assign _zz__zz_decode_IS_RS2_SIGNED_1 = ((decode_INSTRUCTION & 32'h02004074) == 32'h02000030);
   assign _zz__zz_decode_IS_RS2_SIGNED_2 = (|{(_zz__zz_decode_IS_RS2_SIGNED_3 == _zz__zz_decode_IS_RS2_SIGNED_4),(_zz__zz_decode_IS_RS2_SIGNED_5 == _zz__zz_decode_IS_RS2_SIGNED_6)});
   assign _zz__zz_decode_IS_RS2_SIGNED_7 = (|(_zz__zz_decode_IS_RS2_SIGNED_8 == _zz__zz_decode_IS_RS2_SIGNED_9));
-  assign _zz__zz_decode_IS_RS2_SIGNED_10 = {(|{_zz__zz_decode_IS_RS2_SIGNED_11,_zz__zz_decode_IS_RS2_SIGNED_13}),{(|_zz__zz_decode_IS_RS2_SIGNED_15),{_zz__zz_decode_IS_RS2_SIGNED_18,{_zz__zz_decode_IS_RS2_SIGNED_21,_zz__zz_decode_IS_RS2_SIGNED_26}}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_10 = {(|{_zz__zz_decode_IS_RS2_SIGNED_11,_zz__zz_decode_IS_RS2_SIGNED_13}),{(|_zz__zz_decode_IS_RS2_SIGNED_15),{_zz__zz_decode_IS_RS2_SIGNED_18,{_zz__zz_decode_IS_RS2_SIGNED_21,_zz__zz_decode_IS_RS2_SIGNED_23}}}};
   assign _zz__zz_decode_IS_RS2_SIGNED_3 = (decode_INSTRUCTION & 32'h10203050);
   assign _zz__zz_decode_IS_RS2_SIGNED_4 = 32'h10000050;
   assign _zz__zz_decode_IS_RS2_SIGNED_5 = (decode_INSTRUCTION & 32'h10103050);
@@ -1998,152 +2459,154 @@ module VexRiscv (
   assign _zz__zz_decode_IS_RS2_SIGNED_13 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_14) == 32'h00002050);
   assign _zz__zz_decode_IS_RS2_SIGNED_15 = {_zz_decode_IS_RS2_SIGNED_4,(_zz__zz_decode_IS_RS2_SIGNED_16 == _zz__zz_decode_IS_RS2_SIGNED_17)};
   assign _zz__zz_decode_IS_RS2_SIGNED_18 = (|(_zz__zz_decode_IS_RS2_SIGNED_19 == _zz__zz_decode_IS_RS2_SIGNED_20));
-  assign _zz__zz_decode_IS_RS2_SIGNED_21 = (|{_zz__zz_decode_IS_RS2_SIGNED_22,_zz__zz_decode_IS_RS2_SIGNED_24});
-  assign _zz__zz_decode_IS_RS2_SIGNED_26 = {(|_zz__zz_decode_IS_RS2_SIGNED_27),{_zz__zz_decode_IS_RS2_SIGNED_32,{_zz__zz_decode_IS_RS2_SIGNED_35,_zz__zz_decode_IS_RS2_SIGNED_37}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_21 = (|_zz__zz_decode_IS_RS2_SIGNED_22);
+  assign _zz__zz_decode_IS_RS2_SIGNED_23 = {(|_zz__zz_decode_IS_RS2_SIGNED_24),{_zz__zz_decode_IS_RS2_SIGNED_27,{_zz__zz_decode_IS_RS2_SIGNED_29,_zz__zz_decode_IS_RS2_SIGNED_32}}};
   assign _zz__zz_decode_IS_RS2_SIGNED_12 = 32'h00001050;
   assign _zz__zz_decode_IS_RS2_SIGNED_14 = 32'h00002050;
   assign _zz__zz_decode_IS_RS2_SIGNED_16 = (decode_INSTRUCTION & 32'h0000001c);
   assign _zz__zz_decode_IS_RS2_SIGNED_17 = 32'h00000004;
   assign _zz__zz_decode_IS_RS2_SIGNED_19 = (decode_INSTRUCTION & 32'h00000058);
   assign _zz__zz_decode_IS_RS2_SIGNED_20 = 32'h00000040;
-  assign _zz__zz_decode_IS_RS2_SIGNED_22 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_23) == 32'h00005010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_24 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_25) == 32'h00005020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_27 = {(_zz__zz_decode_IS_RS2_SIGNED_28 == _zz__zz_decode_IS_RS2_SIGNED_29),{_zz__zz_decode_IS_RS2_SIGNED_30,_zz__zz_decode_IS_RS2_SIGNED_31}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_32 = (|(_zz__zz_decode_IS_RS2_SIGNED_33 == _zz__zz_decode_IS_RS2_SIGNED_34));
-  assign _zz__zz_decode_IS_RS2_SIGNED_35 = (|_zz__zz_decode_IS_RS2_SIGNED_36);
-  assign _zz__zz_decode_IS_RS2_SIGNED_37 = {(|_zz__zz_decode_IS_RS2_SIGNED_38),{_zz__zz_decode_IS_RS2_SIGNED_40,{_zz__zz_decode_IS_RS2_SIGNED_43,_zz__zz_decode_IS_RS2_SIGNED_45}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_23 = 32'h00007034;
-  assign _zz__zz_decode_IS_RS2_SIGNED_25 = 32'h02007064;
-  assign _zz__zz_decode_IS_RS2_SIGNED_28 = (decode_INSTRUCTION & 32'h40003054);
-  assign _zz__zz_decode_IS_RS2_SIGNED_29 = 32'h40001010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_30 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00001010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_31 = ((decode_INSTRUCTION & 32'h02007054) == 32'h00001010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_33 = (decode_INSTRUCTION & 32'h00000064);
-  assign _zz__zz_decode_IS_RS2_SIGNED_34 = 32'h00000024;
-  assign _zz__zz_decode_IS_RS2_SIGNED_36 = ((decode_INSTRUCTION & 32'h00001000) == 32'h00001000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_38 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_39) == 32'h00002000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_40 = (|{_zz__zz_decode_IS_RS2_SIGNED_41,_zz__zz_decode_IS_RS2_SIGNED_42});
-  assign _zz__zz_decode_IS_RS2_SIGNED_43 = (|_zz__zz_decode_IS_RS2_SIGNED_44);
-  assign _zz__zz_decode_IS_RS2_SIGNED_45 = {(|_zz__zz_decode_IS_RS2_SIGNED_46),{_zz__zz_decode_IS_RS2_SIGNED_51,{_zz__zz_decode_IS_RS2_SIGNED_60,_zz__zz_decode_IS_RS2_SIGNED_62}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_39 = 32'h00003000;
-  assign _zz__zz_decode_IS_RS2_SIGNED_41 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_42 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00001000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_44 = ((decode_INSTRUCTION & 32'h00004048) == 32'h00004008);
-  assign _zz__zz_decode_IS_RS2_SIGNED_46 = {(_zz__zz_decode_IS_RS2_SIGNED_47 == _zz__zz_decode_IS_RS2_SIGNED_48),(_zz__zz_decode_IS_RS2_SIGNED_49 == _zz__zz_decode_IS_RS2_SIGNED_50)};
-  assign _zz__zz_decode_IS_RS2_SIGNED_51 = (|{_zz__zz_decode_IS_RS2_SIGNED_52,{_zz__zz_decode_IS_RS2_SIGNED_53,_zz__zz_decode_IS_RS2_SIGNED_55}});
-  assign _zz__zz_decode_IS_RS2_SIGNED_60 = (|_zz__zz_decode_IS_RS2_SIGNED_61);
-  assign _zz__zz_decode_IS_RS2_SIGNED_62 = {(|_zz__zz_decode_IS_RS2_SIGNED_63),{_zz__zz_decode_IS_RS2_SIGNED_74,{_zz__zz_decode_IS_RS2_SIGNED_87,_zz__zz_decode_IS_RS2_SIGNED_101}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_47 = (decode_INSTRUCTION & 32'h00000034);
-  assign _zz__zz_decode_IS_RS2_SIGNED_48 = 32'h00000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_49 = (decode_INSTRUCTION & 32'h00000064);
-  assign _zz__zz_decode_IS_RS2_SIGNED_50 = 32'h00000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_52 = ((decode_INSTRUCTION & 32'h00002040) == 32'h00002040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_53 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_54) == 32'h00001040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_55 = {(_zz__zz_decode_IS_RS2_SIGNED_56 == _zz__zz_decode_IS_RS2_SIGNED_57),{_zz__zz_decode_IS_RS2_SIGNED_58,_zz_decode_IS_RS2_SIGNED_2}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_61 = ((decode_INSTRUCTION & 32'h00000020) == 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_63 = {(_zz__zz_decode_IS_RS2_SIGNED_64 == _zz__zz_decode_IS_RS2_SIGNED_65),{_zz_decode_IS_RS2_SIGNED_3,{_zz__zz_decode_IS_RS2_SIGNED_66,_zz__zz_decode_IS_RS2_SIGNED_69}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_74 = (|{_zz_decode_IS_RS2_SIGNED_3,{_zz__zz_decode_IS_RS2_SIGNED_75,_zz__zz_decode_IS_RS2_SIGNED_78}});
-  assign _zz__zz_decode_IS_RS2_SIGNED_87 = (|{_zz__zz_decode_IS_RS2_SIGNED_88,_zz__zz_decode_IS_RS2_SIGNED_89});
-  assign _zz__zz_decode_IS_RS2_SIGNED_101 = {(|_zz__zz_decode_IS_RS2_SIGNED_102),{_zz__zz_decode_IS_RS2_SIGNED_105,{_zz__zz_decode_IS_RS2_SIGNED_110,_zz__zz_decode_IS_RS2_SIGNED_114}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_54 = 32'h00001040;
-  assign _zz__zz_decode_IS_RS2_SIGNED_56 = (decode_INSTRUCTION & 32'h00100040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_57 = 32'h00000040;
-  assign _zz__zz_decode_IS_RS2_SIGNED_58 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_59) == 32'h00000040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_64 = (decode_INSTRUCTION & 32'h00000040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_65 = 32'h00000040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_22 = ((decode_INSTRUCTION & 32'h02007054) == 32'h00005010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_24 = {((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_25) == 32'h40001010),((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_26) == 32'h00001010)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_27 = (|((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_28) == 32'h00000024));
+  assign _zz__zz_decode_IS_RS2_SIGNED_29 = (|(_zz__zz_decode_IS_RS2_SIGNED_30 == _zz__zz_decode_IS_RS2_SIGNED_31));
+  assign _zz__zz_decode_IS_RS2_SIGNED_32 = {(|_zz__zz_decode_IS_RS2_SIGNED_33),{(|_zz__zz_decode_IS_RS2_SIGNED_34),{_zz__zz_decode_IS_RS2_SIGNED_37,{_zz__zz_decode_IS_RS2_SIGNED_39,_zz__zz_decode_IS_RS2_SIGNED_42}}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_25 = 32'h40003054;
+  assign _zz__zz_decode_IS_RS2_SIGNED_26 = 32'h02007054;
+  assign _zz__zz_decode_IS_RS2_SIGNED_28 = 32'h00000064;
+  assign _zz__zz_decode_IS_RS2_SIGNED_30 = (decode_INSTRUCTION & 32'h00001000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_31 = 32'h00001000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_33 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_34 = {((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_35) == 32'h00002000),((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_36) == 32'h00001000)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_37 = (|((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_38) == 32'h00004008));
+  assign _zz__zz_decode_IS_RS2_SIGNED_39 = (|{_zz__zz_decode_IS_RS2_SIGNED_40,_zz__zz_decode_IS_RS2_SIGNED_41});
+  assign _zz__zz_decode_IS_RS2_SIGNED_42 = {(|{_zz__zz_decode_IS_RS2_SIGNED_43,_zz__zz_decode_IS_RS2_SIGNED_45}),{(|_zz__zz_decode_IS_RS2_SIGNED_54),{_zz__zz_decode_IS_RS2_SIGNED_56,{_zz__zz_decode_IS_RS2_SIGNED_69,_zz__zz_decode_IS_RS2_SIGNED_82}}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_35 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_36 = 32'h00005000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_38 = 32'h00004048;
+  assign _zz__zz_decode_IS_RS2_SIGNED_40 = ((decode_INSTRUCTION & 32'h00000034) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_41 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_43 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_44) == 32'h00002040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_45 = {(_zz__zz_decode_IS_RS2_SIGNED_46 == _zz__zz_decode_IS_RS2_SIGNED_47),{_zz__zz_decode_IS_RS2_SIGNED_48,{_zz__zz_decode_IS_RS2_SIGNED_50,_zz__zz_decode_IS_RS2_SIGNED_53}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_54 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_55) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_56 = (|{_zz__zz_decode_IS_RS2_SIGNED_57,{_zz__zz_decode_IS_RS2_SIGNED_59,_zz__zz_decode_IS_RS2_SIGNED_60}});
+  assign _zz__zz_decode_IS_RS2_SIGNED_69 = (|{_zz__zz_decode_IS_RS2_SIGNED_70,_zz__zz_decode_IS_RS2_SIGNED_71});
+  assign _zz__zz_decode_IS_RS2_SIGNED_82 = {(|_zz__zz_decode_IS_RS2_SIGNED_83),{_zz__zz_decode_IS_RS2_SIGNED_96,{_zz__zz_decode_IS_RS2_SIGNED_101,_zz__zz_decode_IS_RS2_SIGNED_105}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_44 = 32'h00002040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_46 = (decode_INSTRUCTION & 32'h00001040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_47 = 32'h00001040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_48 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_49) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_50 = (_zz__zz_decode_IS_RS2_SIGNED_51 == _zz__zz_decode_IS_RS2_SIGNED_52);
+  assign _zz__zz_decode_IS_RS2_SIGNED_53 = _zz_decode_IS_RS2_SIGNED_2;
+  assign _zz__zz_decode_IS_RS2_SIGNED_55 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_57 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_58) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_59 = _zz_decode_IS_RS2_SIGNED_3;
+  assign _zz__zz_decode_IS_RS2_SIGNED_60 = {_zz__zz_decode_IS_RS2_SIGNED_61,{_zz__zz_decode_IS_RS2_SIGNED_63,_zz__zz_decode_IS_RS2_SIGNED_66}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_70 = _zz_decode_IS_RS2_SIGNED_3;
+  assign _zz__zz_decode_IS_RS2_SIGNED_71 = {_zz__zz_decode_IS_RS2_SIGNED_72,{_zz__zz_decode_IS_RS2_SIGNED_74,_zz__zz_decode_IS_RS2_SIGNED_77}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_83 = {_zz_decode_IS_RS2_SIGNED_4,{_zz__zz_decode_IS_RS2_SIGNED_84,_zz__zz_decode_IS_RS2_SIGNED_87}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_96 = (|{_zz__zz_decode_IS_RS2_SIGNED_97,_zz__zz_decode_IS_RS2_SIGNED_98});
+  assign _zz__zz_decode_IS_RS2_SIGNED_101 = (|_zz__zz_decode_IS_RS2_SIGNED_102);
+  assign _zz__zz_decode_IS_RS2_SIGNED_105 = {_zz__zz_decode_IS_RS2_SIGNED_106,{_zz__zz_decode_IS_RS2_SIGNED_109,_zz__zz_decode_IS_RS2_SIGNED_113}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_49 = 32'h00100040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_51 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_52 = 32'h00000040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_58 = 32'h00000040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_61 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_62) == 32'h00004020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_63 = (_zz__zz_decode_IS_RS2_SIGNED_64 == _zz__zz_decode_IS_RS2_SIGNED_65);
   assign _zz__zz_decode_IS_RS2_SIGNED_66 = (_zz__zz_decode_IS_RS2_SIGNED_67 == _zz__zz_decode_IS_RS2_SIGNED_68);
-  assign _zz__zz_decode_IS_RS2_SIGNED_69 = {_zz__zz_decode_IS_RS2_SIGNED_70,_zz__zz_decode_IS_RS2_SIGNED_72};
-  assign _zz__zz_decode_IS_RS2_SIGNED_75 = (_zz__zz_decode_IS_RS2_SIGNED_76 == _zz__zz_decode_IS_RS2_SIGNED_77);
-  assign _zz__zz_decode_IS_RS2_SIGNED_78 = {_zz__zz_decode_IS_RS2_SIGNED_79,{_zz__zz_decode_IS_RS2_SIGNED_81,_zz__zz_decode_IS_RS2_SIGNED_84}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_88 = _zz_decode_IS_RS2_SIGNED_4;
-  assign _zz__zz_decode_IS_RS2_SIGNED_89 = {_zz__zz_decode_IS_RS2_SIGNED_90,{_zz__zz_decode_IS_RS2_SIGNED_92,_zz__zz_decode_IS_RS2_SIGNED_95}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_102 = {_zz_decode_IS_RS2_SIGNED_3,_zz__zz_decode_IS_RS2_SIGNED_103};
-  assign _zz__zz_decode_IS_RS2_SIGNED_105 = (|{_zz__zz_decode_IS_RS2_SIGNED_106,_zz__zz_decode_IS_RS2_SIGNED_107});
-  assign _zz__zz_decode_IS_RS2_SIGNED_110 = (|_zz__zz_decode_IS_RS2_SIGNED_111);
-  assign _zz__zz_decode_IS_RS2_SIGNED_114 = {_zz__zz_decode_IS_RS2_SIGNED_115,{_zz__zz_decode_IS_RS2_SIGNED_117,_zz__zz_decode_IS_RS2_SIGNED_128}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_59 = 32'h00000050;
-  assign _zz__zz_decode_IS_RS2_SIGNED_67 = (decode_INSTRUCTION & 32'h00004020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_68 = 32'h00004020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_70 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_71) == 32'h00000010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_72 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_73) == 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_76 = (decode_INSTRUCTION & 32'h00002030);
-  assign _zz__zz_decode_IS_RS2_SIGNED_77 = 32'h00002010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_79 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_80) == 32'h00000010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_81 = (_zz__zz_decode_IS_RS2_SIGNED_82 == _zz__zz_decode_IS_RS2_SIGNED_83);
+  assign _zz__zz_decode_IS_RS2_SIGNED_72 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_73) == 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_74 = (_zz__zz_decode_IS_RS2_SIGNED_75 == _zz__zz_decode_IS_RS2_SIGNED_76);
+  assign _zz__zz_decode_IS_RS2_SIGNED_77 = {_zz__zz_decode_IS_RS2_SIGNED_78,_zz__zz_decode_IS_RS2_SIGNED_80};
   assign _zz__zz_decode_IS_RS2_SIGNED_84 = (_zz__zz_decode_IS_RS2_SIGNED_85 == _zz__zz_decode_IS_RS2_SIGNED_86);
-  assign _zz__zz_decode_IS_RS2_SIGNED_90 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_91) == 32'h00001010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_92 = (_zz__zz_decode_IS_RS2_SIGNED_93 == _zz__zz_decode_IS_RS2_SIGNED_94);
-  assign _zz__zz_decode_IS_RS2_SIGNED_95 = {_zz__zz_decode_IS_RS2_SIGNED_96,{_zz__zz_decode_IS_RS2_SIGNED_97,_zz__zz_decode_IS_RS2_SIGNED_99}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_103 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_104) == 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_106 = _zz_decode_IS_RS2_SIGNED_3;
-  assign _zz__zz_decode_IS_RS2_SIGNED_107 = (_zz__zz_decode_IS_RS2_SIGNED_108 == _zz__zz_decode_IS_RS2_SIGNED_109);
-  assign _zz__zz_decode_IS_RS2_SIGNED_111 = (_zz__zz_decode_IS_RS2_SIGNED_112 == _zz__zz_decode_IS_RS2_SIGNED_113);
-  assign _zz__zz_decode_IS_RS2_SIGNED_115 = (|_zz__zz_decode_IS_RS2_SIGNED_116);
-  assign _zz__zz_decode_IS_RS2_SIGNED_117 = (|_zz__zz_decode_IS_RS2_SIGNED_118);
-  assign _zz__zz_decode_IS_RS2_SIGNED_128 = {_zz__zz_decode_IS_RS2_SIGNED_129,{_zz__zz_decode_IS_RS2_SIGNED_132,_zz__zz_decode_IS_RS2_SIGNED_140}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_71 = 32'h00000030;
-  assign _zz__zz_decode_IS_RS2_SIGNED_73 = 32'h02000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_80 = 32'h00001030;
-  assign _zz__zz_decode_IS_RS2_SIGNED_82 = (decode_INSTRUCTION & 32'h02002060);
-  assign _zz__zz_decode_IS_RS2_SIGNED_83 = 32'h00002020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_85 = (decode_INSTRUCTION & 32'h02003020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_86 = 32'h00000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_91 = 32'h00001010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_93 = (decode_INSTRUCTION & 32'h00002010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_94 = 32'h00002010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_96 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_97 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_98) == 32'h00000004);
-  assign _zz__zz_decode_IS_RS2_SIGNED_99 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_100) == 32'h0);
-  assign _zz__zz_decode_IS_RS2_SIGNED_104 = 32'h00000070;
-  assign _zz__zz_decode_IS_RS2_SIGNED_108 = (decode_INSTRUCTION & 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_109 = 32'h0;
-  assign _zz__zz_decode_IS_RS2_SIGNED_112 = (decode_INSTRUCTION & 32'h00004014);
-  assign _zz__zz_decode_IS_RS2_SIGNED_113 = 32'h00004010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_116 = ((decode_INSTRUCTION & 32'h00006014) == 32'h00002010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_118 = {(_zz__zz_decode_IS_RS2_SIGNED_119 == _zz__zz_decode_IS_RS2_SIGNED_120),{_zz_decode_IS_RS2_SIGNED_2,{_zz__zz_decode_IS_RS2_SIGNED_121,_zz__zz_decode_IS_RS2_SIGNED_123}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_129 = (|(_zz__zz_decode_IS_RS2_SIGNED_130 == _zz__zz_decode_IS_RS2_SIGNED_131));
-  assign _zz__zz_decode_IS_RS2_SIGNED_132 = (|{_zz__zz_decode_IS_RS2_SIGNED_133,_zz__zz_decode_IS_RS2_SIGNED_135});
-  assign _zz__zz_decode_IS_RS2_SIGNED_140 = {(|_zz__zz_decode_IS_RS2_SIGNED_141),{_zz__zz_decode_IS_RS2_SIGNED_144,_zz__zz_decode_IS_RS2_SIGNED_146}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_98 = 32'h0000000c;
-  assign _zz__zz_decode_IS_RS2_SIGNED_100 = 32'h00000028;
-  assign _zz__zz_decode_IS_RS2_SIGNED_119 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz__zz_decode_IS_RS2_SIGNED_120 = 32'h0;
-  assign _zz__zz_decode_IS_RS2_SIGNED_121 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_122) == 32'h00002000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_123 = {(_zz__zz_decode_IS_RS2_SIGNED_124 == _zz__zz_decode_IS_RS2_SIGNED_125),(_zz__zz_decode_IS_RS2_SIGNED_126 == _zz__zz_decode_IS_RS2_SIGNED_127)};
-  assign _zz__zz_decode_IS_RS2_SIGNED_130 = (decode_INSTRUCTION & 32'h00000058);
-  assign _zz__zz_decode_IS_RS2_SIGNED_131 = 32'h0;
-  assign _zz__zz_decode_IS_RS2_SIGNED_133 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_134) == 32'h00000040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_135 = {(_zz__zz_decode_IS_RS2_SIGNED_136 == _zz__zz_decode_IS_RS2_SIGNED_137),(_zz__zz_decode_IS_RS2_SIGNED_138 == _zz__zz_decode_IS_RS2_SIGNED_139)};
-  assign _zz__zz_decode_IS_RS2_SIGNED_141 = {(_zz__zz_decode_IS_RS2_SIGNED_142 == _zz__zz_decode_IS_RS2_SIGNED_143),_zz_decode_IS_RS2_SIGNED_1};
-  assign _zz__zz_decode_IS_RS2_SIGNED_144 = (|{_zz__zz_decode_IS_RS2_SIGNED_145,_zz_decode_IS_RS2_SIGNED_1});
-  assign _zz__zz_decode_IS_RS2_SIGNED_146 = (|(_zz__zz_decode_IS_RS2_SIGNED_147 == _zz__zz_decode_IS_RS2_SIGNED_148));
-  assign _zz__zz_decode_IS_RS2_SIGNED_122 = 32'h00006004;
-  assign _zz__zz_decode_IS_RS2_SIGNED_124 = (decode_INSTRUCTION & 32'h00005004);
-  assign _zz__zz_decode_IS_RS2_SIGNED_125 = 32'h00001000;
-  assign _zz__zz_decode_IS_RS2_SIGNED_126 = (decode_INSTRUCTION & 32'h00004050);
-  assign _zz__zz_decode_IS_RS2_SIGNED_127 = 32'h00004000;
-  assign _zz__zz_decode_IS_RS2_SIGNED_134 = 32'h00000044;
-  assign _zz__zz_decode_IS_RS2_SIGNED_136 = (decode_INSTRUCTION & 32'h00002014);
-  assign _zz__zz_decode_IS_RS2_SIGNED_137 = 32'h00002010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_138 = (decode_INSTRUCTION & 32'h40000034);
-  assign _zz__zz_decode_IS_RS2_SIGNED_139 = 32'h40000030;
-  assign _zz__zz_decode_IS_RS2_SIGNED_142 = (decode_INSTRUCTION & 32'h00000014);
-  assign _zz__zz_decode_IS_RS2_SIGNED_143 = 32'h00000004;
-  assign _zz__zz_decode_IS_RS2_SIGNED_145 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000004);
-  assign _zz__zz_decode_IS_RS2_SIGNED_147 = (decode_INSTRUCTION & 32'h00005048);
-  assign _zz__zz_decode_IS_RS2_SIGNED_148 = 32'h00001008;
+  assign _zz__zz_decode_IS_RS2_SIGNED_87 = {_zz__zz_decode_IS_RS2_SIGNED_88,{_zz__zz_decode_IS_RS2_SIGNED_90,_zz__zz_decode_IS_RS2_SIGNED_93}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_97 = _zz_decode_IS_RS2_SIGNED_3;
+  assign _zz__zz_decode_IS_RS2_SIGNED_98 = (_zz__zz_decode_IS_RS2_SIGNED_99 == _zz__zz_decode_IS_RS2_SIGNED_100);
+  assign _zz__zz_decode_IS_RS2_SIGNED_102 = {_zz_decode_IS_RS2_SIGNED_3,_zz__zz_decode_IS_RS2_SIGNED_103};
+  assign _zz__zz_decode_IS_RS2_SIGNED_106 = (|_zz__zz_decode_IS_RS2_SIGNED_107);
+  assign _zz__zz_decode_IS_RS2_SIGNED_109 = (|_zz__zz_decode_IS_RS2_SIGNED_110);
+  assign _zz__zz_decode_IS_RS2_SIGNED_113 = {_zz__zz_decode_IS_RS2_SIGNED_114,{_zz__zz_decode_IS_RS2_SIGNED_123,_zz__zz_decode_IS_RS2_SIGNED_126}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_62 = 32'h00004020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_64 = (decode_INSTRUCTION & 32'h00000030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_65 = 32'h00000010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_67 = (decode_INSTRUCTION & 32'h02000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_68 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_73 = 32'h00002030;
+  assign _zz__zz_decode_IS_RS2_SIGNED_75 = (decode_INSTRUCTION & 32'h00001030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_76 = 32'h00000010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_78 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_79) == 32'h00002020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_80 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_81) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_85 = (decode_INSTRUCTION & 32'h00001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_86 = 32'h00001010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_88 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_89) == 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_90 = (_zz__zz_decode_IS_RS2_SIGNED_91 == _zz__zz_decode_IS_RS2_SIGNED_92);
+  assign _zz__zz_decode_IS_RS2_SIGNED_93 = {_zz__zz_decode_IS_RS2_SIGNED_94,_zz__zz_decode_IS_RS2_SIGNED_95};
+  assign _zz__zz_decode_IS_RS2_SIGNED_99 = (decode_INSTRUCTION & 32'h00000070);
+  assign _zz__zz_decode_IS_RS2_SIGNED_100 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_103 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_104) == 32'h00000000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_107 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_108) == 32'h00004010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_110 = (_zz__zz_decode_IS_RS2_SIGNED_111 == _zz__zz_decode_IS_RS2_SIGNED_112);
+  assign _zz__zz_decode_IS_RS2_SIGNED_114 = (|{_zz__zz_decode_IS_RS2_SIGNED_115,_zz__zz_decode_IS_RS2_SIGNED_117});
+  assign _zz__zz_decode_IS_RS2_SIGNED_123 = (|_zz__zz_decode_IS_RS2_SIGNED_124);
+  assign _zz__zz_decode_IS_RS2_SIGNED_126 = {_zz__zz_decode_IS_RS2_SIGNED_127,{_zz__zz_decode_IS_RS2_SIGNED_133,_zz__zz_decode_IS_RS2_SIGNED_137}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_79 = 32'h02002060;
+  assign _zz__zz_decode_IS_RS2_SIGNED_81 = 32'h02003020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_89 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_91 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_92 = 32'h00000010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_94 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_95 = ((decode_INSTRUCTION & 32'h00000028) == 32'h00000000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_104 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_108 = 32'h00004014;
+  assign _zz__zz_decode_IS_RS2_SIGNED_111 = (decode_INSTRUCTION & 32'h00006014);
+  assign _zz__zz_decode_IS_RS2_SIGNED_112 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_115 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_116) == 32'h00000000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_117 = {_zz_decode_IS_RS2_SIGNED_2,{_zz__zz_decode_IS_RS2_SIGNED_118,{_zz__zz_decode_IS_RS2_SIGNED_119,_zz__zz_decode_IS_RS2_SIGNED_121}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_124 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_125) == 32'h00000000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_127 = (|{_zz__zz_decode_IS_RS2_SIGNED_128,{_zz__zz_decode_IS_RS2_SIGNED_129,_zz__zz_decode_IS_RS2_SIGNED_131}});
+  assign _zz__zz_decode_IS_RS2_SIGNED_133 = (|{_zz__zz_decode_IS_RS2_SIGNED_134,_zz__zz_decode_IS_RS2_SIGNED_136});
+  assign _zz__zz_decode_IS_RS2_SIGNED_137 = {(|_zz__zz_decode_IS_RS2_SIGNED_138),(|_zz__zz_decode_IS_RS2_SIGNED_141)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_116 = 32'h00000044;
+  assign _zz__zz_decode_IS_RS2_SIGNED_118 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_119 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_120) == 32'h00001000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_121 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_122) == 32'h00004000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_125 = 32'h00000058;
+  assign _zz__zz_decode_IS_RS2_SIGNED_128 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_129 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_130) == 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_131 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_132) == 32'h40000030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_134 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_135) == 32'h00000004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_136 = _zz_decode_IS_RS2_SIGNED_1;
+  assign _zz__zz_decode_IS_RS2_SIGNED_138 = {(_zz__zz_decode_IS_RS2_SIGNED_139 == _zz__zz_decode_IS_RS2_SIGNED_140),_zz_decode_IS_RS2_SIGNED_1};
+  assign _zz__zz_decode_IS_RS2_SIGNED_141 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_142) == 32'h00001008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_120 = 32'h00005004;
+  assign _zz__zz_decode_IS_RS2_SIGNED_122 = 32'h00004050;
+  assign _zz__zz_decode_IS_RS2_SIGNED_130 = 32'h00002014;
+  assign _zz__zz_decode_IS_RS2_SIGNED_132 = 32'h40000034;
+  assign _zz__zz_decode_IS_RS2_SIGNED_135 = 32'h00000014;
+  assign _zz__zz_decode_IS_RS2_SIGNED_139 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz__zz_decode_IS_RS2_SIGNED_140 = 32'h00000004;
+  assign _zz__zz_decode_IS_RS2_SIGNED_142 = 32'h00005048;
   assign _zz_execute_BranchPlugin_branch_src2_6 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_7 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_8 = execute_INSTRUCTION[7];
-  assign _zz_CsrPlugin_csrMapping_readDataInit_25 = 32'h0;
-  assign _zz_PmpPlugin_pmpaddr_port0 = PmpPlugin_pmpaddr[execute_PmpPlugin_fsm_fsmCounter];
-  always @(posedge clk) begin
-    if(_zz_1) begin
-      PmpPlugin_pmpaddr[execute_PmpPlugin_pmpNcfg_] <= _zz_PmpPlugin_pmpaddr_port;
-    end
-  end
-
-  assign _zz_PmpPlugin_pmpaddr_port2 = PmpPlugin_pmpaddr[execute_PmpPlugin_pmpNcfg];
+  assign _zz_CsrPlugin_csrMapping_readDataInit_109 = (_zz_CsrPlugin_csrMapping_readDataInit_65 | _zz_CsrPlugin_csrMapping_readDataInit_66);
+  assign _zz_CsrPlugin_csrMapping_readDataInit_110 = (_zz_CsrPlugin_csrMapping_readDataInit_67 | _zz_CsrPlugin_csrMapping_readDataInit_68);
+  assign _zz_CsrPlugin_csrMapping_readDataInit_111 = (_zz_CsrPlugin_csrMapping_readDataInit_69 | _zz_CsrPlugin_csrMapping_readDataInit_70);
+  assign _zz_CsrPlugin_csrMapping_readDataInit_112 = (_zz_CsrPlugin_csrMapping_readDataInit_71 | _zz_CsrPlugin_csrMapping_readDataInit_72);
+  assign _zz_CsrPlugin_csrMapping_readDataInit_113 = (_zz_CsrPlugin_csrMapping_readDataInit_73 | _zz_CsrPlugin_csrMapping_readDataInit_74);
+  assign _zz_CsrPlugin_csrMapping_readDataInit_114 = (_zz_CsrPlugin_csrMapping_readDataInit_75 | _zz_CsrPlugin_csrMapping_readDataInit_76);
+  assign _zz_CsrPlugin_csrMapping_readDataInit_115 = (_zz_CsrPlugin_csrMapping_readDataInit_77 | _zz_CsrPlugin_csrMapping_readDataInit_78);
+  assign _zz_CsrPlugin_csrMapping_readDataInit_116 = (_zz_CsrPlugin_csrMapping_readDataInit_79 | _zz_CsrPlugin_csrMapping_readDataInit_80);
+  assign _zz_CsrPlugin_csrMapping_readDataInit_117 = (_zz_CsrPlugin_csrMapping_readDataInit_81 | _zz_CsrPlugin_csrMapping_readDataInit_82);
+  assign _zz_CsrPlugin_csrMapping_readDataInit_118 = (_zz_CsrPlugin_csrMapping_readDataInit_83 | _zz_CsrPlugin_csrMapping_readDataInit_84);
+  assign _zz_CsrPlugin_csrMapping_readDataInit_119 = (_zz_CsrPlugin_csrMapping_readDataInit_85 | _zz_CsrPlugin_csrMapping_readDataInit_86);
+  assign _zz_CsrPlugin_csrMapping_readDataInit_120 = (_zz_CsrPlugin_csrMapping_readDataInit_87 | _zz_CsrPlugin_csrMapping_readDataInit_88);
+  assign _zz_CsrPlugin_csrMapping_readDataInit_121 = (_zz_CsrPlugin_csrMapping_readDataInit_122 | _zz_CsrPlugin_csrMapping_readDataInit_89);
+  assign _zz_CsrPlugin_csrMapping_readDataInit_123 = (_zz_CsrPlugin_csrMapping_readDataInit_90 | _zz_CsrPlugin_csrMapping_readDataInit_91);
+  assign _zz_CsrPlugin_csrMapping_readDataInit_124 = (_zz_CsrPlugin_csrMapping_readDataInit_92 | _zz_CsrPlugin_csrMapping_readDataInit_93);
+  assign _zz_CsrPlugin_csrMapping_readDataInit_125 = (_zz_CsrPlugin_csrMapping_readDataInit_94 | _zz_CsrPlugin_csrMapping_readDataInit_95);
+  assign _zz_CsrPlugin_csrMapping_readDataInit_122 = 32'h00000000;
   always @(posedge clk) begin
     if(_zz_decode_RegFilePlugin_rs1Data) begin
       _zz_RegFilePlugin_regFile_port0 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
@@ -2157,16 +2620,11 @@ module VexRiscv (
   end
 
   always @(posedge clk) begin
-    if(_zz_2) begin
+    if(_zz_1) begin
       RegFilePlugin_regFile[lastStageRegFileWrite_payload_address] <= lastStageRegFileWrite_payload_data;
     end
   end
 
-  PmpSetter PmpPlugin_setter (
-    .io_addr (PmpPlugin_setter_io_addr[31:0]), //i
-    .io_base (PmpPlugin_setter_io_base[24:0]), //o
-    .io_mask (PmpPlugin_setter_io_mask[24:0])  //o
-  );
   InstructionCache IBusCachedPlugin_cache (
     .io_flush                              (IBusCachedPlugin_cache_io_flush                           ), //i
     .io_cpu_prefetch_isValid               (IBusCachedPlugin_cache_io_cpu_prefetch_isValid            ), //i
@@ -2206,8 +2664,8 @@ module VexRiscv (
     .io_mem_rsp_valid                      (iBus_rsp_valid                                            ), //i
     .io_mem_rsp_payload_data               (iBus_rsp_payload_data[31:0]                               ), //i
     .io_mem_rsp_payload_error              (iBus_rsp_payload_error                                    ), //i
-    ._zz_when_Fetcher_l401                 (switch_Fetcher_l365[2:0]                                  ), //i
-    ._zz_io_cpu_fetch_data_regNextWhen     (IBusCachedPlugin_injectionPort_payload[31:0]              ), //i
+    ._zz_when_Fetcher_l411                 (IBusCachedPlugin_injector_port_state[2:0]                 ), //i
+    ._zz_io_cpu_fetch_data_regNextWhen     (DebugPlugin_injectionPort_payload[31:0]                   ), //i
     .clk                                   (clk                                                       ), //i
     .reset                                 (reset                                                     )  //i
   );
@@ -2260,8 +2718,9 @@ module VexRiscv (
     .io_cpu_flush_ready                     (dataCache_1_io_cpu_flush_ready                   ), //o
     .io_cpu_flush_payload_singleLine        (dataCache_1_io_cpu_flush_payload_singleLine      ), //i
     .io_cpu_flush_payload_lineId            (dataCache_1_io_cpu_flush_payload_lineId[6:0]     ), //i
+    .io_cpu_writesPending                   (dataCache_1_io_cpu_writesPending                 ), //o
     .io_mem_cmd_valid                       (dataCache_1_io_mem_cmd_valid                     ), //o
-    .io_mem_cmd_ready                       (dataCache_1_io_mem_cmd_ready                     ), //i
+    .io_mem_cmd_ready                       (toplevel_dataCache_1_io_mem_cmd_rValidN          ), //i
     .io_mem_cmd_payload_wr                  (dataCache_1_io_mem_cmd_payload_wr                ), //o
     .io_mem_cmd_payload_uncached            (dataCache_1_io_mem_cmd_payload_uncached          ), //o
     .io_mem_cmd_payload_address             (dataCache_1_io_mem_cmd_payload_address[31:0]     ), //o
@@ -2302,1619 +2761,284 @@ module VexRiscv (
   end
 
   always @(*) begin
-    case(execute_PmpPlugin_fsm_fsmCounter)
-      4'b0000 : _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_0;
-      4'b0001 : _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_1;
-      4'b0010 : _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_2;
-      4'b0011 : _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_3;
-      4'b0100 : _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_4;
-      4'b0101 : _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_5;
-      4'b0110 : _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_6;
-      4'b0111 : _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_7;
-      4'b1000 : _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_8;
-      4'b1001 : _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_9;
-      4'b1010 : _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_10;
-      4'b1011 : _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_11;
-      4'b1100 : _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_12;
-      4'b1101 : _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_13;
-      4'b1110 : _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_14;
-      default : _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_15;
+    case(_zz_when_PmpPlugin_l250_20)
+      3'b000 : _zz_when_PmpPlugin_l250_19 = _zz_when_PmpPlugin_l250;
+      3'b001 : _zz_when_PmpPlugin_l250_19 = _zz_when_PmpPlugin_l250_1;
+      3'b010 : _zz_when_PmpPlugin_l250_19 = _zz_when_PmpPlugin_l250_2;
+      3'b011 : _zz_when_PmpPlugin_l250_19 = _zz_when_PmpPlugin_l250_3;
+      3'b100 : _zz_when_PmpPlugin_l250_19 = _zz_when_PmpPlugin_l250_4;
+      3'b101 : _zz_when_PmpPlugin_l250_19 = _zz_when_PmpPlugin_l250_5;
+      3'b110 : _zz_when_PmpPlugin_l250_19 = _zz_when_PmpPlugin_l250_6;
+      default : _zz_when_PmpPlugin_l250_19 = _zz_when_PmpPlugin_l250_7;
     endcase
   end
 
   always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_0_2)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_15;
+    case(_zz_when_PmpPlugin_l250_22)
+      3'b000 : _zz_when_PmpPlugin_l250_21 = _zz_when_PmpPlugin_l250;
+      3'b001 : _zz_when_PmpPlugin_l250_21 = _zz_when_PmpPlugin_l250_1;
+      3'b010 : _zz_when_PmpPlugin_l250_21 = _zz_when_PmpPlugin_l250_2;
+      3'b011 : _zz_when_PmpPlugin_l250_21 = _zz_when_PmpPlugin_l250_3;
+      3'b100 : _zz_when_PmpPlugin_l250_21 = _zz_when_PmpPlugin_l250_4;
+      3'b101 : _zz_when_PmpPlugin_l250_21 = _zz_when_PmpPlugin_l250_5;
+      3'b110 : _zz_when_PmpPlugin_l250_21 = _zz_when_PmpPlugin_l250_6;
+      default : _zz_when_PmpPlugin_l250_21 = _zz_when_PmpPlugin_l250_7;
     endcase
   end
 
   always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_0_4)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_15;
+    case(_zz_when_PmpPlugin_l250_25)
+      3'b000 : _zz_when_PmpPlugin_l250_24 = _zz_when_PmpPlugin_l250;
+      3'b001 : _zz_when_PmpPlugin_l250_24 = _zz_when_PmpPlugin_l250_1;
+      3'b010 : _zz_when_PmpPlugin_l250_24 = _zz_when_PmpPlugin_l250_2;
+      3'b011 : _zz_when_PmpPlugin_l250_24 = _zz_when_PmpPlugin_l250_3;
+      3'b100 : _zz_when_PmpPlugin_l250_24 = _zz_when_PmpPlugin_l250_4;
+      3'b101 : _zz_when_PmpPlugin_l250_24 = _zz_when_PmpPlugin_l250_5;
+      3'b110 : _zz_when_PmpPlugin_l250_24 = _zz_when_PmpPlugin_l250_6;
+      default : _zz_when_PmpPlugin_l250_24 = _zz_when_PmpPlugin_l250_7;
     endcase
   end
 
   always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_1_1)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_15;
+    case(_zz_when_PmpPlugin_l250_27)
+      3'b000 : _zz_when_PmpPlugin_l250_26 = _zz_when_PmpPlugin_l250;
+      3'b001 : _zz_when_PmpPlugin_l250_26 = _zz_when_PmpPlugin_l250_1;
+      3'b010 : _zz_when_PmpPlugin_l250_26 = _zz_when_PmpPlugin_l250_2;
+      3'b011 : _zz_when_PmpPlugin_l250_26 = _zz_when_PmpPlugin_l250_3;
+      3'b100 : _zz_when_PmpPlugin_l250_26 = _zz_when_PmpPlugin_l250_4;
+      3'b101 : _zz_when_PmpPlugin_l250_26 = _zz_when_PmpPlugin_l250_5;
+      3'b110 : _zz_when_PmpPlugin_l250_26 = _zz_when_PmpPlugin_l250_6;
+      default : _zz_when_PmpPlugin_l250_26 = _zz_when_PmpPlugin_l250_7;
     endcase
   end
 
   always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_1_3)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_15;
+    case(_zz_when_PmpPlugin_l250_30)
+      3'b000 : _zz_when_PmpPlugin_l250_29 = _zz_when_PmpPlugin_l250;
+      3'b001 : _zz_when_PmpPlugin_l250_29 = _zz_when_PmpPlugin_l250_1;
+      3'b010 : _zz_when_PmpPlugin_l250_29 = _zz_when_PmpPlugin_l250_2;
+      3'b011 : _zz_when_PmpPlugin_l250_29 = _zz_when_PmpPlugin_l250_3;
+      3'b100 : _zz_when_PmpPlugin_l250_29 = _zz_when_PmpPlugin_l250_4;
+      3'b101 : _zz_when_PmpPlugin_l250_29 = _zz_when_PmpPlugin_l250_5;
+      3'b110 : _zz_when_PmpPlugin_l250_29 = _zz_when_PmpPlugin_l250_6;
+      default : _zz_when_PmpPlugin_l250_29 = _zz_when_PmpPlugin_l250_7;
     endcase
   end
 
   always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_2_1)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_15;
+    case(_zz_when_PmpPlugin_l250_32)
+      3'b000 : _zz_when_PmpPlugin_l250_31 = _zz_when_PmpPlugin_l250;
+      3'b001 : _zz_when_PmpPlugin_l250_31 = _zz_when_PmpPlugin_l250_1;
+      3'b010 : _zz_when_PmpPlugin_l250_31 = _zz_when_PmpPlugin_l250_2;
+      3'b011 : _zz_when_PmpPlugin_l250_31 = _zz_when_PmpPlugin_l250_3;
+      3'b100 : _zz_when_PmpPlugin_l250_31 = _zz_when_PmpPlugin_l250_4;
+      3'b101 : _zz_when_PmpPlugin_l250_31 = _zz_when_PmpPlugin_l250_5;
+      3'b110 : _zz_when_PmpPlugin_l250_31 = _zz_when_PmpPlugin_l250_6;
+      default : _zz_when_PmpPlugin_l250_31 = _zz_when_PmpPlugin_l250_7;
     endcase
   end
 
   always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_2_3)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_15;
+    case(_zz_IBusCachedPlugin_mmuBus_rsp_allowRead_50)
+      4'b0000 : _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead;
+      4'b0001 : _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_2;
+      4'b0010 : _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_4;
+      4'b0011 : _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_6;
+      4'b0100 : _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_8;
+      4'b0101 : _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_10;
+      4'b0110 : _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_12;
+      4'b0111 : _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_14;
+      4'b1000 : _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_16;
+      4'b1001 : _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_18;
+      4'b1010 : _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_20;
+      4'b1011 : _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_22;
+      4'b1100 : _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_24;
+      4'b1101 : _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_26;
+      4'b1110 : _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_28;
+      default : _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_30;
     endcase
   end
 
   always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_3_1)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_15;
+    case(_zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_50)
+      4'b0000 : _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite;
+      4'b0001 : _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_2;
+      4'b0010 : _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_4;
+      4'b0011 : _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_6;
+      4'b0100 : _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_8;
+      4'b0101 : _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_10;
+      4'b0110 : _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_12;
+      4'b0111 : _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_14;
+      4'b1000 : _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_16;
+      4'b1001 : _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_18;
+      4'b1010 : _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_20;
+      4'b1011 : _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_22;
+      4'b1100 : _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_24;
+      4'b1101 : _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_26;
+      4'b1110 : _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_28;
+      default : _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_30;
     endcase
   end
 
   always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_3_3)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_15;
+    case(_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_50)
+      4'b0000 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute;
+      4'b0001 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_2;
+      4'b0010 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_4;
+      4'b0011 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_6;
+      4'b0100 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_8;
+      4'b0101 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_10;
+      4'b0110 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_12;
+      4'b0111 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_14;
+      4'b1000 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_16;
+      4'b1001 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_18;
+      4'b1010 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_20;
+      4'b1011 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_22;
+      4'b1100 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_24;
+      4'b1101 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_26;
+      4'b1110 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_28;
+      default : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_49 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_30;
     endcase
   end
 
   always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_4_1)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_15;
+    case(_zz_when_PmpPlugin_l250_1_5)
+      3'b000 : _zz_when_PmpPlugin_l250_1_4 = _zz_when_PmpPlugin_l250_8;
+      3'b001 : _zz_when_PmpPlugin_l250_1_4 = _zz_when_PmpPlugin_l250_9;
+      3'b010 : _zz_when_PmpPlugin_l250_1_4 = _zz_when_PmpPlugin_l250_10;
+      3'b011 : _zz_when_PmpPlugin_l250_1_4 = _zz_when_PmpPlugin_l250_11;
+      3'b100 : _zz_when_PmpPlugin_l250_1_4 = _zz_when_PmpPlugin_l250_12;
+      3'b101 : _zz_when_PmpPlugin_l250_1_4 = _zz_when_PmpPlugin_l250_13;
+      3'b110 : _zz_when_PmpPlugin_l250_1_4 = _zz_when_PmpPlugin_l250_14;
+      default : _zz_when_PmpPlugin_l250_1_4 = _zz_when_PmpPlugin_l250_15;
     endcase
   end
 
   always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_4_3)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_15;
+    case(_zz_when_PmpPlugin_l250_1_7)
+      3'b000 : _zz_when_PmpPlugin_l250_1_6 = _zz_when_PmpPlugin_l250_8;
+      3'b001 : _zz_when_PmpPlugin_l250_1_6 = _zz_when_PmpPlugin_l250_9;
+      3'b010 : _zz_when_PmpPlugin_l250_1_6 = _zz_when_PmpPlugin_l250_10;
+      3'b011 : _zz_when_PmpPlugin_l250_1_6 = _zz_when_PmpPlugin_l250_11;
+      3'b100 : _zz_when_PmpPlugin_l250_1_6 = _zz_when_PmpPlugin_l250_12;
+      3'b101 : _zz_when_PmpPlugin_l250_1_6 = _zz_when_PmpPlugin_l250_13;
+      3'b110 : _zz_when_PmpPlugin_l250_1_6 = _zz_when_PmpPlugin_l250_14;
+      default : _zz_when_PmpPlugin_l250_1_6 = _zz_when_PmpPlugin_l250_15;
     endcase
   end
 
   always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_5_1)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_15;
+    case(_zz_when_PmpPlugin_l250_1_10)
+      3'b000 : _zz_when_PmpPlugin_l250_1_9 = _zz_when_PmpPlugin_l250_8;
+      3'b001 : _zz_when_PmpPlugin_l250_1_9 = _zz_when_PmpPlugin_l250_9;
+      3'b010 : _zz_when_PmpPlugin_l250_1_9 = _zz_when_PmpPlugin_l250_10;
+      3'b011 : _zz_when_PmpPlugin_l250_1_9 = _zz_when_PmpPlugin_l250_11;
+      3'b100 : _zz_when_PmpPlugin_l250_1_9 = _zz_when_PmpPlugin_l250_12;
+      3'b101 : _zz_when_PmpPlugin_l250_1_9 = _zz_when_PmpPlugin_l250_13;
+      3'b110 : _zz_when_PmpPlugin_l250_1_9 = _zz_when_PmpPlugin_l250_14;
+      default : _zz_when_PmpPlugin_l250_1_9 = _zz_when_PmpPlugin_l250_15;
     endcase
   end
 
   always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_5_3)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_15;
+    case(_zz_when_PmpPlugin_l250_1_12)
+      3'b000 : _zz_when_PmpPlugin_l250_1_11 = _zz_when_PmpPlugin_l250_8;
+      3'b001 : _zz_when_PmpPlugin_l250_1_11 = _zz_when_PmpPlugin_l250_9;
+      3'b010 : _zz_when_PmpPlugin_l250_1_11 = _zz_when_PmpPlugin_l250_10;
+      3'b011 : _zz_when_PmpPlugin_l250_1_11 = _zz_when_PmpPlugin_l250_11;
+      3'b100 : _zz_when_PmpPlugin_l250_1_11 = _zz_when_PmpPlugin_l250_12;
+      3'b101 : _zz_when_PmpPlugin_l250_1_11 = _zz_when_PmpPlugin_l250_13;
+      3'b110 : _zz_when_PmpPlugin_l250_1_11 = _zz_when_PmpPlugin_l250_14;
+      default : _zz_when_PmpPlugin_l250_1_11 = _zz_when_PmpPlugin_l250_15;
     endcase
   end
 
   always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_6_1)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_15;
+    case(_zz_when_PmpPlugin_l250_1_15)
+      3'b000 : _zz_when_PmpPlugin_l250_1_14 = _zz_when_PmpPlugin_l250_8;
+      3'b001 : _zz_when_PmpPlugin_l250_1_14 = _zz_when_PmpPlugin_l250_9;
+      3'b010 : _zz_when_PmpPlugin_l250_1_14 = _zz_when_PmpPlugin_l250_10;
+      3'b011 : _zz_when_PmpPlugin_l250_1_14 = _zz_when_PmpPlugin_l250_11;
+      3'b100 : _zz_when_PmpPlugin_l250_1_14 = _zz_when_PmpPlugin_l250_12;
+      3'b101 : _zz_when_PmpPlugin_l250_1_14 = _zz_when_PmpPlugin_l250_13;
+      3'b110 : _zz_when_PmpPlugin_l250_1_14 = _zz_when_PmpPlugin_l250_14;
+      default : _zz_when_PmpPlugin_l250_1_14 = _zz_when_PmpPlugin_l250_15;
     endcase
   end
 
   always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_6_3)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_7_1)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_7_3)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_8_1)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_8_3)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_9_1)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_9_3)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_10_1)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_10_3)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_11_1)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_11_3)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_12_1)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_12_3)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_13_1)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_13_3)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_14_1)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_14_3)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_15_1)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_dGuard_hits_15_3)
-      4'b0000 : _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_15;
+    case(_zz_when_PmpPlugin_l250_1_17)
+      3'b000 : _zz_when_PmpPlugin_l250_1_16 = _zz_when_PmpPlugin_l250_8;
+      3'b001 : _zz_when_PmpPlugin_l250_1_16 = _zz_when_PmpPlugin_l250_9;
+      3'b010 : _zz_when_PmpPlugin_l250_1_16 = _zz_when_PmpPlugin_l250_10;
+      3'b011 : _zz_when_PmpPlugin_l250_1_16 = _zz_when_PmpPlugin_l250_11;
+      3'b100 : _zz_when_PmpPlugin_l250_1_16 = _zz_when_PmpPlugin_l250_12;
+      3'b101 : _zz_when_PmpPlugin_l250_1_16 = _zz_when_PmpPlugin_l250_13;
+      3'b110 : _zz_when_PmpPlugin_l250_1_16 = _zz_when_PmpPlugin_l250_14;
+      default : _zz_when_PmpPlugin_l250_1_16 = _zz_when_PmpPlugin_l250_15;
     endcase
   end
 
   always @(*) begin
     case(_zz_DBusCachedPlugin_mmuBus_rsp_allowRead_18)
-      4'b0000 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = PmpPlugin_pmpcfg_0[0];
-      4'b0001 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = PmpPlugin_pmpcfg_1[0];
-      4'b0010 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = PmpPlugin_pmpcfg_2[0];
-      4'b0011 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = PmpPlugin_pmpcfg_3[0];
-      4'b0100 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = PmpPlugin_pmpcfg_4[0];
-      4'b0101 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = PmpPlugin_pmpcfg_5[0];
-      4'b0110 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = PmpPlugin_pmpcfg_6[0];
-      4'b0111 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = PmpPlugin_pmpcfg_7[0];
-      4'b1000 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = PmpPlugin_pmpcfg_8[0];
-      4'b1001 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = PmpPlugin_pmpcfg_9[0];
-      4'b1010 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = PmpPlugin_pmpcfg_10[0];
-      4'b1011 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = PmpPlugin_pmpcfg_11[0];
-      4'b1100 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = PmpPlugin_pmpcfg_12[0];
-      4'b1101 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = PmpPlugin_pmpcfg_13[0];
-      4'b1110 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = PmpPlugin_pmpcfg_14[0];
-      default : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = PmpPlugin_pmpcfg_15[0];
+      4'b0000 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead;
+      4'b0001 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_2;
+      4'b0010 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_4;
+      4'b0011 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_6;
+      4'b0100 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_8;
+      4'b0101 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_10;
+      4'b0110 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_12;
+      4'b0111 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_14;
+      4'b1000 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_16;
+      4'b1001 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_18;
+      4'b1010 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_20;
+      4'b1011 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_22;
+      4'b1100 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_24;
+      4'b1101 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_26;
+      4'b1110 : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_28;
+      default : _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_30;
     endcase
   end
 
   always @(*) begin
     case(_zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_18)
-      4'b0000 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = PmpPlugin_pmpcfg_0[1];
-      4'b0001 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = PmpPlugin_pmpcfg_1[1];
-      4'b0010 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = PmpPlugin_pmpcfg_2[1];
-      4'b0011 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = PmpPlugin_pmpcfg_3[1];
-      4'b0100 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = PmpPlugin_pmpcfg_4[1];
-      4'b0101 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = PmpPlugin_pmpcfg_5[1];
-      4'b0110 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = PmpPlugin_pmpcfg_6[1];
-      4'b0111 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = PmpPlugin_pmpcfg_7[1];
-      4'b1000 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = PmpPlugin_pmpcfg_8[1];
-      4'b1001 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = PmpPlugin_pmpcfg_9[1];
-      4'b1010 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = PmpPlugin_pmpcfg_10[1];
-      4'b1011 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = PmpPlugin_pmpcfg_11[1];
-      4'b1100 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = PmpPlugin_pmpcfg_12[1];
-      4'b1101 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = PmpPlugin_pmpcfg_13[1];
-      4'b1110 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = PmpPlugin_pmpcfg_14[1];
-      default : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = PmpPlugin_pmpcfg_15[1];
+      4'b0000 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite;
+      4'b0001 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_2;
+      4'b0010 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_4;
+      4'b0011 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_6;
+      4'b0100 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_8;
+      4'b0101 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_10;
+      4'b0110 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_12;
+      4'b0111 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_14;
+      4'b1000 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_16;
+      4'b1001 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_18;
+      4'b1010 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_20;
+      4'b1011 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_22;
+      4'b1100 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_24;
+      4'b1101 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_26;
+      4'b1110 : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_28;
+      default : _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_30;
     endcase
   end
 
   always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_0_2)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_0_4)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_1_1)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_1_3)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_2_1)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_2_3)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_3_1)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_3_3)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_4_1)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_4_3)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_5_1)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_5_3)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_6_1)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_6_3)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_7_1)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_7_3)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_8_1)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_8_3)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_9_1)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_9_3)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_10_1)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_10_3)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_11_1)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_11_3)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_12_1)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_12_3)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_13_1)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_13_3)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_14_1)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_14_3)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_15_1)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_14;
-      default : _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_PmpPlugin_iGuard_hits_15_3)
-      4'b0000 : _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_0;
-      4'b0001 : _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_1;
-      4'b0010 : _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_2;
-      4'b0011 : _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_3;
-      4'b0100 : _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_4;
-      4'b0101 : _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_5;
-      4'b0110 : _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_6;
-      4'b0111 : _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_7;
-      4'b1000 : _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_8;
-      4'b1001 : _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_9;
-      4'b1010 : _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_10;
-      4'b1011 : _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_11;
-      4'b1100 : _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_12;
-      4'b1101 : _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_13;
-      4'b1110 : _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_14;
-      default : _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_18)
-      4'b0000 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_17 = PmpPlugin_pmpcfg_0[2];
-      4'b0001 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_17 = PmpPlugin_pmpcfg_1[2];
-      4'b0010 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_17 = PmpPlugin_pmpcfg_2[2];
-      4'b0011 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_17 = PmpPlugin_pmpcfg_3[2];
-      4'b0100 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_17 = PmpPlugin_pmpcfg_4[2];
-      4'b0101 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_17 = PmpPlugin_pmpcfg_5[2];
-      4'b0110 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_17 = PmpPlugin_pmpcfg_6[2];
-      4'b0111 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_17 = PmpPlugin_pmpcfg_7[2];
-      4'b1000 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_17 = PmpPlugin_pmpcfg_8[2];
-      4'b1001 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_17 = PmpPlugin_pmpcfg_9[2];
-      4'b1010 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_17 = PmpPlugin_pmpcfg_10[2];
-      4'b1011 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_17 = PmpPlugin_pmpcfg_11[2];
-      4'b1100 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_17 = PmpPlugin_pmpcfg_12[2];
-      4'b1101 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_17 = PmpPlugin_pmpcfg_13[2];
-      4'b1110 : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_17 = PmpPlugin_pmpcfg_14[2];
-      default : _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_17 = PmpPlugin_pmpcfg_15[2];
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_when_PmpPlugin_l209_1)
-      4'b0000 : _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_0;
-      4'b0001 : _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_1;
-      4'b0010 : _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_2;
-      4'b0011 : _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_3;
-      4'b0100 : _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_4;
-      4'b0101 : _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_5;
-      4'b0110 : _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_6;
-      4'b0111 : _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_7;
-      4'b1000 : _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_8;
-      4'b1001 : _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_9;
-      4'b1010 : _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_10;
-      4'b1011 : _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_11;
-      4'b1100 : _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_12;
-      4'b1101 : _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_13;
-      4'b1110 : _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_14;
-      default : _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_when_PmpPlugin_l209_1_2)
-      4'b0000 : _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_0;
-      4'b0001 : _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_1;
-      4'b0010 : _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_2;
-      4'b0011 : _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_3;
-      4'b0100 : _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_4;
-      4'b0101 : _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_5;
-      4'b0110 : _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_6;
-      4'b0111 : _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_7;
-      4'b1000 : _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_8;
-      4'b1001 : _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_9;
-      4'b1010 : _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_10;
-      4'b1011 : _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_11;
-      4'b1100 : _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_12;
-      4'b1101 : _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_13;
-      4'b1110 : _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_14;
-      default : _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_when_PmpPlugin_l209_2_1)
-      4'b0000 : _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_0;
-      4'b0001 : _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_1;
-      4'b0010 : _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_2;
-      4'b0011 : _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_3;
-      4'b0100 : _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_4;
-      4'b0101 : _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_5;
-      4'b0110 : _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_6;
-      4'b0111 : _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_7;
-      4'b1000 : _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_8;
-      4'b1001 : _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_9;
-      4'b1010 : _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_10;
-      4'b1011 : _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_11;
-      4'b1100 : _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_12;
-      4'b1101 : _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_13;
-      4'b1110 : _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_14;
-      default : _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_when_PmpPlugin_l209_3_1)
-      4'b0000 : _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_0;
-      4'b0001 : _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_1;
-      4'b0010 : _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_2;
-      4'b0011 : _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_3;
-      4'b0100 : _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_4;
-      4'b0101 : _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_5;
-      4'b0110 : _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_6;
-      4'b0111 : _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_7;
-      4'b1000 : _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_8;
-      4'b1001 : _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_9;
-      4'b1010 : _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_10;
-      4'b1011 : _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_11;
-      4'b1100 : _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_12;
-      4'b1101 : _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_13;
-      4'b1110 : _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_14;
-      default : _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(execute_PmpPlugin_pmpNcfg_)
-      4'b0000 : _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_0;
-      4'b0001 : _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_1;
-      4'b0010 : _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_2;
-      4'b0011 : _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_3;
-      4'b0100 : _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_4;
-      4'b0101 : _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_5;
-      4'b0110 : _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_6;
-      4'b0111 : _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_7;
-      4'b1000 : _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_8;
-      4'b1001 : _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_9;
-      4'b1010 : _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_10;
-      4'b1011 : _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_11;
-      4'b1100 : _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_12;
-      4'b1101 : _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_13;
-      4'b1110 : _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_14;
-      default : _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_CsrPlugin_csrMapping_readDataSignal_1)
-      4'b0000 : _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_0;
-      4'b0001 : _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_1;
-      4'b0010 : _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_2;
-      4'b0011 : _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_3;
-      4'b0100 : _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_4;
-      4'b0101 : _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_5;
-      4'b0110 : _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_6;
-      4'b0111 : _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_7;
-      4'b1000 : _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_8;
-      4'b1001 : _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_9;
-      4'b1010 : _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_10;
-      4'b1011 : _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_11;
-      4'b1100 : _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_12;
-      4'b1101 : _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_13;
-      4'b1110 : _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_14;
-      default : _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_CsrPlugin_csrMapping_readDataSignal_3)
-      4'b0000 : _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_0;
-      4'b0001 : _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_1;
-      4'b0010 : _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_2;
-      4'b0011 : _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_3;
-      4'b0100 : _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_4;
-      4'b0101 : _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_5;
-      4'b0110 : _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_6;
-      4'b0111 : _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_7;
-      4'b1000 : _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_8;
-      4'b1001 : _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_9;
-      4'b1010 : _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_10;
-      4'b1011 : _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_11;
-      4'b1100 : _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_12;
-      4'b1101 : _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_13;
-      4'b1110 : _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_14;
-      default : _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_CsrPlugin_csrMapping_readDataSignal_5)
-      4'b0000 : _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_0;
-      4'b0001 : _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_1;
-      4'b0010 : _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_2;
-      4'b0011 : _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_3;
-      4'b0100 : _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_4;
-      4'b0101 : _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_5;
-      4'b0110 : _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_6;
-      4'b0111 : _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_7;
-      4'b1000 : _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_8;
-      4'b1001 : _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_9;
-      4'b1010 : _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_10;
-      4'b1011 : _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_11;
-      4'b1100 : _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_12;
-      4'b1101 : _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_13;
-      4'b1110 : _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_14;
-      default : _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_15;
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_CsrPlugin_csrMapping_readDataSignal_7)
-      4'b0000 : _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_0;
-      4'b0001 : _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_1;
-      4'b0010 : _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_2;
-      4'b0011 : _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_3;
-      4'b0100 : _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_4;
-      4'b0101 : _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_5;
-      4'b0110 : _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_6;
-      4'b0111 : _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_7;
-      4'b1000 : _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_8;
-      4'b1001 : _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_9;
-      4'b1010 : _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_10;
-      4'b1011 : _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_11;
-      4'b1100 : _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_12;
-      4'b1101 : _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_13;
-      4'b1110 : _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_14;
-      default : _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_15;
+    case(_zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_18)
+      4'b0000 : _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute;
+      4'b0001 : _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_2;
+      4'b0010 : _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_4;
+      4'b0011 : _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_6;
+      4'b0100 : _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_8;
+      4'b0101 : _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_10;
+      4'b0110 : _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_12;
+      4'b0111 : _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_14;
+      4'b1000 : _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_16;
+      4'b1001 : _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_18;
+      4'b1010 : _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_20;
+      4'b1011 : _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_22;
+      4'b1100 : _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_24;
+      4'b1101 : _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_26;
+      4'b1110 : _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_28;
+      default : _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_30;
     endcase
   end
 
@@ -4603,50 +3727,9 @@ module VexRiscv (
       default : memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
-  always @(*) begin
-    case(execute_PmpPlugin_fsm_stateReg)
-      execute_PmpPlugin_fsm_enumDef_BOOT : execute_PmpPlugin_fsm_stateReg_string = "BOOT      ";
-      execute_PmpPlugin_fsm_enumDef_stateIdle : execute_PmpPlugin_fsm_stateReg_string = "stateIdle ";
-      execute_PmpPlugin_fsm_enumDef_stateWrite : execute_PmpPlugin_fsm_stateReg_string = "stateWrite";
-      execute_PmpPlugin_fsm_enumDef_stateCfg : execute_PmpPlugin_fsm_stateReg_string = "stateCfg  ";
-      execute_PmpPlugin_fsm_enumDef_stateAddr : execute_PmpPlugin_fsm_stateReg_string = "stateAddr ";
-      default : execute_PmpPlugin_fsm_stateReg_string = "??????????";
-    endcase
-  end
-  always @(*) begin
-    case(execute_PmpPlugin_fsm_stateNext)
-      execute_PmpPlugin_fsm_enumDef_BOOT : execute_PmpPlugin_fsm_stateNext_string = "BOOT      ";
-      execute_PmpPlugin_fsm_enumDef_stateIdle : execute_PmpPlugin_fsm_stateNext_string = "stateIdle ";
-      execute_PmpPlugin_fsm_enumDef_stateWrite : execute_PmpPlugin_fsm_stateNext_string = "stateWrite";
-      execute_PmpPlugin_fsm_enumDef_stateCfg : execute_PmpPlugin_fsm_stateNext_string = "stateCfg  ";
-      execute_PmpPlugin_fsm_enumDef_stateAddr : execute_PmpPlugin_fsm_stateNext_string = "stateAddr ";
-      default : execute_PmpPlugin_fsm_stateNext_string = "??????????";
-    endcase
-  end
   `endif
 
-  always @(*) begin
-    _zz_1 = 1'b0;
-    case(execute_PmpPlugin_fsm_stateReg)
-      execute_PmpPlugin_fsm_enumDef_stateIdle : begin
-      end
-      execute_PmpPlugin_fsm_enumDef_stateWrite : begin
-        if(execute_PmpPlugin_pmpaddrCsr_) begin
-          if(when_PmpPlugin_l216) begin
-            _zz_1 = 1'b1;
-          end
-        end
-      end
-      execute_PmpPlugin_fsm_enumDef_stateCfg : begin
-      end
-      execute_PmpPlugin_fsm_enumDef_stateAddr : begin
-      end
-      default : begin
-      end
-    endcase
-  end
-
-  assign memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW) + $signed(_zz_memory_MUL_LOW_7));
+  assign memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW) + $signed(_zz_memory_MUL_LOW_6));
   assign memory_MUL_HH = execute_to_memory_MUL_HH;
   assign execute_MUL_HH = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bHigh));
   assign execute_MUL_HL = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bSLow));
@@ -4660,7 +3743,7 @@ module VexRiscv (
   assign execute_MEMORY_STORE_DATA_RF = _zz_execute_MEMORY_STORE_DATA_RF;
   assign decode_DO_EBREAK = (((! DebugPlugin_haltIt) && (decode_IS_EBREAK || ((1'b0 || (DebugPlugin_hardwareBreakpoints_0_valid && (DebugPlugin_hardwareBreakpoints_0_pc == _zz_decode_DO_EBREAK))) || (DebugPlugin_hardwareBreakpoints_1_valid && (DebugPlugin_hardwareBreakpoints_1_pc == _zz_decode_DO_EBREAK_1))))) && DebugPlugin_allowEBreak);
   assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
-  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
+  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h00)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h00))));
   assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
   assign decode_IS_RS2_SIGNED = _zz_decode_IS_RS2_SIGNED[31];
@@ -4727,7 +3810,7 @@ module VexRiscv (
   assign decode_RS1_USE = _zz_decode_IS_RS2_SIGNED[5];
   always @(*) begin
     _zz_decode_RS2 = execute_REGFILE_WRITE_DATA;
-    if(when_CsrPlugin_l1189) begin
+    if(when_CsrPlugin_l1587) begin
       _zz_decode_RS2 = CsrPlugin_csrMapping_readDataSignal;
     end
   end
@@ -4823,7 +3906,7 @@ module VexRiscv (
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_execute_SRC2 = execute_PC;
+  assign _zz_execute_to_memory_PC = execute_PC;
   assign execute_SRC2_CTRL = _zz_execute_SRC2_CTRL;
   assign execute_SRC1_CTRL = _zz_execute_SRC1_CTRL;
   assign decode_SRC_USE_SUB_LESS = _zz_decode_IS_RS2_SIGNED[3];
@@ -4831,15 +3914,15 @@ module VexRiscv (
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
   assign execute_ALU_CTRL = _zz_execute_ALU_CTRL;
-  assign execute_SRC2 = _zz_execute_SRC2_5;
+  assign execute_SRC2 = _zz_execute_SRC2_4;
   assign execute_SRC1 = _zz_execute_SRC1;
   assign execute_ALU_BITWISE_CTRL = _zz_execute_ALU_BITWISE_CTRL;
   assign _zz_lastStageRegFileWrite_payload_address = writeBack_INSTRUCTION;
   assign _zz_lastStageRegFileWrite_valid = writeBack_REGFILE_WRITE_VALID;
   always @(*) begin
-    _zz_2 = 1'b0;
+    _zz_1 = 1'b0;
     if(lastStageRegFileWrite_valid) begin
-      _zz_2 = 1'b1;
+      _zz_1 = 1'b1;
     end
   end
 
@@ -4851,10 +3934,10 @@ module VexRiscv (
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00001073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
+  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000107f) == 32'h00001073),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00002073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
   always @(*) begin
     _zz_decode_RS2_2 = writeBack_REGFILE_WRITE_DATA;
-    if(when_DBusCachedPlugin_l492) begin
+    if(when_DBusCachedPlugin_l580) begin
       _zz_decode_RS2_2 = writeBack_DBusCachedPlugin_rspFormated;
     end
     if(when_MulPlugin_l147) begin
@@ -4887,28 +3970,28 @@ module VexRiscv (
   assign decode_FLUSH_ALL = _zz_decode_IS_RS2_SIGNED[0];
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_4 = IBusCachedPlugin_rsp_issueDetected_3;
-    if(when_IBusCachedPlugin_l256) begin
+    if(when_IBusCachedPlugin_l262) begin
       IBusCachedPlugin_rsp_issueDetected_4 = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_3 = IBusCachedPlugin_rsp_issueDetected_2;
-    if(when_IBusCachedPlugin_l250) begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_rsp_issueDetected_3 = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
-    if(when_IBusCachedPlugin_l244) begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
-    if(when_IBusCachedPlugin_l239) begin
+    if(when_IBusCachedPlugin_l245) begin
       IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
@@ -4934,10 +4017,10 @@ module VexRiscv (
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
   always @(*) begin
     decode_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l308) begin
+    if(when_DBusCachedPlugin_l352) begin
       decode_arbitration_haltItself = 1'b1;
     end
-    case(switch_Fetcher_l365)
+    case(IBusCachedPlugin_injector_port_state)
       3'b010 : begin
         decode_arbitration_haltItself = 1'b1;
       end
@@ -4954,7 +4037,7 @@ module VexRiscv (
     if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(when_CsrPlugin_l1129) begin
+    if(when_CsrPlugin_l1527) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
@@ -4982,32 +4065,27 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l350) begin
+    if(when_DBusCachedPlugin_l394) begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(when_CsrPlugin_l1121) begin
-      if(when_CsrPlugin_l1123) begin
+    if(when_CsrPlugin_l1519) begin
+      if(when_CsrPlugin_l1521) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(when_CsrPlugin_l1193) begin
+    if(when_CsrPlugin_l1591) begin
       if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
-      end
-    end
-    if(execute_CsrPlugin_writeInstruction) begin
-      if(when_PmpPlugin_l172) begin
-        execute_arbitration_haltItself = (! execute_PmpPlugin_fsmComplete);
       end
     end
   end
 
   always @(*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if(when_DBusCachedPlugin_l366) begin
+    if(when_DBusCachedPlugin_l410) begin
       execute_arbitration_haltByOther = 1'b1;
     end
-    if(when_DebugPlugin_l295) begin
+    if(when_DebugPlugin_l308) begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
@@ -5024,8 +4102,8 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_flushIt = 1'b0;
-    if(when_DebugPlugin_l295) begin
-      if(when_DebugPlugin_l298) begin
+    if(when_DebugPlugin_l308) begin
+      if(when_DebugPlugin_l311) begin
         execute_arbitration_flushIt = 1'b1;
       end
     end
@@ -5036,8 +4114,8 @@ module VexRiscv (
     if(CsrPlugin_selfException_valid) begin
       execute_arbitration_flushNext = 1'b1;
     end
-    if(when_DebugPlugin_l295) begin
-      if(when_DebugPlugin_l298) begin
+    if(when_DebugPlugin_l308) begin
+      if(when_DebugPlugin_l311) begin
         execute_arbitration_flushNext = 1'b1;
       end
     end
@@ -5076,7 +4154,7 @@ module VexRiscv (
 
   always @(*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l466) begin
+    if(when_DBusCachedPlugin_l553) begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
@@ -5107,10 +4185,10 @@ module VexRiscv (
     if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -5121,24 +4199,24 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @(*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(when_CsrPlugin_l935) begin
+    if(when_CsrPlugin_l1272) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_DebugPlugin_l295) begin
-      if(when_DebugPlugin_l298) begin
+    if(when_DebugPlugin_l308) begin
+      if(when_DebugPlugin_l311) begin
         IBusCachedPlugin_fetcherHalt = 1'b1;
       end
     end
     if(DebugPlugin_haltIt) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_DebugPlugin_l311) begin
+    if(when_DebugPlugin_l324) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
@@ -5146,15 +4224,15 @@ module VexRiscv (
   assign IBusCachedPlugin_forceNoDecodeCond = 1'b0;
   always @(*) begin
     IBusCachedPlugin_incomingInstruction = 1'b0;
-    if(when_Fetcher_l243) begin
+    if(when_Fetcher_l242) begin
       IBusCachedPlugin_incomingInstruction = 1'b1;
     end
   end
 
   always @(*) begin
-    _zz_when_DBusCachedPlugin_l393 = 1'b0;
+    _zz_when_DBusCachedPlugin_l472 = 1'b0;
     if(DebugPlugin_godmode) begin
-      _zz_when_DBusCachedPlugin_l393 = 1'b1;
+      _zz_when_DBusCachedPlugin_l472 = 1'b1;
     end
   end
 
@@ -5167,40 +4245,39 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
-    if(execute_CsrPlugin_readInstruction) begin
-      if(when_PmpPlugin_l155) begin
-        if(execute_PmpPlugin_pmpcfgCsr) begin
-          CsrPlugin_csrMapping_allowCsrSignal = 1'b1;
-        end
-        if(execute_PmpPlugin_pmpaddrCsr) begin
-          CsrPlugin_csrMapping_allowCsrSignal = 1'b1;
-        end
-      end
-    end
-    if(execute_CsrPlugin_writeInstruction) begin
-      if(when_PmpPlugin_l172) begin
-        CsrPlugin_csrMapping_allowCsrSignal = 1'b1;
-      end
+    if(when_CsrPlugin_l1709) begin
+      CsrPlugin_csrMapping_allowCsrSignal = 1'b1;
     end
   end
 
   always @(*) begin
-    CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
-    if(execute_CsrPlugin_readInstruction) begin
-      if(when_PmpPlugin_l155) begin
-        if(execute_PmpPlugin_pmpcfgCsr) begin
-          CsrPlugin_csrMapping_readDataSignal = {{{_zz_CsrPlugin_csrMapping_readDataSignal,_zz_CsrPlugin_csrMapping_readDataSignal_2},_zz_CsrPlugin_csrMapping_readDataSignal_4},_zz_CsrPlugin_csrMapping_readDataSignal_6};
-        end
-        if(execute_PmpPlugin_pmpaddrCsr) begin
-          CsrPlugin_csrMapping_readDataSignal = _zz_PmpPlugin_pmpaddr_port2;
-        end
+    CsrPlugin_csrMapping_doForceFailCsr = 1'b0;
+    if(execute_CsrPlugin_csr_3072) begin
+      if(when_CsrPlugin_l1076) begin
+        CsrPlugin_csrMapping_doForceFailCsr = 1'b1;
+      end
+    end
+    if(execute_CsrPlugin_csr_3200) begin
+      if(when_CsrPlugin_l1076_1) begin
+        CsrPlugin_csrMapping_doForceFailCsr = 1'b1;
+      end
+    end
+    if(execute_CsrPlugin_csr_3074) begin
+      if(when_CsrPlugin_l1076_2) begin
+        CsrPlugin_csrMapping_doForceFailCsr = 1'b1;
+      end
+    end
+    if(execute_CsrPlugin_csr_3202) begin
+      if(when_CsrPlugin_l1076_3) begin
+        CsrPlugin_csrMapping_doForceFailCsr = 1'b1;
       end
     end
   end
 
+  assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
   always @(*) begin
     CsrPlugin_inWfi = 1'b0;
-    if(when_CsrPlugin_l1121) begin
+    if(when_CsrPlugin_l1519) begin
       CsrPlugin_inWfi = 1'b1;
     end
   end
@@ -5214,21 +4291,21 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1077) begin
+    if(when_CsrPlugin_l1456) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
-    if(when_CsrPlugin_l1032) begin
+    if(when_CsrPlugin_l1390) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(when_CsrPlugin_l1077) begin
-      case(switch_CsrPlugin_l1081)
+    if(when_CsrPlugin_l1456) begin
+      case(switch_CsrPlugin_l1460)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -5247,7 +4324,7 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_allowInterrupts = 1'b1;
-    if(when_DebugPlugin_l331) begin
+    if(when_DebugPlugin_l344) begin
       CsrPlugin_allowInterrupts = 1'b0;
     end
   end
@@ -5263,6 +4340,21 @@ module VexRiscv (
     CsrPlugin_allowEbreakException = 1'b1;
     if(DebugPlugin_allowEBreak) begin
       CsrPlugin_allowEbreakException = 1'b0;
+    end
+  end
+
+  always @(*) begin
+    CsrPlugin_xretAwayFromMachine = 1'b0;
+    if(when_CsrPlugin_l1456) begin
+      case(switch_CsrPlugin_l1460)
+        2'b11 : begin
+          if(when_CsrPlugin_l1468) begin
+            CsrPlugin_xretAwayFromMachine = 1'b1;
+          end
+        end
+        default : begin
+        end
+      endcase
     end
   end
 
@@ -5293,9 +4385,8 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l134 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
-  assign IBusCachedPlugin_fetchPc_output_fire_1 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
-  assign when_Fetcher_l134_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
+  assign when_Fetcher_l133 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l133_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
   always @(*) begin
     IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_IBusCachedPlugin_fetchPc_pc);
     if(IBusCachedPlugin_fetchPc_redo_valid) begin
@@ -5318,7 +4409,7 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l161 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
+  assign when_Fetcher_l160 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
   assign IBusCachedPlugin_fetchPc_output_valid = ((! IBusCachedPlugin_fetcherHalt) && IBusCachedPlugin_fetchPc_booted);
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
   always @(*) begin
@@ -5355,7 +4446,7 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_1_output_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b0;
-    if(when_IBusCachedPlugin_l267) begin
+    if(when_IBusCachedPlugin_l273) begin
       IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b1;
     end
   end
@@ -5368,9 +4459,9 @@ module VexRiscv (
   assign IBusCachedPlugin_fetchPc_redo_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_iBusRsp_flush = ((decode_arbitration_removeIt || (decode_arbitration_flushNext && (! decode_arbitration_isStuck))) || IBusCachedPlugin_iBusRsp_redoFetch);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
-  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1 = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
   assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid)) || IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready);
   assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
@@ -5380,18 +4471,18 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
   always @(*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
-    if(when_Fetcher_l323) begin
+    if(when_Fetcher_l322) begin
       IBusCachedPlugin_iBusRsp_readyForError = 1'b0;
     end
   end
 
-  assign when_Fetcher_l243 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
-  assign when_Fetcher_l323 = (! IBusCachedPlugin_pcValids_0);
-  assign when_Fetcher_l332 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
-  assign when_Fetcher_l332_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
-  assign when_Fetcher_l332_2 = (! execute_arbitration_isStuck);
-  assign when_Fetcher_l332_3 = (! memory_arbitration_isStuck);
-  assign when_Fetcher_l332_4 = (! writeBack_arbitration_isStuck);
+  assign when_Fetcher_l242 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
+  assign when_Fetcher_l322 = (! IBusCachedPlugin_pcValids_0);
+  assign when_Fetcher_l331 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l331_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
+  assign when_Fetcher_l331_2 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l331_3 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l331_4 = (! writeBack_arbitration_isStuck);
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
@@ -5399,7 +4490,7 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
   always @(*) begin
     decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
-    case(switch_Fetcher_l365)
+    case(IBusCachedPlugin_injector_port_state)
       3'b010 : begin
         decode_arbitration_isValid = 1'b1;
       end
@@ -5439,56 +4530,56 @@ module VexRiscv (
 
   always @(*) begin
     IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == BranchCtrlEnum_JAL) || ((decode_BRANCH_CTRL == BranchCtrlEnum_B) && _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2[31]));
-    if(_zz_7) begin
+    if(_zz_6) begin
       IBusCachedPlugin_decodePrediction_cmd_hadBranch = 1'b0;
     end
   end
 
-  assign _zz_3 = _zz__zz_3[19];
+  assign _zz_2 = _zz__zz_2[19];
   always @(*) begin
-    _zz_4[10] = _zz_3;
-    _zz_4[9] = _zz_3;
-    _zz_4[8] = _zz_3;
-    _zz_4[7] = _zz_3;
-    _zz_4[6] = _zz_3;
-    _zz_4[5] = _zz_3;
-    _zz_4[4] = _zz_3;
-    _zz_4[3] = _zz_3;
-    _zz_4[2] = _zz_3;
-    _zz_4[1] = _zz_3;
-    _zz_4[0] = _zz_3;
+    _zz_3[10] = _zz_2;
+    _zz_3[9] = _zz_2;
+    _zz_3[8] = _zz_2;
+    _zz_3[7] = _zz_2;
+    _zz_3[6] = _zz_2;
+    _zz_3[5] = _zz_2;
+    _zz_3[4] = _zz_2;
+    _zz_3[3] = _zz_2;
+    _zz_3[2] = _zz_2;
+    _zz_3[1] = _zz_2;
+    _zz_3[0] = _zz_2;
   end
 
-  assign _zz_5 = _zz__zz_5[11];
+  assign _zz_4 = _zz__zz_4[11];
   always @(*) begin
-    _zz_6[18] = _zz_5;
-    _zz_6[17] = _zz_5;
-    _zz_6[16] = _zz_5;
-    _zz_6[15] = _zz_5;
-    _zz_6[14] = _zz_5;
-    _zz_6[13] = _zz_5;
-    _zz_6[12] = _zz_5;
-    _zz_6[11] = _zz_5;
-    _zz_6[10] = _zz_5;
-    _zz_6[9] = _zz_5;
-    _zz_6[8] = _zz_5;
-    _zz_6[7] = _zz_5;
-    _zz_6[6] = _zz_5;
-    _zz_6[5] = _zz_5;
-    _zz_6[4] = _zz_5;
-    _zz_6[3] = _zz_5;
-    _zz_6[2] = _zz_5;
-    _zz_6[1] = _zz_5;
-    _zz_6[0] = _zz_5;
+    _zz_5[18] = _zz_4;
+    _zz_5[17] = _zz_4;
+    _zz_5[16] = _zz_4;
+    _zz_5[15] = _zz_4;
+    _zz_5[14] = _zz_4;
+    _zz_5[13] = _zz_4;
+    _zz_5[12] = _zz_4;
+    _zz_5[11] = _zz_4;
+    _zz_5[10] = _zz_4;
+    _zz_5[9] = _zz_4;
+    _zz_5[8] = _zz_4;
+    _zz_5[7] = _zz_4;
+    _zz_5[6] = _zz_4;
+    _zz_5[5] = _zz_4;
+    _zz_5[4] = _zz_4;
+    _zz_5[3] = _zz_4;
+    _zz_5[2] = _zz_4;
+    _zz_5[1] = _zz_4;
+    _zz_5[0] = _zz_4;
   end
 
   always @(*) begin
     case(decode_BRANCH_CTRL)
       BranchCtrlEnum_JAL : begin
-        _zz_7 = _zz__zz_7[1];
+        _zz_6 = _zz__zz_6[1];
       end
       default : begin
-        _zz_7 = _zz__zz_7_1[1];
+        _zz_6 = _zz__zz_6_1[1];
       end
     endcase
   end
@@ -5556,87 +4647,86 @@ module VexRiscv (
   assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
   always @(*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(when_IBusCachedPlugin_l239) begin
+    if(when_IBusCachedPlugin_l245) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(when_IBusCachedPlugin_l250) begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_cache_io_cpu_fill_valid = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
-    if(when_IBusCachedPlugin_l250) begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_cache_io_cpu_fill_valid = 1'b1;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_valid = 1'b0;
-    if(when_IBusCachedPlugin_l244) begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
-    if(when_IBusCachedPlugin_l256) begin
+    if(when_IBusCachedPlugin_l262) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
   end
 
   always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_payload_code = 4'bxxxx;
-    if(when_IBusCachedPlugin_l244) begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b1100;
     end
-    if(when_IBusCachedPlugin_l256) begin
+    if(when_IBusCachedPlugin_l262) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b0001;
     end
   end
 
   assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_2_input_payload[31 : 2],2'b00};
-  assign when_IBusCachedPlugin_l239 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign when_IBusCachedPlugin_l244 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
-  assign when_IBusCachedPlugin_l250 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
-  assign when_IBusCachedPlugin_l256 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
-  assign when_IBusCachedPlugin_l267 = (IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt);
+  assign when_IBusCachedPlugin_l245 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign when_IBusCachedPlugin_l250 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign when_IBusCachedPlugin_l256 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
+  assign when_IBusCachedPlugin_l262 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
+  assign when_IBusCachedPlugin_l273 = (IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt);
   assign IBusCachedPlugin_iBusRsp_output_valid = IBusCachedPlugin_iBusRsp_stages_2_output_valid;
   assign IBusCachedPlugin_iBusRsp_stages_2_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
   assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_decode_data;
   assign IBusCachedPlugin_iBusRsp_output_payload_pc = IBusCachedPlugin_iBusRsp_stages_2_output_payload;
   assign IBusCachedPlugin_cache_io_flush = (decode_arbitration_isValid && decode_FLUSH_ALL);
-  assign dataCache_1_io_mem_cmd_ready = (! dataCache_1_io_mem_cmd_rValid);
-  assign dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || dataCache_1_io_mem_cmd_rValid);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_wr : dataCache_1_io_mem_cmd_payload_wr);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_uncached : dataCache_1_io_mem_cmd_payload_uncached);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_address = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_address : dataCache_1_io_mem_cmd_payload_address);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_data = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_data : dataCache_1_io_mem_cmd_payload_data);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_mask : dataCache_1_io_mem_cmd_payload_mask);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_size = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_size : dataCache_1_io_mem_cmd_payload_size);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_last : dataCache_1_io_mem_cmd_payload_last);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || (! toplevel_dataCache_1_io_mem_cmd_rValidN));
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_wr : toplevel_dataCache_1_io_mem_cmd_rData_wr);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_uncached : toplevel_dataCache_1_io_mem_cmd_rData_uncached);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_address = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_address : toplevel_dataCache_1_io_mem_cmd_rData_address);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_data = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_data : toplevel_dataCache_1_io_mem_cmd_rData_data);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_mask : toplevel_dataCache_1_io_mem_cmd_rData_mask);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_size = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_size : toplevel_dataCache_1_io_mem_cmd_rData_size);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_last = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_last : toplevel_dataCache_1_io_mem_cmd_rData_last);
   always @(*) begin
-    dataCache_1_io_mem_cmd_s2mPipe_ready = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
-    if(when_Stream_l368) begin
-      dataCache_1_io_mem_cmd_s2mPipe_ready = 1'b1;
+    toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
+    if(when_Stream_l369) begin
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l368 = (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_rValid;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_rData_address;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_rData_data;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size = dataCache_1_io_mem_cmd_s2mPipe_rData_size;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_rData_last;
-  assign dBus_cmd_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
-  assign dBus_cmd_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
-  assign dBus_cmd_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
-  assign dBus_cmd_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
-  assign dBus_cmd_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
-  assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  assign dBus_cmd_payload_size = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
-  assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  assign when_DBusCachedPlugin_l308 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
+  assign when_Stream_l369 = (! toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_address;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_data;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_size;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  assign dBus_cmd_valid = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
+  assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
+  assign dBus_cmd_payload_wr = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
+  assign dBus_cmd_payload_uncached = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
+  assign dBus_cmd_payload_address = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
+  assign dBus_cmd_payload_data = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
+  assign dBus_cmd_payload_mask = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
+  assign dBus_cmd_payload_size = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
+  assign dBus_cmd_payload_last = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  assign when_DBusCachedPlugin_l352 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
   assign dataCache_1_io_cpu_execute_isValid = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
   assign dataCache_1_io_cpu_execute_address = execute_SRC_ADD;
@@ -5655,11 +4745,11 @@ module VexRiscv (
   end
 
   assign dataCache_1_io_cpu_flush_valid = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
-  assign dataCache_1_io_cpu_flush_payload_singleLine = (execute_INSTRUCTION[19 : 15] != 5'h0);
+  assign dataCache_1_io_cpu_flush_payload_singleLine = (execute_INSTRUCTION[19 : 15] != 5'h00);
   assign dataCache_1_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId[6:0];
-  assign dataCache_1_io_cpu_flush_isStall = (dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready));
-  assign when_DBusCachedPlugin_l350 = (dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
-  assign when_DBusCachedPlugin_l366 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
+  assign toplevel_dataCache_1_io_cpu_flush_isStall = (dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready));
+  assign when_DBusCachedPlugin_l394 = (toplevel_dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
+  assign when_DBusCachedPlugin_l410 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
   assign dataCache_1_io_cpu_memory_isValid = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
   assign dataCache_1_io_cpu_memory_address = memory_REGFILE_WRITE_DATA;
   assign DBusCachedPlugin_mmuBus_cmd_0_isValid = dataCache_1_io_cpu_memory_isValid;
@@ -5669,12 +4759,12 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
   always @(*) begin
     dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if(when_DBusCachedPlugin_l393) begin
+    if(when_DBusCachedPlugin_l472) begin
       dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = 1'b1;
     end
   end
 
-  assign when_DBusCachedPlugin_l393 = (_zz_when_DBusCachedPlugin_l393 && (! dataCache_1_io_cpu_memory_isWrite));
+  assign when_DBusCachedPlugin_l472 = (_zz_when_DBusCachedPlugin_l472 && (! dataCache_1_io_cpu_memory_isWrite));
   always @(*) begin
     dataCache_1_io_cpu_writeBack_isValid = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
     if(writeBack_arbitration_haltByOther) begin
@@ -5687,7 +4777,7 @@ module VexRiscv (
   assign dataCache_1_io_cpu_writeBack_storeData[31 : 0] = writeBack_MEMORY_STORE_DATA_RF;
   always @(*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(when_DBusCachedPlugin_l446) begin
+    if(when_DBusCachedPlugin_l533) begin
       if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
@@ -5697,7 +4787,7 @@ module VexRiscv (
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(when_DBusCachedPlugin_l446) begin
+    if(when_DBusCachedPlugin_l533) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
@@ -5716,7 +4806,7 @@ module VexRiscv (
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
-    if(when_DBusCachedPlugin_l446) begin
+    if(when_DBusCachedPlugin_l533) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code};
       end
@@ -5729,12 +4819,13 @@ module VexRiscv (
     end
   end
 
-  assign when_DBusCachedPlugin_l446 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign when_DBusCachedPlugin_l466 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
-  assign writeBack_DBusCachedPlugin_rspSplits_0 = dataCache_1_io_cpu_writeBack_data[7 : 0];
-  assign writeBack_DBusCachedPlugin_rspSplits_1 = dataCache_1_io_cpu_writeBack_data[15 : 8];
-  assign writeBack_DBusCachedPlugin_rspSplits_2 = dataCache_1_io_cpu_writeBack_data[23 : 16];
-  assign writeBack_DBusCachedPlugin_rspSplits_3 = dataCache_1_io_cpu_writeBack_data[31 : 24];
+  assign when_DBusCachedPlugin_l533 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l553 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
+  assign writeBack_DBusCachedPlugin_rspData = dataCache_1_io_cpu_writeBack_data;
+  assign writeBack_DBusCachedPlugin_rspSplits_0 = writeBack_DBusCachedPlugin_rspData[7 : 0];
+  assign writeBack_DBusCachedPlugin_rspSplits_1 = writeBack_DBusCachedPlugin_rspData[15 : 8];
+  assign writeBack_DBusCachedPlugin_rspSplits_2 = writeBack_DBusCachedPlugin_rspData[23 : 16];
+  assign writeBack_DBusCachedPlugin_rspSplits_3 = writeBack_DBusCachedPlugin_rspData[31 : 24];
   always @(*) begin
     writeBack_DBusCachedPlugin_rspShifted[7 : 0] = _zz_writeBack_DBusCachedPlugin_rspShifted;
     writeBack_DBusCachedPlugin_rspShifted[15 : 8] = _zz_writeBack_DBusCachedPlugin_rspShifted_2;
@@ -5743,7 +4834,7 @@ module VexRiscv (
   end
 
   assign writeBack_DBusCachedPlugin_rspRf = writeBack_DBusCachedPlugin_rspShifted[31 : 0];
-  assign switch_Misc_l210 = writeBack_INSTRUCTION[13 : 12];
+  assign switch_Misc_l232 = writeBack_INSTRUCTION[13 : 12];
   assign _zz_writeBack_DBusCachedPlugin_rspFormated = (writeBack_DBusCachedPlugin_rspRf[7] && (! writeBack_INSTRUCTION[14]));
   always @(*) begin
     _zz_writeBack_DBusCachedPlugin_rspFormated_1[31] = _zz_writeBack_DBusCachedPlugin_rspFormated;
@@ -5795,7 +4886,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    case(switch_Misc_l210)
+    case(switch_Misc_l232)
       2'b00 : begin
         writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_1;
       end
@@ -5808,77 +4899,1885 @@ module VexRiscv (
     endcase
   end
 
-  assign when_DBusCachedPlugin_l492 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign when_PmpPlugin_l138 = (! execute_arbitration_isStuck);
+  assign when_DBusCachedPlugin_l580 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
   always @(*) begin
-    execute_PmpPlugin_fsmComplete = 1'b0;
-    if(when_StateMachine_l249) begin
-      execute_PmpPlugin_fsmComplete = 1'b1;
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_1 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead;
+    if(execute_CsrPlugin_csr_928) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_1 = CsrPlugin_csrMapping_writeDataSignal[0];
+      end
     end
   end
 
-  assign execute_PmpPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
-  assign execute_PmpPlugin_pmpNcfg = execute_PmpPlugin_csrAddress[3 : 0];
-  assign execute_PmpPlugin_pmpcfgN = execute_PmpPlugin_pmpNcfg[1 : 0];
-  assign execute_PmpPlugin_pmpcfgCsr = (execute_INSTRUCTION[31 : 24] == 8'h3a);
-  assign execute_PmpPlugin_pmpaddrCsr = (execute_INSTRUCTION[31 : 24] == 8'h3b);
-  assign execute_PmpPlugin_fsm_wantExit = 1'b0;
   always @(*) begin
-    execute_PmpPlugin_fsm_wantStart = 1'b0;
-    case(execute_PmpPlugin_fsm_stateReg)
-      execute_PmpPlugin_fsm_enumDef_stateIdle : begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_1 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite;
+    if(execute_CsrPlugin_csr_928) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_1 = CsrPlugin_csrMapping_writeDataSignal[1];
       end
-      execute_PmpPlugin_fsm_enumDef_stateWrite : begin
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute;
+    if(execute_CsrPlugin_csr_928) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1 = CsrPlugin_csrMapping_writeDataSignal[2];
       end
-      execute_PmpPlugin_fsm_enumDef_stateCfg : begin
+    end
+  end
+
+  always @(*) begin
+    _zz_when_PmpPlugin_l126_1 = _zz_when_PmpPlugin_l126;
+    if(execute_CsrPlugin_csr_928) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_when_PmpPlugin_l126_1 = CsrPlugin_csrMapping_writeDataSignal[7];
       end
-      execute_PmpPlugin_fsm_enumDef_stateAddr : begin
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_2 = _zz_CsrPlugin_csrMapping_readDataInit;
+    if(execute_CsrPlugin_csr_928) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_2 = CsrPlugin_csrMapping_writeDataSignal[4 : 3];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_3 = _zz_CsrPlugin_csrMapping_readDataInit_1;
+    if(execute_CsrPlugin_csr_944) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_3 = CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+      end
+    end
+  end
+
+  assign when_PmpPlugin_l126 = (! _zz_when_PmpPlugin_l126);
+  assign _zz_PmpPlugin_ports_0_hits_0_4 = {2'b00,_zz_CsrPlugin_csrMapping_readDataInit_1};
+  assign _zz_PmpPlugin_ports_0_hits_0_5 = ({2'd0,_zz_PmpPlugin_ports_0_hits_0_4} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_0_6 = (_zz_PmpPlugin_ports_0_hits_0_4 ^ _zz__zz_PmpPlugin_ports_0_hits_0_6);
+  assign _zz_PmpPlugin_ports_0_hits_0_7 = ({2'd0,(_zz_PmpPlugin_ports_0_hits_0_4 & (~ _zz_PmpPlugin_ports_0_hits_0_6))} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_0_1 = _zz_when_PmpPlugin_l126;
+  always @(*) begin
+    _zz_PmpPlugin_ports_0_hits_0 = 1'b1;
+    case(_zz_CsrPlugin_csrMapping_readDataInit_2)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
       end
       default : begin
-        execute_PmpPlugin_fsm_wantStart = 1'b1;
+        _zz_PmpPlugin_ports_0_hits_0 = 1'b0;
       end
     endcase
   end
 
-  assign execute_PmpPlugin_fsm_wantKill = 1'b0;
   always @(*) begin
-    if(execute_PmpPlugin_pmpaddrCsr_) begin
-      PmpPlugin_setter_io_addr = execute_PmpPlugin_writeData_;
-    end else begin
-      PmpPlugin_setter_io_addr = _zz_PmpPlugin_pmpaddr_port0;
+    case(_zz_CsrPlugin_csrMapping_readDataInit_2)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_0_2 = 36'h000000000;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_0_2 = _zz_PmpPlugin_ports_0_hits_0_5;
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_0_2 = _zz_PmpPlugin_ports_0_hits_0_7;
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_0_2 = 36'h000000000;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_2)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_0_3 = _zz_PmpPlugin_ports_0_hits_0_5;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_0_3 = (_zz_PmpPlugin_ports_0_hits_0_5 + 36'h000000004);
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_0_3 = (_zz_PmpPlugin_ports_0_hits_0_7 + _zz__zz_PmpPlugin_ports_0_hits_0_3);
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_0_3 = _zz_PmpPlugin_ports_0_hits_0_5;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_3 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_2;
+    if(execute_CsrPlugin_csr_928) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_3 = CsrPlugin_csrMapping_writeDataSignal[8];
+      end
     end
   end
 
-  assign when_PmpPlugin_l246 = (execute_PmpPlugin_fsm_fsmEnable && (! _zz_when_PmpPlugin_l246[7]));
-  assign _zz_8 = ({15'd0,1'b1} <<< execute_PmpPlugin_fsm_fsmCounter);
-  assign _zz_9 = ({15'd0,1'b1} <<< execute_PmpPlugin_fsm_fsmCounter);
-  assign DBusCachedPlugin_mmuBus_rsp_physicalAddress = DBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
-  assign DBusCachedPlugin_mmuBus_rsp_isIoAccess = DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31];
-  assign DBusCachedPlugin_mmuBus_rsp_isPaging = 1'b0;
-  assign DBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
-  assign DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
-  assign DBusCachedPlugin_mmuBus_rsp_allowExecute = 1'b0;
-  assign DBusCachedPlugin_mmuBus_busy = 1'b0;
-  assign _zz_PmpPlugin_dGuard_hits_0 = DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 7];
-  assign PmpPlugin_dGuard_hits_0 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_0_1) == _zz_PmpPlugin_dGuard_hits_0_3) && (PmpPlugin_pmpcfg_0[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_0[4 : 3] == 2'b11));
-  assign PmpPlugin_dGuard_hits_1 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_1) == _zz_PmpPlugin_dGuard_hits_1_2) && (PmpPlugin_pmpcfg_1[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_1[4 : 3] == 2'b11));
-  assign PmpPlugin_dGuard_hits_2 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_2) == _zz_PmpPlugin_dGuard_hits_2_2) && (PmpPlugin_pmpcfg_2[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_2[4 : 3] == 2'b11));
-  assign PmpPlugin_dGuard_hits_3 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_3) == _zz_PmpPlugin_dGuard_hits_3_2) && (PmpPlugin_pmpcfg_3[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_3[4 : 3] == 2'b11));
-  assign PmpPlugin_dGuard_hits_4 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_4) == _zz_PmpPlugin_dGuard_hits_4_2) && (PmpPlugin_pmpcfg_4[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_4[4 : 3] == 2'b11));
-  assign PmpPlugin_dGuard_hits_5 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_5) == _zz_PmpPlugin_dGuard_hits_5_2) && (PmpPlugin_pmpcfg_5[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_5[4 : 3] == 2'b11));
-  assign PmpPlugin_dGuard_hits_6 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_6) == _zz_PmpPlugin_dGuard_hits_6_2) && (PmpPlugin_pmpcfg_6[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_6[4 : 3] == 2'b11));
-  assign PmpPlugin_dGuard_hits_7 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_7) == _zz_PmpPlugin_dGuard_hits_7_2) && (PmpPlugin_pmpcfg_7[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_7[4 : 3] == 2'b11));
-  assign PmpPlugin_dGuard_hits_8 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_8) == _zz_PmpPlugin_dGuard_hits_8_2) && (PmpPlugin_pmpcfg_8[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_8[4 : 3] == 2'b11));
-  assign PmpPlugin_dGuard_hits_9 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_9) == _zz_PmpPlugin_dGuard_hits_9_2) && (PmpPlugin_pmpcfg_9[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_9[4 : 3] == 2'b11));
-  assign PmpPlugin_dGuard_hits_10 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_10) == _zz_PmpPlugin_dGuard_hits_10_2) && (PmpPlugin_pmpcfg_10[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_10[4 : 3] == 2'b11));
-  assign PmpPlugin_dGuard_hits_11 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_11) == _zz_PmpPlugin_dGuard_hits_11_2) && (PmpPlugin_pmpcfg_11[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_11[4 : 3] == 2'b11));
-  assign PmpPlugin_dGuard_hits_12 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_12) == _zz_PmpPlugin_dGuard_hits_12_2) && (PmpPlugin_pmpcfg_12[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_12[4 : 3] == 2'b11));
-  assign PmpPlugin_dGuard_hits_13 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_13) == _zz_PmpPlugin_dGuard_hits_13_2) && (PmpPlugin_pmpcfg_13[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_13[4 : 3] == 2'b11));
-  assign PmpPlugin_dGuard_hits_14 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_14) == _zz_PmpPlugin_dGuard_hits_14_2) && (PmpPlugin_pmpcfg_14[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_14[4 : 3] == 2'b11));
-  assign PmpPlugin_dGuard_hits_15 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_15) == _zz_PmpPlugin_dGuard_hits_15_2) && (PmpPlugin_pmpcfg_15[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_15[4 : 3] == 2'b11));
-  assign when_PmpPlugin_l277 = (! ({PmpPlugin_dGuard_hits_15,{PmpPlugin_dGuard_hits_14,{PmpPlugin_dGuard_hits_13,{PmpPlugin_dGuard_hits_12,{PmpPlugin_dGuard_hits_11,{PmpPlugin_dGuard_hits_10,{PmpPlugin_dGuard_hits_9,{PmpPlugin_dGuard_hits_8,{PmpPlugin_dGuard_hits_7,{_zz_when_PmpPlugin_l277,_zz_when_PmpPlugin_l277_1}}}}}}}}}} != 16'h0));
   always @(*) begin
-    if(when_PmpPlugin_l277) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_3 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_2;
+    if(execute_CsrPlugin_csr_928) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_3 = CsrPlugin_csrMapping_writeDataSignal[9];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_3 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_2;
+    if(execute_CsrPlugin_csr_928) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_3 = CsrPlugin_csrMapping_writeDataSignal[10];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_when_PmpPlugin_l126_3 = _zz_when_PmpPlugin_l126_2;
+    if(execute_CsrPlugin_csr_928) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_when_PmpPlugin_l126_3 = CsrPlugin_csrMapping_writeDataSignal[15];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_6 = _zz_CsrPlugin_csrMapping_readDataInit_4;
+    if(execute_CsrPlugin_csr_928) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_6 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_7 = _zz_CsrPlugin_csrMapping_readDataInit_5;
+    if(execute_CsrPlugin_csr_945) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_7 = CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+      end
+    end
+  end
+
+  assign when_PmpPlugin_l126_1 = (! _zz_when_PmpPlugin_l126_2);
+  assign _zz_PmpPlugin_ports_0_hits_1_4 = {2'b00,_zz_CsrPlugin_csrMapping_readDataInit_5};
+  assign _zz_PmpPlugin_ports_0_hits_1_5 = ({2'd0,_zz_PmpPlugin_ports_0_hits_1_4} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_1_6 = (_zz_PmpPlugin_ports_0_hits_1_4 ^ _zz__zz_PmpPlugin_ports_0_hits_1_6);
+  assign _zz_PmpPlugin_ports_0_hits_1_7 = ({2'd0,(_zz_PmpPlugin_ports_0_hits_1_4 & (~ _zz_PmpPlugin_ports_0_hits_1_6))} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_1_1 = _zz_when_PmpPlugin_l126_2;
+  always @(*) begin
+    _zz_PmpPlugin_ports_0_hits_1 = 1'b1;
+    case(_zz_CsrPlugin_csrMapping_readDataInit_6)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_1 = 1'b0;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_6)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_1_2 = _zz_PmpPlugin_ports_0_hits_0_3;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_1_2 = _zz_PmpPlugin_ports_0_hits_1_5;
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_1_2 = _zz_PmpPlugin_ports_0_hits_1_7;
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_1_2 = 36'h000000000;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_6)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_1_3 = _zz_PmpPlugin_ports_0_hits_1_5;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_1_3 = (_zz_PmpPlugin_ports_0_hits_1_5 + 36'h000000004);
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_1_3 = (_zz_PmpPlugin_ports_0_hits_1_7 + _zz__zz_PmpPlugin_ports_0_hits_1_3);
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_1_3 = _zz_PmpPlugin_ports_0_hits_1_5;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_5 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_4;
+    if(execute_CsrPlugin_csr_928) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_5 = CsrPlugin_csrMapping_writeDataSignal[16];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_5 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_4;
+    if(execute_CsrPlugin_csr_928) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_5 = CsrPlugin_csrMapping_writeDataSignal[17];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_5 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_4;
+    if(execute_CsrPlugin_csr_928) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_5 = CsrPlugin_csrMapping_writeDataSignal[18];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_when_PmpPlugin_l126_5 = _zz_when_PmpPlugin_l126_4;
+    if(execute_CsrPlugin_csr_928) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_when_PmpPlugin_l126_5 = CsrPlugin_csrMapping_writeDataSignal[23];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_10 = _zz_CsrPlugin_csrMapping_readDataInit_8;
+    if(execute_CsrPlugin_csr_928) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_10 = CsrPlugin_csrMapping_writeDataSignal[20 : 19];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_11 = _zz_CsrPlugin_csrMapping_readDataInit_9;
+    if(execute_CsrPlugin_csr_946) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_11 = CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+      end
+    end
+  end
+
+  assign when_PmpPlugin_l126_2 = (! _zz_when_PmpPlugin_l126_4);
+  assign _zz_PmpPlugin_ports_0_hits_2_4 = {2'b00,_zz_CsrPlugin_csrMapping_readDataInit_9};
+  assign _zz_PmpPlugin_ports_0_hits_2_5 = ({2'd0,_zz_PmpPlugin_ports_0_hits_2_4} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_2_6 = (_zz_PmpPlugin_ports_0_hits_2_4 ^ _zz__zz_PmpPlugin_ports_0_hits_2_6);
+  assign _zz_PmpPlugin_ports_0_hits_2_7 = ({2'd0,(_zz_PmpPlugin_ports_0_hits_2_4 & (~ _zz_PmpPlugin_ports_0_hits_2_6))} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_2_1 = _zz_when_PmpPlugin_l126_4;
+  always @(*) begin
+    _zz_PmpPlugin_ports_0_hits_2 = 1'b1;
+    case(_zz_CsrPlugin_csrMapping_readDataInit_10)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_2 = 1'b0;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_10)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_2_2 = _zz_PmpPlugin_ports_0_hits_1_3;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_2_2 = _zz_PmpPlugin_ports_0_hits_2_5;
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_2_2 = _zz_PmpPlugin_ports_0_hits_2_7;
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_2_2 = 36'h000000000;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_10)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_2_3 = _zz_PmpPlugin_ports_0_hits_2_5;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_2_3 = (_zz_PmpPlugin_ports_0_hits_2_5 + 36'h000000004);
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_2_3 = (_zz_PmpPlugin_ports_0_hits_2_7 + _zz__zz_PmpPlugin_ports_0_hits_2_3);
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_2_3 = _zz_PmpPlugin_ports_0_hits_2_5;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_7 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_6;
+    if(execute_CsrPlugin_csr_928) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_7 = CsrPlugin_csrMapping_writeDataSignal[24];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_7 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_6;
+    if(execute_CsrPlugin_csr_928) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_7 = CsrPlugin_csrMapping_writeDataSignal[25];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_7 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_6;
+    if(execute_CsrPlugin_csr_928) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_7 = CsrPlugin_csrMapping_writeDataSignal[26];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_when_PmpPlugin_l126_7 = _zz_when_PmpPlugin_l126_6;
+    if(execute_CsrPlugin_csr_928) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_when_PmpPlugin_l126_7 = CsrPlugin_csrMapping_writeDataSignal[31];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_14 = _zz_CsrPlugin_csrMapping_readDataInit_12;
+    if(execute_CsrPlugin_csr_928) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_14 = CsrPlugin_csrMapping_writeDataSignal[28 : 27];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_15 = _zz_CsrPlugin_csrMapping_readDataInit_13;
+    if(execute_CsrPlugin_csr_947) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_15 = CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+      end
+    end
+  end
+
+  assign when_PmpPlugin_l126_3 = (! _zz_when_PmpPlugin_l126_6);
+  assign _zz_PmpPlugin_ports_0_hits_3_4 = {2'b00,_zz_CsrPlugin_csrMapping_readDataInit_13};
+  assign _zz_PmpPlugin_ports_0_hits_3_5 = ({2'd0,_zz_PmpPlugin_ports_0_hits_3_4} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_3_6 = (_zz_PmpPlugin_ports_0_hits_3_4 ^ _zz__zz_PmpPlugin_ports_0_hits_3_6);
+  assign _zz_PmpPlugin_ports_0_hits_3_7 = ({2'd0,(_zz_PmpPlugin_ports_0_hits_3_4 & (~ _zz_PmpPlugin_ports_0_hits_3_6))} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_3_1 = _zz_when_PmpPlugin_l126_6;
+  always @(*) begin
+    _zz_PmpPlugin_ports_0_hits_3 = 1'b1;
+    case(_zz_CsrPlugin_csrMapping_readDataInit_14)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_3 = 1'b0;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_14)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_3_2 = _zz_PmpPlugin_ports_0_hits_2_3;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_3_2 = _zz_PmpPlugin_ports_0_hits_3_5;
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_3_2 = _zz_PmpPlugin_ports_0_hits_3_7;
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_3_2 = 36'h000000000;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_14)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_3_3 = _zz_PmpPlugin_ports_0_hits_3_5;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_3_3 = (_zz_PmpPlugin_ports_0_hits_3_5 + 36'h000000004);
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_3_3 = (_zz_PmpPlugin_ports_0_hits_3_7 + _zz__zz_PmpPlugin_ports_0_hits_3_3);
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_3_3 = _zz_PmpPlugin_ports_0_hits_3_5;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_9 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_8;
+    if(execute_CsrPlugin_csr_929) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_9 = CsrPlugin_csrMapping_writeDataSignal[0];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_9 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_8;
+    if(execute_CsrPlugin_csr_929) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_9 = CsrPlugin_csrMapping_writeDataSignal[1];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_9 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_8;
+    if(execute_CsrPlugin_csr_929) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_9 = CsrPlugin_csrMapping_writeDataSignal[2];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_when_PmpPlugin_l126_9 = _zz_when_PmpPlugin_l126_8;
+    if(execute_CsrPlugin_csr_929) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_when_PmpPlugin_l126_9 = CsrPlugin_csrMapping_writeDataSignal[7];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_18 = _zz_CsrPlugin_csrMapping_readDataInit_16;
+    if(execute_CsrPlugin_csr_929) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_18 = CsrPlugin_csrMapping_writeDataSignal[4 : 3];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_19 = _zz_CsrPlugin_csrMapping_readDataInit_17;
+    if(execute_CsrPlugin_csr_948) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_19 = CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+      end
+    end
+  end
+
+  assign when_PmpPlugin_l126_4 = (! _zz_when_PmpPlugin_l126_8);
+  assign _zz_PmpPlugin_ports_0_hits_4_4 = {2'b00,_zz_CsrPlugin_csrMapping_readDataInit_17};
+  assign _zz_PmpPlugin_ports_0_hits_4_5 = ({2'd0,_zz_PmpPlugin_ports_0_hits_4_4} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_4_6 = (_zz_PmpPlugin_ports_0_hits_4_4 ^ _zz__zz_PmpPlugin_ports_0_hits_4_6);
+  assign _zz_PmpPlugin_ports_0_hits_4_7 = ({2'd0,(_zz_PmpPlugin_ports_0_hits_4_4 & (~ _zz_PmpPlugin_ports_0_hits_4_6))} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_4_1 = _zz_when_PmpPlugin_l126_8;
+  always @(*) begin
+    _zz_PmpPlugin_ports_0_hits_4 = 1'b1;
+    case(_zz_CsrPlugin_csrMapping_readDataInit_18)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_4 = 1'b0;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_18)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_4_2 = _zz_PmpPlugin_ports_0_hits_3_3;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_4_2 = _zz_PmpPlugin_ports_0_hits_4_5;
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_4_2 = _zz_PmpPlugin_ports_0_hits_4_7;
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_4_2 = 36'h000000000;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_18)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_4_3 = _zz_PmpPlugin_ports_0_hits_4_5;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_4_3 = (_zz_PmpPlugin_ports_0_hits_4_5 + 36'h000000004);
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_4_3 = (_zz_PmpPlugin_ports_0_hits_4_7 + _zz__zz_PmpPlugin_ports_0_hits_4_3);
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_4_3 = _zz_PmpPlugin_ports_0_hits_4_5;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_11 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_10;
+    if(execute_CsrPlugin_csr_929) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_11 = CsrPlugin_csrMapping_writeDataSignal[8];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_11 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_10;
+    if(execute_CsrPlugin_csr_929) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_11 = CsrPlugin_csrMapping_writeDataSignal[9];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_11 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_10;
+    if(execute_CsrPlugin_csr_929) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_11 = CsrPlugin_csrMapping_writeDataSignal[10];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_when_PmpPlugin_l126_11 = _zz_when_PmpPlugin_l126_10;
+    if(execute_CsrPlugin_csr_929) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_when_PmpPlugin_l126_11 = CsrPlugin_csrMapping_writeDataSignal[15];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_22 = _zz_CsrPlugin_csrMapping_readDataInit_20;
+    if(execute_CsrPlugin_csr_929) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_22 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_23 = _zz_CsrPlugin_csrMapping_readDataInit_21;
+    if(execute_CsrPlugin_csr_949) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_23 = CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+      end
+    end
+  end
+
+  assign when_PmpPlugin_l126_5 = (! _zz_when_PmpPlugin_l126_10);
+  assign _zz_PmpPlugin_ports_0_hits_5_4 = {2'b00,_zz_CsrPlugin_csrMapping_readDataInit_21};
+  assign _zz_PmpPlugin_ports_0_hits_5_5 = ({2'd0,_zz_PmpPlugin_ports_0_hits_5_4} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_5_6 = (_zz_PmpPlugin_ports_0_hits_5_4 ^ _zz__zz_PmpPlugin_ports_0_hits_5_6);
+  assign _zz_PmpPlugin_ports_0_hits_5_7 = ({2'd0,(_zz_PmpPlugin_ports_0_hits_5_4 & (~ _zz_PmpPlugin_ports_0_hits_5_6))} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_5_1 = _zz_when_PmpPlugin_l126_10;
+  always @(*) begin
+    _zz_PmpPlugin_ports_0_hits_5 = 1'b1;
+    case(_zz_CsrPlugin_csrMapping_readDataInit_22)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_5 = 1'b0;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_22)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_5_2 = _zz_PmpPlugin_ports_0_hits_4_3;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_5_2 = _zz_PmpPlugin_ports_0_hits_5_5;
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_5_2 = _zz_PmpPlugin_ports_0_hits_5_7;
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_5_2 = 36'h000000000;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_22)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_5_3 = _zz_PmpPlugin_ports_0_hits_5_5;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_5_3 = (_zz_PmpPlugin_ports_0_hits_5_5 + 36'h000000004);
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_5_3 = (_zz_PmpPlugin_ports_0_hits_5_7 + _zz__zz_PmpPlugin_ports_0_hits_5_3);
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_5_3 = _zz_PmpPlugin_ports_0_hits_5_5;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_13 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_12;
+    if(execute_CsrPlugin_csr_929) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_13 = CsrPlugin_csrMapping_writeDataSignal[16];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_13 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_12;
+    if(execute_CsrPlugin_csr_929) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_13 = CsrPlugin_csrMapping_writeDataSignal[17];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_13 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_12;
+    if(execute_CsrPlugin_csr_929) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_13 = CsrPlugin_csrMapping_writeDataSignal[18];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_when_PmpPlugin_l126_13 = _zz_when_PmpPlugin_l126_12;
+    if(execute_CsrPlugin_csr_929) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_when_PmpPlugin_l126_13 = CsrPlugin_csrMapping_writeDataSignal[23];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_26 = _zz_CsrPlugin_csrMapping_readDataInit_24;
+    if(execute_CsrPlugin_csr_929) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_26 = CsrPlugin_csrMapping_writeDataSignal[20 : 19];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_27 = _zz_CsrPlugin_csrMapping_readDataInit_25;
+    if(execute_CsrPlugin_csr_950) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_27 = CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+      end
+    end
+  end
+
+  assign when_PmpPlugin_l126_6 = (! _zz_when_PmpPlugin_l126_12);
+  assign _zz_PmpPlugin_ports_0_hits_6_4 = {2'b00,_zz_CsrPlugin_csrMapping_readDataInit_25};
+  assign _zz_PmpPlugin_ports_0_hits_6_5 = ({2'd0,_zz_PmpPlugin_ports_0_hits_6_4} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_6_6 = (_zz_PmpPlugin_ports_0_hits_6_4 ^ _zz__zz_PmpPlugin_ports_0_hits_6_6);
+  assign _zz_PmpPlugin_ports_0_hits_6_7 = ({2'd0,(_zz_PmpPlugin_ports_0_hits_6_4 & (~ _zz_PmpPlugin_ports_0_hits_6_6))} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_6_1 = _zz_when_PmpPlugin_l126_12;
+  always @(*) begin
+    _zz_PmpPlugin_ports_0_hits_6 = 1'b1;
+    case(_zz_CsrPlugin_csrMapping_readDataInit_26)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_6 = 1'b0;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_26)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_6_2 = _zz_PmpPlugin_ports_0_hits_5_3;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_6_2 = _zz_PmpPlugin_ports_0_hits_6_5;
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_6_2 = _zz_PmpPlugin_ports_0_hits_6_7;
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_6_2 = 36'h000000000;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_26)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_6_3 = _zz_PmpPlugin_ports_0_hits_6_5;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_6_3 = (_zz_PmpPlugin_ports_0_hits_6_5 + 36'h000000004);
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_6_3 = (_zz_PmpPlugin_ports_0_hits_6_7 + _zz__zz_PmpPlugin_ports_0_hits_6_3);
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_6_3 = _zz_PmpPlugin_ports_0_hits_6_5;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_15 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_14;
+    if(execute_CsrPlugin_csr_929) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_15 = CsrPlugin_csrMapping_writeDataSignal[24];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_15 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_14;
+    if(execute_CsrPlugin_csr_929) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_15 = CsrPlugin_csrMapping_writeDataSignal[25];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_15 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_14;
+    if(execute_CsrPlugin_csr_929) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_15 = CsrPlugin_csrMapping_writeDataSignal[26];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_when_PmpPlugin_l126_15 = _zz_when_PmpPlugin_l126_14;
+    if(execute_CsrPlugin_csr_929) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_when_PmpPlugin_l126_15 = CsrPlugin_csrMapping_writeDataSignal[31];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_30 = _zz_CsrPlugin_csrMapping_readDataInit_28;
+    if(execute_CsrPlugin_csr_929) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_30 = CsrPlugin_csrMapping_writeDataSignal[28 : 27];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_31 = _zz_CsrPlugin_csrMapping_readDataInit_29;
+    if(execute_CsrPlugin_csr_951) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_31 = CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+      end
+    end
+  end
+
+  assign when_PmpPlugin_l126_7 = (! _zz_when_PmpPlugin_l126_14);
+  assign _zz_PmpPlugin_ports_0_hits_7_4 = {2'b00,_zz_CsrPlugin_csrMapping_readDataInit_29};
+  assign _zz_PmpPlugin_ports_0_hits_7_5 = ({2'd0,_zz_PmpPlugin_ports_0_hits_7_4} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_7_6 = (_zz_PmpPlugin_ports_0_hits_7_4 ^ _zz__zz_PmpPlugin_ports_0_hits_7_6);
+  assign _zz_PmpPlugin_ports_0_hits_7_7 = ({2'd0,(_zz_PmpPlugin_ports_0_hits_7_4 & (~ _zz_PmpPlugin_ports_0_hits_7_6))} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_7_1 = _zz_when_PmpPlugin_l126_14;
+  always @(*) begin
+    _zz_PmpPlugin_ports_0_hits_7 = 1'b1;
+    case(_zz_CsrPlugin_csrMapping_readDataInit_30)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_7 = 1'b0;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_30)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_7_2 = _zz_PmpPlugin_ports_0_hits_6_3;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_7_2 = _zz_PmpPlugin_ports_0_hits_7_5;
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_7_2 = _zz_PmpPlugin_ports_0_hits_7_7;
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_7_2 = 36'h000000000;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_30)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_7_3 = _zz_PmpPlugin_ports_0_hits_7_5;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_7_3 = (_zz_PmpPlugin_ports_0_hits_7_5 + 36'h000000004);
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_7_3 = (_zz_PmpPlugin_ports_0_hits_7_7 + _zz__zz_PmpPlugin_ports_0_hits_7_3);
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_7_3 = _zz_PmpPlugin_ports_0_hits_7_5;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_16;
+    if(execute_CsrPlugin_csr_930) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_17 = CsrPlugin_csrMapping_writeDataSignal[0];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_16;
+    if(execute_CsrPlugin_csr_930) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_17 = CsrPlugin_csrMapping_writeDataSignal[1];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_17 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_16;
+    if(execute_CsrPlugin_csr_930) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_17 = CsrPlugin_csrMapping_writeDataSignal[2];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_when_PmpPlugin_l126_17 = _zz_when_PmpPlugin_l126_16;
+    if(execute_CsrPlugin_csr_930) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_when_PmpPlugin_l126_17 = CsrPlugin_csrMapping_writeDataSignal[7];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_34 = _zz_CsrPlugin_csrMapping_readDataInit_32;
+    if(execute_CsrPlugin_csr_930) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_34 = CsrPlugin_csrMapping_writeDataSignal[4 : 3];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_35 = _zz_CsrPlugin_csrMapping_readDataInit_33;
+    if(execute_CsrPlugin_csr_952) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_35 = CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+      end
+    end
+  end
+
+  assign when_PmpPlugin_l126_8 = (! _zz_when_PmpPlugin_l126_16);
+  assign _zz_PmpPlugin_ports_0_hits_8_4 = {2'b00,_zz_CsrPlugin_csrMapping_readDataInit_33};
+  assign _zz_PmpPlugin_ports_0_hits_8_5 = ({2'd0,_zz_PmpPlugin_ports_0_hits_8_4} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_8_6 = (_zz_PmpPlugin_ports_0_hits_8_4 ^ _zz__zz_PmpPlugin_ports_0_hits_8_6);
+  assign _zz_PmpPlugin_ports_0_hits_8_7 = ({2'd0,(_zz_PmpPlugin_ports_0_hits_8_4 & (~ _zz_PmpPlugin_ports_0_hits_8_6))} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_8_1 = _zz_when_PmpPlugin_l126_16;
+  always @(*) begin
+    _zz_PmpPlugin_ports_0_hits_8 = 1'b1;
+    case(_zz_CsrPlugin_csrMapping_readDataInit_34)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_8 = 1'b0;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_34)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_8_2 = _zz_PmpPlugin_ports_0_hits_7_3;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_8_2 = _zz_PmpPlugin_ports_0_hits_8_5;
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_8_2 = _zz_PmpPlugin_ports_0_hits_8_7;
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_8_2 = 36'h000000000;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_34)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_8_3 = _zz_PmpPlugin_ports_0_hits_8_5;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_8_3 = (_zz_PmpPlugin_ports_0_hits_8_5 + 36'h000000004);
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_8_3 = (_zz_PmpPlugin_ports_0_hits_8_7 + _zz__zz_PmpPlugin_ports_0_hits_8_3);
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_8_3 = _zz_PmpPlugin_ports_0_hits_8_5;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_19 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_18;
+    if(execute_CsrPlugin_csr_930) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_19 = CsrPlugin_csrMapping_writeDataSignal[8];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_19 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_18;
+    if(execute_CsrPlugin_csr_930) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_19 = CsrPlugin_csrMapping_writeDataSignal[9];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_19 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_18;
+    if(execute_CsrPlugin_csr_930) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_19 = CsrPlugin_csrMapping_writeDataSignal[10];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_when_PmpPlugin_l126_19 = _zz_when_PmpPlugin_l126_18;
+    if(execute_CsrPlugin_csr_930) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_when_PmpPlugin_l126_19 = CsrPlugin_csrMapping_writeDataSignal[15];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_38 = _zz_CsrPlugin_csrMapping_readDataInit_36;
+    if(execute_CsrPlugin_csr_930) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_38 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_39 = _zz_CsrPlugin_csrMapping_readDataInit_37;
+    if(execute_CsrPlugin_csr_953) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_39 = CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+      end
+    end
+  end
+
+  assign when_PmpPlugin_l126_9 = (! _zz_when_PmpPlugin_l126_18);
+  assign _zz_PmpPlugin_ports_0_hits_9_4 = {2'b00,_zz_CsrPlugin_csrMapping_readDataInit_37};
+  assign _zz_PmpPlugin_ports_0_hits_9_5 = ({2'd0,_zz_PmpPlugin_ports_0_hits_9_4} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_9_6 = (_zz_PmpPlugin_ports_0_hits_9_4 ^ _zz__zz_PmpPlugin_ports_0_hits_9_6);
+  assign _zz_PmpPlugin_ports_0_hits_9_7 = ({2'd0,(_zz_PmpPlugin_ports_0_hits_9_4 & (~ _zz_PmpPlugin_ports_0_hits_9_6))} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_9_1 = _zz_when_PmpPlugin_l126_18;
+  always @(*) begin
+    _zz_PmpPlugin_ports_0_hits_9 = 1'b1;
+    case(_zz_CsrPlugin_csrMapping_readDataInit_38)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_9 = 1'b0;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_38)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_9_2 = _zz_PmpPlugin_ports_0_hits_8_3;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_9_2 = _zz_PmpPlugin_ports_0_hits_9_5;
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_9_2 = _zz_PmpPlugin_ports_0_hits_9_7;
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_9_2 = 36'h000000000;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_38)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_9_3 = _zz_PmpPlugin_ports_0_hits_9_5;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_9_3 = (_zz_PmpPlugin_ports_0_hits_9_5 + 36'h000000004);
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_9_3 = (_zz_PmpPlugin_ports_0_hits_9_7 + _zz__zz_PmpPlugin_ports_0_hits_9_3);
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_9_3 = _zz_PmpPlugin_ports_0_hits_9_5;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_21 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_20;
+    if(execute_CsrPlugin_csr_930) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_21 = CsrPlugin_csrMapping_writeDataSignal[16];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_21 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_20;
+    if(execute_CsrPlugin_csr_930) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_21 = CsrPlugin_csrMapping_writeDataSignal[17];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_21 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_20;
+    if(execute_CsrPlugin_csr_930) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_21 = CsrPlugin_csrMapping_writeDataSignal[18];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_when_PmpPlugin_l126_21 = _zz_when_PmpPlugin_l126_20;
+    if(execute_CsrPlugin_csr_930) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_when_PmpPlugin_l126_21 = CsrPlugin_csrMapping_writeDataSignal[23];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_42 = _zz_CsrPlugin_csrMapping_readDataInit_40;
+    if(execute_CsrPlugin_csr_930) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_42 = CsrPlugin_csrMapping_writeDataSignal[20 : 19];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_43 = _zz_CsrPlugin_csrMapping_readDataInit_41;
+    if(execute_CsrPlugin_csr_954) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_43 = CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+      end
+    end
+  end
+
+  assign when_PmpPlugin_l126_10 = (! _zz_when_PmpPlugin_l126_20);
+  assign _zz_PmpPlugin_ports_0_hits_10_4 = {2'b00,_zz_CsrPlugin_csrMapping_readDataInit_41};
+  assign _zz_PmpPlugin_ports_0_hits_10_5 = ({2'd0,_zz_PmpPlugin_ports_0_hits_10_4} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_10_6 = (_zz_PmpPlugin_ports_0_hits_10_4 ^ _zz__zz_PmpPlugin_ports_0_hits_10_6);
+  assign _zz_PmpPlugin_ports_0_hits_10_7 = ({2'd0,(_zz_PmpPlugin_ports_0_hits_10_4 & (~ _zz_PmpPlugin_ports_0_hits_10_6))} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_10_1 = _zz_when_PmpPlugin_l126_20;
+  always @(*) begin
+    _zz_PmpPlugin_ports_0_hits_10 = 1'b1;
+    case(_zz_CsrPlugin_csrMapping_readDataInit_42)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_10 = 1'b0;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_42)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_10_2 = _zz_PmpPlugin_ports_0_hits_9_3;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_10_2 = _zz_PmpPlugin_ports_0_hits_10_5;
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_10_2 = _zz_PmpPlugin_ports_0_hits_10_7;
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_10_2 = 36'h000000000;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_42)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_10_3 = _zz_PmpPlugin_ports_0_hits_10_5;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_10_3 = (_zz_PmpPlugin_ports_0_hits_10_5 + 36'h000000004);
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_10_3 = (_zz_PmpPlugin_ports_0_hits_10_7 + _zz__zz_PmpPlugin_ports_0_hits_10_3);
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_10_3 = _zz_PmpPlugin_ports_0_hits_10_5;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_23 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_22;
+    if(execute_CsrPlugin_csr_930) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_23 = CsrPlugin_csrMapping_writeDataSignal[24];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_23 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_22;
+    if(execute_CsrPlugin_csr_930) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_23 = CsrPlugin_csrMapping_writeDataSignal[25];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_23 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_22;
+    if(execute_CsrPlugin_csr_930) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_23 = CsrPlugin_csrMapping_writeDataSignal[26];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_when_PmpPlugin_l126_23 = _zz_when_PmpPlugin_l126_22;
+    if(execute_CsrPlugin_csr_930) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_when_PmpPlugin_l126_23 = CsrPlugin_csrMapping_writeDataSignal[31];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_46 = _zz_CsrPlugin_csrMapping_readDataInit_44;
+    if(execute_CsrPlugin_csr_930) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_46 = CsrPlugin_csrMapping_writeDataSignal[28 : 27];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_47 = _zz_CsrPlugin_csrMapping_readDataInit_45;
+    if(execute_CsrPlugin_csr_955) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_47 = CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+      end
+    end
+  end
+
+  assign when_PmpPlugin_l126_11 = (! _zz_when_PmpPlugin_l126_22);
+  assign _zz_PmpPlugin_ports_0_hits_11_4 = {2'b00,_zz_CsrPlugin_csrMapping_readDataInit_45};
+  assign _zz_PmpPlugin_ports_0_hits_11_5 = ({2'd0,_zz_PmpPlugin_ports_0_hits_11_4} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_11_6 = (_zz_PmpPlugin_ports_0_hits_11_4 ^ _zz__zz_PmpPlugin_ports_0_hits_11_6);
+  assign _zz_PmpPlugin_ports_0_hits_11_7 = ({2'd0,(_zz_PmpPlugin_ports_0_hits_11_4 & (~ _zz_PmpPlugin_ports_0_hits_11_6))} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_11_1 = _zz_when_PmpPlugin_l126_22;
+  always @(*) begin
+    _zz_PmpPlugin_ports_0_hits_11 = 1'b1;
+    case(_zz_CsrPlugin_csrMapping_readDataInit_46)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_11 = 1'b0;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_46)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_11_2 = _zz_PmpPlugin_ports_0_hits_10_3;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_11_2 = _zz_PmpPlugin_ports_0_hits_11_5;
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_11_2 = _zz_PmpPlugin_ports_0_hits_11_7;
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_11_2 = 36'h000000000;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_46)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_11_3 = _zz_PmpPlugin_ports_0_hits_11_5;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_11_3 = (_zz_PmpPlugin_ports_0_hits_11_5 + 36'h000000004);
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_11_3 = (_zz_PmpPlugin_ports_0_hits_11_7 + _zz__zz_PmpPlugin_ports_0_hits_11_3);
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_11_3 = _zz_PmpPlugin_ports_0_hits_11_5;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_25 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_24;
+    if(execute_CsrPlugin_csr_931) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_25 = CsrPlugin_csrMapping_writeDataSignal[0];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_25 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_24;
+    if(execute_CsrPlugin_csr_931) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_25 = CsrPlugin_csrMapping_writeDataSignal[1];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_25 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_24;
+    if(execute_CsrPlugin_csr_931) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_25 = CsrPlugin_csrMapping_writeDataSignal[2];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_when_PmpPlugin_l126_25 = _zz_when_PmpPlugin_l126_24;
+    if(execute_CsrPlugin_csr_931) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_when_PmpPlugin_l126_25 = CsrPlugin_csrMapping_writeDataSignal[7];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_50 = _zz_CsrPlugin_csrMapping_readDataInit_48;
+    if(execute_CsrPlugin_csr_931) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_50 = CsrPlugin_csrMapping_writeDataSignal[4 : 3];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_51 = _zz_CsrPlugin_csrMapping_readDataInit_49;
+    if(execute_CsrPlugin_csr_956) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_51 = CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+      end
+    end
+  end
+
+  assign when_PmpPlugin_l126_12 = (! _zz_when_PmpPlugin_l126_24);
+  assign _zz_PmpPlugin_ports_0_hits_12_4 = {2'b00,_zz_CsrPlugin_csrMapping_readDataInit_49};
+  assign _zz_PmpPlugin_ports_0_hits_12_5 = ({2'd0,_zz_PmpPlugin_ports_0_hits_12_4} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_12_6 = (_zz_PmpPlugin_ports_0_hits_12_4 ^ _zz__zz_PmpPlugin_ports_0_hits_12_6);
+  assign _zz_PmpPlugin_ports_0_hits_12_7 = ({2'd0,(_zz_PmpPlugin_ports_0_hits_12_4 & (~ _zz_PmpPlugin_ports_0_hits_12_6))} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_12_1 = _zz_when_PmpPlugin_l126_24;
+  always @(*) begin
+    _zz_PmpPlugin_ports_0_hits_12 = 1'b1;
+    case(_zz_CsrPlugin_csrMapping_readDataInit_50)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_12 = 1'b0;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_50)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_12_2 = _zz_PmpPlugin_ports_0_hits_11_3;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_12_2 = _zz_PmpPlugin_ports_0_hits_12_5;
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_12_2 = _zz_PmpPlugin_ports_0_hits_12_7;
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_12_2 = 36'h000000000;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_50)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_12_3 = _zz_PmpPlugin_ports_0_hits_12_5;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_12_3 = (_zz_PmpPlugin_ports_0_hits_12_5 + 36'h000000004);
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_12_3 = (_zz_PmpPlugin_ports_0_hits_12_7 + _zz__zz_PmpPlugin_ports_0_hits_12_3);
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_12_3 = _zz_PmpPlugin_ports_0_hits_12_5;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_27 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_26;
+    if(execute_CsrPlugin_csr_931) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_27 = CsrPlugin_csrMapping_writeDataSignal[8];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_27 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_26;
+    if(execute_CsrPlugin_csr_931) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_27 = CsrPlugin_csrMapping_writeDataSignal[9];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_27 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_26;
+    if(execute_CsrPlugin_csr_931) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_27 = CsrPlugin_csrMapping_writeDataSignal[10];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_when_PmpPlugin_l126_27 = _zz_when_PmpPlugin_l126_26;
+    if(execute_CsrPlugin_csr_931) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_when_PmpPlugin_l126_27 = CsrPlugin_csrMapping_writeDataSignal[15];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_54 = _zz_CsrPlugin_csrMapping_readDataInit_52;
+    if(execute_CsrPlugin_csr_931) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_54 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_55 = _zz_CsrPlugin_csrMapping_readDataInit_53;
+    if(execute_CsrPlugin_csr_957) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_55 = CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+      end
+    end
+  end
+
+  assign when_PmpPlugin_l126_13 = (! _zz_when_PmpPlugin_l126_26);
+  assign _zz_PmpPlugin_ports_0_hits_13_4 = {2'b00,_zz_CsrPlugin_csrMapping_readDataInit_53};
+  assign _zz_PmpPlugin_ports_0_hits_13_5 = ({2'd0,_zz_PmpPlugin_ports_0_hits_13_4} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_13_6 = (_zz_PmpPlugin_ports_0_hits_13_4 ^ _zz__zz_PmpPlugin_ports_0_hits_13_6);
+  assign _zz_PmpPlugin_ports_0_hits_13_7 = ({2'd0,(_zz_PmpPlugin_ports_0_hits_13_4 & (~ _zz_PmpPlugin_ports_0_hits_13_6))} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_13_1 = _zz_when_PmpPlugin_l126_26;
+  always @(*) begin
+    _zz_PmpPlugin_ports_0_hits_13 = 1'b1;
+    case(_zz_CsrPlugin_csrMapping_readDataInit_54)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_13 = 1'b0;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_54)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_13_2 = _zz_PmpPlugin_ports_0_hits_12_3;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_13_2 = _zz_PmpPlugin_ports_0_hits_13_5;
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_13_2 = _zz_PmpPlugin_ports_0_hits_13_7;
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_13_2 = 36'h000000000;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_54)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_13_3 = _zz_PmpPlugin_ports_0_hits_13_5;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_13_3 = (_zz_PmpPlugin_ports_0_hits_13_5 + 36'h000000004);
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_13_3 = (_zz_PmpPlugin_ports_0_hits_13_7 + _zz__zz_PmpPlugin_ports_0_hits_13_3);
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_13_3 = _zz_PmpPlugin_ports_0_hits_13_5;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_29 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_28;
+    if(execute_CsrPlugin_csr_931) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_29 = CsrPlugin_csrMapping_writeDataSignal[16];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_29 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_28;
+    if(execute_CsrPlugin_csr_931) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_29 = CsrPlugin_csrMapping_writeDataSignal[17];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_29 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_28;
+    if(execute_CsrPlugin_csr_931) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_29 = CsrPlugin_csrMapping_writeDataSignal[18];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_when_PmpPlugin_l126_29 = _zz_when_PmpPlugin_l126_28;
+    if(execute_CsrPlugin_csr_931) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_when_PmpPlugin_l126_29 = CsrPlugin_csrMapping_writeDataSignal[23];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_58 = _zz_CsrPlugin_csrMapping_readDataInit_56;
+    if(execute_CsrPlugin_csr_931) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_58 = CsrPlugin_csrMapping_writeDataSignal[20 : 19];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_59 = _zz_CsrPlugin_csrMapping_readDataInit_57;
+    if(execute_CsrPlugin_csr_958) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_59 = CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+      end
+    end
+  end
+
+  assign when_PmpPlugin_l126_14 = (! _zz_when_PmpPlugin_l126_28);
+  assign _zz_PmpPlugin_ports_0_hits_14_4 = {2'b00,_zz_CsrPlugin_csrMapping_readDataInit_57};
+  assign _zz_PmpPlugin_ports_0_hits_14_5 = ({2'd0,_zz_PmpPlugin_ports_0_hits_14_4} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_14_6 = (_zz_PmpPlugin_ports_0_hits_14_4 ^ _zz__zz_PmpPlugin_ports_0_hits_14_6);
+  assign _zz_PmpPlugin_ports_0_hits_14_7 = ({2'd0,(_zz_PmpPlugin_ports_0_hits_14_4 & (~ _zz_PmpPlugin_ports_0_hits_14_6))} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_14_1 = _zz_when_PmpPlugin_l126_28;
+  always @(*) begin
+    _zz_PmpPlugin_ports_0_hits_14 = 1'b1;
+    case(_zz_CsrPlugin_csrMapping_readDataInit_58)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_14 = 1'b0;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_58)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_14_2 = _zz_PmpPlugin_ports_0_hits_13_3;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_14_2 = _zz_PmpPlugin_ports_0_hits_14_5;
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_14_2 = _zz_PmpPlugin_ports_0_hits_14_7;
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_14_2 = 36'h000000000;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_58)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_14_3 = _zz_PmpPlugin_ports_0_hits_14_5;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_14_3 = (_zz_PmpPlugin_ports_0_hits_14_5 + 36'h000000004);
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_14_3 = (_zz_PmpPlugin_ports_0_hits_14_7 + _zz__zz_PmpPlugin_ports_0_hits_14_3);
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_14_3 = _zz_PmpPlugin_ports_0_hits_14_5;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_31 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_30;
+    if(execute_CsrPlugin_csr_931) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_31 = CsrPlugin_csrMapping_writeDataSignal[24];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_31 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_30;
+    if(execute_CsrPlugin_csr_931) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_31 = CsrPlugin_csrMapping_writeDataSignal[25];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_31 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_30;
+    if(execute_CsrPlugin_csr_931) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_31 = CsrPlugin_csrMapping_writeDataSignal[26];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_when_PmpPlugin_l126_31 = _zz_when_PmpPlugin_l126_30;
+    if(execute_CsrPlugin_csr_931) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_when_PmpPlugin_l126_31 = CsrPlugin_csrMapping_writeDataSignal[31];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_62 = _zz_CsrPlugin_csrMapping_readDataInit_60;
+    if(execute_CsrPlugin_csr_931) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_62 = CsrPlugin_csrMapping_writeDataSignal[28 : 27];
+      end
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_63 = _zz_CsrPlugin_csrMapping_readDataInit_61;
+    if(execute_CsrPlugin_csr_959) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        _zz_CsrPlugin_csrMapping_readDataInit_63 = CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+      end
+    end
+  end
+
+  assign when_PmpPlugin_l126_15 = (! _zz_when_PmpPlugin_l126_30);
+  assign _zz_PmpPlugin_ports_0_hits_15_4 = {2'b00,_zz_CsrPlugin_csrMapping_readDataInit_61};
+  assign _zz_PmpPlugin_ports_0_hits_15_5 = ({2'd0,_zz_PmpPlugin_ports_0_hits_15_4} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_15_6 = (_zz_PmpPlugin_ports_0_hits_15_4 ^ _zz__zz_PmpPlugin_ports_0_hits_15_6);
+  assign _zz_PmpPlugin_ports_0_hits_15_7 = ({2'd0,(_zz_PmpPlugin_ports_0_hits_15_4 & (~ _zz_PmpPlugin_ports_0_hits_15_6))} <<< 2'd2);
+  assign _zz_PmpPlugin_ports_0_hits_15_1 = _zz_when_PmpPlugin_l126_30;
+  always @(*) begin
+    _zz_PmpPlugin_ports_0_hits_15 = 1'b1;
+    case(_zz_CsrPlugin_csrMapping_readDataInit_62)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_15 = 1'b0;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_62)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_15_2 = _zz_PmpPlugin_ports_0_hits_14_3;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_15_2 = _zz_PmpPlugin_ports_0_hits_15_5;
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_15_2 = _zz_PmpPlugin_ports_0_hits_15_7;
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_15_2 = 36'h000000000;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataInit_62)
+      2'b01 : begin
+        _zz_PmpPlugin_ports_0_hits_15_3 = _zz_PmpPlugin_ports_0_hits_15_5;
+      end
+      2'b10 : begin
+        _zz_PmpPlugin_ports_0_hits_15_3 = (_zz_PmpPlugin_ports_0_hits_15_5 + 36'h000000004);
+      end
+      2'b11 : begin
+        _zz_PmpPlugin_ports_0_hits_15_3 = (_zz_PmpPlugin_ports_0_hits_15_7 + _zz__zz_PmpPlugin_ports_0_hits_15_3);
+      end
+      default : begin
+        _zz_PmpPlugin_ports_0_hits_15_3 = _zz_PmpPlugin_ports_0_hits_15_5;
+      end
+    endcase
+  end
+
+  assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
+  assign PmpPlugin_ports_0_hits_0 = (((_zz_PmpPlugin_ports_0_hits_0 && (_zz_PmpPlugin_ports_0_hits_0_2 <= _zz_PmpPlugin_ports_0_hits_0_8)) && (_zz_PmpPlugin_ports_0_hits_0_9 < _zz_PmpPlugin_ports_0_hits_0_3)) && (_zz_PmpPlugin_ports_0_hits_0_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_1 = (((_zz_PmpPlugin_ports_0_hits_1 && (_zz_PmpPlugin_ports_0_hits_1_2 <= _zz_PmpPlugin_ports_0_hits_1_8)) && (_zz_PmpPlugin_ports_0_hits_1_9 < _zz_PmpPlugin_ports_0_hits_1_3)) && (_zz_PmpPlugin_ports_0_hits_1_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_2 = (((_zz_PmpPlugin_ports_0_hits_2 && (_zz_PmpPlugin_ports_0_hits_2_2 <= _zz_PmpPlugin_ports_0_hits_2_8)) && (_zz_PmpPlugin_ports_0_hits_2_9 < _zz_PmpPlugin_ports_0_hits_2_3)) && (_zz_PmpPlugin_ports_0_hits_2_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_3 = (((_zz_PmpPlugin_ports_0_hits_3 && (_zz_PmpPlugin_ports_0_hits_3_2 <= _zz_PmpPlugin_ports_0_hits_3_8)) && (_zz_PmpPlugin_ports_0_hits_3_9 < _zz_PmpPlugin_ports_0_hits_3_3)) && (_zz_PmpPlugin_ports_0_hits_3_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_4 = (((_zz_PmpPlugin_ports_0_hits_4 && (_zz_PmpPlugin_ports_0_hits_4_2 <= _zz_PmpPlugin_ports_0_hits_4_8)) && (_zz_PmpPlugin_ports_0_hits_4_9 < _zz_PmpPlugin_ports_0_hits_4_3)) && (_zz_PmpPlugin_ports_0_hits_4_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_5 = (((_zz_PmpPlugin_ports_0_hits_5 && (_zz_PmpPlugin_ports_0_hits_5_2 <= _zz_PmpPlugin_ports_0_hits_5_8)) && (_zz_PmpPlugin_ports_0_hits_5_9 < _zz_PmpPlugin_ports_0_hits_5_3)) && (_zz_PmpPlugin_ports_0_hits_5_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_6 = (((_zz_PmpPlugin_ports_0_hits_6 && (_zz_PmpPlugin_ports_0_hits_6_2 <= _zz_PmpPlugin_ports_0_hits_6_8)) && (_zz_PmpPlugin_ports_0_hits_6_9 < _zz_PmpPlugin_ports_0_hits_6_3)) && (_zz_PmpPlugin_ports_0_hits_6_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_7 = (((_zz_PmpPlugin_ports_0_hits_7 && (_zz_PmpPlugin_ports_0_hits_7_2 <= _zz_PmpPlugin_ports_0_hits_7_8)) && (_zz_PmpPlugin_ports_0_hits_7_9 < _zz_PmpPlugin_ports_0_hits_7_3)) && (_zz_PmpPlugin_ports_0_hits_7_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_8 = (((_zz_PmpPlugin_ports_0_hits_8 && (_zz_PmpPlugin_ports_0_hits_8_2 <= _zz_PmpPlugin_ports_0_hits_8_8)) && (_zz_PmpPlugin_ports_0_hits_8_9 < _zz_PmpPlugin_ports_0_hits_8_3)) && (_zz_PmpPlugin_ports_0_hits_8_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_9 = (((_zz_PmpPlugin_ports_0_hits_9 && (_zz_PmpPlugin_ports_0_hits_9_2 <= _zz_PmpPlugin_ports_0_hits_9_8)) && (_zz_PmpPlugin_ports_0_hits_9_9 < _zz_PmpPlugin_ports_0_hits_9_3)) && (_zz_PmpPlugin_ports_0_hits_9_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_10 = (((_zz_PmpPlugin_ports_0_hits_10 && (_zz_PmpPlugin_ports_0_hits_10_2 <= _zz_PmpPlugin_ports_0_hits_10_8)) && (_zz_PmpPlugin_ports_0_hits_10_9 < _zz_PmpPlugin_ports_0_hits_10_3)) && (_zz_PmpPlugin_ports_0_hits_10_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_11 = (((_zz_PmpPlugin_ports_0_hits_11 && (_zz_PmpPlugin_ports_0_hits_11_2 <= _zz_PmpPlugin_ports_0_hits_11_8)) && (_zz_PmpPlugin_ports_0_hits_11_9 < _zz_PmpPlugin_ports_0_hits_11_3)) && (_zz_PmpPlugin_ports_0_hits_11_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_12 = (((_zz_PmpPlugin_ports_0_hits_12 && (_zz_PmpPlugin_ports_0_hits_12_2 <= _zz_PmpPlugin_ports_0_hits_12_8)) && (_zz_PmpPlugin_ports_0_hits_12_9 < _zz_PmpPlugin_ports_0_hits_12_3)) && (_zz_PmpPlugin_ports_0_hits_12_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_13 = (((_zz_PmpPlugin_ports_0_hits_13 && (_zz_PmpPlugin_ports_0_hits_13_2 <= _zz_PmpPlugin_ports_0_hits_13_8)) && (_zz_PmpPlugin_ports_0_hits_13_9 < _zz_PmpPlugin_ports_0_hits_13_3)) && (_zz_PmpPlugin_ports_0_hits_13_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_14 = (((_zz_PmpPlugin_ports_0_hits_14 && (_zz_PmpPlugin_ports_0_hits_14_2 <= _zz_PmpPlugin_ports_0_hits_14_8)) && (_zz_PmpPlugin_ports_0_hits_14_9 < _zz_PmpPlugin_ports_0_hits_14_3)) && (_zz_PmpPlugin_ports_0_hits_14_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_15 = (((_zz_PmpPlugin_ports_0_hits_15 && (_zz_PmpPlugin_ports_0_hits_15_2 <= _zz_PmpPlugin_ports_0_hits_15_8)) && (_zz_PmpPlugin_ports_0_hits_15_9 < _zz_PmpPlugin_ports_0_hits_15_3)) && (_zz_PmpPlugin_ports_0_hits_15_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign _zz_when_PmpPlugin_l250 = 5'h00;
+  assign _zz_when_PmpPlugin_l250_1 = 5'h01;
+  assign _zz_when_PmpPlugin_l250_2 = 5'h01;
+  assign _zz_when_PmpPlugin_l250_3 = 5'h02;
+  assign _zz_when_PmpPlugin_l250_4 = 5'h01;
+  assign _zz_when_PmpPlugin_l250_5 = 5'h02;
+  assign _zz_when_PmpPlugin_l250_6 = 5'h02;
+  assign _zz_when_PmpPlugin_l250_7 = 5'h03;
+  assign when_PmpPlugin_l250 = (_zz_when_PmpPlugin_l250_16 == 5'h00);
+  always @(*) begin
+    if(when_PmpPlugin_l250) begin
+      IBusCachedPlugin_mmuBus_rsp_allowRead = (CsrPlugin_privilege == 2'b11);
+    end else begin
+      IBusCachedPlugin_mmuBus_rsp_allowRead = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_49;
+    end
+  end
+
+  always @(*) begin
+    if(when_PmpPlugin_l250) begin
+      IBusCachedPlugin_mmuBus_rsp_allowWrite = (CsrPlugin_privilege == 2'b11);
+    end else begin
+      IBusCachedPlugin_mmuBus_rsp_allowWrite = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_49;
+    end
+  end
+
+  always @(*) begin
+    if(when_PmpPlugin_l250) begin
+      IBusCachedPlugin_mmuBus_rsp_allowExecute = (CsrPlugin_privilege == 2'b11);
+    end else begin
+      IBusCachedPlugin_mmuBus_rsp_allowExecute = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_49;
+    end
+  end
+
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_32 = {PmpPlugin_ports_0_hits_15,{PmpPlugin_ports_0_hits_14,{PmpPlugin_ports_0_hits_13,{PmpPlugin_ports_0_hits_12,{PmpPlugin_ports_0_hits_11,{PmpPlugin_ports_0_hits_10,{PmpPlugin_ports_0_hits_9,{PmpPlugin_ports_0_hits_8,{PmpPlugin_ports_0_hits_7,{PmpPlugin_ports_0_hits_6,{_zz__zz_IBusCachedPlugin_mmuBus_rsp_allowRead_32,_zz__zz_IBusCachedPlugin_mmuBus_rsp_allowRead_32_1}}}}}}}}}}};
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_33 = (_zz_IBusCachedPlugin_mmuBus_rsp_allowRead_32 & (~ _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowRead_33));
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_34 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_33[3];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_35 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_33[5];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_36 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_33[6];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_37 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_33[7];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_38 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_33[9];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_39 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_33[10];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_40 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_33[11];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_41 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_33[12];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_42 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_33[13];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_43 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_33[14];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_44 = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_33[15];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_45 = (((((((_zz_IBusCachedPlugin_mmuBus_rsp_allowRead_33[1] || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_34) || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_35) || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_37) || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_38) || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_40) || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_42) || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_44);
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_46 = (((((((_zz_IBusCachedPlugin_mmuBus_rsp_allowRead_33[2] || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_34) || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_36) || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_37) || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_39) || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_40) || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_43) || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_44);
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_47 = (((((((_zz_IBusCachedPlugin_mmuBus_rsp_allowRead_33[4] || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_35) || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_36) || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_37) || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_41) || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_42) || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_43) || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_44);
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_48 = (((((((_zz_IBusCachedPlugin_mmuBus_rsp_allowRead_33[8] || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_38) || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_39) || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_40) || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_41) || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_42) || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_43) || _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_44);
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_32 = {PmpPlugin_ports_0_hits_15,{PmpPlugin_ports_0_hits_14,{PmpPlugin_ports_0_hits_13,{PmpPlugin_ports_0_hits_12,{PmpPlugin_ports_0_hits_11,{PmpPlugin_ports_0_hits_10,{PmpPlugin_ports_0_hits_9,{PmpPlugin_ports_0_hits_8,{PmpPlugin_ports_0_hits_7,{PmpPlugin_ports_0_hits_6,{_zz__zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_32,_zz__zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_32_1}}}}}}}}}}};
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_33 = (_zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_32 & (~ _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_33));
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_34 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_33[3];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_35 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_33[5];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_36 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_33[6];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_37 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_33[7];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_38 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_33[9];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_39 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_33[10];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_40 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_33[11];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_41 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_33[12];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_42 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_33[13];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_43 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_33[14];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_44 = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_33[15];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_45 = (((((((_zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_33[1] || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_34) || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_35) || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_37) || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_38) || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_40) || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_42) || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_44);
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_46 = (((((((_zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_33[2] || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_34) || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_36) || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_37) || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_39) || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_40) || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_43) || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_44);
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_47 = (((((((_zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_33[4] || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_35) || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_36) || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_37) || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_41) || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_42) || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_43) || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_44);
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_48 = (((((((_zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_33[8] || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_38) || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_39) || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_40) || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_41) || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_42) || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_43) || _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_44);
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_32 = {PmpPlugin_ports_0_hits_15,{PmpPlugin_ports_0_hits_14,{PmpPlugin_ports_0_hits_13,{PmpPlugin_ports_0_hits_12,{PmpPlugin_ports_0_hits_11,{PmpPlugin_ports_0_hits_10,{PmpPlugin_ports_0_hits_9,{PmpPlugin_ports_0_hits_8,{PmpPlugin_ports_0_hits_7,{PmpPlugin_ports_0_hits_6,{_zz__zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_32,_zz__zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_32_1}}}}}}}}}}};
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_33 = (_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_32 & (~ _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_33));
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_34 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_33[3];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_35 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_33[5];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_36 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_33[6];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_37 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_33[7];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_38 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_33[9];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_39 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_33[10];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_40 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_33[11];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_41 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_33[12];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_42 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_33[13];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_43 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_33[14];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_44 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_33[15];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_45 = (((((((_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_33[1] || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_34) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_35) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_37) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_38) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_40) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_42) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_44);
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_46 = (((((((_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_33[2] || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_34) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_36) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_37) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_39) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_40) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_43) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_44);
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_47 = (((((((_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_33[4] || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_35) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_36) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_37) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_41) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_42) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_43) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_44);
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_48 = (((((((_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_33[8] || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_38) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_39) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_40) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_41) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_42) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_43) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_44);
+  assign IBusCachedPlugin_mmuBus_rsp_isIoAccess = IBusCachedPlugin_mmuBus_rsp_physicalAddress[31];
+  assign IBusCachedPlugin_mmuBus_rsp_isPaging = 1'b0;
+  assign IBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
+  assign IBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
+  assign IBusCachedPlugin_mmuBus_busy = 1'b0;
+  assign DBusCachedPlugin_mmuBus_rsp_physicalAddress = DBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
+  assign PmpPlugin_ports_1_hits_0 = (((_zz_PmpPlugin_ports_0_hits_0 && (_zz_PmpPlugin_ports_0_hits_0_2 <= _zz_PmpPlugin_ports_1_hits_0)) && (_zz_PmpPlugin_ports_1_hits_0_1 < _zz_PmpPlugin_ports_0_hits_0_3)) && (_zz_PmpPlugin_ports_0_hits_0_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_1 = (((_zz_PmpPlugin_ports_0_hits_1 && (_zz_PmpPlugin_ports_0_hits_1_2 <= _zz_PmpPlugin_ports_1_hits_1)) && (_zz_PmpPlugin_ports_1_hits_1_1 < _zz_PmpPlugin_ports_0_hits_1_3)) && (_zz_PmpPlugin_ports_0_hits_1_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_2 = (((_zz_PmpPlugin_ports_0_hits_2 && (_zz_PmpPlugin_ports_0_hits_2_2 <= _zz_PmpPlugin_ports_1_hits_2)) && (_zz_PmpPlugin_ports_1_hits_2_1 < _zz_PmpPlugin_ports_0_hits_2_3)) && (_zz_PmpPlugin_ports_0_hits_2_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_3 = (((_zz_PmpPlugin_ports_0_hits_3 && (_zz_PmpPlugin_ports_0_hits_3_2 <= _zz_PmpPlugin_ports_1_hits_3)) && (_zz_PmpPlugin_ports_1_hits_3_1 < _zz_PmpPlugin_ports_0_hits_3_3)) && (_zz_PmpPlugin_ports_0_hits_3_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_4 = (((_zz_PmpPlugin_ports_0_hits_4 && (_zz_PmpPlugin_ports_0_hits_4_2 <= _zz_PmpPlugin_ports_1_hits_4)) && (_zz_PmpPlugin_ports_1_hits_4_1 < _zz_PmpPlugin_ports_0_hits_4_3)) && (_zz_PmpPlugin_ports_0_hits_4_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_5 = (((_zz_PmpPlugin_ports_0_hits_5 && (_zz_PmpPlugin_ports_0_hits_5_2 <= _zz_PmpPlugin_ports_1_hits_5)) && (_zz_PmpPlugin_ports_1_hits_5_1 < _zz_PmpPlugin_ports_0_hits_5_3)) && (_zz_PmpPlugin_ports_0_hits_5_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_6 = (((_zz_PmpPlugin_ports_0_hits_6 && (_zz_PmpPlugin_ports_0_hits_6_2 <= _zz_PmpPlugin_ports_1_hits_6)) && (_zz_PmpPlugin_ports_1_hits_6_1 < _zz_PmpPlugin_ports_0_hits_6_3)) && (_zz_PmpPlugin_ports_0_hits_6_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_7 = (((_zz_PmpPlugin_ports_0_hits_7 && (_zz_PmpPlugin_ports_0_hits_7_2 <= _zz_PmpPlugin_ports_1_hits_7)) && (_zz_PmpPlugin_ports_1_hits_7_1 < _zz_PmpPlugin_ports_0_hits_7_3)) && (_zz_PmpPlugin_ports_0_hits_7_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_8 = (((_zz_PmpPlugin_ports_0_hits_8 && (_zz_PmpPlugin_ports_0_hits_8_2 <= _zz_PmpPlugin_ports_1_hits_8)) && (_zz_PmpPlugin_ports_1_hits_8_1 < _zz_PmpPlugin_ports_0_hits_8_3)) && (_zz_PmpPlugin_ports_0_hits_8_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_9 = (((_zz_PmpPlugin_ports_0_hits_9 && (_zz_PmpPlugin_ports_0_hits_9_2 <= _zz_PmpPlugin_ports_1_hits_9)) && (_zz_PmpPlugin_ports_1_hits_9_1 < _zz_PmpPlugin_ports_0_hits_9_3)) && (_zz_PmpPlugin_ports_0_hits_9_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_10 = (((_zz_PmpPlugin_ports_0_hits_10 && (_zz_PmpPlugin_ports_0_hits_10_2 <= _zz_PmpPlugin_ports_1_hits_10)) && (_zz_PmpPlugin_ports_1_hits_10_1 < _zz_PmpPlugin_ports_0_hits_10_3)) && (_zz_PmpPlugin_ports_0_hits_10_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_11 = (((_zz_PmpPlugin_ports_0_hits_11 && (_zz_PmpPlugin_ports_0_hits_11_2 <= _zz_PmpPlugin_ports_1_hits_11)) && (_zz_PmpPlugin_ports_1_hits_11_1 < _zz_PmpPlugin_ports_0_hits_11_3)) && (_zz_PmpPlugin_ports_0_hits_11_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_12 = (((_zz_PmpPlugin_ports_0_hits_12 && (_zz_PmpPlugin_ports_0_hits_12_2 <= _zz_PmpPlugin_ports_1_hits_12)) && (_zz_PmpPlugin_ports_1_hits_12_1 < _zz_PmpPlugin_ports_0_hits_12_3)) && (_zz_PmpPlugin_ports_0_hits_12_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_13 = (((_zz_PmpPlugin_ports_0_hits_13 && (_zz_PmpPlugin_ports_0_hits_13_2 <= _zz_PmpPlugin_ports_1_hits_13)) && (_zz_PmpPlugin_ports_1_hits_13_1 < _zz_PmpPlugin_ports_0_hits_13_3)) && (_zz_PmpPlugin_ports_0_hits_13_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_14 = (((_zz_PmpPlugin_ports_0_hits_14 && (_zz_PmpPlugin_ports_0_hits_14_2 <= _zz_PmpPlugin_ports_1_hits_14)) && (_zz_PmpPlugin_ports_1_hits_14_1 < _zz_PmpPlugin_ports_0_hits_14_3)) && (_zz_PmpPlugin_ports_0_hits_14_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_15 = (((_zz_PmpPlugin_ports_0_hits_15 && (_zz_PmpPlugin_ports_0_hits_15_2 <= _zz_PmpPlugin_ports_1_hits_15)) && (_zz_PmpPlugin_ports_1_hits_15_1 < _zz_PmpPlugin_ports_0_hits_15_3)) && (_zz_PmpPlugin_ports_0_hits_15_1 || (! (CsrPlugin_privilege == 2'b11))));
+  assign _zz_when_PmpPlugin_l250_8 = 5'h00;
+  assign _zz_when_PmpPlugin_l250_9 = 5'h01;
+  assign _zz_when_PmpPlugin_l250_10 = 5'h01;
+  assign _zz_when_PmpPlugin_l250_11 = 5'h02;
+  assign _zz_when_PmpPlugin_l250_12 = 5'h01;
+  assign _zz_when_PmpPlugin_l250_13 = 5'h02;
+  assign _zz_when_PmpPlugin_l250_14 = 5'h02;
+  assign _zz_when_PmpPlugin_l250_15 = 5'h03;
+  assign when_PmpPlugin_l250_1 = (_zz_when_PmpPlugin_l250_1_1 == 5'h00);
+  always @(*) begin
+    if(when_PmpPlugin_l250_1) begin
       DBusCachedPlugin_mmuBus_rsp_allowRead = (CsrPlugin_privilege == 2'b11);
     end else begin
       DBusCachedPlugin_mmuBus_rsp_allowRead = _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_17;
@@ -5886,14 +6785,22 @@ module VexRiscv (
   end
 
   always @(*) begin
-    if(when_PmpPlugin_l277) begin
+    if(when_PmpPlugin_l250_1) begin
       DBusCachedPlugin_mmuBus_rsp_allowWrite = (CsrPlugin_privilege == 2'b11);
     end else begin
       DBusCachedPlugin_mmuBus_rsp_allowWrite = _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_17;
     end
   end
 
-  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowRead = {PmpPlugin_dGuard_hits_15,{PmpPlugin_dGuard_hits_14,{PmpPlugin_dGuard_hits_13,{PmpPlugin_dGuard_hits_12,{PmpPlugin_dGuard_hits_11,{PmpPlugin_dGuard_hits_10,{PmpPlugin_dGuard_hits_9,{PmpPlugin_dGuard_hits_8,{PmpPlugin_dGuard_hits_7,{PmpPlugin_dGuard_hits_6,{_zz__zz_DBusCachedPlugin_mmuBus_rsp_allowRead,_zz__zz_DBusCachedPlugin_mmuBus_rsp_allowRead_1}}}}}}}}}}};
+  always @(*) begin
+    if(when_PmpPlugin_l250_1) begin
+      DBusCachedPlugin_mmuBus_rsp_allowExecute = (CsrPlugin_privilege == 2'b11);
+    end else begin
+      DBusCachedPlugin_mmuBus_rsp_allowExecute = _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_17;
+    end
+  end
+
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowRead = {PmpPlugin_ports_1_hits_15,{PmpPlugin_ports_1_hits_14,{PmpPlugin_ports_1_hits_13,{PmpPlugin_ports_1_hits_12,{PmpPlugin_ports_1_hits_11,{PmpPlugin_ports_1_hits_10,{PmpPlugin_ports_1_hits_9,{PmpPlugin_ports_1_hits_8,{PmpPlugin_ports_1_hits_7,{PmpPlugin_ports_1_hits_6,{_zz__zz_DBusCachedPlugin_mmuBus_rsp_allowRead,_zz__zz_DBusCachedPlugin_mmuBus_rsp_allowRead_1}}}}}}}}}}};
   assign _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_1 = (_zz_DBusCachedPlugin_mmuBus_rsp_allowRead & (~ _zz__zz_DBusCachedPlugin_mmuBus_rsp_allowRead_1_1));
   assign _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_2 = _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_1[3];
   assign _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_3 = _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_1[5];
@@ -5910,7 +6817,7 @@ module VexRiscv (
   assign _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_14 = (((((((_zz_DBusCachedPlugin_mmuBus_rsp_allowRead_1[2] || _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_2) || _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_4) || _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_5) || _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_7) || _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_8) || _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_11) || _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_12);
   assign _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_15 = (((((((_zz_DBusCachedPlugin_mmuBus_rsp_allowRead_1[4] || _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_3) || _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_4) || _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_5) || _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_9) || _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_10) || _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_11) || _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_12);
   assign _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_16 = (((((((_zz_DBusCachedPlugin_mmuBus_rsp_allowRead_1[8] || _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_6) || _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_7) || _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_8) || _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_9) || _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_10) || _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_11) || _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_12);
-  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite = {PmpPlugin_dGuard_hits_15,{PmpPlugin_dGuard_hits_14,{PmpPlugin_dGuard_hits_13,{PmpPlugin_dGuard_hits_12,{PmpPlugin_dGuard_hits_11,{PmpPlugin_dGuard_hits_10,{PmpPlugin_dGuard_hits_9,{PmpPlugin_dGuard_hits_8,{PmpPlugin_dGuard_hits_7,{PmpPlugin_dGuard_hits_6,{_zz__zz_DBusCachedPlugin_mmuBus_rsp_allowWrite,_zz__zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_1}}}}}}}}}}};
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite = {PmpPlugin_ports_1_hits_15,{PmpPlugin_ports_1_hits_14,{PmpPlugin_ports_1_hits_13,{PmpPlugin_ports_1_hits_12,{PmpPlugin_ports_1_hits_11,{PmpPlugin_ports_1_hits_10,{PmpPlugin_ports_1_hits_9,{PmpPlugin_ports_1_hits_8,{PmpPlugin_ports_1_hits_7,{PmpPlugin_ports_1_hits_6,{_zz__zz_DBusCachedPlugin_mmuBus_rsp_allowWrite,_zz__zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_1}}}}}}}}}}};
   assign _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_1 = (_zz_DBusCachedPlugin_mmuBus_rsp_allowWrite & (~ _zz__zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_1_1));
   assign _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_2 = _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_1[3];
   assign _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_3 = _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_1[5];
@@ -5927,62 +6834,33 @@ module VexRiscv (
   assign _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_14 = (((((((_zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_1[2] || _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_2) || _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_4) || _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_5) || _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_7) || _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_8) || _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_11) || _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_12);
   assign _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_15 = (((((((_zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_1[4] || _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_3) || _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_4) || _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_5) || _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_9) || _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_10) || _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_11) || _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_12);
   assign _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_16 = (((((((_zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_1[8] || _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_6) || _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_7) || _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_8) || _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_9) || _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_10) || _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_11) || _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_12);
-  assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
-  assign IBusCachedPlugin_mmuBus_rsp_isIoAccess = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31];
-  assign IBusCachedPlugin_mmuBus_rsp_isPaging = 1'b0;
-  assign IBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
-  assign IBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
-  assign IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b0;
-  assign IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b0;
-  assign IBusCachedPlugin_mmuBus_busy = 1'b0;
-  assign _zz_PmpPlugin_iGuard_hits_0 = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 7];
-  assign PmpPlugin_iGuard_hits_0 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_0_1) == _zz_PmpPlugin_iGuard_hits_0_3) && (PmpPlugin_pmpcfg_0[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_0[4 : 3] == 2'b11));
-  assign PmpPlugin_iGuard_hits_1 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_1) == _zz_PmpPlugin_iGuard_hits_1_2) && (PmpPlugin_pmpcfg_1[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_1[4 : 3] == 2'b11));
-  assign PmpPlugin_iGuard_hits_2 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_2) == _zz_PmpPlugin_iGuard_hits_2_2) && (PmpPlugin_pmpcfg_2[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_2[4 : 3] == 2'b11));
-  assign PmpPlugin_iGuard_hits_3 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_3) == _zz_PmpPlugin_iGuard_hits_3_2) && (PmpPlugin_pmpcfg_3[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_3[4 : 3] == 2'b11));
-  assign PmpPlugin_iGuard_hits_4 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_4) == _zz_PmpPlugin_iGuard_hits_4_2) && (PmpPlugin_pmpcfg_4[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_4[4 : 3] == 2'b11));
-  assign PmpPlugin_iGuard_hits_5 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_5) == _zz_PmpPlugin_iGuard_hits_5_2) && (PmpPlugin_pmpcfg_5[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_5[4 : 3] == 2'b11));
-  assign PmpPlugin_iGuard_hits_6 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_6) == _zz_PmpPlugin_iGuard_hits_6_2) && (PmpPlugin_pmpcfg_6[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_6[4 : 3] == 2'b11));
-  assign PmpPlugin_iGuard_hits_7 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_7) == _zz_PmpPlugin_iGuard_hits_7_2) && (PmpPlugin_pmpcfg_7[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_7[4 : 3] == 2'b11));
-  assign PmpPlugin_iGuard_hits_8 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_8) == _zz_PmpPlugin_iGuard_hits_8_2) && (PmpPlugin_pmpcfg_8[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_8[4 : 3] == 2'b11));
-  assign PmpPlugin_iGuard_hits_9 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_9) == _zz_PmpPlugin_iGuard_hits_9_2) && (PmpPlugin_pmpcfg_9[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_9[4 : 3] == 2'b11));
-  assign PmpPlugin_iGuard_hits_10 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_10) == _zz_PmpPlugin_iGuard_hits_10_2) && (PmpPlugin_pmpcfg_10[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_10[4 : 3] == 2'b11));
-  assign PmpPlugin_iGuard_hits_11 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_11) == _zz_PmpPlugin_iGuard_hits_11_2) && (PmpPlugin_pmpcfg_11[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_11[4 : 3] == 2'b11));
-  assign PmpPlugin_iGuard_hits_12 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_12) == _zz_PmpPlugin_iGuard_hits_12_2) && (PmpPlugin_pmpcfg_12[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_12[4 : 3] == 2'b11));
-  assign PmpPlugin_iGuard_hits_13 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_13) == _zz_PmpPlugin_iGuard_hits_13_2) && (PmpPlugin_pmpcfg_13[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_13[4 : 3] == 2'b11));
-  assign PmpPlugin_iGuard_hits_14 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_14) == _zz_PmpPlugin_iGuard_hits_14_2) && (PmpPlugin_pmpcfg_14[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_14[4 : 3] == 2'b11));
-  assign PmpPlugin_iGuard_hits_15 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_15) == _zz_PmpPlugin_iGuard_hits_15_2) && (PmpPlugin_pmpcfg_15[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_15[4 : 3] == 2'b11));
-  assign when_PmpPlugin_l299 = (! ({PmpPlugin_iGuard_hits_15,{PmpPlugin_iGuard_hits_14,{PmpPlugin_iGuard_hits_13,{PmpPlugin_iGuard_hits_12,{PmpPlugin_iGuard_hits_11,{PmpPlugin_iGuard_hits_10,{PmpPlugin_iGuard_hits_9,{PmpPlugin_iGuard_hits_8,{PmpPlugin_iGuard_hits_7,{_zz_when_PmpPlugin_l299,_zz_when_PmpPlugin_l299_1}}}}}}}}}} != 16'h0));
-  always @(*) begin
-    if(when_PmpPlugin_l299) begin
-      IBusCachedPlugin_mmuBus_rsp_allowExecute = (CsrPlugin_privilege == 2'b11);
-    end else begin
-      IBusCachedPlugin_mmuBus_rsp_allowExecute = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_17;
-    end
-  end
-
-  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute = {PmpPlugin_iGuard_hits_15,{PmpPlugin_iGuard_hits_14,{PmpPlugin_iGuard_hits_13,{PmpPlugin_iGuard_hits_12,{PmpPlugin_iGuard_hits_11,{PmpPlugin_iGuard_hits_10,{PmpPlugin_iGuard_hits_9,{PmpPlugin_iGuard_hits_8,{PmpPlugin_iGuard_hits_7,{PmpPlugin_iGuard_hits_6,{_zz__zz_IBusCachedPlugin_mmuBus_rsp_allowExecute,_zz__zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1}}}}}}}}}}};
-  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1 = (_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute & (~ _zz__zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1_1));
-  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_2 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1[3];
-  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_3 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1[5];
-  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_4 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1[6];
-  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_5 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1[7];
-  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_6 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1[9];
-  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_7 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1[10];
-  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_8 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1[11];
-  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_9 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1[12];
-  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_10 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1[13];
-  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_11 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1[14];
-  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_12 = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1[15];
-  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_13 = (((((((_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1[1] || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_2) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_3) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_5) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_6) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_8) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_10) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_12);
-  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_14 = (((((((_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1[2] || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_2) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_4) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_5) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_7) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_8) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_11) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_12);
-  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_15 = (((((((_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1[4] || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_3) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_4) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_5) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_9) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_10) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_11) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_12);
-  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_16 = (((((((_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1[8] || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_6) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_7) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_8) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_9) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_10) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_11) || _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_12);
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute = {PmpPlugin_ports_1_hits_15,{PmpPlugin_ports_1_hits_14,{PmpPlugin_ports_1_hits_13,{PmpPlugin_ports_1_hits_12,{PmpPlugin_ports_1_hits_11,{PmpPlugin_ports_1_hits_10,{PmpPlugin_ports_1_hits_9,{PmpPlugin_ports_1_hits_8,{PmpPlugin_ports_1_hits_7,{PmpPlugin_ports_1_hits_6,{_zz__zz_DBusCachedPlugin_mmuBus_rsp_allowExecute,_zz__zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_1}}}}}}}}}}};
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_1 = (_zz_DBusCachedPlugin_mmuBus_rsp_allowExecute & (~ _zz__zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_1_1));
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_2 = _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_1[3];
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_3 = _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_1[5];
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_4 = _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_1[6];
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_5 = _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_1[7];
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_6 = _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_1[9];
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_7 = _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_1[10];
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_8 = _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_1[11];
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_9 = _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_1[12];
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_10 = _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_1[13];
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_11 = _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_1[14];
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_12 = _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_1[15];
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_13 = (((((((_zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_1[1] || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_2) || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_3) || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_5) || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_6) || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_8) || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_10) || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_12);
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_14 = (((((((_zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_1[2] || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_2) || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_4) || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_5) || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_7) || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_8) || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_11) || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_12);
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_15 = (((((((_zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_1[4] || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_3) || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_4) || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_5) || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_9) || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_10) || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_11) || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_12);
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_16 = (((((((_zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_1[8] || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_6) || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_7) || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_8) || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_9) || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_10) || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_11) || _zz_DBusCachedPlugin_mmuBus_rsp_allowExecute_12);
+  assign DBusCachedPlugin_mmuBus_rsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_physicalAddress[31];
+  assign DBusCachedPlugin_mmuBus_rsp_isPaging = 1'b0;
+  assign DBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
+  assign DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
+  assign DBusCachedPlugin_mmuBus_busy = 1'b0;
   assign _zz_decode_IS_RS2_SIGNED_1 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_decode_IS_RS2_SIGNED_2 = ((decode_INSTRUCTION & 32'h00000018) == 32'h0);
+  assign _zz_decode_IS_RS2_SIGNED_2 = ((decode_INSTRUCTION & 32'h00000018) == 32'h00000000);
   assign _zz_decode_IS_RS2_SIGNED_3 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
   assign _zz_decode_IS_RS2_SIGNED_4 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_decode_IS_RS2_SIGNED_5 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
+  assign _zz_decode_IS_RS2_SIGNED_5 = ((decode_INSTRUCTION & 32'h00001000) == 32'h00000000);
   assign _zz_decode_IS_RS2_SIGNED = {(|((decode_INSTRUCTION & 32'h10103050) == 32'h00100050)),{(|_zz_decode_IS_RS2_SIGNED_5),{(|_zz_decode_IS_RS2_SIGNED_5),{(|_zz__zz_decode_IS_RS2_SIGNED),{(|_zz__zz_decode_IS_RS2_SIGNED_1),{_zz__zz_decode_IS_RS2_SIGNED_2,{_zz__zz_decode_IS_RS2_SIGNED_7,_zz__zz_decode_IS_RS2_SIGNED_10}}}}}}};
   assign _zz_decode_SRC1_CTRL_2 = _zz_decode_IS_RS2_SIGNED[2 : 1];
   assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
@@ -6001,7 +6879,7 @@ module VexRiscv (
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
-  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h0);
+  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h00);
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
   assign decode_RegFilePlugin_rs1Data = _zz_RegFilePlugin_regFile_port0;
@@ -6016,14 +6894,14 @@ module VexRiscv (
   always @(*) begin
     lastStageRegFileWrite_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
     if(_zz_10) begin
-      lastStageRegFileWrite_payload_address = 5'h0;
+      lastStageRegFileWrite_payload_address = 5'h00;
     end
   end
 
   always @(*) begin
     lastStageRegFileWrite_payload_data = _zz_decode_RS2_2;
     if(_zz_10) begin
-      lastStageRegFileWrite_payload_data = 32'h0;
+      lastStageRegFileWrite_payload_data = 32'h00000000;
     end
   end
 
@@ -6064,7 +6942,7 @@ module VexRiscv (
         _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
       Src1CtrlEnum_IMU : begin
-        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h000};
       end
       default : begin
         _zz_execute_SRC1 = {27'd0, _zz__zz_execute_SRC1_1};
@@ -6072,67 +6950,67 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_execute_SRC2_1 = execute_INSTRUCTION[31];
+  assign _zz_execute_SRC2 = execute_INSTRUCTION[31];
   always @(*) begin
-    _zz_execute_SRC2_2[19] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[18] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[17] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[16] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[15] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[14] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[13] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[12] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[11] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[10] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[9] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[8] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[7] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[6] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[5] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[4] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[3] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[2] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[1] = _zz_execute_SRC2_1;
-    _zz_execute_SRC2_2[0] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_1[19] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[18] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[17] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[16] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[15] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[14] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[13] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[12] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[11] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[10] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[9] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[8] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[7] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[6] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[5] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[4] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[3] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[2] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[1] = _zz_execute_SRC2;
+    _zz_execute_SRC2_1[0] = _zz_execute_SRC2;
   end
 
-  assign _zz_execute_SRC2_3 = _zz__zz_execute_SRC2_3[11];
+  assign _zz_execute_SRC2_2 = _zz__zz_execute_SRC2_2[11];
   always @(*) begin
-    _zz_execute_SRC2_4[19] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[18] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[17] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[16] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[15] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[14] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[13] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[12] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[11] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[10] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[9] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[8] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[7] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[6] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[5] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[4] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[3] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[2] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[1] = _zz_execute_SRC2_3;
-    _zz_execute_SRC2_4[0] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_3[19] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[18] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[17] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[16] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[15] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[14] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[13] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[12] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[11] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[10] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[9] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[8] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[7] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[6] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[5] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[4] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[3] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[2] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[1] = _zz_execute_SRC2_2;
+    _zz_execute_SRC2_3[0] = _zz_execute_SRC2_2;
   end
 
   always @(*) begin
     case(execute_SRC2_CTRL)
       Src2CtrlEnum_RS : begin
-        _zz_execute_SRC2_5 = execute_RS2;
+        _zz_execute_SRC2_4 = execute_RS2;
       end
       Src2CtrlEnum_IMI : begin
-        _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
+        _zz_execute_SRC2_4 = {_zz_execute_SRC2_1,execute_INSTRUCTION[31 : 20]};
       end
       Src2CtrlEnum_IMS : begin
-        _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_execute_SRC2_4 = {_zz_execute_SRC2_3,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_execute_SRC2_5 = _zz_execute_SRC2;
+        _zz_execute_SRC2_4 = _zz_execute_to_memory_PC;
       end
     endcase
   end
@@ -6298,16 +7176,19 @@ module VexRiscv (
   assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
   assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign switch_Misc_l210_1 = execute_INSTRUCTION[14 : 12];
+  assign switch_Misc_l232_1 = execute_INSTRUCTION[14 : 12];
   always @(*) begin
-    casez(switch_Misc_l210_1)
+    case(switch_Misc_l232_1)
       3'b000 : begin
         _zz_execute_BRANCH_COND_RESULT = execute_BranchPlugin_eq;
       end
       3'b001 : begin
         _zz_execute_BRANCH_COND_RESULT = (! execute_BranchPlugin_eq);
       end
-      3'b1?1 : begin
+      3'b101 : begin
+        _zz_execute_BRANCH_COND_RESULT = (! execute_SRC_LESS);
+      end
+      3'b111 : begin
         _zz_execute_BRANCH_COND_RESULT = (! execute_SRC_LESS);
       end
       default : begin
@@ -6511,9 +7392,12 @@ module VexRiscv (
     end
   end
 
-  assign _zz_when_CsrPlugin_l965 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_when_CsrPlugin_l965_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_when_CsrPlugin_l965_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign CsrPlugin_misa_base = 2'b01;
+  assign CsrPlugin_misa_extensions = 26'h0101064;
+  assign CsrPlugin_mcounteren_TM = 1'b1;
+  assign _zz_when_CsrPlugin_l1302 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l1302_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l1302_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
   assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
@@ -6558,28 +7442,28 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l922 = (! decode_arbitration_isStuck);
-  assign when_CsrPlugin_l922_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l922_2 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l922_3 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l935 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
+  assign when_CsrPlugin_l1259 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l1259_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l1272 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-  assign when_CsrPlugin_l959 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign when_CsrPlugin_l965 = ((_zz_when_CsrPlugin_l965 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l965_1 = ((_zz_when_CsrPlugin_l965_1 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l965_2 = ((_zz_when_CsrPlugin_l965_2 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1296 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l1302 = ((_zz_when_CsrPlugin_l1302 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1302_1 = ((_zz_when_CsrPlugin_l1302_1 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l1302_2 = ((_zz_when_CsrPlugin_l1302_2 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  assign when_CsrPlugin_l993 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l993_1 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l993_2 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l998 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  assign when_CsrPlugin_l1335 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1335_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l1335_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l1340 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
   always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(when_CsrPlugin_l1004) begin
+    if(when_CsrPlugin_l1346) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException) begin
@@ -6587,7 +7471,7 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l1004 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
+  assign when_CsrPlugin_l1346 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
   always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
@@ -6603,6 +7487,7 @@ module VexRiscv (
     end
   end
 
+  assign CsrPlugin_trapCauseEbreakDebug = 1'b0;
   always @(*) begin
     CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
@@ -6625,13 +7510,16 @@ module VexRiscv (
     endcase
   end
 
-  assign when_CsrPlugin_l1032 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign when_CsrPlugin_l1077 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
-  assign switch_CsrPlugin_l1081 = writeBack_INSTRUCTION[29 : 28];
+  assign CsrPlugin_trapEnterDebug = 1'b0;
+  assign when_CsrPlugin_l1390 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1398 = (! CsrPlugin_trapEnterDebug);
+  assign when_CsrPlugin_l1456 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign switch_CsrPlugin_l1460 = writeBack_INSTRUCTION[29 : 28];
+  assign when_CsrPlugin_l1468 = (CsrPlugin_mstatus_MPP < 2'b11);
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign when_CsrPlugin_l1121 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_WFI));
-  assign when_CsrPlugin_l1123 = (! execute_CsrPlugin_wfiWake);
-  assign when_CsrPlugin_l1129 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
+  assign when_CsrPlugin_l1519 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_WFI));
+  assign when_CsrPlugin_l1521 = (! execute_CsrPlugin_wfiWake);
+  assign when_CsrPlugin_l1527 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
   assign execute_CsrPlugin_blockedBySideEffects = ((|{writeBack_arbitration_isValid,memory_arbitration_isValid}) || 1'b0);
   always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
@@ -6639,6 +7527,66 @@ module VexRiscv (
       if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
+    end
+    if(execute_CsrPlugin_csr_944) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(execute_CsrPlugin_csr_945) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(execute_CsrPlugin_csr_946) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(execute_CsrPlugin_csr_947) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(execute_CsrPlugin_csr_948) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(execute_CsrPlugin_csr_949) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(execute_CsrPlugin_csr_950) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(execute_CsrPlugin_csr_951) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(execute_CsrPlugin_csr_952) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(execute_CsrPlugin_csr_953) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(execute_CsrPlugin_csr_954) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(execute_CsrPlugin_csr_955) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(execute_CsrPlugin_csr_956) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(execute_CsrPlugin_csr_957) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(execute_CsrPlugin_csr_958) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(execute_CsrPlugin_csr_959) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(execute_CsrPlugin_csr_928) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(execute_CsrPlugin_csr_929) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(execute_CsrPlugin_csr_930) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(execute_CsrPlugin_csr_931) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
     end
     if(execute_CsrPlugin_csr_3857) begin
       if(execute_CSR_READ_OPCODE) begin
@@ -6719,6 +7667,9 @@ module VexRiscv (
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
+    if(execute_CsrPlugin_csr_774) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
     if(execute_CsrPlugin_csr_3008) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
@@ -6730,18 +7681,18 @@ module VexRiscv (
     if(CsrPlugin_csrMapping_allowCsrSignal) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(when_CsrPlugin_l1315) begin
+    if(when_CsrPlugin_l1725) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if(when_CsrPlugin_l1149) begin
-      if(when_CsrPlugin_l1150) begin
+    if(when_CsrPlugin_l1547) begin
+      if(when_CsrPlugin_l1548) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
@@ -6749,20 +7700,20 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(when_CsrPlugin_l1142) begin
+    if(when_CsrPlugin_l1540) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1157) begin
+    if(when_CsrPlugin_l1555) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(when_CsrPlugin_l1142) begin
+    if(when_CsrPlugin_l1540) begin
       CsrPlugin_selfException_payload_code = 4'b0010;
     end
-    if(when_CsrPlugin_l1157) begin
+    if(when_CsrPlugin_l1555) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -6775,20 +7726,20 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  assign when_CsrPlugin_l1142 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
-  assign when_CsrPlugin_l1149 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
-  assign when_CsrPlugin_l1150 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
-  assign when_CsrPlugin_l1157 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
+  assign when_CsrPlugin_l1540 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
+  assign when_CsrPlugin_l1547 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign when_CsrPlugin_l1548 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1555 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
   always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(when_CsrPlugin_l1310) begin
+    if(when_CsrPlugin_l1719) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -6797,9 +7748,9 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
   assign execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
-  assign switch_Misc_l210_2 = execute_INSTRUCTION[13];
+  assign switch_Misc_l232_2 = execute_INSTRUCTION[13];
   always @(*) begin
-    case(switch_Misc_l210_2)
+    case(switch_Misc_l232_2)
       1'b0 : begin
         _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
@@ -6810,8 +7761,8 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
-  assign when_CsrPlugin_l1189 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign when_CsrPlugin_l1193 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
+  assign when_CsrPlugin_l1587 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1591 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
@@ -6874,12 +7825,12 @@ module VexRiscv (
   assign memory_DivPlugin_div_counter_willOverflow = (memory_DivPlugin_div_counter_willOverflowIfInc && memory_DivPlugin_div_counter_willIncrement);
   always @(*) begin
     if(memory_DivPlugin_div_counter_willOverflow) begin
-      memory_DivPlugin_div_counter_valueNext = 6'h0;
+      memory_DivPlugin_div_counter_valueNext = 6'h00;
     end else begin
       memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_memory_DivPlugin_div_counter_valueNext);
     end
     if(memory_DivPlugin_div_counter_willClear) begin
-      memory_DivPlugin_div_counter_valueNext = 6'h0;
+      memory_DivPlugin_div_counter_valueNext = 6'h00;
     end
   end
 
@@ -6903,17 +7854,17 @@ module VexRiscv (
     _zz_memory_DivPlugin_rs1_1[31 : 0] = execute_RS1;
   end
 
-  assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
-  assign externalInterrupt = (|_zz_CsrPlugin_csrMapping_readDataInit_1);
-  assign when_DebugPlugin_l225 = (DebugPlugin_haltIt && (! DebugPlugin_isPipBusy));
+  assign _zz_externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit_64 & externalInterruptArray_regNext);
+  assign externalInterrupt = (|_zz_externalInterrupt);
+  assign when_DebugPlugin_l238 = (DebugPlugin_haltIt && (! DebugPlugin_isPipBusy));
   assign DebugPlugin_allowEBreak = (DebugPlugin_debugUsed && (! DebugPlugin_disableEbreak));
   always @(*) begin
     debug_bus_cmd_ready = 1'b1;
     if(debug_bus_cmd_valid) begin
-      case(switch_DebugPlugin_l267)
+      case(switch_DebugPlugin_l280)
         6'h01 : begin
           if(debug_bus_cmd_payload_wr) begin
-            debug_bus_cmd_ready = IBusCachedPlugin_injectionPort_ready;
+            debug_bus_cmd_ready = DebugPlugin_injectionPort_ready;
           end
         end
         default : begin
@@ -6924,7 +7875,7 @@ module VexRiscv (
 
   always @(*) begin
     debug_bus_rsp_data = DebugPlugin_busReadDataReg;
-    if(when_DebugPlugin_l244) begin
+    if(when_DebugPlugin_l257) begin
       debug_bus_rsp_data[0] = DebugPlugin_resetIt;
       debug_bus_rsp_data[1] = DebugPlugin_haltIt;
       debug_bus_rsp_data[2] = DebugPlugin_isPipBusy;
@@ -6933,14 +7884,14 @@ module VexRiscv (
     end
   end
 
-  assign when_DebugPlugin_l244 = (! _zz_when_DebugPlugin_l244);
+  assign when_DebugPlugin_l257 = (! _zz_when_DebugPlugin_l257);
   always @(*) begin
-    IBusCachedPlugin_injectionPort_valid = 1'b0;
+    DebugPlugin_injectionPort_valid = 1'b0;
     if(debug_bus_cmd_valid) begin
-      case(switch_DebugPlugin_l267)
+      case(switch_DebugPlugin_l280)
         6'h01 : begin
           if(debug_bus_cmd_payload_wr) begin
-            IBusCachedPlugin_injectionPort_valid = 1'b1;
+            DebugPlugin_injectionPort_valid = 1'b1;
           end
         end
         default : begin
@@ -6949,21 +7900,21 @@ module VexRiscv (
     end
   end
 
-  assign IBusCachedPlugin_injectionPort_payload = debug_bus_cmd_payload_data;
-  assign switch_DebugPlugin_l267 = debug_bus_cmd_payload_address[7 : 2];
-  assign when_DebugPlugin_l271 = debug_bus_cmd_payload_data[16];
-  assign when_DebugPlugin_l271_1 = debug_bus_cmd_payload_data[24];
-  assign when_DebugPlugin_l272 = debug_bus_cmd_payload_data[17];
-  assign when_DebugPlugin_l272_1 = debug_bus_cmd_payload_data[25];
-  assign when_DebugPlugin_l273 = debug_bus_cmd_payload_data[25];
-  assign when_DebugPlugin_l274 = debug_bus_cmd_payload_data[25];
-  assign when_DebugPlugin_l275 = debug_bus_cmd_payload_data[18];
-  assign when_DebugPlugin_l275_1 = debug_bus_cmd_payload_data[26];
-  assign when_DebugPlugin_l295 = (execute_arbitration_isValid && execute_DO_EBREAK);
-  assign when_DebugPlugin_l298 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
-  assign when_DebugPlugin_l311 = (DebugPlugin_stepIt && IBusCachedPlugin_incomingInstruction);
+  assign DebugPlugin_injectionPort_payload = debug_bus_cmd_payload_data;
+  assign switch_DebugPlugin_l280 = debug_bus_cmd_payload_address[7 : 2];
+  assign when_DebugPlugin_l284 = debug_bus_cmd_payload_data[16];
+  assign when_DebugPlugin_l284_1 = debug_bus_cmd_payload_data[24];
+  assign when_DebugPlugin_l285 = debug_bus_cmd_payload_data[17];
+  assign when_DebugPlugin_l285_1 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l286 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l287 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l288 = debug_bus_cmd_payload_data[18];
+  assign when_DebugPlugin_l288_1 = debug_bus_cmd_payload_data[26];
+  assign when_DebugPlugin_l308 = (execute_arbitration_isValid && execute_DO_EBREAK);
+  assign when_DebugPlugin_l311 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
+  assign when_DebugPlugin_l324 = (DebugPlugin_stepIt && IBusCachedPlugin_incomingInstruction);
   assign debug_resetOut = DebugPlugin_resetIt_regNext;
-  assign when_DebugPlugin_l331 = (DebugPlugin_haltIt || DebugPlugin_stepIt);
+  assign when_DebugPlugin_l344 = (DebugPlugin_haltIt || DebugPlugin_stepIt);
   assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
@@ -7081,272 +8032,473 @@ module VexRiscv (
   assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
   assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
   always @(*) begin
-    IBusCachedPlugin_injectionPort_ready = 1'b0;
-    case(switch_Fetcher_l365)
+    DebugPlugin_injectionPort_ready = 1'b0;
+    case(IBusCachedPlugin_injector_port_state)
       3'b100 : begin
-        IBusCachedPlugin_injectionPort_ready = 1'b1;
+        DebugPlugin_injectionPort_ready = 1'b1;
       end
       default : begin
       end
     endcase
   end
 
-  assign when_Fetcher_l381 = (! decode_arbitration_isStuck);
+  assign when_Fetcher_l391 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l1669 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_8 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_9 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_10 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_11 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_12 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_13 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_14 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_15 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_16 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_17 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_18 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_19 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_20 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_21 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_22 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_23 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_24 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_25 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_26 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_27 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_28 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_29 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_30 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_31 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_32 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_33 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_34 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_35 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_36 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_37 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_38 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_39 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_40 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_41 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_42 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_43 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1669_44 = (! execute_arbitration_isStuck);
   always @(*) begin
-    execute_PmpPlugin_fsm_stateNext = execute_PmpPlugin_fsm_stateReg;
-    case(execute_PmpPlugin_fsm_stateReg)
-      execute_PmpPlugin_fsm_enumDef_stateIdle : begin
-        if(execute_PmpPlugin_fsmPending) begin
-          execute_PmpPlugin_fsm_stateNext = execute_PmpPlugin_fsm_enumDef_stateWrite;
-        end
-      end
-      execute_PmpPlugin_fsm_enumDef_stateWrite : begin
-        if(execute_PmpPlugin_pmpcfgCsr_) begin
-          execute_PmpPlugin_fsm_stateNext = execute_PmpPlugin_fsm_enumDef_stateCfg;
-        end
-        if(execute_PmpPlugin_pmpaddrCsr_) begin
-          execute_PmpPlugin_fsm_stateNext = execute_PmpPlugin_fsm_enumDef_stateAddr;
-        end
-      end
-      execute_PmpPlugin_fsm_enumDef_stateCfg : begin
-        if(when_PmpPlugin_l229) begin
-          execute_PmpPlugin_fsm_stateNext = execute_PmpPlugin_fsm_enumDef_stateIdle;
-        end
-      end
-      execute_PmpPlugin_fsm_enumDef_stateAddr : begin
-        execute_PmpPlugin_fsm_stateNext = execute_PmpPlugin_fsm_enumDef_stateIdle;
-      end
-      default : begin
-      end
-    endcase
-    if(execute_PmpPlugin_fsm_wantStart) begin
-      execute_PmpPlugin_fsm_stateNext = execute_PmpPlugin_fsm_enumDef_stateIdle;
-    end
-    if(execute_PmpPlugin_fsm_wantKill) begin
-      execute_PmpPlugin_fsm_stateNext = execute_PmpPlugin_fsm_enumDef_BOOT;
-    end
-  end
-
-  assign _zz_PmpPlugin_pmpcfg_0 = execute_PmpPlugin_writeData_[7 : 0];
-  assign _zz_PmpPlugin_pmpcfg_0_1 = execute_PmpPlugin_writeData_[15 : 8];
-  assign _zz_PmpPlugin_pmpcfg_0_2 = execute_PmpPlugin_writeData_[23 : 16];
-  assign _zz_PmpPlugin_pmpcfg_0_3 = execute_PmpPlugin_writeData_[31 : 24];
-  assign when_PmpPlugin_l209 = (! _zz_when_PmpPlugin_l209[7]);
-  assign _zz_11 = ({15'd0,1'b1} <<< {execute_PmpPlugin_pmpcfgN_,2'b00});
-  assign when_PmpPlugin_l209_1 = (! _zz_when_PmpPlugin_l209_1_1[7]);
-  assign _zz_12 = ({15'd0,1'b1} <<< {execute_PmpPlugin_pmpcfgN_,2'b01});
-  assign when_PmpPlugin_l209_2 = (! _zz_when_PmpPlugin_l209_2[7]);
-  assign _zz_13 = ({15'd0,1'b1} <<< {execute_PmpPlugin_pmpcfgN_,2'b10});
-  assign when_PmpPlugin_l209_3 = (! _zz_when_PmpPlugin_l209_3[7]);
-  assign _zz_14 = ({15'd0,1'b1} <<< {execute_PmpPlugin_pmpcfgN_,2'b11});
-  assign when_PmpPlugin_l216 = (! _zz_when_PmpPlugin_l216[7]);
-  assign when_PmpPlugin_l229 = (execute_PmpPlugin_fsm_fsmCounter[1 : 0] == 2'b11);
-  assign when_StateMachine_l233 = ((execute_PmpPlugin_fsm_stateReg == execute_PmpPlugin_fsm_enumDef_stateWrite) && (! (execute_PmpPlugin_fsm_stateNext == execute_PmpPlugin_fsm_enumDef_stateWrite)));
-  assign when_StateMachine_l249 = ((! (execute_PmpPlugin_fsm_stateReg == execute_PmpPlugin_fsm_enumDef_stateIdle)) && (execute_PmpPlugin_fsm_stateNext == execute_PmpPlugin_fsm_enumDef_stateIdle));
-  assign when_StateMachine_l249_1 = ((! (execute_PmpPlugin_fsm_stateReg == execute_PmpPlugin_fsm_enumDef_stateCfg)) && (execute_PmpPlugin_fsm_stateNext == execute_PmpPlugin_fsm_enumDef_stateCfg));
-  assign when_StateMachine_l249_2 = ((! (execute_PmpPlugin_fsm_stateReg == execute_PmpPlugin_fsm_enumDef_stateAddr)) && (execute_PmpPlugin_fsm_stateNext == execute_PmpPlugin_fsm_enumDef_stateAddr));
-  assign when_CsrPlugin_l1277 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_2 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_3 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_4 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_5 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_6 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_7 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_8 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_9 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_10 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_11 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_12 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_13 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_14 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_15 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_16 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_17 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_18 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_19 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_20 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_21 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_22 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1277_23 = (! execute_arbitration_isStuck);
-  always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_65 = 32'h00000000;
     if(execute_CsrPlugin_csr_3264) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_2[12 : 0] = 13'h1000;
-      _zz_CsrPlugin_csrMapping_readDataInit_2[25 : 20] = 6'h20;
+      _zz_CsrPlugin_csrMapping_readDataInit_65[12 : 0] = 13'h1000;
+      _zz_CsrPlugin_csrMapping_readDataInit_65[25 : 20] = 6'h20;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_66 = 32'h00000000;
+    if(execute_CsrPlugin_csr_944) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_66[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_1;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_67 = 32'h00000000;
+    if(execute_CsrPlugin_csr_945) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_67[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_5;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_68 = 32'h00000000;
+    if(execute_CsrPlugin_csr_946) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_68[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_9;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_69 = 32'h00000000;
+    if(execute_CsrPlugin_csr_947) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_69[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_13;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_70 = 32'h00000000;
+    if(execute_CsrPlugin_csr_948) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_70[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_17;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_71 = 32'h00000000;
+    if(execute_CsrPlugin_csr_949) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_71[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_21;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_72 = 32'h00000000;
+    if(execute_CsrPlugin_csr_950) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_72[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_25;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_73 = 32'h00000000;
+    if(execute_CsrPlugin_csr_951) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_73[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_29;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_74 = 32'h00000000;
+    if(execute_CsrPlugin_csr_952) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_74[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_33;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_75 = 32'h00000000;
+    if(execute_CsrPlugin_csr_953) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_75[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_37;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_76 = 32'h00000000;
+    if(execute_CsrPlugin_csr_954) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_76[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_41;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_77 = 32'h00000000;
+    if(execute_CsrPlugin_csr_955) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_77[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_45;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_78 = 32'h00000000;
+    if(execute_CsrPlugin_csr_956) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_78[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_49;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_79 = 32'h00000000;
+    if(execute_CsrPlugin_csr_957) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_79[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_53;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_80 = 32'h00000000;
+    if(execute_CsrPlugin_csr_958) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_80[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_57;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_81 = 32'h00000000;
+    if(execute_CsrPlugin_csr_959) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_81[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_61;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_82 = 32'h00000000;
+    if(execute_CsrPlugin_csr_928) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_82[31 : 31] = _zz_when_PmpPlugin_l126_6;
+      _zz_CsrPlugin_csrMapping_readDataInit_82[23 : 23] = _zz_when_PmpPlugin_l126_4;
+      _zz_CsrPlugin_csrMapping_readDataInit_82[15 : 15] = _zz_when_PmpPlugin_l126_2;
+      _zz_CsrPlugin_csrMapping_readDataInit_82[7 : 7] = _zz_when_PmpPlugin_l126;
+      _zz_CsrPlugin_csrMapping_readDataInit_82[28 : 27] = _zz_CsrPlugin_csrMapping_readDataInit_12;
+      _zz_CsrPlugin_csrMapping_readDataInit_82[26 : 26] = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_6;
+      _zz_CsrPlugin_csrMapping_readDataInit_82[25 : 25] = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_6;
+      _zz_CsrPlugin_csrMapping_readDataInit_82[24 : 24] = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_6;
+      _zz_CsrPlugin_csrMapping_readDataInit_82[20 : 19] = _zz_CsrPlugin_csrMapping_readDataInit_8;
+      _zz_CsrPlugin_csrMapping_readDataInit_82[18 : 18] = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_4;
+      _zz_CsrPlugin_csrMapping_readDataInit_82[17 : 17] = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_4;
+      _zz_CsrPlugin_csrMapping_readDataInit_82[16 : 16] = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_4;
+      _zz_CsrPlugin_csrMapping_readDataInit_82[12 : 11] = _zz_CsrPlugin_csrMapping_readDataInit_4;
+      _zz_CsrPlugin_csrMapping_readDataInit_82[10 : 10] = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_2;
+      _zz_CsrPlugin_csrMapping_readDataInit_82[9 : 9] = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_2;
+      _zz_CsrPlugin_csrMapping_readDataInit_82[8 : 8] = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_2;
+      _zz_CsrPlugin_csrMapping_readDataInit_82[4 : 3] = _zz_CsrPlugin_csrMapping_readDataInit;
+      _zz_CsrPlugin_csrMapping_readDataInit_82[2 : 2] = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute;
+      _zz_CsrPlugin_csrMapping_readDataInit_82[1 : 1] = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite;
+      _zz_CsrPlugin_csrMapping_readDataInit_82[0 : 0] = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_83 = 32'h00000000;
+    if(execute_CsrPlugin_csr_929) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_83[31 : 31] = _zz_when_PmpPlugin_l126_14;
+      _zz_CsrPlugin_csrMapping_readDataInit_83[23 : 23] = _zz_when_PmpPlugin_l126_12;
+      _zz_CsrPlugin_csrMapping_readDataInit_83[15 : 15] = _zz_when_PmpPlugin_l126_10;
+      _zz_CsrPlugin_csrMapping_readDataInit_83[7 : 7] = _zz_when_PmpPlugin_l126_8;
+      _zz_CsrPlugin_csrMapping_readDataInit_83[28 : 27] = _zz_CsrPlugin_csrMapping_readDataInit_28;
+      _zz_CsrPlugin_csrMapping_readDataInit_83[26 : 26] = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_14;
+      _zz_CsrPlugin_csrMapping_readDataInit_83[25 : 25] = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_14;
+      _zz_CsrPlugin_csrMapping_readDataInit_83[24 : 24] = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_14;
+      _zz_CsrPlugin_csrMapping_readDataInit_83[20 : 19] = _zz_CsrPlugin_csrMapping_readDataInit_24;
+      _zz_CsrPlugin_csrMapping_readDataInit_83[18 : 18] = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_12;
+      _zz_CsrPlugin_csrMapping_readDataInit_83[17 : 17] = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_12;
+      _zz_CsrPlugin_csrMapping_readDataInit_83[16 : 16] = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_12;
+      _zz_CsrPlugin_csrMapping_readDataInit_83[12 : 11] = _zz_CsrPlugin_csrMapping_readDataInit_20;
+      _zz_CsrPlugin_csrMapping_readDataInit_83[10 : 10] = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_10;
+      _zz_CsrPlugin_csrMapping_readDataInit_83[9 : 9] = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_10;
+      _zz_CsrPlugin_csrMapping_readDataInit_83[8 : 8] = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_10;
+      _zz_CsrPlugin_csrMapping_readDataInit_83[4 : 3] = _zz_CsrPlugin_csrMapping_readDataInit_16;
+      _zz_CsrPlugin_csrMapping_readDataInit_83[2 : 2] = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_8;
+      _zz_CsrPlugin_csrMapping_readDataInit_83[1 : 1] = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_8;
+      _zz_CsrPlugin_csrMapping_readDataInit_83[0 : 0] = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_8;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_84 = 32'h00000000;
+    if(execute_CsrPlugin_csr_930) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_84[31 : 31] = _zz_when_PmpPlugin_l126_22;
+      _zz_CsrPlugin_csrMapping_readDataInit_84[23 : 23] = _zz_when_PmpPlugin_l126_20;
+      _zz_CsrPlugin_csrMapping_readDataInit_84[15 : 15] = _zz_when_PmpPlugin_l126_18;
+      _zz_CsrPlugin_csrMapping_readDataInit_84[7 : 7] = _zz_when_PmpPlugin_l126_16;
+      _zz_CsrPlugin_csrMapping_readDataInit_84[28 : 27] = _zz_CsrPlugin_csrMapping_readDataInit_44;
+      _zz_CsrPlugin_csrMapping_readDataInit_84[26 : 26] = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_22;
+      _zz_CsrPlugin_csrMapping_readDataInit_84[25 : 25] = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_22;
+      _zz_CsrPlugin_csrMapping_readDataInit_84[24 : 24] = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_22;
+      _zz_CsrPlugin_csrMapping_readDataInit_84[20 : 19] = _zz_CsrPlugin_csrMapping_readDataInit_40;
+      _zz_CsrPlugin_csrMapping_readDataInit_84[18 : 18] = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_20;
+      _zz_CsrPlugin_csrMapping_readDataInit_84[17 : 17] = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_20;
+      _zz_CsrPlugin_csrMapping_readDataInit_84[16 : 16] = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_20;
+      _zz_CsrPlugin_csrMapping_readDataInit_84[12 : 11] = _zz_CsrPlugin_csrMapping_readDataInit_36;
+      _zz_CsrPlugin_csrMapping_readDataInit_84[10 : 10] = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_18;
+      _zz_CsrPlugin_csrMapping_readDataInit_84[9 : 9] = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_18;
+      _zz_CsrPlugin_csrMapping_readDataInit_84[8 : 8] = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_18;
+      _zz_CsrPlugin_csrMapping_readDataInit_84[4 : 3] = _zz_CsrPlugin_csrMapping_readDataInit_32;
+      _zz_CsrPlugin_csrMapping_readDataInit_84[2 : 2] = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_16;
+      _zz_CsrPlugin_csrMapping_readDataInit_84[1 : 1] = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_16;
+      _zz_CsrPlugin_csrMapping_readDataInit_84[0 : 0] = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_16;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_85 = 32'h00000000;
+    if(execute_CsrPlugin_csr_931) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_85[31 : 31] = _zz_when_PmpPlugin_l126_30;
+      _zz_CsrPlugin_csrMapping_readDataInit_85[23 : 23] = _zz_when_PmpPlugin_l126_28;
+      _zz_CsrPlugin_csrMapping_readDataInit_85[15 : 15] = _zz_when_PmpPlugin_l126_26;
+      _zz_CsrPlugin_csrMapping_readDataInit_85[7 : 7] = _zz_when_PmpPlugin_l126_24;
+      _zz_CsrPlugin_csrMapping_readDataInit_85[28 : 27] = _zz_CsrPlugin_csrMapping_readDataInit_60;
+      _zz_CsrPlugin_csrMapping_readDataInit_85[26 : 26] = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_30;
+      _zz_CsrPlugin_csrMapping_readDataInit_85[25 : 25] = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_30;
+      _zz_CsrPlugin_csrMapping_readDataInit_85[24 : 24] = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_30;
+      _zz_CsrPlugin_csrMapping_readDataInit_85[20 : 19] = _zz_CsrPlugin_csrMapping_readDataInit_56;
+      _zz_CsrPlugin_csrMapping_readDataInit_85[18 : 18] = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_28;
+      _zz_CsrPlugin_csrMapping_readDataInit_85[17 : 17] = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_28;
+      _zz_CsrPlugin_csrMapping_readDataInit_85[16 : 16] = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_28;
+      _zz_CsrPlugin_csrMapping_readDataInit_85[12 : 11] = _zz_CsrPlugin_csrMapping_readDataInit_52;
+      _zz_CsrPlugin_csrMapping_readDataInit_85[10 : 10] = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_26;
+      _zz_CsrPlugin_csrMapping_readDataInit_85[9 : 9] = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_26;
+      _zz_CsrPlugin_csrMapping_readDataInit_85[8 : 8] = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_26;
+      _zz_CsrPlugin_csrMapping_readDataInit_85[4 : 3] = _zz_CsrPlugin_csrMapping_readDataInit_48;
+      _zz_CsrPlugin_csrMapping_readDataInit_85[2 : 2] = _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_24;
+      _zz_CsrPlugin_csrMapping_readDataInit_85[1 : 1] = _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_24;
+      _zz_CsrPlugin_csrMapping_readDataInit_85[0 : 0] = _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_24;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_86 = 32'h00000000;
     if(execute_CsrPlugin_csr_3857) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_3[0 : 0] = 1'b1;
+      _zz_CsrPlugin_csrMapping_readDataInit_86[0 : 0] = 1'b1;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_87 = 32'h00000000;
     if(execute_CsrPlugin_csr_3858) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_4[1 : 0] = 2'b10;
+      _zz_CsrPlugin_csrMapping_readDataInit_87[1 : 0] = 2'b10;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_88 = 32'h00000000;
     if(execute_CsrPlugin_csr_3859) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_5[1 : 0] = 2'b11;
+      _zz_CsrPlugin_csrMapping_readDataInit_88[1 : 0] = 2'b11;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_89 = 32'h00000000;
     if(execute_CsrPlugin_csr_769) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_6[31 : 30] = CsrPlugin_misa_base;
-      _zz_CsrPlugin_csrMapping_readDataInit_6[25 : 0] = CsrPlugin_misa_extensions;
+      _zz_CsrPlugin_csrMapping_readDataInit_89[31 : 30] = CsrPlugin_misa_base;
+      _zz_CsrPlugin_csrMapping_readDataInit_89[25 : 0] = CsrPlugin_misa_extensions;
     end
   end
 
-  assign switch_CsrPlugin_l723 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
+  assign switch_CsrPlugin_l1031 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_90 = 32'h00000000;
     if(execute_CsrPlugin_csr_768) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_7[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_7[3 : 3] = CsrPlugin_mstatus_MIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_7[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_CsrPlugin_csrMapping_readDataInit_90[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_90[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_90[12 : 11] = CsrPlugin_mstatus_MPP;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_91 = 32'h00000000;
     if(execute_CsrPlugin_csr_836) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_8[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_8[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_CsrPlugin_csrMapping_readDataInit_8[3 : 3] = CsrPlugin_mip_MSIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_91[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_91[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_91[3 : 3] = CsrPlugin_mip_MSIP;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_92 = 32'h00000000;
     if(execute_CsrPlugin_csr_772) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_9[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_9[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_CsrPlugin_csrMapping_readDataInit_9[3 : 3] = CsrPlugin_mie_MSIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_92[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_92[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_92[3 : 3] = CsrPlugin_mie_MSIE;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_10 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_93 = 32'h00000000;
     if(execute_CsrPlugin_csr_773) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_10[31 : 2] = CsrPlugin_mtvec_base;
-      _zz_CsrPlugin_csrMapping_readDataInit_10[1 : 0] = CsrPlugin_mtvec_mode;
+      _zz_CsrPlugin_csrMapping_readDataInit_93[31 : 2] = CsrPlugin_mtvec_base;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_11 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_94 = 32'h00000000;
     if(execute_CsrPlugin_csr_833) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_11[31 : 0] = CsrPlugin_mepc;
+      _zz_CsrPlugin_csrMapping_readDataInit_94[31 : 0] = CsrPlugin_mepc;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_12 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_95 = 32'h00000000;
     if(execute_CsrPlugin_csr_832) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_12[31 : 0] = CsrPlugin_mscratch;
+      _zz_CsrPlugin_csrMapping_readDataInit_95[31 : 0] = CsrPlugin_mscratch;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_13 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_96 = 32'h00000000;
     if(execute_CsrPlugin_csr_834) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_13[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_CsrPlugin_csrMapping_readDataInit_13[3 : 0] = CsrPlugin_mcause_exceptionCode;
+      _zz_CsrPlugin_csrMapping_readDataInit_96[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_CsrPlugin_csrMapping_readDataInit_96[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_14 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_97 = 32'h00000000;
     if(execute_CsrPlugin_csr_835) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_14[31 : 0] = CsrPlugin_mtval;
+      _zz_CsrPlugin_csrMapping_readDataInit_97[31 : 0] = CsrPlugin_mtval;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_15 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_98 = 32'h00000000;
     if(execute_CsrPlugin_csr_2816) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_15[31 : 0] = CsrPlugin_mcycle[31 : 0];
+      _zz_CsrPlugin_csrMapping_readDataInit_98[31 : 0] = CsrPlugin_mcycle[31 : 0];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_16 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_99 = 32'h00000000;
     if(execute_CsrPlugin_csr_2944) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_16[31 : 0] = CsrPlugin_mcycle[63 : 32];
+      _zz_CsrPlugin_csrMapping_readDataInit_99[31 : 0] = CsrPlugin_mcycle[63 : 32];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_17 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_100 = 32'h00000000;
     if(execute_CsrPlugin_csr_2818) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_17[31 : 0] = CsrPlugin_minstret[31 : 0];
+      _zz_CsrPlugin_csrMapping_readDataInit_100[31 : 0] = CsrPlugin_minstret[31 : 0];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_18 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_101 = 32'h00000000;
     if(execute_CsrPlugin_csr_2946) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_18[31 : 0] = CsrPlugin_minstret[63 : 32];
+      _zz_CsrPlugin_csrMapping_readDataInit_101[31 : 0] = CsrPlugin_minstret[63 : 32];
     end
   end
 
+  assign when_CsrPlugin_l1076 = ((CsrPlugin_privilege < 2'b11) && (! CsrPlugin_mcounteren_CY));
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_19 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_102 = 32'h00000000;
     if(execute_CsrPlugin_csr_3072) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_19[31 : 0] = CsrPlugin_mcycle[31 : 0];
+      _zz_CsrPlugin_csrMapping_readDataInit_102[31 : 0] = CsrPlugin_mcycle[31 : 0];
     end
   end
 
+  assign when_CsrPlugin_l1076_1 = ((CsrPlugin_privilege < 2'b11) && (! CsrPlugin_mcounteren_CY));
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_20 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_103 = 32'h00000000;
     if(execute_CsrPlugin_csr_3200) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_20[31 : 0] = CsrPlugin_mcycle[63 : 32];
+      _zz_CsrPlugin_csrMapping_readDataInit_103[31 : 0] = CsrPlugin_mcycle[63 : 32];
     end
   end
 
+  assign when_CsrPlugin_l1076_2 = ((CsrPlugin_privilege < 2'b11) && (! CsrPlugin_mcounteren_IR));
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_21 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_104 = 32'h00000000;
     if(execute_CsrPlugin_csr_3074) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_21[31 : 0] = CsrPlugin_minstret[31 : 0];
+      _zz_CsrPlugin_csrMapping_readDataInit_104[31 : 0] = CsrPlugin_minstret[31 : 0];
     end
   end
 
+  assign when_CsrPlugin_l1076_3 = ((CsrPlugin_privilege < 2'b11) && (! CsrPlugin_mcounteren_IR));
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_22 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_105 = 32'h00000000;
     if(execute_CsrPlugin_csr_3202) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_22[31 : 0] = CsrPlugin_minstret[63 : 32];
+      _zz_CsrPlugin_csrMapping_readDataInit_105[31 : 0] = CsrPlugin_minstret[63 : 32];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_23 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_106 = 32'h00000000;
+    if(execute_CsrPlugin_csr_774) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_106[0 : 0] = CsrPlugin_mcounteren_CY;
+      _zz_CsrPlugin_csrMapping_readDataInit_106[2 : 2] = CsrPlugin_mcounteren_IR;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_107 = 32'h00000000;
     if(execute_CsrPlugin_csr_3008) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_23[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
+      _zz_CsrPlugin_csrMapping_readDataInit_107[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_64;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_24 = 32'h0;
+    _zz_CsrPlugin_csrMapping_readDataInit_108 = 32'h00000000;
     if(execute_CsrPlugin_csr_4032) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_24[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_1;
+      _zz_CsrPlugin_csrMapping_readDataInit_108[31 : 0] = _zz_externalInterrupt;
     end
   end
 
-  assign CsrPlugin_csrMapping_readDataInit = (((((_zz_CsrPlugin_csrMapping_readDataInit_2 | _zz_CsrPlugin_csrMapping_readDataInit_3) | (_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5)) | ((_zz_CsrPlugin_csrMapping_readDataInit_25 | _zz_CsrPlugin_csrMapping_readDataInit_6) | (_zz_CsrPlugin_csrMapping_readDataInit_7 | _zz_CsrPlugin_csrMapping_readDataInit_8))) | (((_zz_CsrPlugin_csrMapping_readDataInit_9 | _zz_CsrPlugin_csrMapping_readDataInit_10) | (_zz_CsrPlugin_csrMapping_readDataInit_11 | _zz_CsrPlugin_csrMapping_readDataInit_12)) | ((_zz_CsrPlugin_csrMapping_readDataInit_13 | _zz_CsrPlugin_csrMapping_readDataInit_14) | (_zz_CsrPlugin_csrMapping_readDataInit_15 | _zz_CsrPlugin_csrMapping_readDataInit_16)))) | (((_zz_CsrPlugin_csrMapping_readDataInit_17 | _zz_CsrPlugin_csrMapping_readDataInit_18) | (_zz_CsrPlugin_csrMapping_readDataInit_19 | _zz_CsrPlugin_csrMapping_readDataInit_20)) | ((_zz_CsrPlugin_csrMapping_readDataInit_21 | _zz_CsrPlugin_csrMapping_readDataInit_22) | (_zz_CsrPlugin_csrMapping_readDataInit_23 | _zz_CsrPlugin_csrMapping_readDataInit_24))));
-  assign when_PmpPlugin_l155 = (CsrPlugin_privilege == 2'b11);
-  assign when_PmpPlugin_l172 = ((execute_PmpPlugin_pmpcfgCsr || execute_PmpPlugin_pmpaddrCsr) && (CsrPlugin_privilege == 2'b11));
-  assign when_PmpPlugin_l175 = ((! execute_PmpPlugin_fsmPending) && CsrPlugin_csrMapping_hazardFree);
-  assign when_CsrPlugin_l1310 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign when_CsrPlugin_l1315 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign CsrPlugin_csrMapping_readDataInit = (((((_zz_CsrPlugin_csrMapping_readDataInit_109 | _zz_CsrPlugin_csrMapping_readDataInit_110) | (_zz_CsrPlugin_csrMapping_readDataInit_111 | _zz_CsrPlugin_csrMapping_readDataInit_112)) | ((_zz_CsrPlugin_csrMapping_readDataInit_113 | _zz_CsrPlugin_csrMapping_readDataInit_114) | (_zz_CsrPlugin_csrMapping_readDataInit_115 | _zz_CsrPlugin_csrMapping_readDataInit_116))) | (((_zz_CsrPlugin_csrMapping_readDataInit_117 | _zz_CsrPlugin_csrMapping_readDataInit_118) | (_zz_CsrPlugin_csrMapping_readDataInit_119 | _zz_CsrPlugin_csrMapping_readDataInit_120)) | ((_zz_CsrPlugin_csrMapping_readDataInit_121 | _zz_CsrPlugin_csrMapping_readDataInit_123) | (_zz_CsrPlugin_csrMapping_readDataInit_124 | _zz_CsrPlugin_csrMapping_readDataInit_125)))) | ((((_zz_CsrPlugin_csrMapping_readDataInit_96 | _zz_CsrPlugin_csrMapping_readDataInit_97) | (_zz_CsrPlugin_csrMapping_readDataInit_98 | _zz_CsrPlugin_csrMapping_readDataInit_99)) | ((_zz_CsrPlugin_csrMapping_readDataInit_100 | _zz_CsrPlugin_csrMapping_readDataInit_101) | (_zz_CsrPlugin_csrMapping_readDataInit_102 | _zz_CsrPlugin_csrMapping_readDataInit_103))) | (((_zz_CsrPlugin_csrMapping_readDataInit_104 | _zz_CsrPlugin_csrMapping_readDataInit_105) | (_zz_CsrPlugin_csrMapping_readDataInit_106 | _zz_CsrPlugin_csrMapping_readDataInit_107)) | _zz_CsrPlugin_csrMapping_readDataInit_108)));
+  assign _zz_when_CsrPlugin_l1709 = (execute_CsrPlugin_csrAddress & 12'hf60);
+  assign when_CsrPlugin_l1709 = (((execute_arbitration_isValid && execute_IS_CSR) && (5'h03 <= execute_CsrPlugin_csrAddress[4 : 0])) && (((_zz_when_CsrPlugin_l1709 == 12'hb00) || (((_zz_when_CsrPlugin_l1709 == 12'hc00) && (! execute_CsrPlugin_writeInstruction)) && (CsrPlugin_privilege == 2'b11))) || ((execute_CsrPlugin_csrAddress & 12'hfe0) == 12'h320)));
+  always @(*) begin
+    when_CsrPlugin_l1719 = CsrPlugin_csrMapping_doForceFailCsr;
+    if(when_CsrPlugin_l1717) begin
+      when_CsrPlugin_l1719 = 1'b1;
+    end
+  end
+
+  assign when_CsrPlugin_l1717 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1725 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
   assign iBusWishbone_ADR = {_zz_iBusWishbone_ADR_1,_zz_iBusWishbone_ADR};
   assign iBusWishbone_CTI = ((_zz_iBusWishbone_ADR == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
@@ -7372,20 +8524,20 @@ module VexRiscv (
   assign iBus_rsp_valid = _zz_iBus_rsp_valid;
   assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
   assign iBus_rsp_payload_error = 1'b0;
-  assign _zz_dBus_cmd_ready_5 = (dBus_cmd_payload_size == 3'b101);
-  assign _zz_dBus_cmd_ready_1 = dBus_cmd_valid;
-  assign _zz_dBus_cmd_ready_3 = dBus_cmd_payload_wr;
-  assign _zz_dBus_cmd_ready_4 = ((! _zz_dBus_cmd_ready_5) || (_zz_dBus_cmd_ready == 3'b111));
-  assign dBus_cmd_ready = (_zz_dBus_cmd_ready_2 && (_zz_dBus_cmd_ready_3 || _zz_dBus_cmd_ready_4));
-  assign dBusWishbone_ADR = ((_zz_dBus_cmd_ready_5 ? {{dBus_cmd_payload_address[31 : 5],_zz_dBus_cmd_ready},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
-  assign dBusWishbone_CTI = (_zz_dBus_cmd_ready_5 ? (_zz_dBus_cmd_ready_4 ? 3'b111 : 3'b010) : 3'b000);
+  assign _zz_dBusWishbone_ADR_1 = (dBus_cmd_payload_size == 3'b101);
+  assign _zz_dBusWishbone_CYC = dBus_cmd_valid;
+  assign _zz_dBus_cmd_ready_1 = dBus_cmd_payload_wr;
+  assign _zz_dBus_cmd_ready_2 = ((! _zz_dBusWishbone_ADR_1) || (_zz_dBusWishbone_ADR == 3'b111));
+  assign dBus_cmd_ready = (_zz_dBus_cmd_ready && (_zz_dBus_cmd_ready_1 || _zz_dBus_cmd_ready_2));
+  assign dBusWishbone_ADR = ((_zz_dBusWishbone_ADR_1 ? {{dBus_cmd_payload_address[31 : 5],_zz_dBusWishbone_ADR},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2'd2);
+  assign dBusWishbone_CTI = (_zz_dBusWishbone_ADR_1 ? (_zz_dBus_cmd_ready_2 ? 3'b111 : 3'b010) : 3'b000);
   assign dBusWishbone_BTE = 2'b00;
-  assign dBusWishbone_SEL = (_zz_dBus_cmd_ready_3 ? dBus_cmd_payload_mask : 4'b1111);
-  assign dBusWishbone_WE = _zz_dBus_cmd_ready_3;
+  assign dBusWishbone_SEL = (_zz_dBus_cmd_ready_1 ? dBus_cmd_payload_mask : 4'b1111);
+  assign dBusWishbone_WE = _zz_dBus_cmd_ready_1;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_payload_data;
-  assign _zz_dBus_cmd_ready_2 = (_zz_dBus_cmd_ready_1 && dBusWishbone_ACK);
-  assign dBusWishbone_CYC = _zz_dBus_cmd_ready_1;
-  assign dBusWishbone_STB = _zz_dBus_cmd_ready_1;
+  assign _zz_dBus_cmd_ready = (_zz_dBusWishbone_CYC && dBusWishbone_ACK);
+  assign dBusWishbone_CYC = _zz_dBusWishbone_CYC;
+  assign dBusWishbone_STB = _zz_dBusWishbone_CYC;
   assign dBus_rsp_valid = _zz_dBus_rsp_valid;
   assign dBus_rsp_payload_data = dBusWishbone_DAT_MISO_regNext;
   assign dBus_rsp_payload_error = 1'b0;
@@ -7395,51 +8547,62 @@ module VexRiscv (
       IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
-      _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+      _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= 1'b0;
       _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= 32'h0;
-      dataCache_1_io_mem_cmd_rValid <= 1'b0;
-      dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= 32'h0;
-      PmpPlugin_pmpcfg_0 <= 8'h0;
-      PmpPlugin_pmpcfg_1 <= 8'h0;
-      PmpPlugin_pmpcfg_2 <= 8'h0;
-      PmpPlugin_pmpcfg_3 <= 8'h0;
-      PmpPlugin_pmpcfg_4 <= 8'h0;
-      PmpPlugin_pmpcfg_5 <= 8'h0;
-      PmpPlugin_pmpcfg_6 <= 8'h0;
-      PmpPlugin_pmpcfg_7 <= 8'h0;
-      PmpPlugin_pmpcfg_8 <= 8'h0;
-      PmpPlugin_pmpcfg_9 <= 8'h0;
-      PmpPlugin_pmpcfg_10 <= 8'h0;
-      PmpPlugin_pmpcfg_11 <= 8'h0;
-      PmpPlugin_pmpcfg_12 <= 8'h0;
-      PmpPlugin_pmpcfg_13 <= 8'h0;
-      PmpPlugin_pmpcfg_14 <= 8'h0;
-      PmpPlugin_pmpcfg_15 <= 8'h0;
-      execute_PmpPlugin_fsmPending <= 1'b0;
-      execute_PmpPlugin_pmpcfgCsr_ <= 1'b0;
-      execute_PmpPlugin_pmpaddrCsr_ <= 1'b0;
-      execute_PmpPlugin_fsm_fsmEnable <= 1'b0;
-      execute_PmpPlugin_fsm_fsmCounter <= 4'b0000;
+      IBusCachedPlugin_rspCounter <= 32'h00000000;
+      toplevel_dataCache_1_io_mem_cmd_rValidN <= 1'b1;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
+      DBusCachedPlugin_rspCounter <= 32'h00000000;
+      _zz_when_PmpPlugin_l126 <= 1'b0;
+      _zz_CsrPlugin_csrMapping_readDataInit <= 2'b00;
+      _zz_when_PmpPlugin_l126_2 <= 1'b0;
+      _zz_CsrPlugin_csrMapping_readDataInit_4 <= 2'b00;
+      _zz_when_PmpPlugin_l126_4 <= 1'b0;
+      _zz_CsrPlugin_csrMapping_readDataInit_8 <= 2'b00;
+      _zz_when_PmpPlugin_l126_6 <= 1'b0;
+      _zz_CsrPlugin_csrMapping_readDataInit_12 <= 2'b00;
+      _zz_when_PmpPlugin_l126_8 <= 1'b0;
+      _zz_CsrPlugin_csrMapping_readDataInit_16 <= 2'b00;
+      _zz_when_PmpPlugin_l126_10 <= 1'b0;
+      _zz_CsrPlugin_csrMapping_readDataInit_20 <= 2'b00;
+      _zz_when_PmpPlugin_l126_12 <= 1'b0;
+      _zz_CsrPlugin_csrMapping_readDataInit_24 <= 2'b00;
+      _zz_when_PmpPlugin_l126_14 <= 1'b0;
+      _zz_CsrPlugin_csrMapping_readDataInit_28 <= 2'b00;
+      _zz_when_PmpPlugin_l126_16 <= 1'b0;
+      _zz_CsrPlugin_csrMapping_readDataInit_32 <= 2'b00;
+      _zz_when_PmpPlugin_l126_18 <= 1'b0;
+      _zz_CsrPlugin_csrMapping_readDataInit_36 <= 2'b00;
+      _zz_when_PmpPlugin_l126_20 <= 1'b0;
+      _zz_CsrPlugin_csrMapping_readDataInit_40 <= 2'b00;
+      _zz_when_PmpPlugin_l126_22 <= 1'b0;
+      _zz_CsrPlugin_csrMapping_readDataInit_44 <= 2'b00;
+      _zz_when_PmpPlugin_l126_24 <= 1'b0;
+      _zz_CsrPlugin_csrMapping_readDataInit_48 <= 2'b00;
+      _zz_when_PmpPlugin_l126_26 <= 1'b0;
+      _zz_CsrPlugin_csrMapping_readDataInit_52 <= 2'b00;
+      _zz_when_PmpPlugin_l126_28 <= 1'b0;
+      _zz_CsrPlugin_csrMapping_readDataInit_56 <= 2'b00;
+      _zz_when_PmpPlugin_l126_30 <= 1'b0;
+      _zz_CsrPlugin_csrMapping_readDataInit_60 <= 2'b00;
       _zz_10 <= 1'b1;
       HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
       _zz_CsrPlugin_privilege <= 2'b11;
-      CsrPlugin_misa_base <= 2'b01;
-      CsrPlugin_misa_extensions <= 26'h0101064;
       CsrPlugin_mstatus_MIE <= 1'b0;
       CsrPlugin_mstatus_MPIE <= 1'b0;
       CsrPlugin_mstatus_MPP <= 2'b11;
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
-      CsrPlugin_mcycle <= 64'h0;
-      CsrPlugin_minstret <= 64'h0;
+      CsrPlugin_mcycle <= 64'h0000000000000000;
+      CsrPlugin_minstret <= 64'h0000000000000000;
+      CsrPlugin_mcounteren_IR <= 1'b1;
+      CsrPlugin_mcounteren_CY <= 1'b1;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= 1'b0;
@@ -7451,16 +8614,15 @@ module VexRiscv (
       CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
-      memory_DivPlugin_div_counter_value <= 6'h0;
-      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h0;
+      memory_DivPlugin_div_counter_value <= 6'h00;
+      _zz_CsrPlugin_csrMapping_readDataInit_64 <= 32'h00000000;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
-      switch_Fetcher_l365 <= 3'b000;
-      execute_PmpPlugin_fsm_stateReg <= execute_PmpPlugin_fsm_enumDef_BOOT;
+      IBusCachedPlugin_injector_port_state <= 3'b000;
       _zz_iBusWishbone_ADR <= 3'b000;
       _zz_iBus_rsp_valid <= 1'b0;
-      _zz_dBus_cmd_ready <= 3'b000;
+      _zz_dBusWishbone_ADR <= 3'b000;
       _zz_dBus_rsp_valid <= 1'b0;
     end else begin
       if(IBusCachedPlugin_fetchPc_correction) begin
@@ -7470,23 +8632,23 @@ module VexRiscv (
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusCachedPlugin_fetchPc_booted <= 1'b1;
-      if(when_Fetcher_l134) begin
+      if(when_Fetcher_l133) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_output_fire_1) begin
+      if(IBusCachedPlugin_fetchPc_output_fire) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b1;
       end
-      if(when_Fetcher_l134_1) begin
+      if(when_Fetcher_l133_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(when_Fetcher_l161) begin
+      if(when_Fetcher_l160) begin
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
       if(IBusCachedPlugin_iBusRsp_flush) begin
-        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= 1'b0;
       end
       if(_zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready) begin
-        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
       if(IBusCachedPlugin_iBusRsp_flush) begin
         _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
@@ -7497,13 +8659,13 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if(when_Fetcher_l332) begin
+      if(when_Fetcher_l331) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(when_Fetcher_l332_1) begin
+      if(when_Fetcher_l331_1) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= IBusCachedPlugin_injector_nextPcCalc_valids_0;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -7512,7 +8674,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(when_Fetcher_l332_2) begin
+      if(when_Fetcher_l331_2) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= IBusCachedPlugin_injector_nextPcCalc_valids_1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -7521,7 +8683,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(when_Fetcher_l332_3) begin
+      if(when_Fetcher_l331_3) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -7530,7 +8692,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if(when_Fetcher_l332_4) begin
+      if(when_Fetcher_l331_4) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= IBusCachedPlugin_injector_nextPcCalc_valids_3;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -7540,19 +8702,80 @@ module VexRiscv (
         IBusCachedPlugin_rspCounter <= (IBusCachedPlugin_rspCounter + 32'h00000001);
       end
       if(dataCache_1_io_mem_cmd_valid) begin
-        dataCache_1_io_mem_cmd_rValid <= 1'b1;
+        toplevel_dataCache_1_io_mem_cmd_rValidN <= 1'b0;
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
-        dataCache_1_io_mem_cmd_rValid <= 1'b0;
+      if(toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+        toplevel_dataCache_1_io_mem_cmd_rValidN <= 1'b1;
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
-        dataCache_1_io_mem_cmd_s2mPipe_rValid <= dataCache_1_io_mem_cmd_s2mPipe_valid;
+      if(toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+        toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_valid;
       end
       if(dBus_rsp_valid) begin
         DBusCachedPlugin_rspCounter <= (DBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      if(when_PmpPlugin_l138) begin
-        execute_PmpPlugin_fsmPending <= 1'b0;
+      if(when_PmpPlugin_l126) begin
+        _zz_when_PmpPlugin_l126 <= _zz_when_PmpPlugin_l126_1;
+        _zz_CsrPlugin_csrMapping_readDataInit <= _zz_CsrPlugin_csrMapping_readDataInit_2;
+      end
+      if(when_PmpPlugin_l126_1) begin
+        _zz_when_PmpPlugin_l126_2 <= _zz_when_PmpPlugin_l126_3;
+        _zz_CsrPlugin_csrMapping_readDataInit_4 <= _zz_CsrPlugin_csrMapping_readDataInit_6;
+      end
+      if(when_PmpPlugin_l126_2) begin
+        _zz_when_PmpPlugin_l126_4 <= _zz_when_PmpPlugin_l126_5;
+        _zz_CsrPlugin_csrMapping_readDataInit_8 <= _zz_CsrPlugin_csrMapping_readDataInit_10;
+      end
+      if(when_PmpPlugin_l126_3) begin
+        _zz_when_PmpPlugin_l126_6 <= _zz_when_PmpPlugin_l126_7;
+        _zz_CsrPlugin_csrMapping_readDataInit_12 <= _zz_CsrPlugin_csrMapping_readDataInit_14;
+      end
+      if(when_PmpPlugin_l126_4) begin
+        _zz_when_PmpPlugin_l126_8 <= _zz_when_PmpPlugin_l126_9;
+        _zz_CsrPlugin_csrMapping_readDataInit_16 <= _zz_CsrPlugin_csrMapping_readDataInit_18;
+      end
+      if(when_PmpPlugin_l126_5) begin
+        _zz_when_PmpPlugin_l126_10 <= _zz_when_PmpPlugin_l126_11;
+        _zz_CsrPlugin_csrMapping_readDataInit_20 <= _zz_CsrPlugin_csrMapping_readDataInit_22;
+      end
+      if(when_PmpPlugin_l126_6) begin
+        _zz_when_PmpPlugin_l126_12 <= _zz_when_PmpPlugin_l126_13;
+        _zz_CsrPlugin_csrMapping_readDataInit_24 <= _zz_CsrPlugin_csrMapping_readDataInit_26;
+      end
+      if(when_PmpPlugin_l126_7) begin
+        _zz_when_PmpPlugin_l126_14 <= _zz_when_PmpPlugin_l126_15;
+        _zz_CsrPlugin_csrMapping_readDataInit_28 <= _zz_CsrPlugin_csrMapping_readDataInit_30;
+      end
+      if(when_PmpPlugin_l126_8) begin
+        _zz_when_PmpPlugin_l126_16 <= _zz_when_PmpPlugin_l126_17;
+        _zz_CsrPlugin_csrMapping_readDataInit_32 <= _zz_CsrPlugin_csrMapping_readDataInit_34;
+      end
+      if(when_PmpPlugin_l126_9) begin
+        _zz_when_PmpPlugin_l126_18 <= _zz_when_PmpPlugin_l126_19;
+        _zz_CsrPlugin_csrMapping_readDataInit_36 <= _zz_CsrPlugin_csrMapping_readDataInit_38;
+      end
+      if(when_PmpPlugin_l126_10) begin
+        _zz_when_PmpPlugin_l126_20 <= _zz_when_PmpPlugin_l126_21;
+        _zz_CsrPlugin_csrMapping_readDataInit_40 <= _zz_CsrPlugin_csrMapping_readDataInit_42;
+      end
+      if(when_PmpPlugin_l126_11) begin
+        _zz_when_PmpPlugin_l126_22 <= _zz_when_PmpPlugin_l126_23;
+        _zz_CsrPlugin_csrMapping_readDataInit_44 <= _zz_CsrPlugin_csrMapping_readDataInit_46;
+      end
+      if(when_PmpPlugin_l126_12) begin
+        _zz_when_PmpPlugin_l126_24 <= _zz_when_PmpPlugin_l126_25;
+        _zz_CsrPlugin_csrMapping_readDataInit_48 <= _zz_CsrPlugin_csrMapping_readDataInit_50;
+      end
+      if(when_PmpPlugin_l126_13) begin
+        _zz_when_PmpPlugin_l126_26 <= _zz_when_PmpPlugin_l126_27;
+        _zz_CsrPlugin_csrMapping_readDataInit_52 <= _zz_CsrPlugin_csrMapping_readDataInit_54;
+      end
+      if(when_PmpPlugin_l126_14) begin
+        _zz_when_PmpPlugin_l126_28 <= _zz_when_PmpPlugin_l126_29;
+        _zz_CsrPlugin_csrMapping_readDataInit_56 <= _zz_CsrPlugin_csrMapping_readDataInit_58;
+      end
+      if(when_PmpPlugin_l126_15) begin
+        _zz_when_PmpPlugin_l126_30 <= _zz_when_PmpPlugin_l126_31;
+        _zz_CsrPlugin_csrMapping_readDataInit_60 <= _zz_CsrPlugin_csrMapping_readDataInit_62;
       end
       _zz_10 <= 1'b0;
       HazardSimplePlugin_writeBackBuffer_valid <= HazardSimplePlugin_writeBackWrites_valid;
@@ -7560,51 +8783,51 @@ module VexRiscv (
       if(writeBack_arbitration_isFiring) begin
         CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
       end
-      if(when_CsrPlugin_l922) begin
+      if(when_CsrPlugin_l1259) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if(when_CsrPlugin_l922_1) begin
+      if(when_CsrPlugin_l1259_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if(when_CsrPlugin_l922_2) begin
+      if(when_CsrPlugin_l1259_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if(when_CsrPlugin_l922_3) begin
+      if(when_CsrPlugin_l1259_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(when_CsrPlugin_l959) begin
-        if(when_CsrPlugin_l965) begin
+      if(when_CsrPlugin_l1296) begin
+        if(when_CsrPlugin_l1302) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_1) begin
+        if(when_CsrPlugin_l1302_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l965_2) begin
+        if(when_CsrPlugin_l1302_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
       CsrPlugin_lastStageWasWfi <= (writeBack_arbitration_isFiring && (writeBack_ENV_CTRL == EnvCtrlEnum_WFI));
       if(CsrPlugin_pipelineLiberator_active) begin
-        if(when_CsrPlugin_l993) begin
+        if(when_CsrPlugin_l1335) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if(when_CsrPlugin_l993_1) begin
+        if(when_CsrPlugin_l1335_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if(when_CsrPlugin_l993_2) begin
+        if(when_CsrPlugin_l1335_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(when_CsrPlugin_l998) begin
+      if(when_CsrPlugin_l1340) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
@@ -7613,20 +8836,22 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(when_CsrPlugin_l1032) begin
-        _zz_CsrPlugin_privilege <= CsrPlugin_targetPrivilege;
-        case(CsrPlugin_targetPrivilege)
-          2'b11 : begin
-            CsrPlugin_mstatus_MIE <= 1'b0;
-            CsrPlugin_mstatus_MPIE <= CsrPlugin_mstatus_MIE;
-            CsrPlugin_mstatus_MPP <= CsrPlugin_privilege;
-          end
-          default : begin
-          end
-        endcase
+      if(when_CsrPlugin_l1390) begin
+        if(when_CsrPlugin_l1398) begin
+          _zz_CsrPlugin_privilege <= CsrPlugin_targetPrivilege;
+          case(CsrPlugin_targetPrivilege)
+            2'b11 : begin
+              CsrPlugin_mstatus_MIE <= 1'b0;
+              CsrPlugin_mstatus_MPIE <= CsrPlugin_mstatus_MIE;
+              CsrPlugin_mstatus_MPP <= CsrPlugin_privilege;
+            end
+            default : begin
+            end
+          endcase
+        end
       end
-      if(when_CsrPlugin_l1077) begin
-        case(switch_CsrPlugin_l1081)
+      if(when_CsrPlugin_l1456) begin
+        case(switch_CsrPlugin_l1460)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -7637,7 +8862,7 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l965_2,{_zz_when_CsrPlugin_l965_1,_zz_when_CsrPlugin_l965}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l1302_2,{_zz_when_CsrPlugin_l1302_1,_zz_when_CsrPlugin_l1302}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
       if(when_Pipeline_l151) begin
         execute_arbitration_isValid <= 1'b0;
@@ -7657,270 +8882,34 @@ module VexRiscv (
       if(when_Pipeline_l154_2) begin
         writeBack_arbitration_isValid <= memory_arbitration_isValid;
       end
-      case(switch_Fetcher_l365)
+      case(IBusCachedPlugin_injector_port_state)
         3'b000 : begin
-          if(IBusCachedPlugin_injectionPort_valid) begin
-            switch_Fetcher_l365 <= 3'b001;
+          if(DebugPlugin_injectionPort_valid) begin
+            IBusCachedPlugin_injector_port_state <= 3'b001;
           end
         end
         3'b001 : begin
-          switch_Fetcher_l365 <= 3'b010;
+          IBusCachedPlugin_injector_port_state <= 3'b010;
         end
         3'b010 : begin
-          switch_Fetcher_l365 <= 3'b011;
+          IBusCachedPlugin_injector_port_state <= 3'b011;
         end
         3'b011 : begin
-          if(when_Fetcher_l381) begin
-            switch_Fetcher_l365 <= 3'b100;
+          if(when_Fetcher_l391) begin
+            IBusCachedPlugin_injector_port_state <= 3'b100;
           end
         end
         3'b100 : begin
-          switch_Fetcher_l365 <= 3'b000;
+          IBusCachedPlugin_injector_port_state <= 3'b000;
         end
         default : begin
         end
       endcase
-      execute_PmpPlugin_fsm_stateReg <= execute_PmpPlugin_fsm_stateNext;
-      case(execute_PmpPlugin_fsm_stateReg)
-        execute_PmpPlugin_fsm_enumDef_stateIdle : begin
-        end
-        execute_PmpPlugin_fsm_enumDef_stateWrite : begin
-          if(execute_PmpPlugin_pmpcfgCsr_) begin
-            if(when_PmpPlugin_l209) begin
-              if(_zz_11[0]) begin
-                PmpPlugin_pmpcfg_0 <= _zz_PmpPlugin_pmpcfg_0;
-              end
-              if(_zz_11[1]) begin
-                PmpPlugin_pmpcfg_1 <= _zz_PmpPlugin_pmpcfg_0;
-              end
-              if(_zz_11[2]) begin
-                PmpPlugin_pmpcfg_2 <= _zz_PmpPlugin_pmpcfg_0;
-              end
-              if(_zz_11[3]) begin
-                PmpPlugin_pmpcfg_3 <= _zz_PmpPlugin_pmpcfg_0;
-              end
-              if(_zz_11[4]) begin
-                PmpPlugin_pmpcfg_4 <= _zz_PmpPlugin_pmpcfg_0;
-              end
-              if(_zz_11[5]) begin
-                PmpPlugin_pmpcfg_5 <= _zz_PmpPlugin_pmpcfg_0;
-              end
-              if(_zz_11[6]) begin
-                PmpPlugin_pmpcfg_6 <= _zz_PmpPlugin_pmpcfg_0;
-              end
-              if(_zz_11[7]) begin
-                PmpPlugin_pmpcfg_7 <= _zz_PmpPlugin_pmpcfg_0;
-              end
-              if(_zz_11[8]) begin
-                PmpPlugin_pmpcfg_8 <= _zz_PmpPlugin_pmpcfg_0;
-              end
-              if(_zz_11[9]) begin
-                PmpPlugin_pmpcfg_9 <= _zz_PmpPlugin_pmpcfg_0;
-              end
-              if(_zz_11[10]) begin
-                PmpPlugin_pmpcfg_10 <= _zz_PmpPlugin_pmpcfg_0;
-              end
-              if(_zz_11[11]) begin
-                PmpPlugin_pmpcfg_11 <= _zz_PmpPlugin_pmpcfg_0;
-              end
-              if(_zz_11[12]) begin
-                PmpPlugin_pmpcfg_12 <= _zz_PmpPlugin_pmpcfg_0;
-              end
-              if(_zz_11[13]) begin
-                PmpPlugin_pmpcfg_13 <= _zz_PmpPlugin_pmpcfg_0;
-              end
-              if(_zz_11[14]) begin
-                PmpPlugin_pmpcfg_14 <= _zz_PmpPlugin_pmpcfg_0;
-              end
-              if(_zz_11[15]) begin
-                PmpPlugin_pmpcfg_15 <= _zz_PmpPlugin_pmpcfg_0;
-              end
-            end
-            if(when_PmpPlugin_l209_1) begin
-              if(_zz_12[0]) begin
-                PmpPlugin_pmpcfg_0 <= _zz_PmpPlugin_pmpcfg_0_1;
-              end
-              if(_zz_12[1]) begin
-                PmpPlugin_pmpcfg_1 <= _zz_PmpPlugin_pmpcfg_0_1;
-              end
-              if(_zz_12[2]) begin
-                PmpPlugin_pmpcfg_2 <= _zz_PmpPlugin_pmpcfg_0_1;
-              end
-              if(_zz_12[3]) begin
-                PmpPlugin_pmpcfg_3 <= _zz_PmpPlugin_pmpcfg_0_1;
-              end
-              if(_zz_12[4]) begin
-                PmpPlugin_pmpcfg_4 <= _zz_PmpPlugin_pmpcfg_0_1;
-              end
-              if(_zz_12[5]) begin
-                PmpPlugin_pmpcfg_5 <= _zz_PmpPlugin_pmpcfg_0_1;
-              end
-              if(_zz_12[6]) begin
-                PmpPlugin_pmpcfg_6 <= _zz_PmpPlugin_pmpcfg_0_1;
-              end
-              if(_zz_12[7]) begin
-                PmpPlugin_pmpcfg_7 <= _zz_PmpPlugin_pmpcfg_0_1;
-              end
-              if(_zz_12[8]) begin
-                PmpPlugin_pmpcfg_8 <= _zz_PmpPlugin_pmpcfg_0_1;
-              end
-              if(_zz_12[9]) begin
-                PmpPlugin_pmpcfg_9 <= _zz_PmpPlugin_pmpcfg_0_1;
-              end
-              if(_zz_12[10]) begin
-                PmpPlugin_pmpcfg_10 <= _zz_PmpPlugin_pmpcfg_0_1;
-              end
-              if(_zz_12[11]) begin
-                PmpPlugin_pmpcfg_11 <= _zz_PmpPlugin_pmpcfg_0_1;
-              end
-              if(_zz_12[12]) begin
-                PmpPlugin_pmpcfg_12 <= _zz_PmpPlugin_pmpcfg_0_1;
-              end
-              if(_zz_12[13]) begin
-                PmpPlugin_pmpcfg_13 <= _zz_PmpPlugin_pmpcfg_0_1;
-              end
-              if(_zz_12[14]) begin
-                PmpPlugin_pmpcfg_14 <= _zz_PmpPlugin_pmpcfg_0_1;
-              end
-              if(_zz_12[15]) begin
-                PmpPlugin_pmpcfg_15 <= _zz_PmpPlugin_pmpcfg_0_1;
-              end
-            end
-            if(when_PmpPlugin_l209_2) begin
-              if(_zz_13[0]) begin
-                PmpPlugin_pmpcfg_0 <= _zz_PmpPlugin_pmpcfg_0_2;
-              end
-              if(_zz_13[1]) begin
-                PmpPlugin_pmpcfg_1 <= _zz_PmpPlugin_pmpcfg_0_2;
-              end
-              if(_zz_13[2]) begin
-                PmpPlugin_pmpcfg_2 <= _zz_PmpPlugin_pmpcfg_0_2;
-              end
-              if(_zz_13[3]) begin
-                PmpPlugin_pmpcfg_3 <= _zz_PmpPlugin_pmpcfg_0_2;
-              end
-              if(_zz_13[4]) begin
-                PmpPlugin_pmpcfg_4 <= _zz_PmpPlugin_pmpcfg_0_2;
-              end
-              if(_zz_13[5]) begin
-                PmpPlugin_pmpcfg_5 <= _zz_PmpPlugin_pmpcfg_0_2;
-              end
-              if(_zz_13[6]) begin
-                PmpPlugin_pmpcfg_6 <= _zz_PmpPlugin_pmpcfg_0_2;
-              end
-              if(_zz_13[7]) begin
-                PmpPlugin_pmpcfg_7 <= _zz_PmpPlugin_pmpcfg_0_2;
-              end
-              if(_zz_13[8]) begin
-                PmpPlugin_pmpcfg_8 <= _zz_PmpPlugin_pmpcfg_0_2;
-              end
-              if(_zz_13[9]) begin
-                PmpPlugin_pmpcfg_9 <= _zz_PmpPlugin_pmpcfg_0_2;
-              end
-              if(_zz_13[10]) begin
-                PmpPlugin_pmpcfg_10 <= _zz_PmpPlugin_pmpcfg_0_2;
-              end
-              if(_zz_13[11]) begin
-                PmpPlugin_pmpcfg_11 <= _zz_PmpPlugin_pmpcfg_0_2;
-              end
-              if(_zz_13[12]) begin
-                PmpPlugin_pmpcfg_12 <= _zz_PmpPlugin_pmpcfg_0_2;
-              end
-              if(_zz_13[13]) begin
-                PmpPlugin_pmpcfg_13 <= _zz_PmpPlugin_pmpcfg_0_2;
-              end
-              if(_zz_13[14]) begin
-                PmpPlugin_pmpcfg_14 <= _zz_PmpPlugin_pmpcfg_0_2;
-              end
-              if(_zz_13[15]) begin
-                PmpPlugin_pmpcfg_15 <= _zz_PmpPlugin_pmpcfg_0_2;
-              end
-            end
-            if(when_PmpPlugin_l209_3) begin
-              if(_zz_14[0]) begin
-                PmpPlugin_pmpcfg_0 <= _zz_PmpPlugin_pmpcfg_0_3;
-              end
-              if(_zz_14[1]) begin
-                PmpPlugin_pmpcfg_1 <= _zz_PmpPlugin_pmpcfg_0_3;
-              end
-              if(_zz_14[2]) begin
-                PmpPlugin_pmpcfg_2 <= _zz_PmpPlugin_pmpcfg_0_3;
-              end
-              if(_zz_14[3]) begin
-                PmpPlugin_pmpcfg_3 <= _zz_PmpPlugin_pmpcfg_0_3;
-              end
-              if(_zz_14[4]) begin
-                PmpPlugin_pmpcfg_4 <= _zz_PmpPlugin_pmpcfg_0_3;
-              end
-              if(_zz_14[5]) begin
-                PmpPlugin_pmpcfg_5 <= _zz_PmpPlugin_pmpcfg_0_3;
-              end
-              if(_zz_14[6]) begin
-                PmpPlugin_pmpcfg_6 <= _zz_PmpPlugin_pmpcfg_0_3;
-              end
-              if(_zz_14[7]) begin
-                PmpPlugin_pmpcfg_7 <= _zz_PmpPlugin_pmpcfg_0_3;
-              end
-              if(_zz_14[8]) begin
-                PmpPlugin_pmpcfg_8 <= _zz_PmpPlugin_pmpcfg_0_3;
-              end
-              if(_zz_14[9]) begin
-                PmpPlugin_pmpcfg_9 <= _zz_PmpPlugin_pmpcfg_0_3;
-              end
-              if(_zz_14[10]) begin
-                PmpPlugin_pmpcfg_10 <= _zz_PmpPlugin_pmpcfg_0_3;
-              end
-              if(_zz_14[11]) begin
-                PmpPlugin_pmpcfg_11 <= _zz_PmpPlugin_pmpcfg_0_3;
-              end
-              if(_zz_14[12]) begin
-                PmpPlugin_pmpcfg_12 <= _zz_PmpPlugin_pmpcfg_0_3;
-              end
-              if(_zz_14[13]) begin
-                PmpPlugin_pmpcfg_13 <= _zz_PmpPlugin_pmpcfg_0_3;
-              end
-              if(_zz_14[14]) begin
-                PmpPlugin_pmpcfg_14 <= _zz_PmpPlugin_pmpcfg_0_3;
-              end
-              if(_zz_14[15]) begin
-                PmpPlugin_pmpcfg_15 <= _zz_PmpPlugin_pmpcfg_0_3;
-              end
-            end
-          end
-        end
-        execute_PmpPlugin_fsm_enumDef_stateCfg : begin
-          execute_PmpPlugin_fsm_fsmCounter <= (execute_PmpPlugin_fsm_fsmCounter + 4'b0001);
-        end
-        execute_PmpPlugin_fsm_enumDef_stateAddr : begin
-        end
-        default : begin
-        end
-      endcase
-      if(when_StateMachine_l233) begin
-        execute_PmpPlugin_fsm_fsmEnable <= 1'b1;
-      end
-      if(when_StateMachine_l249) begin
-        execute_PmpPlugin_fsmPending <= 1'b0;
-        execute_PmpPlugin_fsm_fsmEnable <= 1'b0;
-        execute_PmpPlugin_fsm_fsmCounter <= 4'b0000;
-      end
-      if(when_StateMachine_l249_1) begin
-        execute_PmpPlugin_fsm_fsmCounter <= {execute_PmpPlugin_pmpcfgN_,2'b00};
-      end
-      if(when_StateMachine_l249_2) begin
-        execute_PmpPlugin_fsm_fsmCounter <= execute_PmpPlugin_pmpNcfg_;
-      end
-      if(execute_CsrPlugin_csr_769) begin
-        if(execute_CsrPlugin_writeEnable) begin
-          CsrPlugin_misa_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 30];
-          CsrPlugin_misa_extensions <= CsrPlugin_csrMapping_writeDataSignal[25 : 0];
-        end
-      end
       if(execute_CsrPlugin_csr_768) begin
         if(execute_CsrPlugin_writeEnable) begin
           CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
           CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
-          case(switch_CsrPlugin_l723)
+          case(switch_CsrPlugin_l1031)
             2'b11 : begin
               CsrPlugin_mstatus_MPP <= 2'b11;
             end
@@ -7959,18 +8948,15 @@ module VexRiscv (
           CsrPlugin_minstret[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
         end
       end
-      if(execute_CsrPlugin_csr_3008) begin
+      if(execute_CsrPlugin_csr_774) begin
         if(execute_CsrPlugin_writeEnable) begin
-          _zz_CsrPlugin_csrMapping_readDataInit <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+          CsrPlugin_mcounteren_CY <= CsrPlugin_csrMapping_writeDataSignal[0];
+          CsrPlugin_mcounteren_IR <= CsrPlugin_csrMapping_writeDataSignal[2];
         end
       end
-      if(execute_CsrPlugin_writeInstruction) begin
-        if(when_PmpPlugin_l172) begin
-          if(when_PmpPlugin_l175) begin
-            execute_PmpPlugin_fsmPending <= 1'b1;
-            execute_PmpPlugin_pmpcfgCsr_ <= execute_PmpPlugin_pmpcfgCsr;
-            execute_PmpPlugin_pmpaddrCsr_ <= execute_PmpPlugin_pmpaddrCsr;
-          end
+      if(execute_CsrPlugin_csr_3008) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          _zz_CsrPlugin_csrMapping_readDataInit_64 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
         end
       end
       if(when_InstructionCache_l239) begin
@@ -7979,13 +8965,13 @@ module VexRiscv (
         end
       end
       _zz_iBus_rsp_valid <= (iBusWishbone_CYC && iBusWishbone_ACK);
-      if((_zz_dBus_cmd_ready_1 && _zz_dBus_cmd_ready_2)) begin
-        _zz_dBus_cmd_ready <= (_zz_dBus_cmd_ready + 3'b001);
-        if(_zz_dBus_cmd_ready_4) begin
-          _zz_dBus_cmd_ready <= 3'b000;
+      if((_zz_dBusWishbone_CYC && _zz_dBus_cmd_ready)) begin
+        _zz_dBusWishbone_ADR <= (_zz_dBusWishbone_ADR + 3'b001);
+        if(_zz_dBus_cmd_ready_2) begin
+          _zz_dBusWishbone_ADR <= 3'b000;
         end
       end
-      _zz_dBus_rsp_valid <= ((_zz_dBus_cmd_ready_1 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
+      _zz_dBus_rsp_valid <= ((_zz_dBusWishbone_CYC && (! dBusWishbone_WE)) && dBusWishbone_ACK);
     end
   end
 
@@ -7999,121 +8985,119 @@ module VexRiscv (
     if(IBusCachedPlugin_iBusRsp_stages_2_input_ready) begin
       IBusCachedPlugin_s2_tightlyCoupledHit <= IBusCachedPlugin_s1_tightlyCoupledHit;
     end
-    if(dataCache_1_io_mem_cmd_ready) begin
-      dataCache_1_io_mem_cmd_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
-      dataCache_1_io_mem_cmd_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
-      dataCache_1_io_mem_cmd_rData_address <= dataCache_1_io_mem_cmd_payload_address;
-      dataCache_1_io_mem_cmd_rData_data <= dataCache_1_io_mem_cmd_payload_data;
-      dataCache_1_io_mem_cmd_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
-      dataCache_1_io_mem_cmd_rData_size <= dataCache_1_io_mem_cmd_payload_size;
-      dataCache_1_io_mem_cmd_rData_last <= dataCache_1_io_mem_cmd_payload_last;
+    if(toplevel_dataCache_1_io_mem_cmd_rValidN) begin
+      toplevel_dataCache_1_io_mem_cmd_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
+      toplevel_dataCache_1_io_mem_cmd_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
+      toplevel_dataCache_1_io_mem_cmd_rData_address <= dataCache_1_io_mem_cmd_payload_address;
+      toplevel_dataCache_1_io_mem_cmd_rData_data <= dataCache_1_io_mem_cmd_payload_data;
+      toplevel_dataCache_1_io_mem_cmd_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
+      toplevel_dataCache_1_io_mem_cmd_rData_size <= dataCache_1_io_mem_cmd_payload_size;
+      toplevel_dataCache_1_io_mem_cmd_rData_last <= dataCache_1_io_mem_cmd_payload_last;
     end
-    if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
-      dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_address <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_data <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_size <= dataCache_1_io_mem_cmd_s2mPipe_payload_size;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_last <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+    if(toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_address <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_data <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_size <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_size;
+      toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_last <= toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_last;
     end
-    if(when_PmpPlugin_l246) begin
-      if(_zz_8[0]) begin
-        PmpPlugin_base_0 <= PmpPlugin_setter_io_base;
-      end
-      if(_zz_8[1]) begin
-        PmpPlugin_base_1 <= PmpPlugin_setter_io_base;
-      end
-      if(_zz_8[2]) begin
-        PmpPlugin_base_2 <= PmpPlugin_setter_io_base;
-      end
-      if(_zz_8[3]) begin
-        PmpPlugin_base_3 <= PmpPlugin_setter_io_base;
-      end
-      if(_zz_8[4]) begin
-        PmpPlugin_base_4 <= PmpPlugin_setter_io_base;
-      end
-      if(_zz_8[5]) begin
-        PmpPlugin_base_5 <= PmpPlugin_setter_io_base;
-      end
-      if(_zz_8[6]) begin
-        PmpPlugin_base_6 <= PmpPlugin_setter_io_base;
-      end
-      if(_zz_8[7]) begin
-        PmpPlugin_base_7 <= PmpPlugin_setter_io_base;
-      end
-      if(_zz_8[8]) begin
-        PmpPlugin_base_8 <= PmpPlugin_setter_io_base;
-      end
-      if(_zz_8[9]) begin
-        PmpPlugin_base_9 <= PmpPlugin_setter_io_base;
-      end
-      if(_zz_8[10]) begin
-        PmpPlugin_base_10 <= PmpPlugin_setter_io_base;
-      end
-      if(_zz_8[11]) begin
-        PmpPlugin_base_11 <= PmpPlugin_setter_io_base;
-      end
-      if(_zz_8[12]) begin
-        PmpPlugin_base_12 <= PmpPlugin_setter_io_base;
-      end
-      if(_zz_8[13]) begin
-        PmpPlugin_base_13 <= PmpPlugin_setter_io_base;
-      end
-      if(_zz_8[14]) begin
-        PmpPlugin_base_14 <= PmpPlugin_setter_io_base;
-      end
-      if(_zz_8[15]) begin
-        PmpPlugin_base_15 <= PmpPlugin_setter_io_base;
-      end
-      if(_zz_9[0]) begin
-        PmpPlugin_mask_0 <= PmpPlugin_setter_io_mask;
-      end
-      if(_zz_9[1]) begin
-        PmpPlugin_mask_1 <= PmpPlugin_setter_io_mask;
-      end
-      if(_zz_9[2]) begin
-        PmpPlugin_mask_2 <= PmpPlugin_setter_io_mask;
-      end
-      if(_zz_9[3]) begin
-        PmpPlugin_mask_3 <= PmpPlugin_setter_io_mask;
-      end
-      if(_zz_9[4]) begin
-        PmpPlugin_mask_4 <= PmpPlugin_setter_io_mask;
-      end
-      if(_zz_9[5]) begin
-        PmpPlugin_mask_5 <= PmpPlugin_setter_io_mask;
-      end
-      if(_zz_9[6]) begin
-        PmpPlugin_mask_6 <= PmpPlugin_setter_io_mask;
-      end
-      if(_zz_9[7]) begin
-        PmpPlugin_mask_7 <= PmpPlugin_setter_io_mask;
-      end
-      if(_zz_9[8]) begin
-        PmpPlugin_mask_8 <= PmpPlugin_setter_io_mask;
-      end
-      if(_zz_9[9]) begin
-        PmpPlugin_mask_9 <= PmpPlugin_setter_io_mask;
-      end
-      if(_zz_9[10]) begin
-        PmpPlugin_mask_10 <= PmpPlugin_setter_io_mask;
-      end
-      if(_zz_9[11]) begin
-        PmpPlugin_mask_11 <= PmpPlugin_setter_io_mask;
-      end
-      if(_zz_9[12]) begin
-        PmpPlugin_mask_12 <= PmpPlugin_setter_io_mask;
-      end
-      if(_zz_9[13]) begin
-        PmpPlugin_mask_13 <= PmpPlugin_setter_io_mask;
-      end
-      if(_zz_9[14]) begin
-        PmpPlugin_mask_14 <= PmpPlugin_setter_io_mask;
-      end
-      if(_zz_9[15]) begin
-        PmpPlugin_mask_15 <= PmpPlugin_setter_io_mask;
-      end
+    if(when_PmpPlugin_l126) begin
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowRead <= _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_1;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite <= _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_1;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute <= _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1;
+      _zz_CsrPlugin_csrMapping_readDataInit_1 <= _zz_CsrPlugin_csrMapping_readDataInit_3;
+    end
+    if(when_PmpPlugin_l126_1) begin
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_2 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_3;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_2 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_3;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_2 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_3;
+      _zz_CsrPlugin_csrMapping_readDataInit_5 <= _zz_CsrPlugin_csrMapping_readDataInit_7;
+    end
+    if(when_PmpPlugin_l126_2) begin
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_4 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_5;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_4 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_5;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_4 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_5;
+      _zz_CsrPlugin_csrMapping_readDataInit_9 <= _zz_CsrPlugin_csrMapping_readDataInit_11;
+    end
+    if(when_PmpPlugin_l126_3) begin
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_6 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_7;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_6 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_7;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_6 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_7;
+      _zz_CsrPlugin_csrMapping_readDataInit_13 <= _zz_CsrPlugin_csrMapping_readDataInit_15;
+    end
+    if(when_PmpPlugin_l126_4) begin
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_8 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_9;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_8 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_9;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_8 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_9;
+      _zz_CsrPlugin_csrMapping_readDataInit_17 <= _zz_CsrPlugin_csrMapping_readDataInit_19;
+    end
+    if(when_PmpPlugin_l126_5) begin
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_10 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_11;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_10 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_11;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_10 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_11;
+      _zz_CsrPlugin_csrMapping_readDataInit_21 <= _zz_CsrPlugin_csrMapping_readDataInit_23;
+    end
+    if(when_PmpPlugin_l126_6) begin
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_12 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_13;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_12 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_13;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_12 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_13;
+      _zz_CsrPlugin_csrMapping_readDataInit_25 <= _zz_CsrPlugin_csrMapping_readDataInit_27;
+    end
+    if(when_PmpPlugin_l126_7) begin
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_14 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_15;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_14 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_15;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_14 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_15;
+      _zz_CsrPlugin_csrMapping_readDataInit_29 <= _zz_CsrPlugin_csrMapping_readDataInit_31;
+    end
+    if(when_PmpPlugin_l126_8) begin
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_16 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_17;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_16 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_17;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_16 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_17;
+      _zz_CsrPlugin_csrMapping_readDataInit_33 <= _zz_CsrPlugin_csrMapping_readDataInit_35;
+    end
+    if(when_PmpPlugin_l126_9) begin
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_18 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_19;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_18 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_19;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_18 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_19;
+      _zz_CsrPlugin_csrMapping_readDataInit_37 <= _zz_CsrPlugin_csrMapping_readDataInit_39;
+    end
+    if(when_PmpPlugin_l126_10) begin
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_20 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_21;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_20 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_21;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_20 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_21;
+      _zz_CsrPlugin_csrMapping_readDataInit_41 <= _zz_CsrPlugin_csrMapping_readDataInit_43;
+    end
+    if(when_PmpPlugin_l126_11) begin
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_22 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_23;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_22 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_23;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_22 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_23;
+      _zz_CsrPlugin_csrMapping_readDataInit_45 <= _zz_CsrPlugin_csrMapping_readDataInit_47;
+    end
+    if(when_PmpPlugin_l126_12) begin
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_24 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_25;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_24 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_25;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_24 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_25;
+      _zz_CsrPlugin_csrMapping_readDataInit_49 <= _zz_CsrPlugin_csrMapping_readDataInit_51;
+    end
+    if(when_PmpPlugin_l126_13) begin
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_26 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_27;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_26 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_27;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_26 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_27;
+      _zz_CsrPlugin_csrMapping_readDataInit_53 <= _zz_CsrPlugin_csrMapping_readDataInit_55;
+    end
+    if(when_PmpPlugin_l126_14) begin
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_28 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_29;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_28 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_29;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_28 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_29;
+      _zz_CsrPlugin_csrMapping_readDataInit_57 <= _zz_CsrPlugin_csrMapping_readDataInit_59;
+    end
+    if(when_PmpPlugin_l126_15) begin
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_30 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowRead_31;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_30 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowWrite_31;
+      _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_30 <= _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_31;
+      _zz_CsrPlugin_csrMapping_readDataInit_61 <= _zz_CsrPlugin_csrMapping_readDataInit_63;
     end
     HazardSimplePlugin_writeBackBuffer_payload_address <= HazardSimplePlugin_writeBackWrites_payload_address;
     HazardSimplePlugin_writeBackBuffer_payload_data <= HazardSimplePlugin_writeBackWrites_payload_data;
@@ -8136,33 +9120,35 @@ module VexRiscv (
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(when_CsrPlugin_l959) begin
-      if(when_CsrPlugin_l965) begin
+    if(when_CsrPlugin_l1296) begin
+      if(when_CsrPlugin_l1302) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l965_1) begin
+      if(when_CsrPlugin_l1302_1) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l965_2) begin
+      if(when_CsrPlugin_l1302_2) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(when_CsrPlugin_l1032) begin
-      case(CsrPlugin_targetPrivilege)
-        2'b11 : begin
-          CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
-          CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
-          CsrPlugin_mepc <= writeBack_PC;
-          if(CsrPlugin_hadException) begin
-            CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
+    if(when_CsrPlugin_l1390) begin
+      if(when_CsrPlugin_l1398) begin
+        case(CsrPlugin_targetPrivilege)
+          2'b11 : begin
+            CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
+            CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
+            CsrPlugin_mepc <= writeBack_PC;
+            if(CsrPlugin_hadException) begin
+              CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
+            end
           end
-        end
-        default : begin
-        end
-      endcase
+          default : begin
+          end
+        endcase
+      end
     end
     if(when_MulDivIterativePlugin_l126) begin
       memory_DivPlugin_div_done <= 1'b1;
@@ -8180,17 +9166,17 @@ module VexRiscv (
       end
     end
     if(when_MulDivIterativePlugin_l162) begin
-      memory_DivPlugin_accumulator <= 65'h0;
+      memory_DivPlugin_accumulator <= 65'h00000000000000000;
       memory_DivPlugin_rs1 <= ((_zz_memory_DivPlugin_rs1 ? (~ _zz_memory_DivPlugin_rs1_1) : _zz_memory_DivPlugin_rs1_1) + _zz_memory_DivPlugin_rs1_2);
       memory_DivPlugin_rs2 <= ((_zz_memory_DivPlugin_rs2 ? (~ execute_RS2) : execute_RS2) + _zz_memory_DivPlugin_rs2_1);
-      memory_DivPlugin_div_needRevert <= ((_zz_memory_DivPlugin_rs1 ^ (_zz_memory_DivPlugin_rs2 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
+      memory_DivPlugin_div_needRevert <= ((_zz_memory_DivPlugin_rs1 ^ (_zz_memory_DivPlugin_rs2 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h00000000) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
     end
     externalInterruptArray_regNext <= externalInterruptArray;
     if(when_Pipeline_l124) begin
       decode_to_execute_PC <= decode_PC;
     end
     if(when_Pipeline_l124_1) begin
-      execute_to_memory_PC <= _zz_execute_SRC2;
+      execute_to_memory_PC <= _zz_execute_to_memory_PC;
     end
     if(when_Pipeline_l124_2) begin
       memory_to_writeBack_PC <= memory_PC;
@@ -8375,76 +9361,139 @@ module VexRiscv (
     if(when_Pipeline_l124_62) begin
       memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
     end
-    if(when_CsrPlugin_l1277) begin
+    if(when_CsrPlugin_l1669) begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
     end
-    if(when_CsrPlugin_l1277_1) begin
+    if(when_CsrPlugin_l1669_1) begin
+      execute_CsrPlugin_csr_944 <= (decode_INSTRUCTION[31 : 20] == 12'h3b0);
+    end
+    if(when_CsrPlugin_l1669_2) begin
+      execute_CsrPlugin_csr_945 <= (decode_INSTRUCTION[31 : 20] == 12'h3b1);
+    end
+    if(when_CsrPlugin_l1669_3) begin
+      execute_CsrPlugin_csr_946 <= (decode_INSTRUCTION[31 : 20] == 12'h3b2);
+    end
+    if(when_CsrPlugin_l1669_4) begin
+      execute_CsrPlugin_csr_947 <= (decode_INSTRUCTION[31 : 20] == 12'h3b3);
+    end
+    if(when_CsrPlugin_l1669_5) begin
+      execute_CsrPlugin_csr_948 <= (decode_INSTRUCTION[31 : 20] == 12'h3b4);
+    end
+    if(when_CsrPlugin_l1669_6) begin
+      execute_CsrPlugin_csr_949 <= (decode_INSTRUCTION[31 : 20] == 12'h3b5);
+    end
+    if(when_CsrPlugin_l1669_7) begin
+      execute_CsrPlugin_csr_950 <= (decode_INSTRUCTION[31 : 20] == 12'h3b6);
+    end
+    if(when_CsrPlugin_l1669_8) begin
+      execute_CsrPlugin_csr_951 <= (decode_INSTRUCTION[31 : 20] == 12'h3b7);
+    end
+    if(when_CsrPlugin_l1669_9) begin
+      execute_CsrPlugin_csr_952 <= (decode_INSTRUCTION[31 : 20] == 12'h3b8);
+    end
+    if(when_CsrPlugin_l1669_10) begin
+      execute_CsrPlugin_csr_953 <= (decode_INSTRUCTION[31 : 20] == 12'h3b9);
+    end
+    if(when_CsrPlugin_l1669_11) begin
+      execute_CsrPlugin_csr_954 <= (decode_INSTRUCTION[31 : 20] == 12'h3ba);
+    end
+    if(when_CsrPlugin_l1669_12) begin
+      execute_CsrPlugin_csr_955 <= (decode_INSTRUCTION[31 : 20] == 12'h3bb);
+    end
+    if(when_CsrPlugin_l1669_13) begin
+      execute_CsrPlugin_csr_956 <= (decode_INSTRUCTION[31 : 20] == 12'h3bc);
+    end
+    if(when_CsrPlugin_l1669_14) begin
+      execute_CsrPlugin_csr_957 <= (decode_INSTRUCTION[31 : 20] == 12'h3bd);
+    end
+    if(when_CsrPlugin_l1669_15) begin
+      execute_CsrPlugin_csr_958 <= (decode_INSTRUCTION[31 : 20] == 12'h3be);
+    end
+    if(when_CsrPlugin_l1669_16) begin
+      execute_CsrPlugin_csr_959 <= (decode_INSTRUCTION[31 : 20] == 12'h3bf);
+    end
+    if(when_CsrPlugin_l1669_17) begin
+      execute_CsrPlugin_csr_928 <= (decode_INSTRUCTION[31 : 20] == 12'h3a0);
+    end
+    if(when_CsrPlugin_l1669_18) begin
+      execute_CsrPlugin_csr_929 <= (decode_INSTRUCTION[31 : 20] == 12'h3a1);
+    end
+    if(when_CsrPlugin_l1669_19) begin
+      execute_CsrPlugin_csr_930 <= (decode_INSTRUCTION[31 : 20] == 12'h3a2);
+    end
+    if(when_CsrPlugin_l1669_20) begin
+      execute_CsrPlugin_csr_931 <= (decode_INSTRUCTION[31 : 20] == 12'h3a3);
+    end
+    if(when_CsrPlugin_l1669_21) begin
       execute_CsrPlugin_csr_3857 <= (decode_INSTRUCTION[31 : 20] == 12'hf11);
     end
-    if(when_CsrPlugin_l1277_2) begin
+    if(when_CsrPlugin_l1669_22) begin
       execute_CsrPlugin_csr_3858 <= (decode_INSTRUCTION[31 : 20] == 12'hf12);
     end
-    if(when_CsrPlugin_l1277_3) begin
+    if(when_CsrPlugin_l1669_23) begin
       execute_CsrPlugin_csr_3859 <= (decode_INSTRUCTION[31 : 20] == 12'hf13);
     end
-    if(when_CsrPlugin_l1277_4) begin
+    if(when_CsrPlugin_l1669_24) begin
       execute_CsrPlugin_csr_3860 <= (decode_INSTRUCTION[31 : 20] == 12'hf14);
     end
-    if(when_CsrPlugin_l1277_5) begin
+    if(when_CsrPlugin_l1669_25) begin
       execute_CsrPlugin_csr_769 <= (decode_INSTRUCTION[31 : 20] == 12'h301);
     end
-    if(when_CsrPlugin_l1277_6) begin
+    if(when_CsrPlugin_l1669_26) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if(when_CsrPlugin_l1277_7) begin
+    if(when_CsrPlugin_l1669_27) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if(when_CsrPlugin_l1277_8) begin
+    if(when_CsrPlugin_l1669_28) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if(when_CsrPlugin_l1277_9) begin
+    if(when_CsrPlugin_l1669_29) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if(when_CsrPlugin_l1277_10) begin
+    if(when_CsrPlugin_l1669_30) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if(when_CsrPlugin_l1277_11) begin
+    if(when_CsrPlugin_l1669_31) begin
       execute_CsrPlugin_csr_832 <= (decode_INSTRUCTION[31 : 20] == 12'h340);
     end
-    if(when_CsrPlugin_l1277_12) begin
+    if(when_CsrPlugin_l1669_32) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if(when_CsrPlugin_l1277_13) begin
+    if(when_CsrPlugin_l1669_33) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if(when_CsrPlugin_l1277_14) begin
+    if(when_CsrPlugin_l1669_34) begin
       execute_CsrPlugin_csr_2816 <= (decode_INSTRUCTION[31 : 20] == 12'hb00);
     end
-    if(when_CsrPlugin_l1277_15) begin
+    if(when_CsrPlugin_l1669_35) begin
       execute_CsrPlugin_csr_2944 <= (decode_INSTRUCTION[31 : 20] == 12'hb80);
     end
-    if(when_CsrPlugin_l1277_16) begin
+    if(when_CsrPlugin_l1669_36) begin
       execute_CsrPlugin_csr_2818 <= (decode_INSTRUCTION[31 : 20] == 12'hb02);
     end
-    if(when_CsrPlugin_l1277_17) begin
+    if(when_CsrPlugin_l1669_37) begin
       execute_CsrPlugin_csr_2946 <= (decode_INSTRUCTION[31 : 20] == 12'hb82);
     end
-    if(when_CsrPlugin_l1277_18) begin
+    if(when_CsrPlugin_l1669_38) begin
       execute_CsrPlugin_csr_3072 <= (decode_INSTRUCTION[31 : 20] == 12'hc00);
     end
-    if(when_CsrPlugin_l1277_19) begin
+    if(when_CsrPlugin_l1669_39) begin
       execute_CsrPlugin_csr_3200 <= (decode_INSTRUCTION[31 : 20] == 12'hc80);
     end
-    if(when_CsrPlugin_l1277_20) begin
+    if(when_CsrPlugin_l1669_40) begin
       execute_CsrPlugin_csr_3074 <= (decode_INSTRUCTION[31 : 20] == 12'hc02);
     end
-    if(when_CsrPlugin_l1277_21) begin
+    if(when_CsrPlugin_l1669_41) begin
       execute_CsrPlugin_csr_3202 <= (decode_INSTRUCTION[31 : 20] == 12'hc82);
     end
-    if(when_CsrPlugin_l1277_22) begin
+    if(when_CsrPlugin_l1669_42) begin
+      execute_CsrPlugin_csr_774 <= (decode_INSTRUCTION[31 : 20] == 12'h306);
+    end
+    if(when_CsrPlugin_l1669_43) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if(when_CsrPlugin_l1277_23) begin
+    if(when_CsrPlugin_l1669_44) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
     if(execute_CsrPlugin_csr_836) begin
@@ -8455,7 +9504,6 @@ module VexRiscv (
     if(execute_CsrPlugin_csr_773) begin
       if(execute_CsrPlugin_writeEnable) begin
         CsrPlugin_mtvec_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 2];
-        CsrPlugin_mtvec_mode <= CsrPlugin_csrMapping_writeDataSignal[1 : 0];
       end
     end
     if(execute_CsrPlugin_csr_833) begin
@@ -8479,15 +9527,6 @@ module VexRiscv (
         CsrPlugin_mtval <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_writeInstruction) begin
-      if(when_PmpPlugin_l172) begin
-        if(when_PmpPlugin_l175) begin
-          execute_PmpPlugin_writeData_ <= CsrPlugin_csrMapping_writeDataSignal;
-          execute_PmpPlugin_pmpNcfg_ <= execute_PmpPlugin_pmpNcfg;
-          execute_PmpPlugin_pmpcfgN_ <= execute_PmpPlugin_pmpcfgN;
-        end
-      end
-    end
     iBusWishbone_DAT_MISO_regNext <= iBusWishbone_DAT_MISO;
     dBusWishbone_DAT_MISO_regNext <= dBusWishbone_DAT_MISO;
   end
@@ -8502,9 +9541,9 @@ module VexRiscv (
     if(writeBack_arbitration_isValid) begin
       DebugPlugin_busReadDataReg <= _zz_decode_RS2_2;
     end
-    _zz_when_DebugPlugin_l244 <= debug_bus_cmd_payload_address[2];
+    _zz_when_DebugPlugin_l257 <= debug_bus_cmd_payload_address[2];
     if(debug_bus_cmd_valid) begin
-      case(switch_DebugPlugin_l267)
+      case(switch_DebugPlugin_l280)
         6'h10 : begin
           if(debug_bus_cmd_payload_wr) begin
             DebugPlugin_hardwareBreakpoints_0_pc <= debug_bus_cmd_payload_data[31 : 1];
@@ -8519,7 +9558,7 @@ module VexRiscv (
         end
       endcase
     end
-    if(when_DebugPlugin_l295) begin
+    if(when_DebugPlugin_l308) begin
       DebugPlugin_busReadDataReg <= execute_PC;
     end
     DebugPlugin_resetIt_regNext <= DebugPlugin_resetIt;
@@ -8537,39 +9576,39 @@ module VexRiscv (
       DebugPlugin_hardwareBreakpoints_0_valid <= 1'b0;
       DebugPlugin_hardwareBreakpoints_1_valid <= 1'b0;
     end else begin
-      if(when_DebugPlugin_l225) begin
+      if(when_DebugPlugin_l238) begin
         DebugPlugin_godmode <= 1'b1;
       end
       if(debug_bus_cmd_valid) begin
         DebugPlugin_debugUsed <= 1'b1;
       end
       if(debug_bus_cmd_valid) begin
-        case(switch_DebugPlugin_l267)
-          6'h0 : begin
+        case(switch_DebugPlugin_l280)
+          6'h00 : begin
             if(debug_bus_cmd_payload_wr) begin
               DebugPlugin_stepIt <= debug_bus_cmd_payload_data[4];
-              if(when_DebugPlugin_l271) begin
+              if(when_DebugPlugin_l284) begin
                 DebugPlugin_resetIt <= 1'b1;
               end
-              if(when_DebugPlugin_l271_1) begin
+              if(when_DebugPlugin_l284_1) begin
                 DebugPlugin_resetIt <= 1'b0;
               end
-              if(when_DebugPlugin_l272) begin
+              if(when_DebugPlugin_l285) begin
                 DebugPlugin_haltIt <= 1'b1;
               end
-              if(when_DebugPlugin_l272_1) begin
+              if(when_DebugPlugin_l285_1) begin
                 DebugPlugin_haltIt <= 1'b0;
               end
-              if(when_DebugPlugin_l273) begin
+              if(when_DebugPlugin_l286) begin
                 DebugPlugin_haltedByBreak <= 1'b0;
               end
-              if(when_DebugPlugin_l274) begin
+              if(when_DebugPlugin_l287) begin
                 DebugPlugin_godmode <= 1'b0;
               end
-              if(when_DebugPlugin_l275) begin
+              if(when_DebugPlugin_l288) begin
                 DebugPlugin_disableEbreak <= 1'b1;
               end
-              if(when_DebugPlugin_l275_1) begin
+              if(when_DebugPlugin_l288_1) begin
                 DebugPlugin_disableEbreak <= 1'b0;
               end
             end
@@ -8588,13 +9627,13 @@ module VexRiscv (
           end
         endcase
       end
-      if(when_DebugPlugin_l295) begin
-        if(when_DebugPlugin_l298) begin
+      if(when_DebugPlugin_l308) begin
+        if(when_DebugPlugin_l311) begin
           DebugPlugin_haltIt <= 1'b1;
           DebugPlugin_haltedByBreak <= 1'b1;
         end
       end
-      if(when_DebugPlugin_l311) begin
+      if(when_DebugPlugin_l324) begin
         if(decode_arbitration_isValid) begin
           DebugPlugin_haltIt <= 1'b1;
         end
@@ -8606,76 +9645,75 @@ module VexRiscv (
 endmodule
 
 module DataCache (
-  input               io_cpu_execute_isValid,
-  input      [31:0]   io_cpu_execute_address,
-  output reg          io_cpu_execute_haltIt,
-  input               io_cpu_execute_args_wr,
-  input      [1:0]    io_cpu_execute_args_size,
-  input               io_cpu_execute_args_totalyConsistent,
-  output              io_cpu_execute_refilling,
-  input               io_cpu_memory_isValid,
-  input               io_cpu_memory_isStuck,
-  output              io_cpu_memory_isWrite,
-  input      [31:0]   io_cpu_memory_address,
-  input      [31:0]   io_cpu_memory_mmuRsp_physicalAddress,
-  input               io_cpu_memory_mmuRsp_isIoAccess,
-  input               io_cpu_memory_mmuRsp_isPaging,
-  input               io_cpu_memory_mmuRsp_allowRead,
-  input               io_cpu_memory_mmuRsp_allowWrite,
-  input               io_cpu_memory_mmuRsp_allowExecute,
-  input               io_cpu_memory_mmuRsp_exception,
-  input               io_cpu_memory_mmuRsp_refilling,
-  input               io_cpu_memory_mmuRsp_bypassTranslation,
-  input               io_cpu_writeBack_isValid,
-  input               io_cpu_writeBack_isStuck,
-  input               io_cpu_writeBack_isFiring,
-  input               io_cpu_writeBack_isUser,
-  output reg          io_cpu_writeBack_haltIt,
-  output              io_cpu_writeBack_isWrite,
-  input      [31:0]   io_cpu_writeBack_storeData,
-  output reg [31:0]   io_cpu_writeBack_data,
-  input      [31:0]   io_cpu_writeBack_address,
-  output              io_cpu_writeBack_mmuException,
-  output              io_cpu_writeBack_unalignedAccess,
-  output reg          io_cpu_writeBack_accessError,
-  output              io_cpu_writeBack_keepMemRspData,
-  input               io_cpu_writeBack_fence_SW,
-  input               io_cpu_writeBack_fence_SR,
-  input               io_cpu_writeBack_fence_SO,
-  input               io_cpu_writeBack_fence_SI,
-  input               io_cpu_writeBack_fence_PW,
-  input               io_cpu_writeBack_fence_PR,
-  input               io_cpu_writeBack_fence_PO,
-  input               io_cpu_writeBack_fence_PI,
-  input      [3:0]    io_cpu_writeBack_fence_FM,
-  output              io_cpu_writeBack_exclusiveOk,
-  output reg          io_cpu_redo,
-  input               io_cpu_flush_valid,
-  output              io_cpu_flush_ready,
-  input               io_cpu_flush_payload_singleLine,
-  input      [6:0]    io_cpu_flush_payload_lineId,
-  output reg          io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output reg          io_mem_cmd_payload_wr,
-  output              io_mem_cmd_payload_uncached,
-  output reg [31:0]   io_mem_cmd_payload_address,
-  output     [31:0]   io_mem_cmd_payload_data,
-  output     [3:0]    io_mem_cmd_payload_mask,
-  output reg [2:0]    io_mem_cmd_payload_size,
-  output              io_mem_cmd_payload_last,
-  input               io_mem_rsp_valid,
-  input               io_mem_rsp_payload_last,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input               clk,
-  input               reset
+  input  wire          io_cpu_execute_isValid,
+  input  wire [31:0]   io_cpu_execute_address,
+  output reg           io_cpu_execute_haltIt,
+  input  wire          io_cpu_execute_args_wr,
+  input  wire [1:0]    io_cpu_execute_args_size,
+  input  wire          io_cpu_execute_args_totalyConsistent,
+  output wire          io_cpu_execute_refilling,
+  input  wire          io_cpu_memory_isValid,
+  input  wire          io_cpu_memory_isStuck,
+  output wire          io_cpu_memory_isWrite,
+  input  wire [31:0]   io_cpu_memory_address,
+  input  wire [31:0]   io_cpu_memory_mmuRsp_physicalAddress,
+  input  wire          io_cpu_memory_mmuRsp_isIoAccess,
+  input  wire          io_cpu_memory_mmuRsp_isPaging,
+  input  wire          io_cpu_memory_mmuRsp_allowRead,
+  input  wire          io_cpu_memory_mmuRsp_allowWrite,
+  input  wire          io_cpu_memory_mmuRsp_allowExecute,
+  input  wire          io_cpu_memory_mmuRsp_exception,
+  input  wire          io_cpu_memory_mmuRsp_refilling,
+  input  wire          io_cpu_memory_mmuRsp_bypassTranslation,
+  input  wire          io_cpu_writeBack_isValid,
+  input  wire          io_cpu_writeBack_isStuck,
+  input  wire          io_cpu_writeBack_isFiring,
+  input  wire          io_cpu_writeBack_isUser,
+  output reg           io_cpu_writeBack_haltIt,
+  output wire          io_cpu_writeBack_isWrite,
+  input  wire [31:0]   io_cpu_writeBack_storeData,
+  output reg  [31:0]   io_cpu_writeBack_data,
+  input  wire [31:0]   io_cpu_writeBack_address,
+  output wire          io_cpu_writeBack_mmuException,
+  output wire          io_cpu_writeBack_unalignedAccess,
+  output reg           io_cpu_writeBack_accessError,
+  output wire          io_cpu_writeBack_keepMemRspData,
+  input  wire          io_cpu_writeBack_fence_SW,
+  input  wire          io_cpu_writeBack_fence_SR,
+  input  wire          io_cpu_writeBack_fence_SO,
+  input  wire          io_cpu_writeBack_fence_SI,
+  input  wire          io_cpu_writeBack_fence_PW,
+  input  wire          io_cpu_writeBack_fence_PR,
+  input  wire          io_cpu_writeBack_fence_PO,
+  input  wire          io_cpu_writeBack_fence_PI,
+  input  wire [3:0]    io_cpu_writeBack_fence_FM,
+  output wire          io_cpu_writeBack_exclusiveOk,
+  output reg           io_cpu_redo,
+  input  wire          io_cpu_flush_valid,
+  output wire          io_cpu_flush_ready,
+  input  wire          io_cpu_flush_payload_singleLine,
+  input  wire [6:0]    io_cpu_flush_payload_lineId,
+  output wire          io_cpu_writesPending,
+  output reg           io_mem_cmd_valid,
+  input  wire          io_mem_cmd_ready,
+  output reg           io_mem_cmd_payload_wr,
+  output wire          io_mem_cmd_payload_uncached,
+  output reg  [31:0]   io_mem_cmd_payload_address,
+  output wire [31:0]   io_mem_cmd_payload_data,
+  output wire [3:0]    io_mem_cmd_payload_mask,
+  output reg  [2:0]    io_mem_cmd_payload_size,
+  output wire          io_mem_cmd_payload_last,
+  input  wire          io_mem_rsp_valid,
+  input  wire          io_mem_rsp_payload_last,
+  input  wire [31:0]   io_mem_rsp_payload_data,
+  input  wire          io_mem_rsp_payload_error,
+  input  wire          clk,
+  input  wire          reset
 );
 
   reg        [21:0]   _zz_ways_0_tags_port0;
   reg        [31:0]   _zz_ways_0_data_port0;
   wire       [21:0]   _zz_ways_0_tags_port;
-  wire       [9:0]    _zz_stage0_dataColisions;
-  wire       [9:0]    _zz__zz_stageA_dataColisions;
   wire       [0:0]    _zz_when;
   wire       [2:0]    _zz_loader_counter_valueNext;
   wire       [0:0]    _zz_loader_counter_valueNext_1;
@@ -8712,40 +9750,40 @@ module DataCache (
   wire                _zz_ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRsp;
-  wire                when_DataCache_l642;
   wire                when_DataCache_l645;
-  wire                when_DataCache_l664;
+  wire                when_DataCache_l648;
+  wire                when_DataCache_l667;
   wire                rspSync;
   wire                rspLast;
   reg                 memCmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_DataCache_l686;
+  wire                when_DataCache_l689;
   reg        [3:0]    _zz_stage0_mask;
   wire       [3:0]    stage0_mask;
   wire       [0:0]    stage0_dataColisions;
   wire       [0:0]    stage0_wayInvalidate;
   wire                stage0_isAmo;
-  wire                when_DataCache_l771;
+  wire                when_DataCache_l776;
   reg                 stageA_request_wr;
   reg        [1:0]    stageA_request_size;
   reg                 stageA_request_totalyConsistent;
-  wire                when_DataCache_l771_1;
+  wire                when_DataCache_l776_1;
   reg        [3:0]    stageA_mask;
   wire                stageA_isAmo;
   wire                stageA_isLrsc;
   wire       [0:0]    stageA_wayHits;
-  wire                when_DataCache_l771_2;
+  wire                when_DataCache_l776_2;
   reg        [0:0]    stageA_wayInvalidate;
-  wire                when_DataCache_l771_3;
+  wire                when_DataCache_l776_3;
   reg        [0:0]    stage0_dataColisions_regNextWhen;
   wire       [0:0]    _zz_stageA_dataColisions;
   wire       [0:0]    stageA_dataColisions;
-  wire                when_DataCache_l822;
+  wire                when_DataCache_l827;
   reg                 stageB_request_wr;
   reg        [1:0]    stageB_request_size;
   reg                 stageB_request_totalyConsistent;
   reg                 stageB_mmuRspFreeze;
-  wire                when_DataCache_l824;
+  wire                when_DataCache_l829;
   reg        [31:0]   stageB_mmuRsp_physicalAddress;
   reg                 stageB_mmuRsp_isIoAccess;
   reg                 stageB_mmuRsp_isPaging;
@@ -8755,52 +9793,54 @@ module DataCache (
   reg                 stageB_mmuRsp_exception;
   reg                 stageB_mmuRsp_refilling;
   reg                 stageB_mmuRsp_bypassTranslation;
-  wire                when_DataCache_l821;
+  wire                when_DataCache_l826;
   reg                 stageB_tagsReadRsp_0_valid;
   reg                 stageB_tagsReadRsp_0_error;
   reg        [19:0]   stageB_tagsReadRsp_0_address;
-  wire                when_DataCache_l821_1;
+  wire                when_DataCache_l826_1;
   reg        [31:0]   stageB_dataReadRsp_0;
-  wire                when_DataCache_l820;
+  wire                when_DataCache_l825;
   reg        [0:0]    stageB_wayInvalidate;
   wire                stageB_consistancyHazard;
-  wire                when_DataCache_l820_1;
+  wire                when_DataCache_l825_1;
   reg        [0:0]    stageB_dataColisions;
-  wire                when_DataCache_l820_2;
+  wire                when_DataCache_l825_2;
   reg                 stageB_unaligned;
-  wire                when_DataCache_l820_3;
+  wire                when_DataCache_l825_3;
   reg        [0:0]    stageB_waysHitsBeforeInvalidate;
   wire       [0:0]    stageB_waysHits;
   wire                stageB_waysHit;
   wire       [31:0]   stageB_dataMux;
-  wire                when_DataCache_l820_4;
+  wire                when_DataCache_l825_4;
   reg        [3:0]    stageB_mask;
   reg                 stageB_loaderValid;
   wire       [31:0]   stageB_ioMemRspMuxed;
   reg                 stageB_flusher_waitDone;
   wire                stageB_flusher_hold;
   reg        [7:0]    stageB_flusher_counter;
-  wire                when_DataCache_l850;
-  wire                when_DataCache_l856;
+  wire                when_DataCache_l855;
+  wire                when_DataCache_l861;
+  wire                when_DataCache_l863;
   reg                 stageB_flusher_start;
+  wire                when_DataCache_l877;
   wire                stageB_isAmo;
   wire                stageB_isAmoCached;
   wire                stageB_isExternalLsrc;
   wire                stageB_isExternalAmo;
   wire       [31:0]   stageB_requestDataBypass;
   reg                 stageB_cpuWriteToCache;
-  wire                when_DataCache_l926;
+  wire                when_DataCache_l931;
   wire                stageB_badPermissions;
   wire                stageB_loadStoreFault;
   wire                stageB_bypassCache;
-  wire                when_DataCache_l995;
-  wire                when_DataCache_l1004;
+  wire                when_DataCache_l1000;
   wire                when_DataCache_l1009;
-  wire                when_DataCache_l1020;
-  wire                when_DataCache_l1032;
-  wire                when_DataCache_l991;
-  wire                when_DataCache_l1066;
-  wire                when_DataCache_l1075;
+  wire                when_DataCache_l1014;
+  wire                when_DataCache_l1025;
+  wire                when_DataCache_l1037;
+  wire                when_DataCache_l996;
+  wire                when_DataCache_l1072;
+  wire                when_DataCache_l1081;
   reg                 loader_valid;
   reg                 loader_counter_willIncrement;
   wire                loader_counter_willClear;
@@ -8812,12 +9852,12 @@ module DataCache (
   reg                 loader_error;
   wire                loader_kill;
   reg                 loader_killReg;
-  wire                when_DataCache_l1090;
+  wire                when_DataCache_l1097;
   wire                loader_done;
-  wire                when_DataCache_l1118;
-  reg                 loader_valid_regNext;
-  wire                when_DataCache_l1122;
   wire                when_DataCache_l1125;
+  reg                 loader_valid_regNext;
+  wire                when_DataCache_l1129;
+  wire                when_DataCache_l1132;
   (* no_rw_check , ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
   (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
   (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
@@ -8828,8 +9868,6 @@ module DataCache (
   reg [7:0] _zz_ways_0_datasymbol_read_2;
   reg [7:0] _zz_ways_0_datasymbol_read_3;
 
-  assign _zz_stage0_dataColisions = (io_cpu_execute_address[11 : 2] >>> 0);
-  assign _zz__zz_stageA_dataColisions = (io_cpu_memory_address[11 : 2] >>> 0);
   assign _zz_when = 1'b1;
   assign _zz_loader_counter_valueNext_1 = loader_counter_willIncrement;
   assign _zz_loader_counter_valueNext = {2'd0, _zz_loader_counter_valueNext_1};
@@ -8876,14 +9914,14 @@ module DataCache (
 
   always @(*) begin
     _zz_1 = 1'b0;
-    if(when_DataCache_l645) begin
+    if(when_DataCache_l648) begin
       _zz_1 = 1'b1;
     end
   end
 
   always @(*) begin
     _zz_2 = 1'b0;
-    if(when_DataCache_l642) begin
+    if(when_DataCache_l645) begin
       _zz_2 = 1'b1;
     end
   end
@@ -8897,43 +9935,45 @@ module DataCache (
   assign _zz_ways_0_dataReadRspMem = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
   assign ways_0_dataReadRspMem = _zz_ways_0_data_port0;
   assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
-  assign when_DataCache_l642 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
-  assign when_DataCache_l645 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
+  assign when_DataCache_l645 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
+  assign when_DataCache_l648 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
   always @(*) begin
     tagsReadCmd_valid = 1'b0;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       tagsReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     tagsReadCmd_payload = 7'bxxxxxxx;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
     end
   end
 
   always @(*) begin
     dataReadCmd_valid = 1'b0;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       dataReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     dataReadCmd_payload = 10'bxxxxxxxxxx;
-    if(when_DataCache_l664) begin
+    if(when_DataCache_l667) begin
       dataReadCmd_payload = io_cpu_execute_address[11 : 2];
     end
   end
 
   always @(*) begin
     tagsWriteCmd_valid = 1'b0;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_valid = 1'b1;
     end
-    if(when_DataCache_l1066) begin
-      tagsWriteCmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        tagsWriteCmd_valid = 1'b0;
+      end
     end
     if(loader_done) begin
       tagsWriteCmd_valid = 1'b1;
@@ -8942,7 +9982,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_way = 1'bx;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_payload_way = 1'b1;
     end
     if(loader_done) begin
@@ -8952,7 +9992,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_address = 7'bxxxxxxx;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_payload_address = stageB_flusher_counter[6:0];
     end
     if(loader_done) begin
@@ -8962,7 +10002,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_data_valid = 1'bx;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       tagsWriteCmd_payload_data_valid = 1'b0;
     end
     if(loader_done) begin
@@ -8987,14 +10027,16 @@ module DataCache (
   always @(*) begin
     dataWriteCmd_valid = 1'b0;
     if(stageB_cpuWriteToCache) begin
-      if(when_DataCache_l926) begin
+      if(when_DataCache_l931) begin
         dataWriteCmd_valid = 1'b1;
       end
     end
-    if(when_DataCache_l1066) begin
-      dataWriteCmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        dataWriteCmd_valid = 1'b0;
+      end
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_valid = 1'b1;
     end
   end
@@ -9004,7 +10046,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_way = stageB_waysHits;
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_way = loader_waysAllocator;
     end
   end
@@ -9014,7 +10056,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
     end
   end
@@ -9024,7 +10066,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_data = io_mem_rsp_payload_data;
     end
   end
@@ -9037,15 +10079,15 @@ module DataCache (
         dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
       end
     end
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       dataWriteCmd_payload_mask = 4'b1111;
     end
   end
 
-  assign when_DataCache_l664 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  assign when_DataCache_l667 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
   always @(*) begin
     io_cpu_execute_haltIt = 1'b0;
-    if(when_DataCache_l850) begin
+    if(when_DataCache_l855) begin
       io_cpu_execute_haltIt = 1'b1;
     end
   end
@@ -9053,7 +10095,7 @@ module DataCache (
   assign rspSync = 1'b1;
   assign rspLast = 1'b1;
   assign io_mem_cmd_fire = (io_mem_cmd_valid && io_mem_cmd_ready);
-  assign when_DataCache_l686 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l689 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     _zz_stage0_mask = 4'bxxxx;
     case(io_cpu_execute_args_size)
@@ -9072,45 +10114,45 @@ module DataCache (
   end
 
   assign stage0_mask = (_zz_stage0_mask <<< io_cpu_execute_address[1 : 0]);
-  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_stage0_dataColisions)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_execute_address[11 : 2])) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stage0_wayInvalidate = 1'b0;
   assign stage0_isAmo = 1'b0;
-  assign when_DataCache_l771 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l771_1 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l776 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l776_1 = (! io_cpu_memory_isStuck);
   assign io_cpu_memory_isWrite = stageA_request_wr;
   assign stageA_isAmo = 1'b0;
   assign stageA_isLrsc = 1'b0;
   assign stageA_wayHits = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign when_DataCache_l771_2 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l771_3 = (! io_cpu_memory_isStuck);
-  assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz__zz_stageA_dataColisions)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign when_DataCache_l776_2 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l776_3 = (! io_cpu_memory_isStuck);
+  assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_memory_address[11 : 2])) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_stageA_dataColisions);
-  assign when_DataCache_l822 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l827 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_mmuRspFreeze = 1'b0;
-    if(when_DataCache_l1125) begin
+    if(when_DataCache_l1132) begin
       stageB_mmuRspFreeze = 1'b1;
     end
   end
 
-  assign when_DataCache_l824 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
-  assign when_DataCache_l821 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l821_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l820 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l829 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
+  assign when_DataCache_l826 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l826_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825 = (! io_cpu_writeBack_isStuck);
   assign stageB_consistancyHazard = 1'b0;
-  assign when_DataCache_l820_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l820_2 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l820_3 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_2 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_3 = (! io_cpu_writeBack_isStuck);
   assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
   assign stageB_waysHit = (|stageB_waysHits);
   assign stageB_dataMux = stageB_dataReadRsp_0;
-  assign when_DataCache_l820_4 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l825_4 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_loaderValid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
             if(io_mem_cmd_ready) begin
               stageB_loaderValid = 1'b1;
             end
@@ -9118,8 +10160,10 @@ module DataCache (
         end
       end
     end
-    if(when_DataCache_l1066) begin
-      stageB_loaderValid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        stageB_loaderValid = 1'b0;
+      end
     end
   end
 
@@ -9128,28 +10172,32 @@ module DataCache (
     io_cpu_writeBack_haltIt = 1'b1;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l991) begin
-          if(when_DataCache_l995) begin
+        if(when_DataCache_l996) begin
+          if(when_DataCache_l1000) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
         end else begin
-          if(when_DataCache_l1004) begin
-            if(when_DataCache_l1009) begin
+          if(when_DataCache_l1009) begin
+            if(when_DataCache_l1014) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1066) begin
-      io_cpu_writeBack_haltIt = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        io_cpu_writeBack_haltIt = 1'b0;
+      end
     end
   end
 
   assign stageB_flusher_hold = 1'b0;
-  assign when_DataCache_l850 = (! stageB_flusher_counter[7]);
-  assign when_DataCache_l856 = (! stageB_flusher_hold);
+  assign when_DataCache_l855 = (! stageB_flusher_counter[7]);
+  assign when_DataCache_l861 = (! stageB_flusher_hold);
+  assign when_DataCache_l863 = (io_cpu_flush_valid && io_cpu_flush_payload_singleLine);
   assign io_cpu_flush_ready = (stageB_flusher_waitDone && stageB_flusher_counter[7]);
+  assign when_DataCache_l877 = (io_cpu_flush_valid && io_cpu_flush_payload_singleLine);
   assign stageB_isAmo = 1'b0;
   assign stageB_isAmoCached = 1'b0;
   assign stageB_isExternalLsrc = 1'b0;
@@ -9159,8 +10207,8 @@ module DataCache (
     stageB_cpuWriteToCache = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(when_DataCache_l1009) begin
             stageB_cpuWriteToCache = 1'b1;
           end
         end
@@ -9168,26 +10216,28 @@ module DataCache (
     end
   end
 
-  assign when_DataCache_l926 = (stageB_request_wr && stageB_waysHit);
+  assign when_DataCache_l931 = (stageB_request_wr && stageB_waysHit);
   assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_isAmo)));
   assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
   always @(*) begin
     io_cpu_redo = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(when_DataCache_l1004) begin
-            if(when_DataCache_l1020) begin
+        if(!when_DataCache_l996) begin
+          if(when_DataCache_l1009) begin
+            if(when_DataCache_l1025) begin
               io_cpu_redo = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1075) begin
-      io_cpu_redo = 1'b1;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1081) begin
+        io_cpu_redo = 1'b1;
+      end
     end
-    if(when_DataCache_l1122) begin
+    if(when_DataCache_l1129) begin
       io_cpu_redo = 1'b1;
     end
   end
@@ -9208,23 +10258,25 @@ module DataCache (
     io_mem_cmd_valid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l991) begin
+        if(when_DataCache_l996) begin
           io_mem_cmd_valid = (! memCmdSent);
         end else begin
-          if(when_DataCache_l1004) begin
+          if(when_DataCache_l1009) begin
             if(stageB_request_wr) begin
               io_mem_cmd_valid = 1'b1;
             end
           end else begin
-            if(when_DataCache_l1032) begin
+            if(when_DataCache_l1037) begin
               io_mem_cmd_valid = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1066) begin
-      io_mem_cmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid) begin
+      if(when_DataCache_l1072) begin
+        io_mem_cmd_valid = 1'b0;
+      end
     end
   end
 
@@ -9232,9 +10284,9 @@ module DataCache (
     io_mem_cmd_payload_address = stageB_mmuRsp_physicalAddress;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
-            io_mem_cmd_payload_address[4 : 0] = 5'h0;
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
+            io_mem_cmd_payload_address[4 : 0] = 5'h00;
           end
         end
       end
@@ -9246,8 +10298,8 @@ module DataCache (
     io_mem_cmd_payload_wr = stageB_request_wr;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
             io_mem_cmd_payload_wr = 1'b0;
           end
         end
@@ -9262,8 +10314,8 @@ module DataCache (
     io_mem_cmd_payload_size = {1'd0, stageB_request_size};
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l991) begin
-          if(!when_DataCache_l1004) begin
+        if(!when_DataCache_l996) begin
+          if(!when_DataCache_l1009) begin
             io_mem_cmd_payload_size = 3'b101;
           end
         end
@@ -9273,12 +10325,12 @@ module DataCache (
 
   assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
   assign io_cpu_writeBack_keepMemRspData = 1'b0;
-  assign when_DataCache_l995 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
-  assign when_DataCache_l1004 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
-  assign when_DataCache_l1009 = ((! stageB_request_wr) || io_mem_cmd_ready);
-  assign when_DataCache_l1020 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
-  assign when_DataCache_l1032 = (! memCmdSent);
-  assign when_DataCache_l991 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  assign when_DataCache_l1000 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
+  assign when_DataCache_l1009 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
+  assign when_DataCache_l1014 = ((! stageB_request_wr) || io_mem_cmd_ready);
+  assign when_DataCache_l1025 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
+  assign when_DataCache_l1037 = (! memCmdSent);
+  assign when_DataCache_l996 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
   always @(*) begin
     if(stageB_bypassCache) begin
       io_cpu_writeBack_data = stageB_ioMemRspMuxed;
@@ -9287,11 +10339,11 @@ module DataCache (
     end
   end
 
-  assign when_DataCache_l1066 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign when_DataCache_l1075 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
+  assign when_DataCache_l1072 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign when_DataCache_l1081 = (stageB_mmuRsp_refilling || stageB_consistancyHazard);
   always @(*) begin
     loader_counter_willIncrement = 1'b0;
-    if(when_DataCache_l1090) begin
+    if(when_DataCache_l1097) begin
       loader_counter_willIncrement = 1'b1;
     end
   end
@@ -9307,12 +10359,12 @@ module DataCache (
   end
 
   assign loader_kill = 1'b0;
-  assign when_DataCache_l1090 = ((loader_valid && io_mem_rsp_valid) && rspLast);
+  assign when_DataCache_l1097 = ((loader_valid && io_mem_rsp_valid) && rspLast);
   assign loader_done = loader_counter_willOverflow;
-  assign when_DataCache_l1118 = (! loader_valid);
-  assign when_DataCache_l1122 = (loader_valid && (! loader_valid_regNext));
+  assign when_DataCache_l1125 = (! loader_valid);
+  assign when_DataCache_l1129 = (loader_valid && (! loader_valid_regNext));
   assign io_cpu_execute_refilling = loader_valid;
-  assign when_DataCache_l1125 = (stageB_loaderValid || loader_valid);
+  assign when_DataCache_l1132 = (stageB_loaderValid || loader_valid);
   always @(posedge clk) begin
     tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
     tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
@@ -9320,26 +10372,26 @@ module DataCache (
     tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
     tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
     tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if(when_DataCache_l771) begin
+    if(when_DataCache_l776) begin
       stageA_request_wr <= io_cpu_execute_args_wr;
       stageA_request_size <= io_cpu_execute_args_size;
       stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
     end
-    if(when_DataCache_l771_1) begin
+    if(when_DataCache_l776_1) begin
       stageA_mask <= stage0_mask;
     end
-    if(when_DataCache_l771_2) begin
+    if(when_DataCache_l776_2) begin
       stageA_wayInvalidate <= stage0_wayInvalidate;
     end
-    if(when_DataCache_l771_3) begin
+    if(when_DataCache_l776_3) begin
       stage0_dataColisions_regNextWhen <= stage0_dataColisions;
     end
-    if(when_DataCache_l822) begin
+    if(when_DataCache_l827) begin
       stageB_request_wr <= stageA_request_wr;
       stageB_request_size <= stageA_request_size;
       stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
     end
-    if(when_DataCache_l824) begin
+    if(when_DataCache_l829) begin
       stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
       stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
       stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
@@ -9350,27 +10402,27 @@ module DataCache (
       stageB_mmuRsp_refilling <= io_cpu_memory_mmuRsp_refilling;
       stageB_mmuRsp_bypassTranslation <= io_cpu_memory_mmuRsp_bypassTranslation;
     end
-    if(when_DataCache_l821) begin
+    if(when_DataCache_l826) begin
       stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
       stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
       stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
     end
-    if(when_DataCache_l821_1) begin
+    if(when_DataCache_l826_1) begin
       stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
     end
-    if(when_DataCache_l820) begin
+    if(when_DataCache_l825) begin
       stageB_wayInvalidate <= stageA_wayInvalidate;
     end
-    if(when_DataCache_l820_1) begin
+    if(when_DataCache_l825_1) begin
       stageB_dataColisions <= stageA_dataColisions;
     end
-    if(when_DataCache_l820_2) begin
+    if(when_DataCache_l825_2) begin
       stageB_unaligned <= ({((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)),((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0))} != 2'b00);
     end
-    if(when_DataCache_l820_3) begin
+    if(when_DataCache_l825_3) begin
       stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
     end
-    if(when_DataCache_l820_4) begin
+    if(when_DataCache_l825_4) begin
       stageB_mask <= stageA_mask;
     end
     loader_valid_regNext <= loader_valid;
@@ -9380,7 +10432,7 @@ module DataCache (
     if(reset) begin
       memCmdSent <= 1'b0;
       stageB_flusher_waitDone <= 1'b0;
-      stageB_flusher_counter <= 8'h0;
+      stageB_flusher_counter <= 8'h00;
       stageB_flusher_start <= 1'b1;
       loader_valid <= 1'b0;
       loader_counter_value <= 3'b000;
@@ -9391,16 +10443,16 @@ module DataCache (
       if(io_mem_cmd_fire) begin
         memCmdSent <= 1'b1;
       end
-      if(when_DataCache_l686) begin
+      if(when_DataCache_l689) begin
         memCmdSent <= 1'b0;
       end
       if(io_cpu_flush_ready) begin
         stageB_flusher_waitDone <= 1'b0;
       end
-      if(when_DataCache_l850) begin
-        if(when_DataCache_l856) begin
+      if(when_DataCache_l855) begin
+        if(when_DataCache_l861) begin
           stageB_flusher_counter <= (stageB_flusher_counter + 8'h01);
-          if(io_cpu_flush_payload_singleLine) begin
+          if(when_DataCache_l863) begin
             stageB_flusher_counter[7] <= 1'b1;
           end
         end
@@ -9408,17 +10460,17 @@ module DataCache (
       stageB_flusher_start <= (((((((! stageB_flusher_waitDone) && (! stageB_flusher_start)) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
       if(stageB_flusher_start) begin
         stageB_flusher_waitDone <= 1'b1;
-        stageB_flusher_counter <= 8'h0;
-        if(io_cpu_flush_payload_singleLine) begin
+        stageB_flusher_counter <= 8'h00;
+        if(when_DataCache_l877) begin
           stageB_flusher_counter <= {1'b0,io_cpu_flush_payload_lineId};
         end
       end
       `ifndef SYNTHESIS
         `ifdef FORMAL
-          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))); // DataCache.scala:L1077
+          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))); // DataCache.scala:L1084
         `else
           if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-            $display("ERROR writeBack stuck by another plugin is not allowed"); // DataCache.scala:L1077
+            $display("ERROR writeBack stuck by another plugin is not allowed"); // DataCache.scala:L1084
           end
         `endif
       `endif
@@ -9429,7 +10481,7 @@ module DataCache (
       if(loader_kill) begin
         loader_killReg <= 1'b1;
       end
-      if(when_DataCache_l1090) begin
+      if(when_DataCache_l1097) begin
         loader_error <= (loader_error || io_mem_rsp_payload_error);
       end
       if(loader_done) begin
@@ -9437,7 +10489,7 @@ module DataCache (
         loader_error <= 1'b0;
         loader_killReg <= 1'b0;
       end
-      if(when_DataCache_l1118) begin
+      if(when_DataCache_l1125) begin
         loader_waysAllocator <= _zz_loader_waysAllocator[0:0];
       end
     end
@@ -9447,48 +10499,48 @@ module DataCache (
 endmodule
 
 module InstructionCache (
-  input               io_flush,
-  input               io_cpu_prefetch_isValid,
-  output reg          io_cpu_prefetch_haltIt,
-  input      [31:0]   io_cpu_prefetch_pc,
-  input               io_cpu_fetch_isValid,
-  input               io_cpu_fetch_isStuck,
-  input               io_cpu_fetch_isRemoved,
-  input      [31:0]   io_cpu_fetch_pc,
-  output     [31:0]   io_cpu_fetch_data,
-  input      [31:0]   io_cpu_fetch_mmuRsp_physicalAddress,
-  input               io_cpu_fetch_mmuRsp_isIoAccess,
-  input               io_cpu_fetch_mmuRsp_isPaging,
-  input               io_cpu_fetch_mmuRsp_allowRead,
-  input               io_cpu_fetch_mmuRsp_allowWrite,
-  input               io_cpu_fetch_mmuRsp_allowExecute,
-  input               io_cpu_fetch_mmuRsp_exception,
-  input               io_cpu_fetch_mmuRsp_refilling,
-  input               io_cpu_fetch_mmuRsp_bypassTranslation,
-  output     [31:0]   io_cpu_fetch_physicalAddress,
-  input               io_cpu_decode_isValid,
-  input               io_cpu_decode_isStuck,
-  input      [31:0]   io_cpu_decode_pc,
-  output     [31:0]   io_cpu_decode_physicalAddress,
-  output     [31:0]   io_cpu_decode_data,
-  output              io_cpu_decode_cacheMiss,
-  output              io_cpu_decode_error,
-  output              io_cpu_decode_mmuRefilling,
-  output              io_cpu_decode_mmuException,
-  input               io_cpu_decode_isUser,
-  input               io_cpu_fill_valid,
-  input      [31:0]   io_cpu_fill_payload,
-  output              io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output     [31:0]   io_mem_cmd_payload_address,
-  output     [2:0]    io_mem_cmd_payload_size,
-  input               io_mem_rsp_valid,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input      [2:0]    _zz_when_Fetcher_l401,
-  input      [31:0]   _zz_io_cpu_fetch_data_regNextWhen,
-  input               clk,
-  input               reset
+  input  wire          io_flush,
+  input  wire          io_cpu_prefetch_isValid,
+  output reg           io_cpu_prefetch_haltIt,
+  input  wire [31:0]   io_cpu_prefetch_pc,
+  input  wire          io_cpu_fetch_isValid,
+  input  wire          io_cpu_fetch_isStuck,
+  input  wire          io_cpu_fetch_isRemoved,
+  input  wire [31:0]   io_cpu_fetch_pc,
+  output wire [31:0]   io_cpu_fetch_data,
+  input  wire [31:0]   io_cpu_fetch_mmuRsp_physicalAddress,
+  input  wire          io_cpu_fetch_mmuRsp_isIoAccess,
+  input  wire          io_cpu_fetch_mmuRsp_isPaging,
+  input  wire          io_cpu_fetch_mmuRsp_allowRead,
+  input  wire          io_cpu_fetch_mmuRsp_allowWrite,
+  input  wire          io_cpu_fetch_mmuRsp_allowExecute,
+  input  wire          io_cpu_fetch_mmuRsp_exception,
+  input  wire          io_cpu_fetch_mmuRsp_refilling,
+  input  wire          io_cpu_fetch_mmuRsp_bypassTranslation,
+  output wire [31:0]   io_cpu_fetch_physicalAddress,
+  input  wire          io_cpu_decode_isValid,
+  input  wire          io_cpu_decode_isStuck,
+  input  wire [31:0]   io_cpu_decode_pc,
+  output wire [31:0]   io_cpu_decode_physicalAddress,
+  output wire [31:0]   io_cpu_decode_data,
+  output wire          io_cpu_decode_cacheMiss,
+  output wire          io_cpu_decode_error,
+  output wire          io_cpu_decode_mmuRefilling,
+  output wire          io_cpu_decode_mmuException,
+  input  wire          io_cpu_decode_isUser,
+  input  wire          io_cpu_fill_valid,
+  input  wire [31:0]   io_cpu_fill_payload,
+  output wire          io_mem_cmd_valid,
+  input  wire          io_mem_cmd_ready,
+  output wire [31:0]   io_mem_cmd_payload_address,
+  output wire [2:0]    io_mem_cmd_payload_size,
+  input  wire          io_mem_rsp_valid,
+  input  wire [31:0]   io_mem_rsp_payload_data,
+  input  wire          io_mem_rsp_payload_error,
+  input  wire [2:0]    _zz_when_Fetcher_l411,
+  input  wire [31:0]   _zz_io_cpu_fetch_data_regNextWhen,
+  input  wire          clk,
+  input  wire          reset
 );
 
   reg        [31:0]   _zz_banks_0_port1;
@@ -9508,7 +10560,7 @@ module InstructionCache (
   wire                when_InstructionCache_l351;
   reg                 lineLoader_cmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_Utils_l515;
+  wire                when_Utils_l560;
   reg                 lineLoader_wayToAllocate_willIncrement;
   wire                lineLoader_wayToAllocate_willClear;
   wire                lineLoader_wayToAllocate_willOverflowIfInc;
@@ -9554,7 +10606,7 @@ module InstructionCache (
   reg                 decodeStage_hit_valid;
   wire                when_InstructionCache_l459_2;
   reg                 decodeStage_hit_error;
-  wire                when_Fetcher_l401;
+  wire                when_Fetcher_l411;
   (* no_rw_check , ram_style = "block" *) reg [31:0] banks_0 [0:1023];
   (* no_rw_check , ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
 
@@ -9624,12 +10676,12 @@ module InstructionCache (
   assign when_InstructionCache_l351 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
   assign io_mem_cmd_fire = (io_mem_cmd_valid && io_mem_cmd_ready);
   assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
-  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
+  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h00};
   assign io_mem_cmd_payload_size = 3'b101;
-  assign when_Utils_l515 = (! lineLoader_valid);
+  assign when_Utils_l560 = (! lineLoader_valid);
   always @(*) begin
     lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if(when_Utils_l515) begin
+    if(when_Utils_l560) begin
       lineLoader_wayToAllocate_willIncrement = 1'b1;
     end
   end
@@ -9673,7 +10725,7 @@ module InstructionCache (
   assign io_cpu_decode_mmuRefilling = decodeStage_mmuRsp_refilling;
   assign io_cpu_decode_mmuException = (((! decodeStage_mmuRsp_refilling) && decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute)));
   assign io_cpu_decode_physicalAddress = decodeStage_mmuRsp_physicalAddress;
-  assign when_Fetcher_l401 = (_zz_when_Fetcher_l401 != 3'b000);
+  assign when_Fetcher_l411 = (_zz_when_Fetcher_l411 != 3'b000);
   always @(posedge clk) begin
     if(reset) begin
       lineLoader_valid <= 1'b0;
@@ -9721,7 +10773,7 @@ module InstructionCache (
     end
     _zz_when_InstructionCache_l342 <= lineLoader_flushCounter[7];
     if(when_InstructionCache_l351) begin
-      lineLoader_flushCounter <= 8'h0;
+      lineLoader_flushCounter <= 8'h00;
     end
     if(when_InstructionCache_l435) begin
       io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;
@@ -9743,26 +10795,10 @@ module InstructionCache (
     if(when_InstructionCache_l459_2) begin
       decodeStage_hit_error <= fetchStage_hit_error;
     end
-    if(when_Fetcher_l401) begin
+    if(when_Fetcher_l411) begin
       io_cpu_fetch_data_regNextWhen <= _zz_io_cpu_fetch_data_regNextWhen;
     end
   end
 
-
-endmodule
-
-module PmpSetter (
-  input      [31:0]   io_addr,
-  output     [24:0]   io_base,
-  output     [24:0]   io_mask
-);
-
-  wire       [31:0]   _zz_ones;
-  wire       [31:0]   ones;
-
-  assign _zz_ones = (io_addr + 32'h00000001);
-  assign ones = (io_addr & (~ _zz_ones));
-  assign io_base = (io_addr[29 : 5] ^ ones[29 : 5]);
-  assign io_mask = (~ {ones[28 : 5],1'b1});
 
 endmodule

--- a/pythondata_cpu_vexriscv/verilog/build.sbt
+++ b/pythondata_cpu_vexriscv/verilog/build.sbt
@@ -1,11 +1,11 @@
-val spinalVersion = "1.6.0"
+val spinalVersion = "1.9.4"
 
 lazy val root = (project in file(".")).
   settings(
     inThisBuild(List(
       organization := "com.github.spinalhdl",
       scalaVersion := "2.11.12",
-      version      := "0.1.0-SNAPSHOT"
+      version      := "2.0.0"
     )),
     name := "VexRiscvOnWishbone",
     libraryDependencies ++= Seq(

--- a/pythondata_cpu_vexriscv/verilog/project/build.properties
+++ b/pythondata_cpu_vexriscv/verilog/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.7
+sbt.version=1.9.7

--- a/pythondata_cpu_vexriscv/verilog/src/main/scala/vexriscv/GenCoreDefault.scala
+++ b/pythondata_cpu_vexriscv/verilog/src/main/scala/vexriscv/GenCoreDefault.scala
@@ -159,7 +159,7 @@ object GenCoreDefault{
         },
         if (linux) new MmuPlugin(
           ioRange = (x => x(31 downto 28) === 0xB || x(31 downto 28) === 0xE || x(31 downto 28) === 0xF)
-        ) else if (argConfig.pmpRegions > 0) new PmpPlugin(
+        ) else if (argConfig.pmpRegions > 0) new PmpPluginNapot(
           regions = argConfig.pmpRegions, granularity = argConfig.pmpGranularity, ioRange = _.msb
         ) else new StaticMemoryTranslatorPlugin(
           ioRange      = _.msb

--- a/pythondata_cpu_vexriscv/verilog/src/main/scala/vexriscv/GenCoreDefault.scala
+++ b/pythondata_cpu_vexriscv/verilog/src/main/scala/vexriscv/GenCoreDefault.scala
@@ -27,6 +27,7 @@ case class ArgConfig(
   dCacheSize : Int = 4096,
   pmpRegions : Int = 0,
   pmpGranularity : Int = 256,
+  pmpAddressMatchingModes : String = "na4,napot,tor",
   mulDiv : Boolean = true,
   cfu : Boolean = false,
   atomics: Boolean = false,
@@ -68,6 +69,7 @@ object GenCoreDefault{
       opt[Int]("dCacheSize")     action { (v, c) => c.copy(dCacheSize = v) } text("Set data cache size, 0 mean no cache")
       opt[Int]("pmpRegions")    action { (v, c) => c.copy(pmpRegions = v)   } text("Number of PMP regions, 0 disables PMP")
       opt[Int]("pmpGranularity")    action { (v, c) => c.copy(pmpGranularity = v)   } text("Granularity of PMP regions (in bytes)")
+      opt[String]("pmpAddressMatchingModes")    action { (v, c) => c.copy(pmpAddressMatchingModes = v)   } text("Which PMP address matching modes to support (comma-separated, out of [NA4, NAPOT, TOR])")
       opt[Boolean]("mulDiv")    action { (v, c) => c.copy(mulDiv = v)   } text("set RV32IM")
       opt[Boolean]("cfu")       action { (v, c) => c.copy(cfu = v)   } text("If true, add custom function unit interface")
       opt[Boolean]("atomics")    action { (v, c) => c.copy(atomics = v)   } text("set RV32I[A]")
@@ -159,9 +161,30 @@ object GenCoreDefault{
         },
         if (linux) new MmuPlugin(
           ioRange = (x => x(31 downto 28) === 0xB || x(31 downto 28) === 0xE || x(31 downto 28) === 0xF)
-        ) else if (argConfig.pmpRegions > 0) new PmpPluginNapot(
-          regions = argConfig.pmpRegions, granularity = argConfig.pmpGranularity, ioRange = _.msb
-        ) else new StaticMemoryTranslatorPlugin(
+        ) else if (argConfig.pmpRegions > 0) {
+          val splitModes = argConfig.pmpAddressMatchingModes.toLowerCase().split(",");
+
+          // Ensure the user didn't request any unsupported modes
+          val unknownModes = splitModes.filterNot(s => List("na4", "napot", "tor").contains(s));
+          if (unknownModes.length > 0) {
+            throw new Exception("Unknown PMP addressing mode: " + unknownModes(0));
+          }
+
+          if (splitModes.sameElements(List("napot"))) {
+            println("Using optimized PmpPluginNapot, supporting only the NAPOT addressing mode.");
+            new PmpPluginNapot(
+              regions = argConfig.pmpRegions,
+              granularity = argConfig.pmpGranularity,
+              ioRange = _.msb
+            )
+          } else {
+            println("Using PmpPlugin supporting the NA4, NAPOT, and TOR addressing modes.");
+            println("This will ignore the pmpGranularity argument and have 4-byte granularity.");
+            new PmpPlugin (
+              regions = 16, ioRange = _.msb
+            )
+          }
+        } else new StaticMemoryTranslatorPlugin(
           ioRange      = _.msb
         ),
 


### PR DESCRIPTION
This updates the pinned VexRiscv commit to b6118e6cc2a3, which (amongst other things) integrates the changes
- https://github.com/SpinalHDL/VexRiscv/pull/374
- https://github.com/SpinalHDL/VexRiscv/pull/378

These changes fix a bug in the "PmpPluginOld" (which supports all PMP addressing modes of NA4, NAPOT, and TOR) relating to address calculation for NAPOT regions. Futhermore, they "undeprecate" the `PmpPluginOld` by renaming it to `PmpPlugin`, indicating its full-featuredness compared to the now-called `PmpPluginNapot`.

Shipping both of these plugins, upstream VexRiscv allows this repository to select the appropriate one depending on the particular user preferences. To this end, I introduce a `pmpAddressMatchingModes` switch, where users can indicate which modes shall be supported in their CPU. For the `VexRiscv_Secure` target, it now defaults to the full-featured PMP plugin, effectively reverting to the state of #9. Changing this to the `PmpPluginNapot` as done in #12 unexpectedly broke downstream consumers such as TockOS, which thus needed to build and ship their own CPU variant (https://github.com/tock/tock/pull/2860). Thus, this change should allow OSes such as Tock, which require a spec-compliant PMP implementation, to revert back to the pre-built `VexRiscv_Secure` CPU target.

I can add a `VexRiscv_SecureNapot` target, to also retain the more optimized, but feature-limited and non-spec compliant version, if desired.

Furthermore, this PR updates the `sbt` version to 1.9.7, to work around an issue with using it with recent JREs (`[error] [launcher] error during sbt launcher: java.lang.UnsupportedOperationException: The Security Manager is deprecated and will be removed in a future release`), and updates the SpinalHDL versions to match those of the upstream VexRiscv repo.